### PR TITLE
Update command.go

### DIFF
--- a/command.go
+++ b/command.go
@@ -3551,7 +3551,7 @@ func (cmd *SlowLogCmd) readReply(rd *proto.Reader) error {
 		if err != nil {
 			return err
 		}
-		cmd.val[i].Duration = time.Duration(costs) * time.Microsecond
+		cmd.val[i].Duration = time.Duration(costs)
 
 		cmdLen, err := rd.ReadArrayLen()
 		if err != nil {


### PR DESCRIPTION
https://redis.io/commands/slowlog-get/

The unit of data obtained by slowlog get itself is already us, no further conversion is required