### PR TITLE
Incorrect bool response from HSet()

### DIFF
--- a/v2/command.go
+++ b/v2/command.go
@@ -201,7 +201,7 @@ func (cmd *BoolCmd) parseReply(rd reader) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return v.(int64) == 1, nil
+	return v.(int64) == 0 || v.(int64) == 1, nil
 }
 
 func (cmd *BoolCmd) Val() bool {


### PR DESCRIPTION
Executing a successful HSet() on an existing redis hash field return a _false_ status instead of _true_.

http://redis.io/commands/hset lists two success states for HSET:

```
1 if field is a new field in the hash and value was set.
0 if field already exists in the hash and the value was updated.
```
