### PR TITLE
fix: group lag can be null

### DIFF
--- a/command.go
+++ b/command.go
@@ -2057,7 +2057,7 @@ func (cmd *XInfoGroupsCmd) readReply(rd *proto.Reader) error {
 				}
 			case "lag":
 				group.Lag, err = rd.ReadInt()
-				if err != nil {
+				if err != nil && err != Nil {
 					return err
 				}
 			default:
@@ -2367,7 +2367,7 @@ func readStreamGroups(rd *proto.Reader) ([]XInfoStreamGroup, error) {
 				}
 			case "lag":
 				group.Lag, err = rd.ReadInt()
-				if err != nil {
+				if err != nil && err != Nil {
 					return nil, err
 				}
 			case "pel-count":


### PR DESCRIPTION
*fixes 3+ hours of me trying to understand why things don't work* 

see https://github.com/redis/redis/blob/383d902ce68131cf40d6122ce09e305e672e8555/src/t_stream.c#L1456

change the behavior so that if lag is null, the group lag will be set to 0 instead of returning an error