### PR TITLE
feat: add lock for hooks.dial

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -838,7 +838,7 @@ type ClusterClient struct {
 	state         *clusterStateHolder
 	cmdsInfoCache *cmdsInfoCache
 	cmdable
-	hooksMixin
+	*hooksMixin
 }
 
 // NewClusterClient returns a Redis Cluster client as described in
@@ -847,8 +847,9 @@ func NewClusterClient(opt *ClusterOptions) *ClusterClient {
 	opt.init()
 
 	c := &ClusterClient{
-		opt:   opt,
-		nodes: newClusterNodes(opt),
+		opt:        opt,
+		nodes:      newClusterNodes(opt),
+		hooksMixin: &hooksMixin{},
 	}
 
 	c.state = newClusterStateHolder(c.loadState)

--- a/ring.go
+++ b/ring.go
@@ -487,7 +487,7 @@ func (c *ringSharding) Close() error {
 // Otherwise you should use Redis Cluster.
 type Ring struct {
 	cmdable
-	hooksMixin
+	*hooksMixin
 
 	opt               *RingOptions
 	sharding          *ringSharding
@@ -504,6 +504,7 @@ func NewRing(opt *RingOptions) *Ring {
 		opt:               opt,
 		sharding:          newRingSharding(opt),
 		heartbeatCancelFn: hbCancel,
+		hooksMixin:        &hooksMixin{},
 	}
 
 	ring.cmdsInfoCache = newCmdsInfoCache(ring.cmdsInfo)

--- a/sentinel.go
+++ b/sentinel.go
@@ -211,6 +211,7 @@ func NewFailoverClient(failoverOpt *FailoverOptions) *Client {
 		baseClient: &baseClient{
 			opt: opt,
 		},
+		hooksMixin: &hooksMixin{},
 	}
 	rdb.init()
 
@@ -267,7 +268,7 @@ func masterReplicaDialer(
 // SentinelClient is a client for a Redis Sentinel.
 type SentinelClient struct {
 	*baseClient
-	hooksMixin
+	*hooksMixin
 }
 
 func NewSentinelClient(opt *Options) *SentinelClient {
@@ -276,6 +277,7 @@ func NewSentinelClient(opt *Options) *SentinelClient {
 		baseClient: &baseClient{
 			opt: opt,
 		},
+		hooksMixin: &hooksMixin{},
 	}
 
 	c.initHooks(hooks{

--- a/tx.go
+++ b/tx.go
@@ -19,7 +19,7 @@ type Tx struct {
 	baseClient
 	cmdable
 	statefulCmdable
-	hooksMixin
+	*hooksMixin
 }
 
 func (c *Client) newTx() *Tx {


### PR DESCRIPTION
See #2453 

We added a lock to `DialHook`, but `ProcessHook`, `ProcessPipelineHook` are still not thread-safe.

If the `Options.MinIdleConns` parameter is set, go-redis will create a network connection asynchronously, and there may be a data race (hooks.dial) with the `AddHook()` API, and even a part of the network connection is created before the `AddHook` operation.

We only need to pay for the overhead of the read lock for the DialHook.