### PR TITLE
chore: add some error types that should be retried or a bad connection

### DIFF
--- a/error.go
+++ b/error.go
@@ -150,10 +150,7 @@ func isReadOnlyError(err error) bool {
 }
 
 func isResetError(err error) bool {
-	if err.Error() == "Connection reset by peer" {
-		return true
-	}
-	return false
+	return err.Error() == "Connection reset by peer"
 }
 
 func isMovedSameConnAddr(err error, addr string) bool {

--- a/internal/log.go
+++ b/internal/log.go
@@ -9,6 +9,9 @@ import (
 
 type Logging interface {
 	Printf(ctx context.Context, format string, v ...interface{})
+	Println(ctx context.Context, v ...interface{})
+	Fatalf(ctx context.Context, format string, v ...interface{})
+	Fatalln(ctx context.Context, v ...interface{})
 }
 
 type logger struct {
@@ -17,6 +20,20 @@ type logger struct {
 
 func (l *logger) Printf(ctx context.Context, format string, v ...interface{}) {
 	_ = l.log.Output(2, fmt.Sprintf(format, v...))
+}
+
+func (l *logger) Println(ctx context.Context, v ...interface{}) {
+	_ = l.log.Output(2, fmt.Sprintln(v...))
+}
+
+func (l *logger) Fatalf(ctx context.Context, format string, v ...interface{}) {
+	_ = l.log.Output(2, fmt.Sprintf(format, v...))
+	os.Exit(1)
+}
+
+func (l *logger) Fatalln(ctx context.Context, v ...interface{}) {
+	_ = l.log.Output(2, fmt.Sprintln(v...))
+	os.Exit(1)
 }
 
 // Logger calls Output to print to the stderr.


### PR DESCRIPTION
1. Connection reset by peer
    Client connection is closed, maybe I should treat it as a bad connection.
3. ERR redis temporary failure
    Access timeout, Should retry
5. FLUSHDB
    When adding or subtracting data nodes in a cluster, the FLUSHDB command is disabled and returns the error "ERR FLUSHDB is not allowed in migrating mode", which I think is also required as a retry case (although it is relatively rare).