### PR TITLE
Add comment for XReadGroupArgs to note the inconsistency of the default behavior between Redis & go-redis

### DIFF
--- a/stream_commands.go
+++ b/stream_commands.go
@@ -215,9 +215,9 @@ func (c cmdable) XGroupDelConsumer(ctx context.Context, stream, group, consumer 
 type XReadGroupArgs struct {
 	Group    string
 	Consumer string
-	Streams  []string // list of streams and ids, e.g. stream1 stream2 id1 id2
+	Streams  []string      // list of streams and ids, e.g. stream1 stream2 id1 id2
 	Count    int64
-	Block    time.Duration
+	Block    time.Duration // [Block 0] by default (if no value set), or set a negative value (like -time.Millisecond) to make it non-blocking
 	NoAck    bool
 }
 


### PR DESCRIPTION
As mentioned in [issue 1941](https://github.com/redis/go-redis/issues/1941#issuecomment-1869927864), the default behavior between Redis and go-redis is inconsistent.

In Redis, the default behavior of [`XREADGROUP`](https://redis.io/commands/xreadgroup/) is non-blocking (without setting the value of `[BLOCK milliseconds]`.

Therefore, it is natural to think of ignoring the setting of field `Block` in `XReadGroupArgs`, which means the value of `Block` in `XReadGroupArgs` will be the zero-value of `time.Duration`.

However, in the implementation of go-redis, from the perspective of the function `func (cmdable) XReadGroup(...)`, it doesn't know if the user set the `Block`'s value to 0, or if the user didn't set the `Block`'s value causing Go to assign a zero-value to the `Block`. 

But go-redis ignores the possible ambiguity and just take the arg as `[BLOCK 0]`, whick blocks our program as mentioned in [issue 1941](https://github.com/redis/go-redis/issues/1941#issuecomment-1869927864).

```go
if a.Block >= 0 {
  args = append(args, "block", int64(a.Block/time.Millisecond))
  keyPos += 2
}
```

In the event that we can't need to ensure API compatibility, we can only add comments to the `Block`.