### PR TITLE
chore: fix staticcheck

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -612,7 +612,7 @@ var _ = Describe("Commands", func() {
 			// if too much time (>1s) is used during command execution, it may also cause the test to fail.
 			// so the ObjectIdleTime result should be <=now-start+1s
 			// link: https://github.com/redis/redis/blob/5b48d900498c85bbf4772c1d466c214439888115/src/object.c#L1265-L1272
-			Expect(idleTime.Val()).To(BeNumerically("<=", time.Now().Sub(start)+time.Second))
+			Expect(idleTime.Val()).To(BeNumerically("<=", time.Since(start)+time.Second))
 		})
 
 		It("should Persist", func() {

--- a/internal/proto/reader_test.go
+++ b/internal/proto/reader_test.go
@@ -78,7 +78,7 @@ func TestReader_ReadLine(t *testing.T) {
 		t.Errorf("Should be able to read the full buffer: %v", err)
 	}
 
-	if bytes.Compare(read, original[:len(original)-2]) != 0 {
+	if !bytes.Equal(read, original[:len(original)-2]) {
 		t.Errorf("Values must be equal: %d expected %d", len(read), len(original[:len(original)-2]))
 	}
 }


### PR DESCRIPTION
commands_test.go:615:50: should use time.Since instead of time.Now().Sub (S1012)
internal/proto/reader_test.go:81:5: should use !bytes.Equal(read, original[:len(original)-2]) instead (S1004)
