### PR TITLE
Adding Go 1.21.x for CI coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.19.x, 1.20.x, 1.21.x]
 
     services:
       redis:

--- a/.github/workflows/doctests.yaml
+++ b/.github/workflows/doctests.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ "1.18", "1.19", "1.20" ]
+        go-version: [ "1.18", "1.19", "1.20", "1.21" ]
 
     steps:
       - name: Set up ${{ matrix.go-version }}


### PR DESCRIPTION
Add support to go 1.21.x