### PR TITLE
add: hscan data struct

### DIFF
--- a/internal/hscan/structmap.go
+++ b/internal/hscan/structmap.go
@@ -107,6 +107,8 @@ func (s StructValue) Scan(key string, value string) error {
 		switch scan := v.Interface().(type) {
 		case Scanner:
 			return scan.ScanRedis(value)
+		case encoding.BinaryUnmarshaler:
+			return scan.UnmarshalBinary(util.StringToBytes(value))
 		case encoding.TextUnmarshaler:
 			return scan.UnmarshalText(util.StringToBytes(value))
 		}

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -138,6 +138,12 @@ func (w *Writer) WriteArg(v interface{}) error {
 			return err
 		}
 		return w.bytes(b)
+	case encoding.TextMarshaler:
+		b, err := v.MarshalText()
+		if err != nil {
+			return err
+		}
+		return w.bytes(b)
 	case net.IP:
 		return w.bytes(v)
 	default:


### PR DESCRIPTION
I think the hash stored using `encoding.BinaryMarshaler`, 
then parse time should also use `encoding.BinaryUnmarshaler` parsing
Now write using `encoding.BinaryMarshaler`
`Scan` reads using `encoding.TextUnmarshaler`
Look strange


so add case:

`encoding.BinaryUnmarshaler`
`encoding.TextMarshaler`