### PR TITLE
Add option to customize span name

### DIFF
--- a/extra/redisotel/config.go
+++ b/extra/redisotel/config.go
@@ -12,8 +12,9 @@ import (
 type config struct {
 	// Common options.
 
-	dbSystem string
-	attrs    []attribute.KeyValue
+	dbSystem   string
+	attrs      []attribute.KeyValue
+	spanNameFn func(hook TracingHook, defaultName string) string
 
 	// Tracing options.
 
@@ -82,7 +83,7 @@ func WithAttributes(attrs ...attribute.KeyValue) Option {
 	})
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 type TracingOption interface {
 	baseOption
@@ -114,7 +115,22 @@ func WithDBStatement(on bool) TracingOption {
 	})
 }
 
-//------------------------------------------------------------------------------
+type TracingHook int
+
+const (
+	TracingHookDial TracingHook = iota
+	TracingHookProcess
+	TracingHookProcessPipeline
+)
+
+// WithSpanName provides a function to customize the span names.
+func WithSpanName(f func(hook TracingHook, defaultName string) string) TracingOption {
+	return tracingOption(func(conf *config) {
+		conf.spanNameFn = f
+	})
+}
+
+// ------------------------------------------------------------------------------
 
 type MetricsOption interface {
 	baseOption


### PR DESCRIPTION
This PR adds an option to customize span name.

```go
	hook := newTracingHook(
		"",
		WithTracerProvider(provider),
		WithSpanName(func(hook TracingHook, defaultName string) string {
			if hook == TracingHookProcess {
				return "redis." + defaultName
			}
			return defaultName
		}),
	)
```
