### PR TITLE
format float: 32bit to 64bit for large num

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -5,7 +5,7 @@ import (
 )
 
 func formatFloat(f float64) string {
-	return strconv.FormatFloat(f, 'f', -1, 32)
+	return strconv.FormatFloat(f, 'f', -1, 64)
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
fix a large num format bug.
e.g.
if set to 32bit, 996945664 will convert to 996945660.
