### PR TITLE
Allow scanning redis values into pointer fields

### DIFF
--- a/command.go
+++ b/command.go
@@ -5369,7 +5369,6 @@ func (cmd *InfoCmd) readReply(rd *proto.Reader) error {
 	}
 
 	return nil
-
 }
 
 func (cmd *InfoCmd) Item(section, key string) string {

--- a/internal/hscan/hscan.go
+++ b/internal/hscan/hscan.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-
-	"github.com/redis/go-redis/v9/internal/util"
 )
 
 // decoderFunc represents decoding functions for default built-in types.
@@ -206,16 +204,4 @@ func decodeSlice(f reflect.Value, s string) error {
 
 func decodeUnsupported(v reflect.Value, s string) error {
 	return fmt.Errorf("redis.Scan(unsupported %s)", v.Type())
-}
-
-func decodePtr(v reflect.Value, s string) error {
-	if v.Type().Elem().Kind() == reflect.Bool {
-		b, err := strconv.ParseBool(s)
-		if err != nil {
-			return err
-		}
-		v.Set(reflect.ValueOf(util.ToPtr(b)))
-		return nil
-	}
-	return decodeUnsupported(v, s)
 }

--- a/internal/hscan/hscan.go
+++ b/internal/hscan/hscan.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+
+	"github.com/redis/go-redis/v9/internal/util"
 )
 
 // decoderFunc represents decoding functions for default built-in types.
@@ -204,4 +206,16 @@ func decodeSlice(f reflect.Value, s string) error {
 
 func decodeUnsupported(v reflect.Value, s string) error {
 	return fmt.Errorf("redis.Scan(unsupported %s)", v.Type())
+}
+
+func decodePtr(v reflect.Value, s string) error {
+	if v.Type().Elem().Kind() == reflect.Bool {
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return err
+		}
+		v.Set(reflect.ValueOf(util.ToPtr(b)))
+		return nil
+	}
+	return decodeUnsupported(v, s)
 }

--- a/internal/hscan/hscan_test.go
+++ b/internal/hscan/hscan_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"
+	"github.com/redis/go-redis/v9/internal/util"
 )
 
 type data struct {
@@ -29,6 +30,7 @@ type data struct {
 	Float   float32 `redis:"float"`
 	Float64 float64 `redis:"float64"`
 	Bool    bool    `redis:"bool"`
+	BoolRef *bool   `redis:"boolRef"`
 }
 
 type TimeRFC3339Nano struct {
@@ -117,10 +119,10 @@ var _ = Describe("Scan", func() {
 		Expect(Scan(&d, i{"key"}, i{"value"})).NotTo(HaveOccurred())
 		Expect(d).To(Equal(data{}))
 
-		keys := i{"string", "byte", "int", "int64", "uint", "uint64", "float", "float64", "bool"}
+		keys := i{"string", "byte", "int", "int64", "uint", "uint64", "float", "float64", "bool", "boolRef"}
 		vals := i{
 			"str!", "bytes!", "123", "123456789123456789", "456", "987654321987654321",
-			"123.456", "123456789123456789.987654321987654321", "1",
+			"123.456", "123456789123456789.987654321987654321", "1", "1",
 		}
 		Expect(Scan(&d, keys, vals)).NotTo(HaveOccurred())
 		Expect(d).To(Equal(data{
@@ -133,6 +135,7 @@ var _ = Describe("Scan", func() {
 			Float:   123.456,
 			Float64: 1.2345678912345678e+17,
 			Bool:    true,
+			BoolRef: util.ToPtr(true),
 		}))
 
 		// Scan a different type with the same values to test that
@@ -167,6 +170,7 @@ var _ = Describe("Scan", func() {
 			Float:   1.0,
 			Float64: 1.2345678912345678e+17,
 			Bool:    true,
+			BoolRef: util.ToPtr(true),
 		}))
 	})
 

--- a/internal/hscan/hscan_test.go
+++ b/internal/hscan/hscan_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"
+
 	"github.com/redis/go-redis/v9/internal/util"
 )
 

--- a/internal/hscan/structmap.go
+++ b/internal/hscan/structmap.go
@@ -61,7 +61,11 @@ func newStructSpec(t reflect.Type, fieldTag string) *structSpec {
 		}
 
 		// Use the built-in decoder.
-		out.set(tag, &structField{index: i, fn: decoders[f.Type.Kind()]})
+		kind := f.Type.Kind()
+		if kind == reflect.Pointer {
+			kind = f.Type.Elem().Kind()
+		}
+		out.set(tag, &structField{index: i, fn: decoders[kind]})
 	}
 
 	return out

--- a/json.go
+++ b/json.go
@@ -66,7 +66,6 @@ type JSONCmd struct {
 var _ Cmder = (*JSONCmd)(nil)
 
 func newJSONCmd(ctx context.Context, args ...interface{}) *JSONCmd {
-
 	return &JSONCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -95,7 +94,6 @@ func (cmd *JSONCmd) Val() string {
 	} else {
 		return cmd.val
 	}
-
 }
 
 func (cmd *JSONCmd) Result() (string, error) {
@@ -103,7 +101,6 @@ func (cmd *JSONCmd) Result() (string, error) {
 }
 
 func (cmd JSONCmd) Expanded() (interface{}, error) {
-
 	if len(cmd.val) != 0 && cmd.expanded == nil {
 		err := json.Unmarshal([]byte(cmd.val), &cmd.expanded)
 		if err != nil {
@@ -115,7 +112,6 @@ func (cmd JSONCmd) Expanded() (interface{}, error) {
 }
 
 func (cmd *JSONCmd) readReply(rd *proto.Reader) error {
-
 	// nil response from JSON.(M)GET (cmd.baseCmd.err will be "redis: nil")
 	if cmd.baseCmd.Err() == Nil {
 		cmd.val = ""
@@ -131,7 +127,7 @@ func (cmd *JSONCmd) readReply(rd *proto.Reader) error {
 			return err
 		}
 
-		var expanded = make([]interface{}, size)
+		expanded := make([]interface{}, size)
 
 		for i := 0; i < size; i++ {
 			if expanded[i], err = rd.ReadReply(); err != nil {
@@ -186,7 +182,6 @@ func (cmd *JSONSliceCmd) Result() ([]interface{}, error) {
 }
 
 func (cmd *JSONSliceCmd) readReply(rd *proto.Reader) error {
-
 	if cmd.baseCmd.Err() == Nil {
 		cmd.val = nil
 		return Nil
@@ -220,7 +215,6 @@ func (cmd *JSONSliceCmd) readReply(rd *proto.Reader) error {
 		}
 	}
 	return nil
-
 }
 
 /*******************************************************************************
@@ -262,7 +256,6 @@ func (cmd *IntPointerSliceCmd) Result() ([]*int64, error) {
 }
 
 func (cmd *IntPointerSliceCmd) readReply(rd *proto.Reader) error {
-
 	n, err := rd.ReadArrayLen()
 	if err != nil {
 		return err

--- a/json_test.go
+++ b/json_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"
+
 	"github.com/redis/go-redis/v9"
 )
 
@@ -13,7 +14,6 @@ type JSONGetTestStruct struct {
 }
 
 var _ = Describe("JSON Commands", Label("json"), func() {
-
 	ctx := context.TODO()
 	var client *redis.Client
 
@@ -27,7 +27,6 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 	})
 
 	Describe("arrays", Label("arrays"), func() {
-
 		It("should JSONArrAppend", Label("json.arrappend", "json"), func() {
 			cmd1 := client.JSONSet(ctx, "append2", "$", `{"a": [10], "b": {"a": [12, 13]}}`)
 			Expect(cmd1.Err()).NotTo(HaveOccurred())
@@ -76,7 +75,6 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 			res, err = client.JSONArrIndexWithArgs(ctx, "index2", "$", &redis.JSONArrIndexArgs{Stop: &stop}, 4).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res[0]).To(Equal(int64(-1)))
-
 		})
 
 		It("should JSONArrIndex and JSONArrIndexWithArgs with $", Label("json.arrindex", "json"), func() {
@@ -235,7 +233,6 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 			Expect(cmd3.Err()).NotTo(HaveOccurred())
 			Expect(cmd3.Val()).To(Equal("[[100,200,200]]"))
 		})
-
 	})
 
 	Describe("get/set", Label("getset"), func() {
@@ -257,7 +254,6 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 			res, err = client.JSONGetWithArgs(ctx, "get3", &redis.JSONGetArgs{Indent: "-", Newline: `~`, Space: `!`}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal(`[~-{~--"a":!1,~--"b":!2~-}~]`))
-
 		})
 
 		It("should JSONMerge", Label("json.merge", "json"), func() {
@@ -330,13 +326,10 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 			iRes, err = client.JSONMGet(ctx, "$..a", "non_existing_doc", "non_existing_doc1").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(iRes).To(Equal([]interface{}{nil, nil}))
-
 		})
-
 	})
 
 	Describe("Misc", Label("misc"), func() {
-
 		It("should JSONClear", Label("json.clear", "json"), func() {
 			cmd1 := client.JSONSet(ctx, "clear1", "$", `[1]`)
 			Expect(cmd1.Err()).NotTo(HaveOccurred())
@@ -460,7 +453,6 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 			cmd3 := client.JSONGet(ctx, "forget3", "$")
 			Expect(cmd3.Err()).NotTo(HaveOccurred())
 			Expect(cmd3.Val()).To(Equal(`[{"b":{"b":"annie"}}]`))
-
 		})
 
 		It("should JSONForget with $", Label("json.forget", "json"), func() {
@@ -622,7 +614,6 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 			cmd3, err := client.JSONGet(ctx, "strapp1", "$").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cmd3).To(Equal(`["foobar"]`))
-
 		})
 
 		It("should JSONStrAppend and JSONStrLen with $", Label("json.strappend", "json.strlen", "json"), func() {


### PR DESCRIPTION
Sometimes it's convenient to represent your data with structs that contain pointer fields:
```
type Message struct {
     hasPermission *bool `redis:"has_permission,omitempty"`
}
```
With nil indicating that the value is absent. 

This change allows go-redis to scan data into pointer fields