### PR TITLE
Copy client hooks to child connections.

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -276,7 +276,7 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 	}
 
 	connPool := pool.NewSingleConnPool(c.connPool, cn)
-	conn := newConn(c.opt, connPool)
+	conn := newConn(c.opt, connPool, hooksMixin{})
 
 	var auth bool
 	protocol := c.opt.Protocol
@@ -636,7 +636,7 @@ func (c *Client) WithTimeout(timeout time.Duration) *Client {
 }
 
 func (c *Client) Conn() *Conn {
-	return newConn(c.opt, pool.NewStickyConnPool(c.connPool))
+	return newConn(c.opt, pool.NewStickyConnPool(c.connPool), c.hooksMixin)
 }
 
 // Do create a Cmd from the args and processes the cmd.
@@ -772,7 +772,7 @@ type Conn struct {
 	hooksMixin
 }
 
-func newConn(opt *Options, connPool pool.Pooler) *Conn {
+func newConn(opt *Options, connPool pool.Pooler, parentHooks hooksMixin) *Conn {
 	c := Conn{
 		baseClient: baseClient{
 			opt:      opt,
@@ -782,6 +782,7 @@ func newConn(opt *Options, connPool pool.Pooler) *Conn {
 
 	c.cmdable = c.Process
 	c.statefulCmdable = c.Process
+	c.hooksMixin = parentHooks
 	c.initHooks(hooks{
 		dial:       c.baseClient.dial,
 		process:    c.baseClient.process,

--- a/redis_gears_test.go
+++ b/redis_gears_test.go
@@ -17,14 +17,14 @@ func libCodeWithConfig(libName string) string {
 	lib := `#!js api_version=1.0 name=%s
 
 	var last_update_field_name = "__last_update__"
-	
+
 	if (redis.config.last_update_field_name !== undefined) {
 		if (typeof redis.config.last_update_field_name != 'string') {
 			throw "last_update_field_name must be a string";
 		}
 		last_update_field_name = redis.config.last_update_field_name
 	}
-	
+
 	redis.registerFunction("hset", function(client, key, field, val){
 		// get the current time in ms
 		var curr_time = client.call("time")[0];
@@ -47,7 +47,6 @@ var _ = Describe("RedisGears commands", Label("gears"), func() {
 	})
 
 	It("should TFunctionLoad, TFunctionLoadArgs and TFunctionDelete ", Label("gears", "tfunctionload"), func() {
-
 		resultAdd, err := client.TFunctionLoad(ctx, libCode("libtflo1")).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resultAdd).To(BeEquivalentTo("OK"))
@@ -60,6 +59,7 @@ var _ = Describe("RedisGears commands", Label("gears"), func() {
 		Expect(resultAdd).To(BeEquivalentTo("OK"))
 
 	})
+
 	It("should TFunctionList", Label("gears", "tfunctionlist"), func() {
 		resultAdd, err := client.TFunctionLoad(ctx, libCode("libtfli1")).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -73,7 +73,13 @@ var _ = Describe("RedisGears commands", Label("gears"), func() {
 		opt := &redis.TFunctionListOptions{Withcode: true, Verbose: 2}
 		resultListArgs, err := client.TFunctionListArgs(ctx, opt).Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resultListArgs[0]["code"]).To(BeEquivalentTo(libCode("libtfli1")))
+
+		resultFunctionCodes := make([]string, len(resultListArgs))
+		for i, function := range resultListArgs {
+			resultFunctionCodes[i] = function["code"].(string)
+		}
+
+		Expect(resultFunctionCodes).To(ConsistOf(libCode("libtfli1"), libCode("libtfli2")))
 		resultAdd, err = client.TFunctionDelete(ctx, "libtfli1").Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resultAdd).To(BeEquivalentTo("OK"))
@@ -135,5 +141,4 @@ var _ = Describe("RedisGears commands", Label("gears"), func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resultAdd).To(BeEquivalentTo("OK"))
 	})
-
 })


### PR DESCRIPTION
Enables parent hooks on child connections to allow mocking to hook into the commands run on those connections.

Also fixes a flapping test on Redis Gears, caused by an assumption in the order of returned functions.