### PR TITLE
docs: correct the format error of the url in 'Connecting via a redis url' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ import (
 var ctx = context.Background()
 
 func ExampleClient() {
-    url := "redis://localhost:6379?password=hello&protocol=3"
+    url := "redis://user:secret@localhost:6379/0?protocol=3"
     opts, err := redis.ParseURL(url)
     if err != nil {
         panic(err)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ import (
 var ctx = context.Background()
 
 func ExampleClient() {
-    url := "redis://user:secret@localhost:6379/0?protocol=3"
+    url := "redis://user:password@localhost:6379/0?protocol=3"
     opts, err := redis.ParseURL(url)
     if err != nil {
         panic(err)


### PR DESCRIPTION
Fix #2788
