### PR TITLE
Add parsing of multiple URLs for cluster mode in redis

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -2,11 +2,15 @@ package redis_test
 
 import (
 	"context"
+	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -1281,3 +1285,197 @@ var _ = Describe("ClusterClient timeout", func() {
 		testTimeout()
 	})
 })
+
+func TestParseClusterURLs(t *testing.T) {
+	cases := []struct {
+		test string
+		urls []string
+		o    *redis.ClusterOptions // expected value
+		err  error
+	}{
+		{
+			test: "ParseRedisURL",
+			urls: []string{"redis://localhost:123"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}},
+		}, {
+			test: "ParseRedissURL",
+			urls: []string{"rediss://localhost:123"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, TLSConfig: &tls.Config{ /* no deep comparison */ }},
+		}, {
+			test: "MissingRedisPort",
+			urls: []string{"redis://localhost"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:6379"}},
+		}, {
+			test: "MissingRedissPort",
+			urls: []string{"rediss://localhost"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:6379"}, TLSConfig: &tls.Config{ /* no deep comparison */ }},
+		}, {
+			test: "MultipleRedisURLs",
+			urls: []string{"redis://localhost:123", "redis://localhost:1234"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234"}},
+		}, {
+			test: "MultipleRedissURLs",
+			urls: []string{"rediss://localhost:123", "rediss://localhost:1234"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234"}, TLSConfig: &tls.Config{ /* no deep comparison */ }},
+		}, {
+			test: "OnlyPassword",
+			urls: []string{"redis://:bar@localhost:123"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Password: "bar"},
+		}, {
+			test: "OnlyUser",
+			urls: []string{"redis://foo@localhost:123"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Username: "foo"},
+		}, {
+			test: "RedisUsernamePassword",
+			urls: []string{"redis://foo:bar@localhost:123"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Username: "foo", Password: "bar"},
+		}, {
+			test: "RedissUsernamePassword",
+			urls: []string{"rediss://foo:bar@localhost:123", "rediss://foo:bar@localhost:1234"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234"}, Username: "foo", Password: "bar", TLSConfig: &tls.Config{ /* no deep comparison */ }},
+		}, {
+			test: "QueryParameters",
+			urls: []string{"redis://localhost:123?read_timeout=2&pool_fifo=true"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ReadTimeout: 2 * time.Second, PoolFIFO: true},
+		}, {
+			test: "UseFinalQueryParameters",
+			urls: []string{"redis://localhost:123?read_timeout=2&pool_fifo=true", "redis://localhost:1234?read_timeout=3&pool_fifo=true"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234"}, ReadTimeout: 3 * time.Second, PoolFIFO: true},
+		}, {
+			test: "DisabledTimeout",
+			urls: []string{"redis://localhost:123?idle_timeout=0"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, IdleTimeout: -1},
+		}, {
+			test: "DisabledTimeoutNeg",
+			urls: []string{"redis://localhost:123?idle_timeout=-1"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, IdleTimeout: -1},
+		}, {
+			test: "UseDefault",
+			urls: []string{"redis://localhost:123?idle_timeout="},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, IdleTimeout: 0},
+		}, {
+			test: "UseDefaultMissing=",
+			urls: []string{"redis://localhost:123?idle_timeout"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, IdleTimeout: 0},
+		}, {
+			test: "RedisPasswordMismatch",
+			urls: []string{"redis://foo:bar@localhost:123", "redis://foo:barr@localhost:1234"},
+			err:  errors.New(`redis: mismatch passwords`),
+		}, {
+			test: "RedisUsernameMismatch",
+			urls: []string{"redis://fooo:bar@localhost:123", "redis://foo:bar@localhost:1234"},
+			err:  errors.New(`redis: mismatch usernames: fooo and foo`),
+		}, {
+			test: "RedissPasswordMismatch",
+			urls: []string{"rediss://foo:bar@localhost:123", "rediss://foo:barr@localhost:1234"},
+			err:  errors.New(`redis: mismatch passwords`),
+		}, {
+			test: "RedissUsernameMismatch",
+			urls: []string{"rediss://foo:bar@localhost:123", "rediss://fooo:bar@localhost:1234"},
+			err:  errors.New(`redis: mismatch usernames: foo and fooo`),
+		}, {
+			test: "SchemeMismatch",
+			urls: []string{"rediss://foo:bar@localhost:123", "redis://foo:bar@localhost:1234"},
+			err:  errors.New(`redis: mismatch schemes: rediss and redis`),
+		}, {
+			test: "SchemeMismatch",
+			urls: []string{"redis://foo:bar@localhost:123", "localhost:1234"},
+			err:  errors.New(`redis: mismatch schemes: redis and localhost`),
+		}, {
+			test: "InvalidInt",
+			urls: []string{"redis://localhost?pool_size=five"},
+			err:  errors.New(`redis: invalid pool_size number: strconv.Atoi: parsing "five": invalid syntax`),
+		}, {
+			test: "InvalidBool",
+			urls: []string{"redis://localhost?pool_fifo=yes"},
+			err:  errors.New(`redis: invalid pool_fifo boolean: expected true/false/1/0 or an empty string, got "yes"`),
+		}, {
+			test: "UnknownParam",
+			urls: []string{"redis://localhost?abc=123"},
+			err:  errors.New("redis: unexpected option: abc"),
+		}, {
+			test: "InvalidScheme",
+			urls: []string{"https://google.com"},
+			err:  errors.New("redis: invalid URL scheme: https"),
+		},
+	}
+
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.test, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := redis.ParseClusterURLs(tc.urls)
+			if tc.err == nil && err != nil {
+				t.Fatalf("unexpected error: %q", err)
+				return
+			}
+			if tc.err != nil && err != nil {
+				if tc.err.Error() != err.Error() {
+					t.Fatalf("got %q, expected %q", err, tc.err)
+				}
+				return
+			}
+			comprareOptions(t, actual, tc.o)
+		})
+	}
+}
+
+func comprareOptions(t *testing.T, actual, expected *redis.ClusterOptions) {
+	t.Helper()
+
+	if !reflect.DeepEqual(actual.Addrs, expected.Addrs) {
+		t.Errorf("got %q, want %q", actual.Addrs, expected.Addrs)
+	}
+	if actual.TLSConfig == nil && expected.TLSConfig != nil {
+		t.Errorf("got nil TLSConfig, expected a TLSConfig")
+	}
+	if actual.TLSConfig != nil && expected.TLSConfig == nil {
+		t.Errorf("got TLSConfig, expected no TLSConfig")
+	}
+	if actual.Username != expected.Username {
+		t.Errorf("Username: got %q, expected %q", actual.Username, expected.Username)
+	}
+	if actual.Password != expected.Password {
+		t.Errorf("Password: got %q, expected %q", actual.Password, expected.Password)
+	}
+	if actual.MaxRetries != expected.MaxRetries {
+		t.Errorf("MaxRetries: got %v, expected %v", actual.MaxRetries, expected.MaxRetries)
+	}
+	if actual.MinRetryBackoff != expected.MinRetryBackoff {
+		t.Errorf("MinRetryBackoff: got %v, expected %v", actual.MinRetryBackoff, expected.MinRetryBackoff)
+	}
+	if actual.MaxRetryBackoff != expected.MaxRetryBackoff {
+		t.Errorf("MaxRetryBackoff: got %v, expected %v", actual.MaxRetryBackoff, expected.MaxRetryBackoff)
+	}
+	if actual.DialTimeout != expected.DialTimeout {
+		t.Errorf("DialTimeout: got %v, expected %v", actual.DialTimeout, expected.DialTimeout)
+	}
+	if actual.ReadTimeout != expected.ReadTimeout {
+		t.Errorf("ReadTimeout: got %v, expected %v", actual.ReadTimeout, expected.ReadTimeout)
+	}
+	if actual.WriteTimeout != expected.WriteTimeout {
+		t.Errorf("WriteTimeout: got %v, expected %v", actual.WriteTimeout, expected.WriteTimeout)
+	}
+	if actual.PoolFIFO != expected.PoolFIFO {
+		t.Errorf("PoolFIFO: got %v, expected %v", actual.PoolFIFO, expected.PoolFIFO)
+	}
+	if actual.PoolSize != expected.PoolSize {
+		t.Errorf("PoolSize: got %v, expected %v", actual.PoolSize, expected.PoolSize)
+	}
+	if actual.MinIdleConns != expected.MinIdleConns {
+		t.Errorf("MinIdleConns: got %v, expected %v", actual.MinIdleConns, expected.MinIdleConns)
+	}
+	if actual.MaxConnAge != expected.MaxConnAge {
+		t.Errorf("MaxConnAge: got %v, expected %v", actual.MaxConnAge, expected.MaxConnAge)
+	}
+	if actual.PoolTimeout != expected.PoolTimeout {
+		t.Errorf("PoolTimeout: got %v, expected %v", actual.PoolTimeout, expected.PoolTimeout)
+	}
+	if actual.IdleTimeout != expected.IdleTimeout {
+		t.Errorf("IdleTimeout: got %v, expected %v", actual.IdleTimeout, expected.IdleTimeout)
+	}
+	if actual.IdleCheckFrequency != expected.IdleCheckFrequency {
+		t.Errorf("IdleCheckFrequency: got %v, expected %v", actual.IdleCheckFrequency, expected.IdleCheckFrequency)
+	}
+}


### PR DESCRIPTION
**What this PR does**
This PR adds a new function, `ParseClusterURLs`, which takes an array of strings and turns it into the array of addresses used for redis in cluster mode along with configurations passed in.

**How it works**
It is very similar to the `ParseURL` function, except for this function loops through an array of URLs. It will get the username and password for the cluster as well as configurations sent in through the query parameters.

Since the connection to the cluster can only have one username and password, if it differs between URLs in the array, the function will fail. Additionally, if the schemes differ, it will fail. I did _not_ implement checks on the query parameters differing. If we want this done, I definitely could do it, but with the defaults and the init function it starts getting a bit uglier to check for all of those. If the query parameters do differ, it will use the last one in the array.

Example of arrays that will succeed:
```
["redis://localhost:6378", "redis://localhost:6379"]
["rediss://localhost:6378", "rediss://localhost:6379"]
["redis://foo:bar@localhost:6378?read_timeout=1s", "redis://foo:bar@localhost:6379?read_timeout=2s"] // no checks on query parameters
```

Example of arrays that will fail:
```
["redis://localhost:6378", "localhost:6379"] // schemes differ
["redis://foo:bar@localhost:6378", "redis://foo@localhost:6379"] // passwords differ
["redis://foo:bar@localhost:6378", "redis://foo:hello@localhost:6379"] // passwords differ
["redis://foo:bar@localhost:6378", "redis://bar:hello@localhost:6379"] // usernames differ
```
