### PR TITLE
doc: pass ctx in BLpop example for infinite wait time

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -227,7 +227,7 @@ func ExampleClient_BLPop() {
 		panic(err)
 	}
 
-	// use `rdb.BLPop(0, "queue")` for infinite waiting time
+	// use `rdb.BLPop(ctx, 0, "queue")` for infinite waiting time
 	result, err := rdb.BLPop(ctx, 1*time.Second, "queue").Result()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
The current example will not compile.