### PR TITLE
Add read/write instrumentation via OpenTelemetry

### DIFF
--- a/example/otel/example-client.go
+++ b/example/otel/example-client.go
@@ -73,7 +73,9 @@ func main() {
 	rdb.Del(ctx, "First value")
 	rdb.Del(ctx, "Second value")
 
-	// Wait some time to allow spans to export
-	<-time.After(5 * time.Second)
+
 	span.End()
+
+	// wait for spans to export
+	<-time.After(5 * time.Second)
 }

--- a/example/otel/example-client.go
+++ b/example/otel/example-client.go
@@ -73,7 +73,6 @@ func main() {
 	rdb.Del(ctx, "First value")
 	rdb.Del(ctx, "Second value")
 
-
 	span.End()
 
 	// wait for spans to export

--- a/internal/instruments.go
+++ b/internal/instruments.go
@@ -5,11 +5,14 @@ import (
 
 	"go.opentelemetry.io/otel/api/global"
 	"go.opentelemetry.io/otel/api/metric"
+	"go.opentelemetry.io/otel/api/unit"
 )
 
 var (
 	// WritesCounter is a count of write commands performed.
 	WritesCounter metric.Int64Counter
+	// BytesWritten records the number of bytes written to redis.
+	BytesWritten metric.Int64ValueRecorder
 	// NewConnectionsCounter is a count of new connections.
 	NewConnectionsCounter metric.Int64Counter
 )
@@ -25,6 +28,11 @@ func init() {
 
 	WritesCounter = meter.NewInt64Counter("redis.writes",
 		metric.WithDescription("the number of writes initiated"),
+	)
+
+	BytesWritten = meter.NewInt64ValueRecorder("redis.writes.bytes",
+		metric.WithDescription("the number of bytes written to redis"),
+		metric.WithUnit(unit.Bytes),
 	)
 
 	NewConnectionsCounter = meter.NewInt64Counter("redis.new_connections",

--- a/internal/instruments.go
+++ b/internal/instruments.go
@@ -13,6 +13,8 @@ var (
 	WritesCounter metric.Int64Counter
 	// BytesWritten records the number of bytes written to redis.
 	BytesWritten metric.Int64ValueRecorder
+	// BytesRead records the number of bytes read from redis.
+	BytesRead metric.Int64ValueRecorder
 	// NewConnectionsCounter is a count of new connections.
 	NewConnectionsCounter metric.Int64Counter
 )
@@ -32,6 +34,11 @@ func init() {
 
 	BytesWritten = meter.NewInt64ValueRecorder("redis.writes.bytes",
 		metric.WithDescription("the number of bytes written to redis"),
+		metric.WithUnit(unit.Bytes),
+	)
+
+	BytesRead = meter.NewInt64ValueRecorder("redis.reads.bytes",
+		metric.WithDescription("the number of bytes read from redis"),
 		metric.WithUnit(unit.Bytes),
 	)
 

--- a/internal/instruments.go
+++ b/internal/instruments.go
@@ -4,8 +4,19 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/api/global"
+	"go.opentelemetry.io/otel/api/kv"
 	"go.opentelemetry.io/otel/api/metric"
 	"go.opentelemetry.io/otel/api/unit"
+)
+
+const (
+	// Label Keys
+
+	// dbErrorMessageKey is the label key for an error message.
+	dbErrorMessageKey = kv.Key("db.redis.error")
+	// dbErrorSourceKey is the key for the label describing whether
+	// the error originated from a read or a write.
+	dbErrorSourceKey = kv.Key("db.redis.error.source")
 )
 
 var (
@@ -15,9 +26,26 @@ var (
 	BytesWritten metric.Int64ValueRecorder
 	// BytesRead records the number of bytes read from redis.
 	BytesRead metric.Int64ValueRecorder
+	// redisErrors is a count of the number of errors encountered.
+	redisErrors metric.Int64Counter
 	// NewConnectionsCounter is a count of new connections.
 	NewConnectionsCounter metric.Int64Counter
 )
+
+// dbErrorMessage returns an error message as a KeyValue pair.
+func dbErrorMessage(msg string) kv.KeyValue {
+	return dbErrorMessageKey.String(msg)
+}
+
+// dbErrorSourceWrite returns the write ErrorSource.
+func dbErrorSourceWrite() kv.KeyValue {
+	return dbErrorSourceKey.String("write")
+}
+
+// dbErrorSourceRead returns the read ErrorSource.
+func dbErrorSourceRead() kv.KeyValue {
+	return dbErrorSourceKey.String("read")
+}
 
 func init() {
 	defer func() {
@@ -40,6 +68,10 @@ func init() {
 	BytesRead = meter.NewInt64ValueRecorder("redis.reads.bytes",
 		metric.WithDescription("the number of bytes read from redis"),
 		metric.WithUnit(unit.Bytes),
+	)
+
+	redisErrors = meter.NewInt64Counter("redis.errors",
+		metric.WithDescription("the number of errors encountered"),
 	)
 
 	NewConnectionsCounter = meter.NewInt64Counter("redis.new_connections",

--- a/internal/instruments.go
+++ b/internal/instruments.go
@@ -22,6 +22,8 @@ const (
 var (
 	// WritesCounter is a count of write commands performed.
 	WritesCounter metric.Int64Counter
+	// ReadsCounter is a count of reads performed.
+	ReadsCounter metric.Int64Counter
 	// BytesWritten records the number of bytes written to redis.
 	BytesWritten metric.Int64ValueRecorder
 	// BytesRead records the number of bytes read from redis.
@@ -37,12 +39,14 @@ func dbErrorMessage(msg string) kv.KeyValue {
 	return dbErrorMessageKey.String(msg)
 }
 
-// dbErrorSourceWrite returns the write ErrorSource.
+// dbErrorSourceWrite returns a KeyValue pair denoting
+// that the error occurred during a write.
 func dbErrorSourceWrite() kv.KeyValue {
 	return dbErrorSourceKey.String("write")
 }
 
-// dbErrorSourceRead returns the read ErrorSource.
+// dbErrorSourceRead returns a KeyValue pair denoting
+// that the error occurred during a read.
 func dbErrorSourceRead() kv.KeyValue {
 	return dbErrorSourceKey.String("read")
 }
@@ -58,6 +62,10 @@ func init() {
 
 	WritesCounter = meter.NewInt64Counter("redis.writes",
 		metric.WithDescription("the number of writes initiated"),
+	)
+
+	ReadsCounter = meter.NewInt64Counter("redis.reads",
+		metric.WithDescription("the number of reads initiated"),
 	)
 
 	BytesWritten = meter.NewInt64ValueRecorder("redis.writes.bytes",

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -83,6 +83,9 @@ func (cn *Conn) WithReader(ctx context.Context, timeout time.Duration, fn func(r
 			internal.CountReadError(ctx, err)
 			return internal.RecordError(ctx, err)
 		}
+
+		internal.ReadsCounter.Add(ctx, 1)
+
 		return nil
 	})
 }

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -13,7 +13,7 @@ import (
 
 var noDeadline = time.Time{}
 
-type tracedConn struct{
+type tracedConn struct {
 	net.Conn
 	ctx context.Context
 }
@@ -146,5 +146,11 @@ func (cn *Conn) deadline(ctx context.Context, timeout time.Duration) time.Time {
 func (t *tracedConn) Write(b []byte) (int, error) {
 	n, err := t.Conn.Write(b)
 	internal.BytesWritten.Record(t.ctx, int64(n))
+	return n, err
+}
+
+func (t *tracedConn) Read(b []byte) (int, error) {
+	n, err := t.Conn.Read(b)
+	internal.BytesRead.Record(t.ctx, int64(n))
 	return n, err
 }

--- a/internal/util.go
+++ b/internal/util.go
@@ -153,3 +153,31 @@ func RecordError(ctx context.Context, err error) error {
 	}
 	return err
 }
+
+// CountWriteError increments the redisError instrument
+// adding a write label to the count. The error message
+// is also included as a label.
+func CountWriteError(ctx context.Context, err error) {
+	if err != proto.Nil {
+		redisErrors.Add(
+			ctx,
+			1,
+			dbErrorMessage(err.Error()),
+			dbErrorSourceWrite(),
+		)
+	}
+}
+
+// CountReadError increments the redisError instrument
+// adding a read label to the count. The error message
+// is also included as a label.
+func CountReadError(ctx context.Context, err error) {
+	if err != proto.Nil {
+		redisErrors.Add(
+			ctx,
+			1,
+			dbErrorMessage(err.Error()),
+			dbErrorSourceRead(),
+		)
+	}
+}


### PR DESCRIPTION
Part of: #1392 

### Description
This PR adds read/write metrics to go-redis/redis. The following instruments were added:

- The number of reads
- The number of bytes written
- The number of bytes read
- Errors (read/write)

I embedded `net.Conn` into a `tracedConn` struct that enabled me to collect bytes written/read. Let me know what you think of this approach. 

### TODO
- There are general semantic conventions regarding attributes/labels. I would like to add the necessary labels to the metrics, but I would like to get approval of my general approach to collecting read/write bytes first, before adding the labels.