### PR TITLE
Fix DisableIdentity and IdentitySuffix option forwarding"

### DIFF
--- a/bench_decode_test.go
+++ b/bench_decode_test.go
@@ -30,7 +30,7 @@ func NewClientStub(resp []byte) *ClientStub {
 		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return stub.stubConn(initHello), nil
 		},
-		DisableIndentity: true,
+		DisableIdentity: true,
 	})
 	return stub
 }
@@ -46,7 +46,7 @@ func NewClusterClientStub(resp []byte) *ClientStub {
 		Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			return stub.stubConn(initHello), nil
 		},
-		DisableIndentity: true,
+		DisableIdentity: true,
 
 		ClusterSlots: func(_ context.Context) ([]ClusterSlot, error) {
 			return []ClusterSlot{

--- a/options.go
+++ b/options.go
@@ -143,7 +143,7 @@ type Options struct {
 	readOnly bool
 
 	// Disable set-lib on connect. Default is false.
-	DisableIndentity bool
+	DisableIdentity bool
 
 	// Add suffix to client name. Default is empty.
 	IdentitySuffix string

--- a/osscluster.go
+++ b/osscluster.go
@@ -85,8 +85,8 @@ type ClusterOptions struct {
 	ConnMaxIdleTime time.Duration
 	ConnMaxLifetime time.Duration
 
-	TLSConfig        *tls.Config
-	DisableIndentity bool // Disable set-lib on connect. Default is false.
+	TLSConfig       *tls.Config
+	DisableIdentity bool // Disable set-lib on connect. Default is false.
 
 	IdentitySuffix string // Add suffix to client name. Default is empty.
 }
@@ -286,17 +286,17 @@ func (opt *ClusterOptions) clientOptions() *Options {
 		WriteTimeout:          opt.WriteTimeout,
 		ContextTimeoutEnabled: opt.ContextTimeoutEnabled,
 
-		PoolFIFO:         opt.PoolFIFO,
-		PoolSize:         opt.PoolSize,
-		PoolTimeout:      opt.PoolTimeout,
-		MinIdleConns:     opt.MinIdleConns,
-		MaxIdleConns:     opt.MaxIdleConns,
-		MaxActiveConns:   opt.MaxActiveConns,
-		ConnMaxIdleTime:  opt.ConnMaxIdleTime,
-		ConnMaxLifetime:  opt.ConnMaxLifetime,
-		DisableIndentity: opt.DisableIndentity,
-		IdentitySuffix:   opt.IdentitySuffix,
-		TLSConfig:        opt.TLSConfig,
+		PoolFIFO:        opt.PoolFIFO,
+		PoolSize:        opt.PoolSize,
+		PoolTimeout:     opt.PoolTimeout,
+		MinIdleConns:    opt.MinIdleConns,
+		MaxIdleConns:    opt.MaxIdleConns,
+		MaxActiveConns:  opt.MaxActiveConns,
+		ConnMaxIdleTime: opt.ConnMaxIdleTime,
+		ConnMaxLifetime: opt.ConnMaxLifetime,
+		DisableIdentity: opt.DisableIdentity,
+		IdentitySuffix:  opt.IdentitySuffix,
+		TLSConfig:       opt.TLSConfig,
 		// If ClusterSlots is populated, then we probably have an artificial
 		// cluster whose nodes are not in clustering mode (otherwise there isn't
 		// much use for ClusterSlots config).  This means we cannot execute the

--- a/redis.go
+++ b/redis.go
@@ -334,7 +334,7 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 			pipe.ClientSetName(ctx, c.opt.ClientName)
 		}
 
-		if !c.opt.DisableIndentity {
+		if !c.opt.DisableIdentity {
 			libName := ""
 			libVer := Version()
 			if c.opt.IdentitySuffix != "" {

--- a/ring.go
+++ b/ring.go
@@ -98,8 +98,8 @@ type RingOptions struct {
 	TLSConfig *tls.Config
 	Limiter   Limiter
 
-	DisableIndentity bool
-	IdentitySuffix   string
+	DisableIdentity bool
+	IdentitySuffix  string
 }
 
 func (opt *RingOptions) init() {
@@ -166,8 +166,8 @@ func (opt *RingOptions) clientOptions() *Options {
 		TLSConfig: opt.TLSConfig,
 		Limiter:   opt.Limiter,
 
-		DisableIndentity: opt.DisableIndentity,
-		IdentitySuffix:   opt.IdentitySuffix,
+		DisableIdentity: opt.DisableIdentity,
+		IdentitySuffix:  opt.IdentitySuffix,
 	}
 }
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -80,8 +80,8 @@ type FailoverOptions struct {
 
 	TLSConfig *tls.Config
 
-	DisableIndentity bool
-	IdentitySuffix   string
+	DisableIdentity bool
+	IdentitySuffix  string
 }
 
 func (opt *FailoverOptions) clientOptions() *Options {
@@ -117,8 +117,8 @@ func (opt *FailoverOptions) clientOptions() *Options {
 
 		TLSConfig: opt.TLSConfig,
 
-		DisableIndentity: opt.DisableIndentity,
-		IdentitySuffix:   opt.IdentitySuffix,
+		DisableIdentity: opt.DisableIdentity,
+		IdentitySuffix:  opt.IdentitySuffix,
 	}
 }
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -153,6 +153,9 @@ func (opt *FailoverOptions) sentinelOptions(addr string) *Options {
 		ConnMaxLifetime: opt.ConnMaxLifetime,
 
 		TLSConfig: opt.TLSConfig,
+
+		DisableIdentity: opt.DisableIdentity,
+		IdentitySuffix:  opt.IdentitySuffix,
 	}
 }
 
@@ -190,6 +193,9 @@ func (opt *FailoverOptions) clusterOptions() *ClusterOptions {
 		ConnMaxLifetime: opt.ConnMaxLifetime,
 
 		TLSConfig: opt.TLSConfig,
+
+		DisableIdentity: opt.DisableIdentity,
+		IdentitySuffix:  opt.IdentitySuffix,
 	}
 }
 

--- a/universal.go
+++ b/universal.go
@@ -66,8 +66,8 @@ type UniversalOptions struct {
 
 	MasterName string
 
-	DisableIndentity bool
-	IdentitySuffix   string
+	DisableIdentity bool
+	IdentitySuffix  string
 }
 
 // Cluster returns cluster options created from the universal options.
@@ -112,8 +112,8 @@ func (o *UniversalOptions) Cluster() *ClusterOptions {
 
 		TLSConfig: o.TLSConfig,
 
-		DisableIndentity: o.DisableIndentity,
-		IdentitySuffix:   o.IdentitySuffix,
+		DisableIdentity: o.DisableIdentity,
+		IdentitySuffix:  o.IdentitySuffix,
 	}
 }
 
@@ -158,8 +158,8 @@ func (o *UniversalOptions) Failover() *FailoverOptions {
 
 		TLSConfig: o.TLSConfig,
 
-		DisableIndentity: o.DisableIndentity,
-		IdentitySuffix:   o.IdentitySuffix,
+		DisableIdentity: o.DisableIdentity,
+		IdentitySuffix:  o.IdentitySuffix,
 	}
 }
 
@@ -201,8 +201,8 @@ func (o *UniversalOptions) Simple() *Options {
 
 		TLSConfig: o.TLSConfig,
 
-		DisableIndentity: o.DisableIndentity,
-		IdentitySuffix:   o.IdentitySuffix,
+		DisableIdentity: o.DisableIdentity,
+		IdentitySuffix:  o.IdentitySuffix,
 	}
 }
 


### PR DESCRIPTION
Fix #2911

DisableIdentity and IdentitySuffix options are not correctly forwarded by sentinelOptions and clusterOptions.

Because 9.5.0 now uses redis 7.2 setinfo options by default, this breakd older redis versions unless DisableIdentity is used.

It still breakd FailoverClients since DisableIdentity is not forwarded to base client.