### PR TITLE
Add customizable retry logic

### DIFF
--- a/error.go
+++ b/error.go
@@ -12,6 +12,7 @@ import (
 
 // ErrClosed performs any operation on the closed client will return this error.
 var ErrClosed = pool.ErrClosed
+var ErrPoolTimeout = pool.ErrPoolTimeout
 
 type Error interface {
 	error
@@ -25,7 +26,7 @@ type Error interface {
 
 var _ Error = proto.RedisError("")
 
-func shouldRetry(err error, retryTimeout bool) bool {
+func DefaultShouldRetry(err error, retryTimeout bool) bool {
 	switch err {
 	case io.EOF, io.ErrUnexpectedEOF:
 		return true

--- a/options.go
+++ b/options.go
@@ -16,6 +16,8 @@ import (
 	"github.com/go-redis/redis/v8/internal/pool"
 )
 
+type ShouldRetryFunc = func(error, bool) bool
+
 // Limiter is the interface of a rate limiter or a circuit breaker.
 type Limiter interface {
 	// Allow returns nil if operation is allowed or an error otherwise.
@@ -64,6 +66,7 @@ type Options struct {
 	// Maximum backoff between each retry.
 	// Default is 512 milliseconds; -1 disables backoff.
 	MaxRetryBackoff time.Duration
+	ShouldRetry     ShouldRetryFunc
 
 	// Dial timeout for establishing new connections.
 	// Default is 5 seconds.
@@ -181,6 +184,9 @@ func (opt *Options) init() {
 		opt.MaxRetryBackoff = 0
 	case 0:
 		opt.MaxRetryBackoff = 512 * time.Millisecond
+	}
+	if opt.ShouldRetry == nil {
+		opt.ShouldRetry = DefaultShouldRetry
 	}
 }
 

--- a/redis.go
+++ b/redis.go
@@ -348,7 +348,7 @@ func (c *baseClient) _process(ctx context.Context, cmd Cmder, attempt int) (bool
 		return false, nil
 	}
 
-	retry := shouldRetry(err, atomic.LoadUint32(&retryTimeout) == 1)
+	retry := c.opt.ShouldRetry(err, atomic.LoadUint32(&retryTimeout) == 1)
 	return retry, err
 }
 
@@ -426,7 +426,7 @@ func (c *baseClient) _generalProcessPipeline(
 			canRetry, err = p(ctx, cn, cmds)
 			return err
 		})
-		if lastErr == nil || !canRetry || !shouldRetry(lastErr, true) {
+		if lastErr == nil || !canRetry || !c.opt.ShouldRetry(lastErr, true) {
 			return lastErr
 		}
 	}

--- a/sentinel.go
+++ b/sentinel.go
@@ -58,6 +58,7 @@ type FailoverOptions struct {
 	MaxRetries      int
 	MinRetryBackoff time.Duration
 	MaxRetryBackoff time.Duration
+	ShouldRetry     ShouldRetryFunc
 
 	DialTimeout  time.Duration
 	ReadTimeout  time.Duration
@@ -90,6 +91,7 @@ func (opt *FailoverOptions) clientOptions() *Options {
 		MaxRetries:      opt.MaxRetries,
 		MinRetryBackoff: opt.MinRetryBackoff,
 		MaxRetryBackoff: opt.MaxRetryBackoff,
+		ShouldRetry:     opt.ShouldRetry,
 
 		DialTimeout:  opt.DialTimeout,
 		ReadTimeout:  opt.ReadTimeout,
@@ -121,6 +123,7 @@ func (opt *FailoverOptions) sentinelOptions(addr string) *Options {
 		MaxRetries:      opt.MaxRetries,
 		MinRetryBackoff: opt.MinRetryBackoff,
 		MaxRetryBackoff: opt.MaxRetryBackoff,
+		ShouldRetry:     opt.ShouldRetry,
 
 		DialTimeout:  opt.DialTimeout,
 		ReadTimeout:  opt.ReadTimeout,
@@ -153,6 +156,7 @@ func (opt *FailoverOptions) clusterOptions() *ClusterOptions {
 
 		MinRetryBackoff: opt.MinRetryBackoff,
 		MaxRetryBackoff: opt.MaxRetryBackoff,
+		ShouldRetry:     opt.ShouldRetry,
 
 		DialTimeout:  opt.DialTimeout,
 		ReadTimeout:  opt.ReadTimeout,

--- a/universal.go
+++ b/universal.go
@@ -30,6 +30,7 @@ type UniversalOptions struct {
 	MaxRetries      int
 	MinRetryBackoff time.Duration
 	MaxRetryBackoff time.Duration
+	ShouldRetry     ShouldRetryFunc
 
 	DialTimeout  time.Duration
 	ReadTimeout  time.Duration
@@ -82,6 +83,7 @@ func (o *UniversalOptions) Cluster() *ClusterOptions {
 		MaxRetries:      o.MaxRetries,
 		MinRetryBackoff: o.MinRetryBackoff,
 		MaxRetryBackoff: o.MaxRetryBackoff,
+		ShouldRetry:     o.ShouldRetry,
 
 		DialTimeout:        o.DialTimeout,
 		ReadTimeout:        o.ReadTimeout,
@@ -119,6 +121,7 @@ func (o *UniversalOptions) Failover() *FailoverOptions {
 		MaxRetries:      o.MaxRetries,
 		MinRetryBackoff: o.MinRetryBackoff,
 		MaxRetryBackoff: o.MaxRetryBackoff,
+		ShouldRetry:     o.ShouldRetry,
 
 		DialTimeout:  o.DialTimeout,
 		ReadTimeout:  o.ReadTimeout,
@@ -155,6 +158,7 @@ func (o *UniversalOptions) Simple() *Options {
 		MaxRetries:      o.MaxRetries,
 		MinRetryBackoff: o.MinRetryBackoff,
 		MaxRetryBackoff: o.MaxRetryBackoff,
+		ShouldRetry:     o.ShouldRetry,
 
 		DialTimeout:  o.DialTimeout,
 		ReadTimeout:  o.ReadTimeout,


### PR DESCRIPTION
Added a field ShouldRetry to all client option structs, to allow
custom behavior on retries. Existing shouldRetry function is renamed
to DefaultShouldRetry, and is the default as the name suggests.

Also exporting pool.ErrPoolTimeout