### PR TITLE
[redis-cluster] do not mark fail node on Nil error

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1329,7 +1329,7 @@ func (c *ClusterClient) pipelineReadCmds(
 		err := cmd.readReply(rd)
 		cmd.SetErr(err)
 
-		if err == nil {
+		if err == nil || err == Nil {
 			continue
 		}
 


### PR DESCRIPTION
Cluster client pipeline in ReadOnly mode, consider Nil error as logic command response, dont mark node as failed in cluster.
Marking node as failed on Nil(not existing key) lead to switch to master node and if master node not available mark cluster down.
For redis server cluster it is not big a deal as default behavior to promote slave node to master, while other databases with redis protocol such as kvrocks don't support default promotion and clients will experience downtime.

Closes #2653 