### PR TITLE
Option types must propagage missing fields

### DIFF
--- a/options.go
+++ b/options.go
@@ -142,7 +142,7 @@ type Options struct {
 	// Enables read only queries on slave/follower nodes.
 	readOnly bool
 
-	// // Disable set-lib on connect. Default is false.
+	// Disable set-lib on connect. Default is false.
 	DisableIndentity bool
 }
 

--- a/ring.go
+++ b/ring.go
@@ -73,7 +73,10 @@ type RingOptions struct {
 	Protocol int
 	Username string
 	Password string
-	DB       int
+
+	CredentialsProvider func() (username string, password string)
+
+	DB int
 
 	MaxRetries      int
 	MinRetryBackoff time.Duration
@@ -82,6 +85,8 @@ type RingOptions struct {
 	DialTimeout  time.Duration
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
+
+	ContextTimeoutEnabled bool
 
 	// PoolFIFO uses FIFO mode for each node connection pool GET/PUT (default LIFO).
 	PoolFIFO bool
@@ -95,6 +100,8 @@ type RingOptions struct {
 
 	TLSConfig *tls.Config
 	Limiter   Limiter
+
+	DisableIndentity bool
 }
 
 func (opt *RingOptions) init() {
@@ -140,13 +147,18 @@ func (opt *RingOptions) clientOptions() *Options {
 		Protocol: opt.Protocol,
 		Username: opt.Username,
 		Password: opt.Password,
-		DB:       opt.DB,
+
+		CredentialsProvider: opt.CredentialsProvider,
+
+		DB: opt.DB,
 
 		MaxRetries: -1,
 
 		DialTimeout:  opt.DialTimeout,
 		ReadTimeout:  opt.ReadTimeout,
 		WriteTimeout: opt.WriteTimeout,
+
+		ContextTimeoutEnabled: opt.ContextTimeoutEnabled,
 
 		PoolFIFO:        opt.PoolFIFO,
 		PoolSize:        opt.PoolSize,
@@ -158,6 +170,8 @@ func (opt *RingOptions) clientOptions() *Options {
 
 		TLSConfig: opt.TLSConfig,
 		Limiter:   opt.Limiter,
+
+		DisableIndentity: opt.DisableIndentity,
 	}
 }
 

--- a/ring.go
+++ b/ring.go
@@ -73,10 +73,7 @@ type RingOptions struct {
 	Protocol int
 	Username string
 	Password string
-
-	CredentialsProvider func() (username string, password string)
-
-	DB int
+	DB       int
 
 	MaxRetries      int
 	MinRetryBackoff time.Duration
@@ -147,10 +144,7 @@ func (opt *RingOptions) clientOptions() *Options {
 		Protocol: opt.Protocol,
 		Username: opt.Username,
 		Password: opt.Password,
-
-		CredentialsProvider: opt.CredentialsProvider,
-
-		DB: opt.DB,
+		DB:       opt.DB,
 
 		MaxRetries: -1,
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -78,6 +78,8 @@ type FailoverOptions struct {
 	ConnMaxLifetime time.Duration
 
 	TLSConfig *tls.Config
+
+	DisableIndentity bool
 }
 
 func (opt *FailoverOptions) clientOptions() *Options {
@@ -111,6 +113,8 @@ func (opt *FailoverOptions) clientOptions() *Options {
 		ConnMaxLifetime: opt.ConnMaxLifetime,
 
 		TLSConfig: opt.TLSConfig,
+
+		DisableIndentity: opt.DisableIndentity,
 	}
 }
 

--- a/universal.go
+++ b/universal.go
@@ -64,6 +64,8 @@ type UniversalOptions struct {
 	// Only failover clients.
 
 	MasterName string
+
+	DisableIndentity bool
 }
 
 // Cluster returns cluster options created from the universal options.
@@ -106,6 +108,8 @@ func (o *UniversalOptions) Cluster() *ClusterOptions {
 		ConnMaxLifetime: o.ConnMaxLifetime,
 
 		TLSConfig: o.TLSConfig,
+
+		DisableIndentity: o.DisableIndentity,
 	}
 }
 
@@ -148,6 +152,8 @@ func (o *UniversalOptions) Failover() *FailoverOptions {
 		ConnMaxLifetime: o.ConnMaxLifetime,
 
 		TLSConfig: o.TLSConfig,
+
+		DisableIndentity: o.DisableIndentity,
 	}
 }
 
@@ -187,6 +193,8 @@ func (o *UniversalOptions) Simple() *Options {
 		ConnMaxLifetime: o.ConnMaxLifetime,
 
 		TLSConfig: o.TLSConfig,
+
+		DisableIndentity: o.DisableIndentity,
 	}
 }
 


### PR DESCRIPTION
option `DisableIndentity` and `ContextTimeoutEnabled` sometimes are not available or not propagate betweend option types.

BTW I think it is strange that exists an option `CredentialsProvider` but we only use in the _simple_ case, why Universal, Ring or Cluster does not use it?

same for `Limiter`

```go
       CredentialsProvider func() (username string, password string)
	// Limiter interface used to implement circuit breaker or rate limiter.
	Limiter Limiter
```