### PR TITLE
Add BitMapCmdable to Cmdable.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -210,21 +210,22 @@ type Cmdable interface {
 	ModuleLoadex(ctx context.Context, conf *ModuleLoadexConfig) *StringCmd
 
 	ACLCmdable
+	BitMapCmdable
+	ClusterCmdable
+	GearsCmdable
+	GenericCmdable
+	GeoCmdable
 	HashCmdable
 	HyperLogLogCmdable
-	GeoCmdable
-	GenericCmdable
 	ListCmdable
+	ProbabilisticCmdable
+	PubSubCmdable
+	ScriptingFunctionsCmdable
 	SetCmdable
 	SortedSetCmdable
-	ClusterCmdable
-	ScriptingFunctionsCmdable
 	StringCmdable
-	PubSubCmdable
-	GearsCmdable
-	ProbabilisticCmdable
-	TimeseriesCmdable
 	StreamCmdable
+	TimeseriesCmdable
 }
 
 type StatefulCmdable interface {


### PR DESCRIPTION
This pull request resolves https://github.com/redis/go-redis/issues/2736 and https://github.com/go-redis/redismock/issues/83

I copied the approach in https://github.com/redis/go-redis/pull/2725, and reviewed the changes in https://github.com/redis/go-redis/pull/2716 for other interfaces we might need to add (didn't find any others).

I added `BitMapCmdable` and sorted the list for readability.