### PR TITLE
newConn race fix, fix check pool exhausted, replacing the MaxActiveConns parameter with PoolSizeStrict

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -164,17 +164,12 @@ func (p *ConnPool) NewConn(ctx context.Context) (*Conn, error) {
 }
 
 func (p *ConnPool) newConn(ctx context.Context, pooled bool) (*Conn, error) {
-	var poolExhausted bool
-
 	p.connsMu.Lock()
-	if p.cfg.PoolSizeStrict {
-		poolExhausted = len(p.conns) >= p.poolSize
-	}
-	p.connsMu.Unlock()
-
-	if poolExhausted {
+	if p.cfg.PoolSizeStrict && len(p.conns) >= p.poolSize {
+		p.connsMu.Unlock()
 		return nil, ErrPoolExhausted
 	}
+	p.connsMu.Unlock()
 
 	cn, err := p.dialConn(ctx, pooled)
 	if err != nil {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -62,10 +62,10 @@ type Options struct {
 
 	PoolFIFO        bool
 	PoolSize        int
+	PoolSizeStrict  bool
 	PoolTimeout     time.Duration
 	MinIdleConns    int
 	MaxIdleConns    int
-	MaxActiveConns  int
 	ConnMaxIdleTime time.Duration
 	ConnMaxLifetime time.Duration
 }
@@ -167,8 +167,8 @@ func (p *ConnPool) newConn(ctx context.Context, pooled bool) (*Conn, error) {
 	var poolExhausted bool
 
 	p.connsMu.Lock()
-	if p.cfg.MaxActiveConns > 0 {
-		poolExhausted = p.poolSize >= p.cfg.MaxActiveConns
+	if p.cfg.PoolSizeStrict {
+		poolExhausted = len(p.conns) >= p.poolSize
 	}
 	p.connsMu.Unlock()
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -165,7 +165,7 @@ func (p *ConnPool) NewConn(ctx context.Context) (*Conn, error) {
 
 func (p *ConnPool) newConn(ctx context.Context, pooled bool) (*Conn, error) {
 	p.connsMu.Lock()
-	if p.cfg.PoolSizeStrict && len(p.conns) >= p.poolSize {
+	if p.cfg.PoolSizeStrict && len(p.conns) >= p.cfg.PoolSize {
 		p.connsMu.Unlock()
 		return nil, ErrPoolExhausted
 	}

--- a/osscluster.go
+++ b/osscluster.go
@@ -76,11 +76,11 @@ type ClusterOptions struct {
 	ContextTimeoutEnabled bool
 
 	PoolFIFO        bool
-	PoolSize        int // applies per cluster node and not for the whole cluster
+	PoolSize        int  // applies per cluster node and not for the whole cluster
+	PoolSizeStrict  bool // applies per cluster node and not for the whole cluster
 	PoolTimeout     time.Duration
 	MinIdleConns    int
 	MaxIdleConns    int
-	MaxActiveConns  int // applies per cluster node and not for the whole cluster
 	ConnMaxIdleTime time.Duration
 	ConnMaxLifetime time.Duration
 
@@ -233,9 +233,9 @@ func setupClusterQueryParams(u *url.URL, o *ClusterOptions) (*ClusterOptions, er
 	o.WriteTimeout = q.duration("write_timeout")
 	o.PoolFIFO = q.bool("pool_fifo")
 	o.PoolSize = q.int("pool_size")
+	o.PoolSizeStrict = q.bool("pool_size_strict")
 	o.MinIdleConns = q.int("min_idle_conns")
 	o.MaxIdleConns = q.int("max_idle_conns")
-	o.MaxActiveConns = q.int("max_active_conns")
 	o.PoolTimeout = q.duration("pool_timeout")
 	o.ConnMaxLifetime = q.duration("conn_max_lifetime")
 	o.ConnMaxIdleTime = q.duration("conn_max_idle_time")
@@ -284,10 +284,10 @@ func (opt *ClusterOptions) clientOptions() *Options {
 
 		PoolFIFO:         opt.PoolFIFO,
 		PoolSize:         opt.PoolSize,
+		PoolSizeStrict:   opt.PoolSizeStrict,
 		PoolTimeout:      opt.PoolTimeout,
 		MinIdleConns:     opt.MinIdleConns,
 		MaxIdleConns:     opt.MaxIdleConns,
-		MaxActiveConns:   opt.MaxActiveConns,
 		ConnMaxIdleTime:  opt.ConnMaxIdleTime,
 		ConnMaxLifetime:  opt.ConnMaxLifetime,
 		DisableIndentity: opt.DisableIndentity,

--- a/ring.go
+++ b/ring.go
@@ -88,10 +88,10 @@ type RingOptions struct {
 	PoolFIFO bool
 
 	PoolSize        int
+	PoolSizeStrict  bool
 	PoolTimeout     time.Duration
 	MinIdleConns    int
 	MaxIdleConns    int
-	MaxActiveConns  int
 	ConnMaxIdleTime time.Duration
 	ConnMaxLifetime time.Duration
 
@@ -155,10 +155,10 @@ func (opt *RingOptions) clientOptions() *Options {
 
 		PoolFIFO:        opt.PoolFIFO,
 		PoolSize:        opt.PoolSize,
+		PoolSizeStrict:  opt.PoolSizeStrict,
 		PoolTimeout:     opt.PoolTimeout,
 		MinIdleConns:    opt.MinIdleConns,
 		MaxIdleConns:    opt.MaxIdleConns,
-		MaxActiveConns:  opt.MaxActiveConns,
 		ConnMaxIdleTime: opt.ConnMaxIdleTime,
 		ConnMaxLifetime: opt.ConnMaxLifetime,
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -71,10 +71,10 @@ type FailoverOptions struct {
 	PoolFIFO bool
 
 	PoolSize        int
+	PoolSizeStrict  bool
 	PoolTimeout     time.Duration
 	MinIdleConns    int
 	MaxIdleConns    int
-	MaxActiveConns  int
 	ConnMaxIdleTime time.Duration
 	ConnMaxLifetime time.Duration
 
@@ -107,10 +107,10 @@ func (opt *FailoverOptions) clientOptions() *Options {
 
 		PoolFIFO:        opt.PoolFIFO,
 		PoolSize:        opt.PoolSize,
+		PoolSizeStrict:  opt.PoolSizeStrict,
 		PoolTimeout:     opt.PoolTimeout,
 		MinIdleConns:    opt.MinIdleConns,
 		MaxIdleConns:    opt.MaxIdleConns,
-		MaxActiveConns:  opt.MaxActiveConns,
 		ConnMaxIdleTime: opt.ConnMaxIdleTime,
 		ConnMaxLifetime: opt.ConnMaxLifetime,
 
@@ -143,10 +143,10 @@ func (opt *FailoverOptions) sentinelOptions(addr string) *Options {
 
 		PoolFIFO:        opt.PoolFIFO,
 		PoolSize:        opt.PoolSize,
+		PoolSizeStrict:  opt.PoolSizeStrict,
 		PoolTimeout:     opt.PoolTimeout,
 		MinIdleConns:    opt.MinIdleConns,
 		MaxIdleConns:    opt.MaxIdleConns,
-		MaxActiveConns:  opt.MaxActiveConns,
 		ConnMaxIdleTime: opt.ConnMaxIdleTime,
 		ConnMaxLifetime: opt.ConnMaxLifetime,
 
@@ -180,10 +180,10 @@ func (opt *FailoverOptions) clusterOptions() *ClusterOptions {
 
 		PoolFIFO:        opt.PoolFIFO,
 		PoolSize:        opt.PoolSize,
+		PoolSizeStrict:  opt.PoolSizeStrict,
 		PoolTimeout:     opt.PoolTimeout,
 		MinIdleConns:    opt.MinIdleConns,
 		MaxIdleConns:    opt.MaxIdleConns,
-		MaxActiveConns:  opt.MaxActiveConns,
 		ConnMaxIdleTime: opt.ConnMaxIdleTime,
 		ConnMaxLifetime: opt.ConnMaxLifetime,
 

--- a/universal.go
+++ b/universal.go
@@ -45,10 +45,10 @@ type UniversalOptions struct {
 	PoolFIFO bool
 
 	PoolSize        int
+	PoolSizeStrict  bool
 	PoolTimeout     time.Duration
 	MinIdleConns    int
 	MaxIdleConns    int
-	MaxActiveConns  int
 	ConnMaxIdleTime time.Duration
 	ConnMaxLifetime time.Duration
 
@@ -102,10 +102,10 @@ func (o *UniversalOptions) Cluster() *ClusterOptions {
 		PoolFIFO: o.PoolFIFO,
 
 		PoolSize:        o.PoolSize,
+		PoolSizeStrict:  o.PoolSizeStrict,
 		PoolTimeout:     o.PoolTimeout,
 		MinIdleConns:    o.MinIdleConns,
 		MaxIdleConns:    o.MaxIdleConns,
-		MaxActiveConns:  o.MaxActiveConns,
 		ConnMaxIdleTime: o.ConnMaxIdleTime,
 		ConnMaxLifetime: o.ConnMaxLifetime,
 
@@ -147,10 +147,10 @@ func (o *UniversalOptions) Failover() *FailoverOptions {
 
 		PoolFIFO:        o.PoolFIFO,
 		PoolSize:        o.PoolSize,
+		PoolSizeStrict:  o.PoolSizeStrict,
 		PoolTimeout:     o.PoolTimeout,
 		MinIdleConns:    o.MinIdleConns,
 		MaxIdleConns:    o.MaxIdleConns,
-		MaxActiveConns:  o.MaxActiveConns,
 		ConnMaxIdleTime: o.ConnMaxIdleTime,
 		ConnMaxLifetime: o.ConnMaxLifetime,
 
@@ -189,10 +189,10 @@ func (o *UniversalOptions) Simple() *Options {
 
 		PoolFIFO:        o.PoolFIFO,
 		PoolSize:        o.PoolSize,
+		PoolSizeStrict:  o.PoolSizeStrict,
 		PoolTimeout:     o.PoolTimeout,
 		MinIdleConns:    o.MinIdleConns,
 		MaxIdleConns:    o.MaxIdleConns,
-		MaxActiveConns:  o.MaxActiveConns,
 		ConnMaxIdleTime: o.ConnMaxIdleTime,
 		ConnMaxLifetime: o.ConnMaxLifetime,
 


### PR DESCRIPTION
This library implements non-standard pool behavior. Where the pool size is essentially not an honest pool size and can increase without limitation, which under heavy loads will lead to the server being flooded with connections.

PoolSizeStrict - enabling classic pool mode, when it is guaranteed that no more connections will open to the server than specified in PoolSize.

An example of classic pool behavior:

https://github.com/gomodule/redigo/blob/master/redis/pool.go#L147C1-L147C1

https://github.com/gomodule/redigo/blob/master/redis/pool.go#L247