### PR TITLE
Fix OpenTelemetry link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 > use it to monitor applications and set up automatic alerts to receive notifications via email,
 > Slack, Telegram, and others.
 >
-> See [OpenTelemetry](example/otel) example which demonstrates how you can use Uptrace to monitor
+> See [OpenTelemetry](master/example/otel) example which demonstrates how you can use Uptrace to monitor
 > go-redis.
 
 ## Documentation


### PR DESCRIPTION
The current link returns a 404