### PR TITLE
Close rate-limiter when closing pool

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -260,7 +260,7 @@ func (p *connPool) Close() error {
 		return nil
 	}
 	p.closed = true
-	var retErr error
+	retErr := p.rl.Close()
 	for {
 		e := p.conns.Front()
 		if e == nil {

--- a/rate_limit.go
+++ b/rate_limit.go
@@ -6,11 +6,15 @@ import (
 
 type rateLimiter struct {
 	C chan struct{}
+
+	closer, done chan struct{}
 }
 
 func newRateLimiter(limit time.Duration, chanSize int) *rateLimiter {
 	rl := &rateLimiter{
-		C: make(chan struct{}, chanSize),
+		C:      make(chan struct{}, chanSize),
+		closer: make(chan struct{}, 1),
+		done:   make(chan struct{}, 1),
 	}
 	for i := 0; i < chanSize; i++ {
 		rl.C <- struct{}{}
@@ -19,9 +23,18 @@ func newRateLimiter(limit time.Duration, chanSize int) *rateLimiter {
 	return rl
 }
 
+func (rl *rateLimiter) Close() error {
+	close(rl.closer)
+	<-rl.done
+	return nil
+}
+
 func (rl *rateLimiter) loop(limit time.Duration) {
 	for {
 		select {
+		case <-rl.closer:
+			close(rl.done)
+			return
 		case rl.C <- struct{}{}:
 		default:
 		}


### PR DESCRIPTION
That rate-limiter instances are never closed, which lead to thousands of stale goroutines in my case. Because `singleConnPool` is not public, https://github.com/bsm/redis-balancer/blob/master/backend.go#L83 is creating normal client connections for its background checks. When the client is closed, the pool is released too, but the `rateLimiter.loop` is never shut down properly.
