### PR TITLE
fix: Blocking commands respect canceled context

### DIFF
--- a/internal_test.go
+++ b/internal_test.go
@@ -351,4 +351,21 @@ var _ = Describe("withConn", func() {
 		Expect(newConn).NotTo(Equal(conn))
 		Expect(client.connPool.Len()).To(Equal(1))
 	})
+
+	It("should remove the connection from the pool if the context is canceled", func() {
+		var conn *pool.Conn
+
+		ctx2, cancel := context.WithCancel(ctx)
+		cancel()
+
+		client.withConn(ctx2, func(ctx context.Context, c *pool.Conn) error {
+			conn = c
+			return nil
+		})
+
+		newConn, err := client.connPool.Get(ctx)
+		Expect(err).To(BeNil())
+		Expect(newConn).NotTo(Equal(conn))
+		Expect(client.connPool.Len()).To(Equal(1))
+	})
 })

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -1,6 +1,7 @@
 package redis_test
 
 import (
+	"context"
 	"io"
 	"net"
 	"sync"
@@ -566,5 +567,25 @@ var _ = Describe("PubSub", func() {
 		Eventually(ch).Should(Receive(&msg))
 		Expect(msg.Channel).To(Equal("mychannel"))
 		Expect(msg.Payload).To(Equal(text))
+	})
+
+	Describe("canceled context", func() {
+		It("should unblock ReceiveMessage", func() {
+			pubsub := client.Subscribe(ctx, "mychannel")
+			defer pubsub.Close()
+
+			ctx2, cancel := context.WithCancel(ctx)
+			errCh := make(chan error, 1)
+			go func() {
+				_, err := pubsub.ReceiveMessage(ctx2)
+				errCh <- err
+			}()
+
+			var gotErr error
+			Consistently(errCh).ShouldNot(Receive(&gotErr), "Received %v", gotErr)
+			cancel()
+			Eventually(errCh).Should(Receive(&gotErr))
+			Expect(gotErr).To(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
## Description

This fixes an issue where blocking commands like `XRead` and `XReadGroup` could not be canceled using the provided context. Similarly with `*PubSub.Receive`.

Fixes #2276
Supersedes #2432 

## Approach

I looked holistically at places in the code where a connection was being used without inspecting the context and applied the same basic pattern. Once a timeout is reached, the recommendation is to close the connection. Note that the change to `*PubSub.ReceiveTimeout` does not explicitly close the connection since that is already handled by the subsequent `*PubSub.releaseConnWithLock`.

Note that with this change, the [`ContextTimeoutEnabled`](https://github.com/redis/go-redis/blob/bdfb4a75ad0de4222af0c16cf4f9cd212822228b/options.go#L91) client option is redundant. Can we deprecate it?

## Testing

The new tests that I added all failed without this change. Note that I did not add new tests for the `processPipeline` and `processTxPipeline` changes, since pipelining blocking commands does not make sense. However, if you can think of a good test case I will be happy to add it.