### PR TITLE
Make `MaxRetries` field of `ClusterOptions` follow same format as `Options`

### DIFF
--- a/osscluster.go
+++ b/osscluster.go
@@ -116,9 +116,6 @@ func (opt *ClusterOptions) init() {
 		opt.WriteTimeout = opt.ReadTimeout
 	}
 
-	if opt.MaxRetries == 0 {
-		opt.MaxRetries = -1
-	}
 	switch opt.MinRetryBackoff {
 	case -1:
 		opt.MinRetryBackoff = 0

--- a/osscluster.go
+++ b/osscluster.go
@@ -116,6 +116,12 @@ func (opt *ClusterOptions) init() {
 		opt.WriteTimeout = opt.ReadTimeout
 	}
 
+	if opt.MaxRetries == -1 {
+		opt.MaxRetries = 0
+	} else if opt.MaxRetries == 0 {
+		opt.MaxRetries = 3
+	}
+
 	switch opt.MinRetryBackoff {
 	case -1:
 		opt.MinRetryBackoff = 0

--- a/osscluster_test.go
+++ b/osscluster_test.go
@@ -1467,75 +1467,71 @@ var _ = Describe("ClusterClient ParseURL", func() {
 		{
 			test: "ParseRedisURL",
 			url:  "redis://localhost:123",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}},
 		}, {
 			test: "ParseRedissURL",
 			url:  "rediss://localhost:123",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, TLSConfig: &tls.Config{ServerName: "localhost"}, MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, TLSConfig: &tls.Config{ServerName: "localhost"}},
 		}, {
 			test: "MissingRedisPort",
 			url:  "redis://localhost",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:6379"}, MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:6379"}},
 		}, {
 			test: "MissingRedissPort",
 			url:  "rediss://localhost",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:6379"}, TLSConfig: &tls.Config{ServerName: "localhost"}, MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:6379"}, TLSConfig: &tls.Config{ServerName: "localhost"}},
 		}, {
 			test: "MultipleRedisURLs",
 			url:  "redis://localhost:123?addr=localhost:1234&addr=localhost:12345",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234", "localhost:12345"}, MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234", "localhost:12345"}},
 		}, {
 			test: "MultipleRedissURLs",
 			url:  "rediss://localhost:123?addr=localhost:1234&addr=localhost:12345",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234", "localhost:12345"}, TLSConfig: &tls.Config{ServerName: "localhost"}, MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234", "localhost:12345"}, TLSConfig: &tls.Config{ServerName: "localhost"}},
 		}, {
 			test: "OnlyPassword",
 			url:  "redis://:bar@localhost:123",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Password: "bar", MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Password: "bar"},
 		}, {
 			test: "OnlyUser",
 			url:  "redis://foo@localhost:123",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Username: "foo", MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Username: "foo"},
 		}, {
 			test: "RedisUsernamePassword",
 			url:  "redis://foo:bar@localhost:123",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Username: "foo", Password: "bar", MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Username: "foo", Password: "bar"},
 		}, {
 			test: "RedissUsernamePassword",
 			url:  "rediss://foo:bar@localhost:123?addr=localhost:1234",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234"}, Username: "foo", Password: "bar", TLSConfig: &tls.Config{ServerName: "localhost"}, MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234"}, Username: "foo", Password: "bar", TLSConfig: &tls.Config{ServerName: "localhost"}},
 		}, {
 			test: "QueryParameters",
 			url:  "redis://localhost:123?read_timeout=2&pool_fifo=true&addr=localhost:1234",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234"}, ReadTimeout: 2 * time.Second, PoolFIFO: true, MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234"}, ReadTimeout: 2 * time.Second, PoolFIFO: true},
 		}, {
 			test: "DisabledTimeout",
 			url:  "redis://localhost:123?conn_max_idle_time=0",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: -1, MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: -1},
 		}, {
 			test: "DisabledTimeoutNeg",
 			url:  "redis://localhost:123?conn_max_idle_time=-1",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: -1, MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: -1},
 		}, {
 			test: "UseDefault",
 			url:  "redis://localhost:123?conn_max_idle_time=",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: 0, MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: 0},
 		}, {
 			test: "Protocol",
 			url:  "redis://localhost:123?protocol=2",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Protocol: 2, MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Protocol: 2},
 		}, {
 			test: "ClientName",
 			url:  "redis://localhost:123?client_name=cluster_hi",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ClientName: "cluster_hi", MaxRetries: 3},
-		}, {
-			test: "SetNoRetry",
-			url:  "redis://localhost:123?max_retries=-1",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: 0},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ClientName: "cluster_hi"},
 		}, {
 			test: "UseDefaultMissing=",
 			url:  "redis://localhost:123?conn_max_idle_time",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: 0, MaxRetries: 3},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: 0},
 		}, {
 			test: "InvalidQueryAddr",
 			url:  "rediss://foo:bar@localhost:123?addr=rediss://foo:barr@localhost:1234",

--- a/osscluster_test.go
+++ b/osscluster_test.go
@@ -1467,71 +1467,75 @@ var _ = Describe("ClusterClient ParseURL", func() {
 		{
 			test: "ParseRedisURL",
 			url:  "redis://localhost:123",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, MaxRetries: 3},
 		}, {
 			test: "ParseRedissURL",
 			url:  "rediss://localhost:123",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, TLSConfig: &tls.Config{ServerName: "localhost"}},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, TLSConfig: &tls.Config{ServerName: "localhost"}, MaxRetries: 3},
 		}, {
 			test: "MissingRedisPort",
 			url:  "redis://localhost",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:6379"}},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:6379"}, MaxRetries: 3},
 		}, {
 			test: "MissingRedissPort",
 			url:  "rediss://localhost",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:6379"}, TLSConfig: &tls.Config{ServerName: "localhost"}},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:6379"}, TLSConfig: &tls.Config{ServerName: "localhost"}, MaxRetries: 3},
 		}, {
 			test: "MultipleRedisURLs",
 			url:  "redis://localhost:123?addr=localhost:1234&addr=localhost:12345",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234", "localhost:12345"}},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234", "localhost:12345"}, MaxRetries: 3},
 		}, {
 			test: "MultipleRedissURLs",
 			url:  "rediss://localhost:123?addr=localhost:1234&addr=localhost:12345",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234", "localhost:12345"}, TLSConfig: &tls.Config{ServerName: "localhost"}},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234", "localhost:12345"}, TLSConfig: &tls.Config{ServerName: "localhost"}, MaxRetries: 3},
 		}, {
 			test: "OnlyPassword",
 			url:  "redis://:bar@localhost:123",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Password: "bar"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Password: "bar", MaxRetries: 3},
 		}, {
 			test: "OnlyUser",
 			url:  "redis://foo@localhost:123",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Username: "foo"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Username: "foo", MaxRetries: 3},
 		}, {
 			test: "RedisUsernamePassword",
 			url:  "redis://foo:bar@localhost:123",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Username: "foo", Password: "bar"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Username: "foo", Password: "bar", MaxRetries: 3},
 		}, {
 			test: "RedissUsernamePassword",
 			url:  "rediss://foo:bar@localhost:123?addr=localhost:1234",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234"}, Username: "foo", Password: "bar", TLSConfig: &tls.Config{ServerName: "localhost"}},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234"}, Username: "foo", Password: "bar", TLSConfig: &tls.Config{ServerName: "localhost"}, MaxRetries: 3},
 		}, {
 			test: "QueryParameters",
 			url:  "redis://localhost:123?read_timeout=2&pool_fifo=true&addr=localhost:1234",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234"}, ReadTimeout: 2 * time.Second, PoolFIFO: true},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123", "localhost:1234"}, ReadTimeout: 2 * time.Second, PoolFIFO: true, MaxRetries: 3},
 		}, {
 			test: "DisabledTimeout",
 			url:  "redis://localhost:123?conn_max_idle_time=0",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: -1},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: -1, MaxRetries: 3},
 		}, {
 			test: "DisabledTimeoutNeg",
 			url:  "redis://localhost:123?conn_max_idle_time=-1",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: -1},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: -1, MaxRetries: 3},
 		}, {
 			test: "UseDefault",
 			url:  "redis://localhost:123?conn_max_idle_time=",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: 0},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: 0, MaxRetries: 3},
 		}, {
 			test: "Protocol",
 			url:  "redis://localhost:123?protocol=2",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Protocol: 2},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, Protocol: 2, MaxRetries: 3},
 		}, {
 			test: "ClientName",
 			url:  "redis://localhost:123?client_name=cluster_hi",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ClientName: "cluster_hi"},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ClientName: "cluster_hi", MaxRetries: 3},
+		}, {
+			test: "SetNoRetry",
+			url:  "redis://localhost:123?max_retries=-1",
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: 0},
 		}, {
 			test: "UseDefaultMissing=",
 			url:  "redis://localhost:123?conn_max_idle_time",
-			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: 0},
+			o:    &redis.ClusterOptions{Addrs: []string{"localhost:123"}, ConnMaxIdleTime: 0, MaxRetries: 3},
 		}, {
 			test: "InvalidQueryAddr",
 			url:  "rediss://foo:bar@localhost:123?addr=rediss://foo:barr@localhost:1234",


### PR DESCRIPTION
This PR makes `MaxRetries` field of `ClusterOptions` to have default `MaxRetries` value of 3, following same format of `RingOptions` and `Options`.

- `RingOptions` code pointer: https://github.com/redis/go-redis/blob/master/ring.go#L119-L123
- `Options` code pointer: https://github.com/leejseo/go-redis/blob/master/options.go#L196-L200

I created this PR since I thought its kind of weird that default zero value of other option leads to the max number of retry 3 while only this option leads to no retry.

(Since this is my first time contributing to go-redis project, I would not be familiar with the convention and I might not know correctly about the rationale beyond the code. I apprieciate any feedbacks about this PR.)