### PR TITLE
make error message more reasonable

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -297,7 +297,6 @@ func (p *ConnPool) waitTurn(ctx context.Context) error {
 	}
 
 	var realPoolTimeout time.Duration
-
 	timer := timers.Get().(*time.Timer)
 	deadline, ok := ctx.Deadline()
 	if ok {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -300,7 +300,7 @@ func (p *ConnPool) waitTurn(ctx context.Context) error {
 	timer := timers.Get().(*time.Timer)
 	deadline, ok := ctx.Deadline()
 	if ok {
-		realPoolTimeout = deadline.Sub(time.Now())
+		realPoolTimeout = time.Until(deadline)
 		if realPoolTimeout > p.cfg.PoolTimeout {
 			realPoolTimeout = p.cfg.PoolTimeout
 		}


### PR DESCRIPTION
Look at the following code snippet:
```golang
func main() {
	rdb := redis.NewClient(&redis.Options{
		Addr:     "3.3.3.3:10000", // make connection io timeout
		PoolSize: 1, // make connection pool timeout
	})
	for i := 0; i < 3; i++ {
		go get(rdb, "0")
	}
	time.Sleep(10000 * time.Hour)
}

func get(rdb *redis.Client, key string) {
	c, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
	defer cancel()
	v := rdb.Get(c, key)
	fmt.Println(v)
}
```
output for the code snippet with this pr:
```
get 0: redis: connection pool timeout
get 0: redis: connection pool timeout
get 0: dial tcp 3.3.3.3:10000: i/o timeout
```
When QPS become very high, rdb.Get may return error with the old logic:
`context deadline exceeded`
which is very confusing and hard to lookup the real problem.

In this pr, i referenced the implementation of context.WithTimeout, to use the smaller duration of configed timeout and timeout in current context. by doing this, the error will be `redis: connection pool timeout`, so users will know why timeout occurred.