### PR TITLE
feat: OnDisconnect hook to track server disconnections

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -60,7 +60,8 @@ type ClusterOptions struct {
 
 	Dialer func(ctx context.Context, network, addr string) (net.Conn, error)
 
-	OnConnect func(ctx context.Context, cn *Conn) error
+	OnConnect    func(ctx context.Context, cn *Conn) error
+	OnDisconnect func(ctx context.Context, cn *Conn) error
 
 	Protocol int
 	Username string
@@ -261,9 +262,10 @@ func setupClusterQueryParams(u *url.URL, o *ClusterOptions) (*ClusterOptions, er
 
 func (opt *ClusterOptions) clientOptions() *Options {
 	return &Options{
-		ClientName: opt.ClientName,
-		Dialer:     opt.Dialer,
-		OnConnect:  opt.OnConnect,
+		ClientName:   opt.ClientName,
+		Dialer:       opt.Dialer,
+		OnConnect:    opt.OnConnect,
+		OnDisconnect: opt.OnDisconnect,
 
 		Protocol: opt.Protocol,
 		Username: opt.Username,

--- a/example/ondisconnect/main.go
+++ b/example/ondisconnect/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"github.com/redis/go-redis/v9"
+	"log"
+	"time"
+)
+
+func main() {
+	cancelCh := make(chan struct{})
+
+	client := redis.NewClient(&redis.Options{
+		Addr:         "65.108.145.58:2716",
+		Username:     "defi",
+		Password:     "SWdmHmf2ekus26Wx",
+		DB:           0,
+		OnDisconnect: redis.DefaultOnDisconnect(5*time.Second, cancelCh),
+	})
+
+	if err := client.Ping(context.Background()); err != nil {
+		log.Fatalln(err)
+	}
+
+	for {
+		p := client.Publish(context.Background(), "test", "hello world")
+		if p.Err() != nil {
+			log.Println(p.Err())
+		}
+		time.Sleep(10 * time.Second)
+	}
+
+}

--- a/redis.go
+++ b/redis.go
@@ -330,6 +330,11 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 	if c.opt.OnConnect != nil {
 		return c.opt.OnConnect(ctx, conn)
 	}
+
+	if c.opt.OnDisconnect != nil {
+		return c.opt.OnDisconnect(ctx, conn)
+	}
+
 	return nil
 }
 

--- a/redis_test.go
+++ b/redis_test.go
@@ -465,6 +465,30 @@ var _ = Describe("Client OnConnect", func() {
 	})
 })
 
+var _ = Describe("Client OnDisconnect", func() {
+	var client *redis.Client
+
+	BeforeEach(func() {
+		opt := redisOptions()
+		opt.DB = 0
+		opt.OnDisconnect = func(ctx context.Context, cn *redis.Conn) error {
+			return cn.ClientSetName(ctx, "on_disconnect").Err()
+		}
+
+		client = redis.NewClient(opt)
+	})
+
+	AfterEach(func() {
+		Expect(client.Close()).NotTo(HaveOccurred())
+	})
+
+	It("calls OnDisconnect", func() {
+		name, err := client.ClientGetName(ctx).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(name).To(Equal("on_disconnect"))
+	})
+})
+
 var _ = Describe("Client context cancelation", func() {
 	var opt *redis.Options
 	var client *redis.Client

--- a/ring.go
+++ b/ring.go
@@ -67,8 +67,9 @@ type RingOptions struct {
 
 	// Following options are copied from Options struct.
 
-	Dialer    func(ctx context.Context, network, addr string) (net.Conn, error)
-	OnConnect func(ctx context.Context, cn *Conn) error
+	Dialer       func(ctx context.Context, network, addr string) (net.Conn, error)
+	OnConnect    func(ctx context.Context, cn *Conn) error
+	OnDisconnect func(ctx context.Context, cn *Conn) error
 
 	Protocol int
 	Username string
@@ -133,9 +134,10 @@ func (opt *RingOptions) init() {
 
 func (opt *RingOptions) clientOptions() *Options {
 	return &Options{
-		ClientName: opt.ClientName,
-		Dialer:     opt.Dialer,
-		OnConnect:  opt.OnConnect,
+		ClientName:   opt.ClientName,
+		Dialer:       opt.Dialer,
+		OnConnect:    opt.OnConnect,
+		OnDisconnect: opt.OnDisconnect,
 
 		Protocol: opt.Protocol,
 		Username: opt.Username,

--- a/sentinel.go
+++ b/sentinel.go
@@ -51,8 +51,9 @@ type FailoverOptions struct {
 
 	// Following options are copied from Options struct.
 
-	Dialer    func(ctx context.Context, network, addr string) (net.Conn, error)
-	OnConnect func(ctx context.Context, cn *Conn) error
+	Dialer       func(ctx context.Context, network, addr string) (net.Conn, error)
+	OnConnect    func(ctx context.Context, cn *Conn) error
+	OnDisconnect func(ctx context.Context, cn *Conn) error
 
 	Protocol int
 	Username string
@@ -85,8 +86,9 @@ func (opt *FailoverOptions) clientOptions() *Options {
 		Addr:       "FailoverClient",
 		ClientName: opt.ClientName,
 
-		Dialer:    opt.Dialer,
-		OnConnect: opt.OnConnect,
+		Dialer:       opt.Dialer,
+		OnConnect:    opt.OnConnect,
+		OnDisconnect: opt.OnDisconnect,
 
 		DB:       opt.DB,
 		Protocol: opt.Protocol,
@@ -119,8 +121,9 @@ func (opt *FailoverOptions) sentinelOptions(addr string) *Options {
 		Addr:       addr,
 		ClientName: opt.ClientName,
 
-		Dialer:    opt.Dialer,
-		OnConnect: opt.OnConnect,
+		Dialer:       opt.Dialer,
+		OnConnect:    opt.OnConnect,
+		OnDisconnect: opt.OnDisconnect,
 
 		DB:       0,
 		Username: opt.SentinelUsername,

--- a/universal.go
+++ b/universal.go
@@ -23,8 +23,9 @@ type UniversalOptions struct {
 
 	// Common options.
 
-	Dialer    func(ctx context.Context, network, addr string) (net.Conn, error)
-	OnConnect func(ctx context.Context, cn *Conn) error
+	Dialer       func(ctx context.Context, network, addr string) (net.Conn, error)
+	OnConnect    func(ctx context.Context, cn *Conn) error
+	OnDisconnect func(ctx context.Context, cn *Conn) error
 
 	Protocol         int
 	Username         string
@@ -159,10 +160,11 @@ func (o *UniversalOptions) Simple() *Options {
 	}
 
 	return &Options{
-		Addr:       addr,
-		ClientName: o.ClientName,
-		Dialer:     o.Dialer,
-		OnConnect:  o.OnConnect,
+		Addr:         addr,
+		ClientName:   o.ClientName,
+		Dialer:       o.Dialer,
+		OnConnect:    o.OnConnect,
+		OnDisconnect: o.OnDisconnect,
 
 		DB:       o.DB,
 		Protocol: o.Protocol,


### PR DESCRIPTION
example:

```go
package main

import (
	"context"
	"github.com/redis/go-redis/v9"
	"log"
	"time"
)

func main() {
	cancelCh := make(chan struct{})

	client := redis.NewClient(&redis.Options{
		Addr:         "localhost:6379",
		Username:     "foo",
		Password:     "bar",
		DB:           0,
		OnDisconnect: redis.DefaultOnDisconnect(5*time.Second, cancelCh),
	})

	if err := client.Ping(context.Background()); err != nil {
		log.Fatalln(err)
	}

}

```