### PR TITLE
Introduce full FIFO pool implementation

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -68,9 +68,10 @@ type ClusterOptions struct {
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
 
-	// PoolFIFO uses FIFO mode for each node connection pool GET/PUT (default LIFO).
-	PoolFIFO bool
-
+	// Type of the connection pool applied per cluster node
+	// Now we support stack pool and fifo pool
+	// Default is stack pool(lifo)
+	PoolType PoolType
 	// PoolSize applies per cluster node and not for the whole cluster.
 	PoolSize           int
 	MinIdleConns       int
@@ -149,7 +150,7 @@ func (opt *ClusterOptions) clientOptions() *Options {
 		ReadTimeout:  opt.ReadTimeout,
 		WriteTimeout: opt.WriteTimeout,
 
-		PoolFIFO:           opt.PoolFIFO,
+		PoolType:           opt.PoolType,
 		PoolSize:           opt.PoolSize,
 		MinIdleConns:       opt.MinIdleConns,
 		MaxConnAge:         opt.MaxConnAge,

--- a/internal/pool/pool_fifo.go
+++ b/internal/pool/pool_fifo.go
@@ -1,0 +1,484 @@
+package pool
+
+import (
+	"container/list"
+	"context"
+	"crypto/sha1"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-redis/redis/v8/internal"
+)
+
+const (
+	idleStatsRecent = 10
+)
+
+type FifoConnPool struct {
+	Pooler
+
+	opt *Options
+
+	dialErrorsNum uint32 // atomic
+
+	lastDialError atomic.Value
+
+	waitTurn *Semaphore
+
+	connsMu      sync.Mutex
+	conns        []*Conn
+	idleConns    list.List
+	poolSize     int
+	idleConnsLen int
+	idleStats    []int
+
+	stats Stats
+
+	_closed  uint32 // atomic
+	closedCh chan struct{}
+}
+
+func NewFifoConnPool(opt *Options) *FifoConnPool {
+	p := &FifoConnPool{
+		opt: opt,
+
+		waitTurn:  NewSemaphore(opt.PoolSize),
+		conns:     make([]*Conn, 0, opt.PoolSize),
+		idleStats: make([]int, idleStatsRecent),
+		closedCh:  make(chan struct{}),
+	}
+
+	p.connsMu.Lock()
+	p.checkMinIdleConns()
+	p.connsMu.Unlock()
+
+	if opt.IdleTimeout > 0 && opt.IdleCheckFrequency > 0 {
+		go p.idleCounter(opt.IdleTimeout)
+		go p.reaper(opt.IdleCheckFrequency)
+	}
+
+	return p
+}
+
+func (pool *FifoConnPool) checkMinIdleConns() {
+	// should lock outside
+	if pool.opt.MinIdleConns == 0 {
+		return
+	}
+	for pool.poolSize < pool.opt.PoolSize && pool.idleConnsLen < pool.opt.MinIdleConns {
+		pool.poolSize++
+		pool.idleConnsLen++
+		go func() {
+			err := pool.addIdleConn()
+			if err != nil {
+				pool.connsMu.Lock()
+				pool.poolSize--
+				pool.idleConnsLen--
+				pool.connsMu.Unlock()
+			}
+		}()
+	}
+}
+
+func (pool *FifoConnPool) addIdleConn() error {
+	cn, err := pool.dialConn(context.TODO(), true)
+	if err != nil {
+		return err
+	}
+
+	pool.connsMu.Lock()
+	pool.conns = append(pool.conns, cn)
+	pool.idleConns.PushBack(cn)
+	pool.connsMu.Unlock()
+	return nil
+}
+
+func (pool *FifoConnPool) dialConn(ctx context.Context, pooled bool) (*Conn, error) {
+	if pool.closed() {
+		return nil, ErrClosed
+	}
+
+	if atomic.LoadUint32(&pool.dialErrorsNum) >= uint32(pool.opt.PoolSize) {
+		return nil, pool.getLastDialError()
+	}
+
+	netConn, err := pool.opt.Dialer(ctx)
+	if err != nil {
+		pool.setLastDialError(err)
+		if atomic.AddUint32(&pool.dialErrorsNum, 1) == uint32(pool.opt.PoolSize) {
+			go pool.tryDial()
+		}
+		return nil, err
+	}
+
+	cn := NewConn(netConn)
+	cn.pooled = pooled
+	return cn, nil
+}
+
+func (pool *FifoConnPool) tryDial() {
+	for {
+		if pool.closed() {
+			return
+		}
+
+		conn, err := pool.opt.Dialer(context.Background())
+		if err != nil {
+			pool.setLastDialError(err)
+			time.Sleep(time.Second)
+			continue
+		}
+
+		atomic.StoreUint32(&pool.dialErrorsNum, 0)
+		_ = conn.Close()
+		return
+	}
+}
+
+func (pool *FifoConnPool) getLastDialError() error {
+	err, _ := pool.lastDialError.Load().(*lastDialErrorWrap)
+	if err != nil {
+		return err.err
+	}
+	return nil
+}
+
+func (pool *FifoConnPool) setLastDialError(err error) {
+	pool.lastDialError.Store(&lastDialErrorWrap{err: err})
+}
+
+func (pool *FifoConnPool) closed() bool {
+	return atomic.LoadUint32(&pool._closed) == 1
+}
+
+func (pool *FifoConnPool) Filter(fn func(*Conn) bool) error {
+	pool.connsMu.Lock()
+	defer pool.connsMu.Unlock()
+
+	var firstErr error
+	for _, cn := range pool.conns {
+		if fn(cn) {
+			if err := pool.closeConn(cn); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+func (pool *FifoConnPool) NewConn(ctx context.Context) (*Conn, error) {
+	return pool.newConn(ctx, false)
+}
+
+func (pool *FifoConnPool) newConn(ctx context.Context, pooled bool) (*Conn, error) {
+	cn, err := pool.dialConn(ctx, pooled)
+	if err != nil {
+		return nil, err
+	}
+
+	pool.connsMu.Lock()
+	pool.conns = append(pool.conns, cn)
+	if pooled {
+		// If pool is full remove the cn on next Put.
+		if pool.poolSize >= pool.opt.PoolSize {
+			cn.pooled = false
+		} else {
+			pool.poolSize++
+		}
+	}
+	pool.connsMu.Unlock()
+
+	return cn, nil
+}
+
+func (pool *FifoConnPool) CloseConn(cn *Conn) error {
+	pool.removeConnWithLock(cn)
+	return pool.closeConn(cn)
+}
+
+func (pool *FifoConnPool) Get(ctx context.Context) (*Conn, error) {
+	if pool.closed() {
+		return nil, ErrClosed
+	}
+
+	if err := pool.waitTurn.Wait(ctx, pool.opt.PoolTimeout); err != nil {
+		if err == ErrPoolTimeout {
+			atomic.AddUint32(&pool.stats.Timeouts, 1)
+		}
+		return nil, err
+	}
+
+	for {
+		pool.connsMu.Lock()
+		cn := pool.popIdle()
+		pool.connsMu.Unlock()
+
+		if cn == nil {
+			break
+		}
+
+		if pool.isMaxLifeConn(cn) {
+			_ = pool.CloseConn(cn)
+			continue
+		}
+
+		atomic.AddUint32(&pool.stats.Hits, 1)
+		return cn, nil
+	}
+
+	atomic.AddUint32(&pool.stats.Misses, 1)
+
+	newConn, err := pool.newConn(ctx, true)
+	if err != nil {
+		pool.waitTurn.Release()
+		return nil, err
+	}
+
+	return newConn, nil
+}
+
+func (pool *FifoConnPool) popIdle() *Conn {
+	if pool.idleConns.Len() == 0 {
+		return nil
+	}
+
+	elem := pool.idleConns.Front()
+	pool.idleConns.Remove(elem)
+	pool.idleConnsLen--
+	pool.checkMinIdleConns()
+	return elem.Value.(*Conn)
+}
+
+func (pool *FifoConnPool) Put(ctx context.Context, cn *Conn) {
+	if cn.rd.Buffered() > 0 {
+		internal.Logger.Printf(ctx, "Conn has unread data")
+		pool.Remove(ctx, cn, BadConnError{})
+		return
+	}
+
+	if !cn.pooled {
+		pool.Remove(ctx, cn, nil)
+		return
+	}
+
+	pool.connsMu.Lock()
+	pool.idleConns.PushBack(cn)
+	pool.idleConnsLen++
+	pool.connsMu.Unlock()
+	pool.waitTurn.Release()
+}
+
+func (pool *FifoConnPool) Remove(ctx context.Context, cn *Conn, reason error) {
+	pool.removeConnWithLock(cn)
+	pool.waitTurn.Release()
+	_ = pool.closeConn(cn)
+}
+
+func (pool *FifoConnPool) Len() int {
+	pool.connsMu.Lock()
+	n := len(pool.conns)
+	pool.connsMu.Unlock()
+	return n
+}
+
+func (pool *FifoConnPool) IdleLen() int {
+	pool.connsMu.Lock()
+	n := pool.idleConnsLen
+	pool.connsMu.Unlock()
+	return n
+}
+
+func (pool *FifoConnPool) Stats() *Stats {
+	idleLen := pool.IdleLen()
+	return &Stats{
+		Hits:     atomic.LoadUint32(&pool.stats.Hits),
+		Misses:   atomic.LoadUint32(&pool.stats.Misses),
+		Timeouts: atomic.LoadUint32(&pool.stats.Timeouts),
+
+		TotalConns: uint32(pool.Len()),
+		IdleConns:  uint32(idleLen),
+		StaleConns: atomic.LoadUint32(&pool.stats.StaleConns),
+	}
+}
+
+func (pool *FifoConnPool) closeConn(cn *Conn) error {
+	if pool.opt.OnClose != nil {
+		_ = pool.opt.OnClose(cn)
+	}
+	return cn.Close()
+}
+
+func (pool *FifoConnPool) Close() error {
+	if !atomic.CompareAndSwapUint32(&pool._closed, 0, 1) {
+		return ErrClosed
+	}
+	close(pool.closedCh)
+
+	var firstErr error
+	pool.connsMu.Lock()
+	for _, cn := range pool.conns {
+		if err := pool.closeConn(cn); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	pool.conns = nil
+	pool.poolSize = 0
+	pool.idleConns = list.List{}
+	pool.idleConnsLen = 0
+	pool.connsMu.Unlock()
+
+	return firstErr
+}
+
+func (pool *FifoConnPool) idleCounter(idleTimeout time.Duration) {
+	ticker := time.NewTicker(idleTimeout / idleStatsRecent)
+	defer ticker.Stop()
+
+	idx := 0
+	for {
+		select {
+		case <-ticker.C:
+			// It is possible that ticker and closedCh arrive together,
+			// and select pseudo-randomly pick ticker case, we double
+			// check here to prevent being executed after closed.
+			if pool.closed() {
+				return
+			}
+
+			pool.connsMu.Lock()
+			pool.idleStats[idx] = pool.idleConnsLen
+			pool.connsMu.Unlock()
+
+			idx++
+			idx %= idleStatsRecent
+		case <-pool.closedCh:
+			return
+		}
+	}
+}
+
+func (pool *FifoConnPool) reaper(frequency time.Duration) {
+	ticker := time.NewTicker(frequency)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			// It is possible that ticker and closedCh arrive together,
+			// and select pseudo-randomly pick ticker case, we double
+			// check here to prevent being executed after closed.
+			if pool.closed() {
+				return
+			}
+			_, err := pool.ReapStaleConns()
+			if err != nil {
+				internal.Logger.Printf(context.Background(), "ReapStaleConns failed: %s", err)
+				continue
+			}
+		case <-pool.closedCh:
+			return
+		}
+	}
+}
+
+func (pool *FifoConnPool) ReapStaleConns() (int, error) {
+	var n int
+	for {
+		pool.waitTurn.Acquire()
+
+		pool.connsMu.Lock()
+		cn := pool.reapStaleConn()
+		pool.connsMu.Unlock()
+
+		pool.waitTurn.Release()
+
+		if cn != nil {
+			_ = pool.closeConn(cn)
+			n++
+		} else {
+			break
+		}
+	}
+	atomic.AddUint32(&pool.stats.StaleConns, uint32(n))
+	return n, nil
+}
+
+func (pool *FifoConnPool) minIdleRecent() int {
+	min := pool.idleConnsLen
+	for _, n := range pool.idleStats {
+		if n < min {
+			min = n
+		}
+	}
+	return min
+}
+
+func (pool *FifoConnPool) reapStaleConn() *Conn {
+	if pool.idleConns.Len() == 0 {
+		return nil
+	}
+
+	minIdleCur := pool.idleConnsLen
+	elem := pool.idleConns.Front()
+	cn := elem.Value.(*Conn)
+
+	now := time.Now()
+	isIdle := false
+	if pool.opt.IdleTimeout > 0 && now.Sub(cn.createdAt) >= pool.opt.IdleTimeout {
+		minIdleRecent := pool.minIdleRecent()
+		if minIdleCur < minIdleRecent {
+			minIdleRecent = minIdleCur
+		}
+
+		if minIdleRecent > pool.opt.MinIdleConns {
+			isIdle = true
+		}
+	}
+
+	if !isIdle && !pool.isMaxLifeConn(cn) {
+		return nil
+	}
+
+	pool.removeConn(cn)
+	pool.idleConnsLen--
+	pool.idleConns.Remove(elem)
+	return cn
+}
+
+func (pool *FifoConnPool) removeConnWithLock(cn *Conn) {
+	pool.connsMu.Lock()
+	defer pool.connsMu.Unlock()
+	pool.removeConn(cn)
+}
+
+func (pool *FifoConnPool) removeConn(cn *Conn) {
+	for i, c := range pool.conns {
+		if c == cn {
+			pool.conns = append(pool.conns[:i], pool.conns[i+1:]...)
+			if cn.pooled {
+				pool.poolSize--
+				pool.checkMinIdleConns()
+			}
+			return
+		}
+	}
+}
+
+func (pool *FifoConnPool) isMaxLifeConn(cn *Conn) bool {
+	if pool.opt.MaxConnAge == 0 {
+		return false
+	}
+
+	now := time.Now()
+	minAge := pool.opt.MaxConnAge * 8 / 10
+	maxAge := pool.opt.MaxConnAge
+	localAddr := "dummy"
+	if cn.netConn != nil && cn.netConn.LocalAddr() != nil {
+		localAddr = cn.netConn.LocalAddr().String()
+	}
+
+	sum := sha1.Sum([]byte(localAddr))
+	age := minAge + (maxAge-minAge)*time.Duration(sum[0])/255
+	return now.Sub(cn.createdAt) >= age
+}

--- a/internal/pool/pool_fifo_test.go
+++ b/internal/pool/pool_fifo_test.go
@@ -1,0 +1,426 @@
+package pool_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redis/v8/internal/pool"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FifoConnPool", func() {
+	ctx := context.Background()
+	var fifoConnPool *pool.FifoConnPool
+
+	BeforeEach(func() {
+		fifoConnPool = pool.NewFifoConnPool(&pool.Options{
+			Dialer:             dummyDialer,
+			PoolSize:           10,
+			PoolTimeout:        time.Hour,
+			IdleTimeout:        time.Millisecond,
+			IdleCheckFrequency: time.Millisecond,
+		})
+	})
+
+	AfterEach(func() {
+		fifoConnPool.Close()
+	})
+
+	It("should unblock client when conn is removed", func() {
+		// Reserve one connection.
+		cn, err := fifoConnPool.Get(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Reserve all other connections.
+		var cns []*pool.Conn
+		for i := 0; i < 9; i++ {
+			cn, err := fifoConnPool.Get(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			cns = append(cns, cn)
+		}
+
+		started := make(chan bool, 1)
+		done := make(chan bool, 1)
+		go func() {
+			defer GinkgoRecover()
+
+			started <- true
+			_, err := fifoConnPool.Get(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			done <- true
+
+			fifoConnPool.Put(ctx, cn)
+		}()
+		<-started
+
+		// Check that Get is blocked.
+		select {
+		case <-done:
+			Fail("Get is not blocked")
+		case <-time.After(time.Millisecond):
+			// ok
+		}
+
+		fifoConnPool.Remove(ctx, cn, nil)
+
+		// Check that Get is unblocked.
+		select {
+		case <-done:
+			// ok
+		case <-time.After(time.Second):
+			Fail("Get is not unblocked")
+		}
+
+		for _, cn := range cns {
+			fifoConnPool.Put(ctx, cn)
+		}
+	})
+})
+
+var _ = Describe("FifoPoolMinIdleConns", func() {
+	const poolSize = 100
+	ctx := context.Background()
+	var minIdleConns int
+	var fifoConnPool *pool.FifoConnPool
+
+	newConnPool := func() *pool.FifoConnPool {
+		fifoConnPool := pool.NewFifoConnPool(&pool.Options{
+			Dialer:             dummyDialer,
+			PoolSize:           poolSize,
+			MinIdleConns:       minIdleConns,
+			PoolTimeout:        100 * time.Millisecond,
+			IdleTimeout:        -1,
+			IdleCheckFrequency: -1,
+		})
+		Eventually(func() int {
+			return fifoConnPool.Len()
+		}).Should(Equal(minIdleConns))
+		return fifoConnPool
+	}
+
+	assert := func() {
+		It("has idle connections when created", func() {
+			Expect(fifoConnPool.Len()).To(Equal(minIdleConns))
+			Expect(fifoConnPool.IdleLen()).To(Equal(minIdleConns))
+		})
+
+		Context("after Get", func() {
+			var cn *pool.Conn
+
+			BeforeEach(func() {
+				var err error
+				cn, err = fifoConnPool.Get(ctx)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() int {
+					return fifoConnPool.Len()
+				}).Should(Equal(minIdleConns + 1))
+			})
+
+			It("has idle connections", func() {
+				Expect(fifoConnPool.Len()).To(Equal(minIdleConns + 1))
+				Expect(fifoConnPool.IdleLen()).To(Equal(minIdleConns))
+			})
+
+			Context("after Remove", func() {
+				BeforeEach(func() {
+					fifoConnPool.Remove(ctx, cn, nil)
+				})
+
+				It("has idle connections", func() {
+					Expect(fifoConnPool.Len()).To(Equal(minIdleConns))
+					Expect(fifoConnPool.IdleLen()).To(Equal(minIdleConns))
+				})
+			})
+		})
+
+		Describe("Get does not exceed pool size", func() {
+			var mu sync.RWMutex
+			var cns []*pool.Conn
+
+			BeforeEach(func() {
+				cns = make([]*pool.Conn, 0)
+
+				perform(poolSize, func(_ int) {
+					defer GinkgoRecover()
+
+					cn, err := fifoConnPool.Get(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					mu.Lock()
+					cns = append(cns, cn)
+					mu.Unlock()
+				})
+
+				Eventually(func() int {
+					return fifoConnPool.Len()
+				}).Should(BeNumerically(">=", poolSize))
+			})
+
+			It("Get is blocked", func() {
+				done := make(chan struct{})
+				go func() {
+					fifoConnPool.Get(ctx)
+					close(done)
+				}()
+
+				select {
+				case <-done:
+					Fail("Get is not blocked")
+				case <-time.After(time.Millisecond):
+					// ok
+				}
+
+				select {
+				case <-done:
+					// ok
+				case <-time.After(time.Second):
+					Fail("Get is not unblocked")
+				}
+			})
+
+			Context("after Put", func() {
+				BeforeEach(func() {
+					perform(len(cns), func(i int) {
+						mu.RLock()
+						fifoConnPool.Put(ctx, cns[i])
+						mu.RUnlock()
+					})
+
+					Eventually(func() int {
+						return fifoConnPool.Len()
+					}).Should(Equal(poolSize))
+				})
+
+				It("pool.Len is back to normal", func() {
+					Expect(fifoConnPool.Len()).To(Equal(poolSize))
+					Expect(fifoConnPool.IdleLen()).To(Equal(poolSize))
+				})
+			})
+
+			Context("after Remove", func() {
+				BeforeEach(func() {
+					perform(len(cns), func(i int) {
+						mu.RLock()
+						fifoConnPool.Remove(ctx, cns[i], nil)
+						mu.RUnlock()
+					})
+
+					Eventually(func() int {
+						return fifoConnPool.Len()
+					}).Should(Equal(minIdleConns))
+				})
+
+				It("has idle connections", func() {
+					Expect(fifoConnPool.Len()).To(Equal(minIdleConns))
+					Expect(fifoConnPool.IdleLen()).To(Equal(minIdleConns))
+				})
+			})
+		})
+	}
+
+	Context("minIdleConns = 1", func() {
+		BeforeEach(func() {
+			minIdleConns = 1
+			fifoConnPool = newConnPool()
+		})
+
+		AfterEach(func() {
+			fifoConnPool.Close()
+		})
+
+		assert()
+	})
+
+	Context("minIdleConns = 32", func() {
+		BeforeEach(func() {
+			minIdleConns = 32
+			fifoConnPool = newConnPool()
+		})
+
+		AfterEach(func() {
+			fifoConnPool.Close()
+		})
+
+		assert()
+	})
+})
+
+var _ = Describe("conns reaper in fifo", func() {
+	const idleTimeout = time.Second
+	const maxAge = time.Hour
+
+	ctx := context.Background()
+	var fifoConnPool *pool.FifoConnPool
+	var conns, staleConns, closedConns []*pool.Conn
+
+	assert := func(typ string) {
+		BeforeEach(func() {
+			closedConns = nil
+			fifoConnPool = pool.NewFifoConnPool(&pool.Options{
+				Dialer:             dummyDialer,
+				PoolSize:           10,
+				IdleTimeout:        idleTimeout,
+				MaxConnAge:         maxAge,
+				PoolTimeout:        time.Second,
+				IdleCheckFrequency: time.Hour,
+				OnClose: func(cn *pool.Conn) error {
+					closedConns = append(closedConns, cn)
+					return nil
+				},
+			})
+			time.Sleep(100 * time.Millisecond)
+
+			conns = nil
+
+			// add stale connections
+			staleConns = nil
+			for i := 0; i < 3; i++ {
+				cn, err := fifoConnPool.Get(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				switch typ {
+				case "aged":
+					cn.SetCreatedAt(time.Now().Add(-2 * maxAge))
+				}
+				conns = append(conns, cn)
+				staleConns = append(staleConns, cn)
+			}
+
+			// add fresh connections
+			for i := 0; i < 3; i++ {
+				cn, err := fifoConnPool.Get(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				// make them cannot be recycled after 1 idle timeout
+				cn.SetCreatedAt(time.Now().Add(2 * idleTimeout))
+				conns = append(conns, cn)
+			}
+
+			for _, cn := range conns {
+				fifoConnPool.Put(ctx, cn)
+			}
+
+			if typ == "idle" {
+				// make them idle
+				time.Sleep(idleTimeout * 12 / 10)
+			}
+
+			Expect(fifoConnPool.Len()).To(Equal(6))
+			Expect(fifoConnPool.IdleLen()).To(Equal(6))
+
+			n, err := fifoConnPool.ReapStaleConns()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(3))
+		})
+
+		AfterEach(func() {
+			_ = fifoConnPool.Close()
+			Expect(fifoConnPool.Len()).To(Equal(0))
+			Expect(fifoConnPool.IdleLen()).To(Equal(0))
+			Expect(len(closedConns)).To(Equal(len(conns)))
+			Expect(closedConns).To(ConsistOf(conns))
+		})
+
+		It("reaps stale connections", func() {
+			Expect(fifoConnPool.Len()).To(Equal(3))
+			Expect(fifoConnPool.IdleLen()).To(Equal(3))
+		})
+
+		It("does not reap fresh connections", func() {
+			n, err := fifoConnPool.ReapStaleConns()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(0))
+		})
+
+		It("stale connections are closed", func() {
+			Expect(len(closedConns)).To(Equal(len(staleConns)))
+			Expect(closedConns).To(ConsistOf(staleConns))
+		})
+
+		It("pool is functional", func() {
+			for j := 0; j < 3; j++ {
+				var freeCns []*pool.Conn
+				for i := 0; i < 3; i++ {
+					cn, err := fifoConnPool.Get(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(cn).NotTo(BeNil())
+					freeCns = append(freeCns, cn)
+				}
+
+				Expect(fifoConnPool.Len()).To(Equal(3))
+				Expect(fifoConnPool.IdleLen()).To(Equal(0))
+
+				cn, err := fifoConnPool.Get(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cn).NotTo(BeNil())
+				conns = append(conns, cn)
+
+				Expect(fifoConnPool.Len()).To(Equal(4))
+				Expect(fifoConnPool.IdleLen()).To(Equal(0))
+
+				fifoConnPool.Remove(ctx, cn, nil)
+
+				Expect(fifoConnPool.Len()).To(Equal(3))
+				Expect(fifoConnPool.IdleLen()).To(Equal(0))
+
+				for _, cn := range freeCns {
+					fifoConnPool.Put(ctx, cn)
+				}
+
+				Expect(fifoConnPool.Len()).To(Equal(3))
+				Expect(fifoConnPool.IdleLen()).To(Equal(3))
+			}
+		})
+	}
+
+	assert("idle")
+	assert("aged")
+})
+
+var _ = Describe("race in fifo", func() {
+	ctx := context.Background()
+	var fifoConnPool *pool.FifoConnPool
+	var C, N int
+
+	BeforeEach(func() {
+		C, N = 10, 1000
+		if testing.Short() {
+			C = 4
+			N = 100
+		}
+	})
+
+	AfterEach(func() {
+		fifoConnPool.Close()
+	})
+
+	It("does not happen on Get, Put, and Remove", func() {
+		fifoConnPool = pool.NewFifoConnPool(&pool.Options{
+			Dialer:             dummyDialer,
+			PoolSize:           10,
+			PoolTimeout:        time.Minute,
+			IdleTimeout:        time.Millisecond,
+			IdleCheckFrequency: time.Millisecond,
+		})
+
+		perform(C, func(id int) {
+			for i := 0; i < N; i++ {
+				cn, err := fifoConnPool.Get(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				if err == nil {
+					fifoConnPool.Put(ctx, cn)
+				}
+			}
+		}, func(id int) {
+			for i := 0; i < N; i++ {
+				cn, err := fifoConnPool.Get(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				if err == nil {
+					fifoConnPool.Remove(ctx, cn, nil)
+				}
+			}
+		})
+	})
+})

--- a/internal/pool/pool_single.go
+++ b/internal/pool/pool_single.go
@@ -45,6 +45,10 @@ func (p *SingleConnPool) Close() error {
 	return nil
 }
 
+func (p *SingleConnPool) Filter(fn func(*Conn) bool) error {
+	return nil
+}
+
 func (p *SingleConnPool) Len() int {
 	return 0
 }

--- a/internal/pool/pool_sticky.go
+++ b/internal/pool/pool_sticky.go
@@ -146,6 +146,10 @@ func (p *StickyConnPool) Close() error {
 	return errors.New("redis: StickyConnPool.Close: infinite loop")
 }
 
+func (p *StickyConnPool) Filter(fn func(*Conn) bool) error {
+	return nil
+}
+
 func (p *StickyConnPool) Reset(ctx context.Context) error {
 	if p.badConnError() == nil {
 		return nil

--- a/internal/pool/semaphore.go
+++ b/internal/pool/semaphore.go
@@ -1,0 +1,59 @@
+package pool
+
+import (
+	"context"
+	"time"
+)
+
+type Semaphore struct {
+	queue chan struct{}
+}
+
+func NewSemaphore(max int) *Semaphore {
+	return &Semaphore{
+		queue: make(chan struct{}, max),
+	}
+}
+
+func (sem *Semaphore) Acquire() {
+	sem.queue <- struct{}{}
+}
+
+func (sem *Semaphore) Wait(ctx context.Context, timeout time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	select {
+	case sem.queue <- struct{}{}:
+		return nil
+	default:
+	}
+
+	timer := timers.Get().(*time.Timer)
+	timer.Reset(timeout)
+
+	select {
+	case <-ctx.Done():
+		if !timer.Stop() {
+			<-timer.C
+		}
+		timers.Put(timer)
+		return ctx.Err()
+	case sem.queue <- struct{}{}:
+		if !timer.Stop() {
+			<-timer.C
+		}
+		timers.Put(timer)
+		return nil
+	case <-timer.C:
+		timers.Put(timer)
+		return ErrPoolTimeout
+	}
+}
+
+func (sem *Semaphore) Release() {
+	<-sem.queue
+}

--- a/ring.go
+++ b/ring.go
@@ -78,9 +78,10 @@ type RingOptions struct {
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
 
-	// PoolFIFO uses FIFO mode for each node connection pool GET/PUT (default LIFO).
-	PoolFIFO bool
-
+	// Type of the connection pool
+	// Now we support stack pool and fifo pool
+	// Default is stack pool(lifo)
+	PoolType           PoolType
 	PoolSize           int
 	MinIdleConns       int
 	MaxConnAge         time.Duration
@@ -141,7 +142,7 @@ func (opt *RingOptions) clientOptions() *Options {
 		ReadTimeout:  opt.ReadTimeout,
 		WriteTimeout: opt.WriteTimeout,
 
-		PoolFIFO:           opt.PoolFIFO,
+		PoolType:           opt.PoolType,
 		PoolSize:           opt.PoolSize,
 		MinIdleConns:       opt.MinIdleConns,
 		MaxConnAge:         opt.MaxConnAge,

--- a/sentinel.go
+++ b/sentinel.go
@@ -57,9 +57,10 @@ type FailoverOptions struct {
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
 
-	// PoolFIFO uses FIFO mode for each node connection pool GET/PUT (default LIFO).
-	PoolFIFO bool
-
+	// Type of the connection pool
+	// Now we support stack pool and fifo pool
+	// Default is stack pool(lifo)
+	PoolType           PoolType
 	PoolSize           int
 	MinIdleConns       int
 	MaxConnAge         time.Duration
@@ -89,7 +90,7 @@ func (opt *FailoverOptions) clientOptions() *Options {
 		ReadTimeout:  opt.ReadTimeout,
 		WriteTimeout: opt.WriteTimeout,
 
-		PoolFIFO:           opt.PoolFIFO,
+		PoolType:           opt.PoolType,
 		PoolSize:           opt.PoolSize,
 		PoolTimeout:        opt.PoolTimeout,
 		IdleTimeout:        opt.IdleTimeout,
@@ -119,7 +120,7 @@ func (opt *FailoverOptions) sentinelOptions(addr string) *Options {
 		ReadTimeout:  opt.ReadTimeout,
 		WriteTimeout: opt.WriteTimeout,
 
-		PoolFIFO:           opt.PoolFIFO,
+		PoolType:           opt.PoolType,
 		PoolSize:           opt.PoolSize,
 		PoolTimeout:        opt.PoolTimeout,
 		IdleTimeout:        opt.IdleTimeout,
@@ -151,7 +152,7 @@ func (opt *FailoverOptions) clusterOptions() *ClusterOptions {
 		ReadTimeout:  opt.ReadTimeout,
 		WriteTimeout: opt.WriteTimeout,
 
-		PoolFIFO:           opt.PoolFIFO,
+		PoolType:           opt.PoolType,
 		PoolSize:           opt.PoolSize,
 		PoolTimeout:        opt.PoolTimeout,
 		IdleTimeout:        opt.IdleTimeout,

--- a/universal.go
+++ b/universal.go
@@ -7,6 +7,13 @@ import (
 	"time"
 )
 
+type PoolType string
+
+const (
+	PoolStack PoolType = ""
+	PoolFifo  PoolType = "fifo"
+)
+
 // UniversalOptions information is required by UniversalClient to establish
 // connections.
 type UniversalOptions struct {
@@ -35,9 +42,10 @@ type UniversalOptions struct {
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
 
-	// PoolFIFO uses FIFO mode for each node connection pool GET/PUT (default LIFO).
-	PoolFIFO bool
-
+	// Type of the connection pool
+	// Now we support stack pool and fifo pool
+	// Default is stack pool(lifo)
+	PoolType           PoolType
 	PoolSize           int
 	MinIdleConns       int
 	MaxConnAge         time.Duration
@@ -86,7 +94,7 @@ func (o *UniversalOptions) Cluster() *ClusterOptions {
 		DialTimeout:        o.DialTimeout,
 		ReadTimeout:        o.ReadTimeout,
 		WriteTimeout:       o.WriteTimeout,
-		PoolFIFO:           o.PoolFIFO,
+		PoolType:           o.PoolType,
 		PoolSize:           o.PoolSize,
 		MinIdleConns:       o.MinIdleConns,
 		MaxConnAge:         o.MaxConnAge,
@@ -124,7 +132,7 @@ func (o *UniversalOptions) Failover() *FailoverOptions {
 		ReadTimeout:  o.ReadTimeout,
 		WriteTimeout: o.WriteTimeout,
 
-		PoolFIFO:           o.PoolFIFO,
+		PoolType:           o.PoolType,
 		PoolSize:           o.PoolSize,
 		MinIdleConns:       o.MinIdleConns,
 		MaxConnAge:         o.MaxConnAge,
@@ -160,7 +168,7 @@ func (o *UniversalOptions) Simple() *Options {
 		ReadTimeout:  o.ReadTimeout,
 		WriteTimeout: o.WriteTimeout,
 
-		PoolFIFO:           o.PoolFIFO,
+		PoolType:           o.PoolType,
 		PoolSize:           o.PoolSize,
 		MinIdleConns:       o.MinIdleConns,
 		MaxConnAge:         o.MaxConnAge,


### PR DESCRIPTION
## Key Points

- Using interface instead of specific pointer type
- Introduce FIFO connection pool implementation
- Add necessary tests

## Notes

In this PR the `PoolFIFO bool` is replaced with a more extensible `PoolType`. It just follows our previous implementation and I don't insist on it. But I think a `type` makes more sense than a `boolean`. Certainly, we should also consider the backward compatibility.

## Detail Design

Please refer to Design on the FIFO connection pool (#1868)
