### PR TITLE
refactor(gears): remove redundant nil check

### DIFF
--- a/gears_commands.go
+++ b/gears_commands.go
@@ -110,15 +110,11 @@ func (c cmdable) TFCallArgs(ctx context.Context, libName string, funcName string
 	lf := libName + "." + funcName
 	args := []interface{}{"TFCALL", lf, numKeys}
 	if options != nil {
-		if options.Keys != nil {
-			for _, key := range options.Keys {
-				args = append(args, key)
-			}
+		for _, key := range options.Keys {
+			args = append(args, key)
 		}
-		if options.Arguments != nil {
-			for _, key := range options.Arguments {
-				args = append(args, key)
-			}
+		for _, key := range options.Arguments {
+			args = append(args, key)
 		}
 	}
 	cmd := NewCmd(ctx, args...)
@@ -140,15 +136,11 @@ func (c cmdable) TFCallASYNCArgs(ctx context.Context, libName string, funcName s
 	lf := fmt.Sprintf("%s.%s", libName, funcName)
 	args := []interface{}{"TFCALLASYNC", lf, numKeys}
 	if options != nil {
-		if options.Keys != nil {
-			for _, key := range options.Keys {
-				args = append(args, key)
-			}
+		for _, key := range options.Keys {
+			args = append(args, key)
 		}
-		if options.Arguments != nil {
-			for _, key := range options.Arguments {
-				args = append(args, key)
-			}
+		for _, key := range options.Arguments {
+			args = append(args, key)
 		}
 	}
 	cmd := NewCmd(ctx, args...)


### PR DESCRIPTION
From the Go specification:

> "1. For a nil slice, the number of iterations is 0." https://go.dev/ref/spec#For_range

Both `Keys` and `Arguments` are `[]string`. Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/R57hixwdkhX