### PR TITLE
Bumping redis versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       redis:
-        image: redis-stack-server:edge
+        image: redis/redis-stack-server:edge
         options: >-
           --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
         ports:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       redis:
-        image: redis:7.2-rc
+        image: redis-stack-server:edge
         options: >-
           --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
         ports:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ bench: testdeps
 
 testdata/redis:
 	mkdir -p $@
-	wget -qO- https://download.redis.io/releases/redis-7.2-rc1.tar.gz | tar xvz --strip-components=1 -C $@
+	wget -qO- https://download.redis.io/releases/redis-7.2-rc3.tar.gz | tar xvz --strip-components=1 -C $@
 
 testdata/redis/src/redis-server: testdata/redis
 	cd $< && make all


### PR DESCRIPTION
Bumping the redis test version to rc3 from rc1. Along the way, I also changed the docker image to redis-stack-server, especially given that various PRs starting to be worked on and collected.

Ideally, this is he first phase.

Will help out #2649 and and #2068 until we do something else.