### PR TITLE
change interfaces probabilistic and redis gears from private to public

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -505,8 +505,8 @@ type Cmdable interface {
 
 	ModuleLoadex(ctx context.Context, conf *ModuleLoadexConfig) *StringCmd
 
-	gearsCmdable
-	probabilisticCmdable
+	GearsCmdable
+	ProbabilisticCmdable
 }
 
 type StatefulCmdable interface {

--- a/probabilistic.go
+++ b/probabilistic.go
@@ -7,7 +7,7 @@ import (
 	"github.com/redis/go-redis/v9/internal/proto"
 )
 
-type probabilisticCmdable interface {
+type ProbabilisticCmdable interface {
 	BFAdd(ctx context.Context, key string, element interface{}) *BoolCmd
 	BFCard(ctx context.Context, key string) *IntCmd
 	BFExists(ctx context.Context, key string, element interface{}) *BoolCmd

--- a/redis_gears.go
+++ b/redis_gears.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-type gearsCmdable interface {
+type GearsCmdable interface {
 	TFunctionLoad(ctx context.Context, lib string) *StatusCmd
 	TFunctionLoadArgs(ctx context.Context, lib string, options *TFunctionLoadOptions) *StatusCmd
 	TFunctionDelete(ctx context.Context, libName string) *StatusCmd
@@ -17,6 +17,7 @@ type gearsCmdable interface {
 	TFCallASYNC(ctx context.Context, libName string, funcName string, numKeys int) *Cmd
 	TFCallASYNCArgs(ctx context.Context, libName string, funcName string, numKeys int, options *TFCallOptions) *Cmd
 }
+
 type TFunctionLoadOptions struct {
 	Replace bool
 	Config  string


### PR DESCRIPTION
Today, if we look into `UniversalClient` interface documentation,

https://pkg.go.dev/github.com/redis/go-redis/v9#UniversalClient

it includes the `Cmdable` interface 

https://pkg.go.dev/github.com/redis/go-redis/v9#Cmdable

however we have no mention or link to the methods defined in gears or probabilistic interfaces because such interfaces are private.


