### PR TITLE
actions: build on go1.20.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x]
 
     services:
       redis:


### PR DESCRIPTION
go1.20 was released on 1st Feb 2023, and has good adoption thus better to test against this as well.

If the build cleans, should the go1.18.x be removed or not?