### PR TITLE
Don't discard attribute type while reading reply

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -71,6 +71,16 @@ var _ = Describe("Cmd", func() {
 		Expect(val).To(Equal(f))
 	})
 
+	It("supports attribute type", func() {
+		attributes, err := client.Do(ctx, "DEBUG", "PROTOCOL", "attrib").Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(attributes).To(Equal(map[interface{}]interface{}{
+			"key-popularity": []interface{}{
+				"key:123", int64(90),
+			},
+		}))
+	})
+
 	It("supports time.Time", func() {
 		tm := time.Date(2019, 1, 1, 9, 45, 10, 222125, time.UTC)
 

--- a/extra/rediscmd/go.sum
+++ b/extra/rediscmd/go.sum
@@ -1,7 +1,9 @@
 github.com/bsm/ginkgo/v2 v2.7.0 h1:ItPMPH90RbmZJt5GtkcNvIRuGEdwlBItdNVoyzaNQao=
 github.com/bsm/ginkgo/v2 v2.7.0/go.mod h1:AiKlXPm7ItEHNc/2+OkrNG4E0ITzojb9/xWzvQ9XZ9w=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.26.0 h1:LhQm+AFcgV2M0WyKroMASzAzCAJVpAxQXv4SaI9a69Y=
 github.com/bsm/gomega v1.26.0/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -109,11 +109,6 @@ func (r *Reader) ReadLine() ([]byte, error) {
 			err = RedisError(blobErr)
 		}
 		return nil, err
-	case RespAttr:
-		if err = r.Discard(line); err != nil {
-			return nil, err
-		}
-		return r.ReadLine()
 	}
 
 	// Compatible with RESP2
@@ -176,7 +171,7 @@ func (r *Reader) ReadReply() (interface{}, error) {
 
 	case RespArray, RespSet, RespPush:
 		return r.readSlice(line)
-	case RespMap:
+	case RespMap, RespAttr:
 		return r.readMap(line)
 	}
 	return nil, fmt.Errorf("redis: can't parse %.100q", line)
@@ -458,7 +453,7 @@ func (r *Reader) ReadMapLen() (int, error) {
 		return 0, err
 	}
 	switch line[0] {
-	case RespMap:
+	case RespMap, RespAttr:
 		return replyLen(line)
 	case RespArray, RespSet, RespPush:
 		// Some commands and RESP2 protocol may respond to array types.

--- a/internal/proto/reader_test.go
+++ b/internal/proto/reader_test.go
@@ -64,12 +64,8 @@ func BenchmarkReader_ParseReply_Map(b *testing.B) {
 	benchmarkParseReply(b, "%2\r\n$5\r\nhello\r\n$5\r\nworld\r\n+key\r\n+value\r\n", false)
 }
 
-func BenchmarkReader_ParseReply_Attribute(b *testing.B) {
-	benchmarkParseReply(b, "|2\r\n$5\r\nhello\r\n$5\r\nworld\r\n+key\r\n+value\r\n", false)
-}
-
 func BenchmarkReader_ParseReply_Attr(b *testing.B) {
-	benchmarkParseReply(b, "%1\r\n+key\r\n+value\r\n+hello\r\n", false)
+	benchmarkParseReply(b, "|2\r\n$5\r\nhello\r\n$5\r\nworld\r\n+key\r\n+value\r\n", false)
 }
 
 func TestReader_ReadLine(t *testing.T) {

--- a/internal/proto/reader_test.go
+++ b/internal/proto/reader_test.go
@@ -64,6 +64,10 @@ func BenchmarkReader_ParseReply_Map(b *testing.B) {
 	benchmarkParseReply(b, "%2\r\n$5\r\nhello\r\n$5\r\nworld\r\n+key\r\n+value\r\n", false)
 }
 
+func BenchmarkReader_ParseReply_Attribute(b *testing.B) {
+	benchmarkParseReply(b, "|2\r\n$5\r\nhello\r\n$5\r\nworld\r\n+key\r\n+value\r\n", false)
+}
+
 func BenchmarkReader_ParseReply_Attr(b *testing.B) {
 	benchmarkParseReply(b, "%1\r\n+key\r\n+value\r\n+hello\r\n", false)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -350,7 +350,12 @@ func startRedis(port string, args ...string) (*redisProcess, error) {
 		return nil, err
 	}
 
-	baseArgs := []string{filepath.Join(dir, "redis.conf"), "--port", port, "--dir", dir, "--enable-module-command", "yes"}
+	baseArgs := []string{filepath.Join(dir, "redis.conf"),
+		"--port", port,
+		"--dir", dir,
+		"--enable-module-command", "yes",
+		"--enable-debug-command", "local",
+	}
 	process, err := execCmd(redisServerBin, append(baseArgs, args...)...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Currently, go-redis will discard the attribute type while reading reply
from the server, it would always return the timeout error if we ran
the `DEBUG PROTOCOL attrib` command.