### PR TITLE
Updating the README with connection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,40 @@ func ExampleClient() {
 }
 ```
 
+The above can be modified to specify the version of the RESP protocol by adding the `protocol` option to the `Options` struct:
+
+```go
+    rdb := redis.NewClient(&redis.Options{
+        Addr:     "localhost:6379",
+        Password: "", // no password set
+        DB:       0,  // use default DB
+        Protocol: 3, // specify 2 for RESP 2 or 3 for RESP 3
+    })
+
+```
+
+### Connecting via a redis url
+
+go-redis also supports connecting via the [redis uri specification](https://github.com/redis/redis-specifications/tree/master/uri/redis.txt). The example below demonstrates how the connection can easily be configured using a string, adhering to this specification.
+
+```go
+import (
+    "context"
+    "github.com/redis/go-redis/v9"
+    "fmt"
+)
+
+var ctx = context.Background()
+
+func ExampleClient() {
+    url := "redis://localhost:6379?password=hello&protocol=3"
+    opts, err := redis.ParseURL(url)
+    if err != nil {
+        panic(err)
+    }
+    rdb := redis.NewClient(opts)
+```
+
 ## Look and feel
 
 Some corner cases:


### PR DESCRIPTION
The README currently has a quickstart, but neglects to mention that one can connect using a Redis URI< or how to modify the protocol version behaviour.

This README now contains two changes:

1. Another simple connection using a string

2. An update to the options, indicating that one can control the RESP version, via the  struct.
