### PR TITLE
fix: add Cmder annotation

### DIFF
--- a/command.go
+++ b/command.go
@@ -18,19 +18,19 @@ import (
 
 type Cmder interface {
 	// command name.
-	// e.g. "set k v ex 10" -> `set`, "cluster info" -> "cluster"
+	// e.g. "set k v ex 10" -> "set", "cluster info" -> "cluster".
 	Name() string
 
 	// full command name.
-	// e.g. "set k v ex 10" -> `set`, "cluster info" -> "cluster info"
+	// e.g. "set k v ex 10" -> "set", "cluster info" -> "cluster info".
 	FullName() string
 
-	// all command args
-	// e.g. "set k v ex 10" -> "[set k1 v1 ex 10]"
+	// all args of the command.
+	// e.g. "set k v ex 10" -> "[set k v ex 10]".
 	Args() []interface{}
 
-	// format req and resp string
-	// e.g. "set k v ex 10" -> "set k1 v1 ex 10: OK", "get k1" -> "get k1: v1"
+	// format request and response string.
+	// e.g. "set k v ex 10" -> "set k v ex 10: OK", "get k" -> "get k: v".
 	String() string
 
 	stringArg(int) string

--- a/command.go
+++ b/command.go
@@ -17,10 +17,22 @@ import (
 )
 
 type Cmder interface {
+	// command name.
+	// e.g. "set k v ex 10" -> `set`, "cluster info" -> "cluster"
 	Name() string
+
+	// full command name.
+	// e.g. "set k v ex 10" -> `set`, "cluster info" -> "cluster info"
 	FullName() string
+
+	// all command args
+	// e.g. "set k v ex 10" -> "[set k1 v1 ex 10]"
 	Args() []interface{}
+
+	// format req and resp string
+	// e.g. "set k v ex 10" -> "set k1 v1 ex 10: OK", "get k1" -> "get k1: v1"
 	String() string
+
 	stringArg(int) string
 	firstKeyPos() int8
 	SetFirstKeyPos(int8)


### PR DESCRIPTION
### summary

Every time I call this methods, I need to test the output, I have added some samples of the output here. Next time I look at the code comments, I'll know how to use these methods. 😁

e.g.  by printing the data, I knew the difference of the methods in `Cmder`.

```go
...

func (redisHook) ProcessHook(hook redis.ProcessHook) redis.ProcessHook {
	return func(ctx context.Context, cmd redis.Cmder) error {
		fmt.Printf("starting processing: <%s>\n", cmd)
		err := hook(ctx, cmd)
		fmt.Printf("finished processing: <%s>\n", cmd)

		fmt.Printf("--- %+v \n", cmd.FullName())
		fmt.Printf("--- %+v \n", cmd.Args())
		fmt.Printf("--- %+v \n", cmd.Name())
		fmt.Printf("--- %+v \n", cmd.String())
		fmt.Printf("--- %+v \n", cmd.Err())

		return err
	}
}

...

```