### PR TITLE
docs: Update redisotel example for v9

### DIFF
--- a/extra/redisotel/README.md
+++ b/extra/redisotel/README.md
@@ -29,6 +29,6 @@ if err := redisotel.InstrumentMetrics(rdb); err != nil {
 }
 ```
 
-See [example](example) and
+See [example](../../example/otel) and
 [Monitoring Go Redis Performance and Errors](https://redis.uptrace.dev/guide/go-redis-monitoring.html)
 for details.

--- a/extra/redisotel/README.md
+++ b/extra/redisotel/README.md
@@ -18,7 +18,15 @@ import (
 
 rdb := rdb.NewClient(&rdb.Options{...})
 
-rdb.AddHook(redisotel.NewTracingHook())
+// Enable tracing instrumentation.
+if err := redisotel.InstrumentTracing(rdb); err != nil {
+	panic(err)
+}
+
+// Enable metrics instrumentation.
+if err := redisotel.InstrumentMetrics(rdb); err != nil {
+	panic(err)
+}
 ```
 
 See [example](example) and


### PR DESCRIPTION
- Update the redisotel example for v9 to match the example at https://redis.uptrace.dev/guide/go-redis-monitoring.html#opentelemetry-instrumentation.
- Fix link to otel example