### PR TITLE
Hible/bug read x message slice

### DIFF
--- a/command.go
+++ b/command.go
@@ -1451,11 +1451,15 @@ func readXMessageSlice(rd *proto.Reader) ([]XMessage, error) {
 		return nil, err
 	}
 
-	msgs := make([]XMessage, n)
-	for i := 0; i < len(msgs); i++ {
-		if msgs[i], err = readXMessage(rd); err != nil {
-			return nil, err
+	msgs := make([]XMessage, 0, n)
+	for i := 0; i < n; i++ {
+		if xMessage, err := readXMessage(rd); err == nil {
+			msgs = append(msgs, xMessage)
 		}
+	}
+	if len(msgs) < 1 {
+		// Compatible with previous returns
+		return nil, proto.Nil
 	}
 	return msgs, nil
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -5383,7 +5383,7 @@ var _ = Describe("Commands", func() {
 					Stream:   "stream",
 					Group:    "group",
 					Consumer: "consumer",
-					Messages: []string{"???-???", "1-0", "2-0", "3-0"},
+					Messages: []string{"1-0", "2-0", "3-0"},
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(msgs).To(Equal([]redis.XMessage{{

--- a/commands_test.go
+++ b/commands_test.go
@@ -5383,7 +5383,7 @@ var _ = Describe("Commands", func() {
 					Stream:   "stream",
 					Group:    "group",
 					Consumer: "consumer",
-					Messages: []string{"4-0", "1-0", "2-0", "3-0"},
+					Messages: []string{"???-???", "1-0", "2-0", "3-0"},
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(msgs).To(Equal([]redis.XMessage{{

--- a/commands_test.go
+++ b/commands_test.go
@@ -5383,7 +5383,7 @@ var _ = Describe("Commands", func() {
 					Stream:   "stream",
 					Group:    "group",
 					Consumer: "consumer",
-					Messages: []string{"1-0", "2-0", "3-0"},
+					Messages: []string{"4-0", "1-0", "2-0", "3-0"},
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(msgs).To(Equal([]redis.XMessage{{


### PR DESCRIPTION
如果没有将xpending里取出的数据进行进行了xdel没有进行ack的情况下，xclaim传入了已经删除了的数据就会导致返回` redis: nil `。
这种情况外部大概率就直接跳过了。