### PR TITLE
fixed #2462  v9 continue support dragonfly,  it's Hello command return "NOAUTH Authentication required" error

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -286,7 +286,7 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 	if err := conn.Hello(ctx, 3, username, password, "").Err(); err == nil {
 		auth = true
 	} else if !strings.HasPrefix(err.Error(), "ERR unknown command") &&
-	// this check is for compatibility DragonflyDB.
+		// this check is for compatibility DragonflyDB.
 		!strings.HasPrefix(err.Error(), "NOAUTH Authentication") {
 		return err
 	}

--- a/redis.go
+++ b/redis.go
@@ -285,7 +285,8 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 	// we continue to provide services with RESP2.
 	if err := conn.Hello(ctx, 3, username, password, "").Err(); err == nil {
 		auth = true
-	} else if !strings.HasPrefix(err.Error(), "ERR unknown command") {
+	} else if !strings.HasPrefix(err.Error(), "ERR unknown command") &&
+		!strings.HasPrefix(err.Error(), "NOAUTH Authentication") {
 		return err
 	}
 

--- a/redis.go
+++ b/redis.go
@@ -286,6 +286,7 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 	if err := conn.Hello(ctx, 3, username, password, "").Err(); err == nil {
 		auth = true
 	} else if !strings.HasPrefix(err.Error(), "ERR unknown command") &&
+	// this check is for compatibility DragonflyDB.
 		!strings.HasPrefix(err.Error(), "NOAUTH Authentication") {
 		return err
 	}


### PR DESCRIPTION
See https://github.com/redis/go-redis/issues/2462

dragonfly dont support hello command, it's return "NOAUTH Authentication required" when use Hello command.