### PR TITLE
Add stream interface back to `Cmdable`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -224,6 +224,7 @@ type Cmdable interface {
 	GearsCmdable
 	ProbabilisticCmdable
 	TimeseriesCmdable
+	StreamCmdable
 }
 
 type StatefulCmdable interface {


### PR DESCRIPTION
Without it we can't call stream functions from `Cmdable`.

That broke some our code since we rely on `UniversalClient` to abstract from `ClusterClient` and  `Client`. Adding back seems to have solve the isse since those two client do implement `StreamCmdable`.
