### PR TITLE
feat: recover addIdleConn may occur panic

### DIFF
--- a/internal/pool/export_test.go
+++ b/internal/pool/export_test.go
@@ -12,3 +12,11 @@ func (cn *Conn) SetCreatedAt(tm time.Time) {
 func (cn *Conn) NetConn() net.Conn {
 	return cn.netConn
 }
+
+func (p *ConnPool) CheckMinIdleConns() {
+	p.checkMinIdleConns()
+}
+
+func (p *ConnPool) QueueLen() int {
+	return len(p.queue)
+}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -118,6 +118,18 @@ func (p *ConnPool) checkMinIdleConns() {
 			p.idleConnsLen++
 
 			go func() {
+				defer func() {
+					if err := recover(); err != nil {
+						p.connsMu.Lock()
+						p.poolSize--
+						p.idleConnsLen--
+						p.connsMu.Unlock()
+
+						p.freeTurn()
+						internal.Logger.Printf(context.Background(), "addIdleConn panic: %+v", err)
+					}
+				}()
+
 				err := p.addIdleConn()
 				if err != nil && err != ErrClosed {
 					p.connsMu.Lock()

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -353,4 +353,22 @@ var _ = Describe("race", func() {
 		Expect(stats.IdleConns).To(Equal(uint32(0)))
 		Expect(stats.TotalConns).To(Equal(uint32(opt.PoolSize)))
 	})
+
+	It("recover addIdleConn panic", func() {
+		opt := &pool.Options{
+			Dialer: func(ctx context.Context) (net.Conn, error) {
+				panic("test panic")
+			},
+			PoolSize:     100,
+			MinIdleConns: 30,
+		}
+		p := pool.NewConnPool(opt)
+
+		p.CheckMinIdleConns()
+
+		Eventually(func() bool {
+			state := p.Stats()
+			return state.TotalConns == 0 && state.IdleConns == 0 && p.QueueLen() == 0
+		}, "3s", "50ms").Should(BeTrue())
+	})
 })


### PR DESCRIPTION
When the user defines the `Dialer` function, we should use `recover` to capture the panic that `addIdleConn` may generate.