### PR TITLE
Test on go1.21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.19.x, 1.20.x, 1.21.x]
 
     services:
       redis:

--- a/.github/workflows/doctests.yaml
+++ b/.github/workflows/doctests.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ "1.18", "1.19", "1.20" ]
+        go-version: [ "1.18", "1.19", "1.20", "1.21" ]
 
     steps:
       - name: Set up ${{ matrix.go-version }}


### PR DESCRIPTION
Updates CI tests to also test against [go1.21.](https://go.dev/blog/go1.21)