### PR TITLE
Fix PubSubNumSub to work with Redis 2.8.14.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1217,10 +1217,10 @@ func (c *Client) PubSubChannels(pattern string) *StringSliceCmd {
 	return cmd
 }
 
-func (c *Client) PubSubNumSub(channels ...string) *StringSliceCmd {
+func (c *Client) PubSubNumSub(channels ...string) *SliceCmd {
 	args := []string{"PUBSUB", "NUMSUB"}
 	args = append(args, channels...)
-	cmd := NewStringSliceCmd(args...)
+	cmd := NewSliceCmd(args...)
 	c.Process(cmd)
 	return cmd
 }

--- a/redis_test.go
+++ b/redis_test.go
@@ -2589,7 +2589,7 @@ func (t *RedisTest) TestPubSubNumSub(c *C) {
 	c.Assert(
 		channels,
 		DeepEquals,
-		[]string{"mychannel", "1", "mychannel2", "1", "mychannel3", "0"},
+		[]interface{}{"mychannel", int64(1), "mychannel2", int64(1), "mychannel3", int64(0)},
 	)
 }
 


### PR DESCRIPTION
Changelog:

```
* [NEW] **WARNING, minor API change**: PUBSUB NUMSUB: return type modified
        to integer. (Matt Stancliff)
```
