### PR TITLE
chore: use ctx parameter in cmdInfo

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -576,7 +576,7 @@ func (c *Ring) cmdInfo(ctx context.Context, name string) *CommandInfo {
 	}
 	info := cmdsInfo[name]
 	if info == nil {
-		internal.Logger.Printf(c.Context(), "info for cmd=%s not found", name)
+		internal.Logger.Printf(ctx, "info for cmd=%s not found", name)
 	}
 	return info
 }


### PR DESCRIPTION
cmdInfo has `ctx` as parameter, so I believe it would be more reasonable to use context parameter rather than client context when logging