### PR TITLE
fix: Fix bool ToBool bug

### DIFF
--- a/command.go
+++ b/command.go
@@ -340,6 +340,8 @@ func (cmd *Cmd) Bool() (bool, error) {
 
 func toBool(val interface{}) (bool, error) {
 	switch val := val.(type) {
+	case bool:
+		return val, nil
 	case int64:
 		return val != 0, nil
 	case string:


### PR DESCRIPTION
Fix ToBool for bool type.

`b.Client.Do(c, "BF.MEXISTS", "key", "values").BoolSlice()`

got _redis: unexpected type=bool for Bool_
