### PR TITLE
Fix Data Race in hooksMixin When Using MinIdleConns and AddHook

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -40,12 +41,15 @@ type (
 )
 
 type hooksMixin struct {
+	hooksMu *sync.Mutex
+
 	slice   []Hook
 	initial hooks
 	current hooks
 }
 
 func (hs *hooksMixin) initHooks(hooks hooks) {
+	hs.hooksMu = new(sync.Mutex)
 	hs.initial = hooks
 	hs.chain()
 }
@@ -116,6 +120,9 @@ func (hs *hooksMixin) AddHook(hook Hook) {
 func (hs *hooksMixin) chain() {
 	hs.initial.setDefaults()
 
+	hs.hooksMu.Lock()
+	defer hs.hooksMu.Unlock()
+
 	hs.current.dial = hs.initial.dial
 	hs.current.process = hs.initial.process
 	hs.current.pipeline = hs.initial.pipeline
@@ -138,9 +145,13 @@ func (hs *hooksMixin) chain() {
 }
 
 func (hs *hooksMixin) clone() hooksMixin {
+	hs.hooksMu.Lock()
+	defer hs.hooksMu.Unlock()
+
 	clone := *hs
 	l := len(clone.slice)
 	clone.slice = clone.slice[:l:l]
+	clone.hooksMu = new(sync.Mutex)
 	return clone
 }
 
@@ -165,6 +176,8 @@ func (hs *hooksMixin) withProcessPipelineHook(
 }
 
 func (hs *hooksMixin) dialHook(ctx context.Context, network, addr string) (net.Conn, error) {
+	hs.hooksMu.Lock()
+	defer hs.hooksMu.Unlock()
 	return hs.current.dial(ctx, network, addr)
 }
 


### PR DESCRIPTION
#2730 

### Overview
This PR addresses a critical data race issue discovered in `hooksMixin` when `MinIdleConns` is set to a value greater than 1, and `client.AddHook` is used concurrently.

### Problem
The data race was identified during test, specifically in scenarios where `MinIdleConns` triggers the creation of idle connections in a separate goroutine, while `client.AddHook` modifies the hooks concurrently. This concurrent access and modification of `hooks.dialer` led to a data race.

### Solution
To resolve this concurrency issue, the following modifications were made:

Introduced a `sync.Mutex` in the `hooksMixin` struct to ensure thread-safe operations.
Implemented locking and unlocking around critical sections in `AddHook` and `dialHook` methods to prevent concurrent read/write conflicts.
Adjusted the clone method in `hooksMixin` to handle the mutex correctly, avoiding the copying of mutex state.

I invite feedback and further review on these changes!