### PR TITLE
 Adding error handling in SSubscribe for cluster connection s

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1700,13 +1700,17 @@ func (c *ClusterClient) PSubscribe(ctx context.Context, channels ...string) *Pub
 }
 
 // SSubscribe Subscribes the client to the specified shard channels.
-func (c *ClusterClient) SSubscribe(ctx context.Context, channels ...string) *PubSub {
+func (c *ClusterClient) SSubscribe(ctx context.Context, channels ...string) (*PubSub, error) {
 	pubsub := c.pubSub()
 	if len(channels) > 0 {
-		_ = pubsub.SSubscribe(ctx, channels...)
+		err := pubsub.SSubscribe(ctx, channels...)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return pubsub
+	return pubsub, nil
 }
+
 
 func (c *ClusterClient) retryBackoff(attempt int) time.Duration {
 	return internal.RetryBackoff(attempt, c.opt.MinRetryBackoff, c.opt.MaxRetryBackoff)

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -554,7 +554,7 @@ var _ = Describe("ClusterClient", func() {
 		})
 
 		It("supports sharded PubSub", func() {
-			pubsub := client.SSubscribe(ctx, "mychannel")
+			pubsub,_ := client.SSubscribe(ctx, "mychannel")
 			defer pubsub.Close()
 
 			Eventually(func() error {

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -107,7 +107,7 @@ var _ = Describe("PubSub", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(channels).To(BeEmpty())
 
-		pubsub := client.SSubscribe(ctx, "mychannel", "mychannel2")
+		pubsub,_ := client.SSubscribe(ctx, "mychannel", "mychannel2")
 		defer pubsub.Close()
 
 		channels, err = client.PubSubShardChannels(ctx, "mychannel*").Result()
@@ -234,7 +234,7 @@ var _ = Describe("PubSub", func() {
 	})
 
 	It("should sharded pub/sub", func() {
-		pubsub := client.SSubscribe(ctx, "mychannel", "mychannel2")
+		pubsub,_ := client.SSubscribe(ctx, "mychannel", "mychannel2")
 		defer pubsub.Close()
 
 		{

--- a/redis.go
+++ b/redis.go
@@ -741,12 +741,15 @@ func (c *Client) PSubscribe(ctx context.Context, channels ...string) *PubSub {
 
 // SSubscribe Subscribes the client to the specified shard channels.
 // Channels can be omitted to create empty subscription.
-func (c *Client) SSubscribe(ctx context.Context, channels ...string) *PubSub {
+func (c *Client) SSubscribe(ctx context.Context, channels ...string) (*PubSub,error) {
 	pubsub := c.pubSub()
 	if len(channels) > 0 {
-		_ = pubsub.SSubscribe(ctx, channels...)
+		err := pubsub.Subscribe(ctx, channels...)
+		if err != nil {
+		return nil, err
+		}
 	}
-	return pubsub
+	return pubsub,nil
 }
 
 //------------------------------------------------------------------------------

--- a/ring.go
+++ b/ring.go
@@ -599,7 +599,7 @@ func (c *Ring) PSubscribe(ctx context.Context, channels ...string) *PubSub {
 }
 
 // SSubscribe Subscribes the client to the specified shard channels.
-func (c *Ring) SSubscribe(ctx context.Context, channels ...string) *PubSub {
+func (c *Ring) SSubscribe(ctx context.Context, channels ...string) (*PubSub,error) {
 	if len(channels) == 0 {
 		panic("at least one channel is required")
 	}

--- a/universal.go
+++ b/universal.go
@@ -200,7 +200,7 @@ type UniversalClient interface {
 	Process(ctx context.Context, cmd Cmder) error
 	Subscribe(ctx context.Context, channels ...string) *PubSub
 	PSubscribe(ctx context.Context, channels ...string) *PubSub
-	SSubscribe(ctx context.Context, channels ...string) *PubSub
+	SSubscribe(ctx context.Context, channels ...string) (*PubSub,error)
 	Close() error
 	PoolStats() *PoolStats
 }


### PR DESCRIPTION
Adding simple error handling in the SSubscribe function in cluster.go

closes #2303 