### PR TITLE
Add CredentialsProvider field to UniversalOptions

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -70,10 +70,11 @@ type RingOptions struct {
 	Dialer    func(ctx context.Context, network, addr string) (net.Conn, error)
 	OnConnect func(ctx context.Context, cn *Conn) error
 
-	Protocol int
-	Username string
-	Password string
-	DB       int
+	Protocol            int
+	Username            string
+	Password            string
+	CredentialsProvider func() (username string, password string)
+	DB                  int
 
 	MaxRetries      int
 	MinRetryBackoff time.Duration
@@ -142,10 +143,11 @@ func (opt *RingOptions) clientOptions() *Options {
 		Dialer:     opt.Dialer,
 		OnConnect:  opt.OnConnect,
 
-		Protocol: opt.Protocol,
-		Username: opt.Username,
-		Password: opt.Password,
-		DB:       opt.DB,
+		Protocol:            opt.Protocol,
+		Username:            opt.Username,
+		Password:            opt.Password,
+		CredentialsProvider: opt.CredentialsProvider,
+		DB:                  opt.DB,
 
 		MaxRetries: -1,
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -54,10 +54,11 @@ type FailoverOptions struct {
 	Dialer    func(ctx context.Context, network, addr string) (net.Conn, error)
 	OnConnect func(ctx context.Context, cn *Conn) error
 
-	Protocol int
-	Username string
-	Password string
-	DB       int
+	Protocol            int
+	Username            string
+	Password            string
+	CredentialsProvider func() (username string, password string)
+	DB                  int
 
 	MaxRetries      int
 	MinRetryBackoff time.Duration
@@ -92,10 +93,11 @@ func (opt *FailoverOptions) clientOptions() *Options {
 		Dialer:    opt.Dialer,
 		OnConnect: opt.OnConnect,
 
-		DB:       opt.DB,
-		Protocol: opt.Protocol,
-		Username: opt.Username,
-		Password: opt.Password,
+		DB:                  opt.DB,
+		Protocol:            opt.Protocol,
+		Username:            opt.Username,
+		Password:            opt.Password,
+		CredentialsProvider: opt.CredentialsProvider,
 
 		MaxRetries:      opt.MaxRetries,
 		MinRetryBackoff: opt.MinRetryBackoff,
@@ -166,9 +168,10 @@ func (opt *FailoverOptions) clusterOptions() *ClusterOptions {
 		Dialer:    opt.Dialer,
 		OnConnect: opt.OnConnect,
 
-		Protocol: opt.Protocol,
-		Username: opt.Username,
-		Password: opt.Password,
+		Protocol:            opt.Protocol,
+		Username:            opt.Username,
+		Password:            opt.Password,
+		CredentialsProvider: opt.CredentialsProvider,
 
 		MaxRedirects: opt.MaxRetries,
 

--- a/universal.go
+++ b/universal.go
@@ -26,9 +26,11 @@ type UniversalOptions struct {
 	Dialer    func(ctx context.Context, network, addr string) (net.Conn, error)
 	OnConnect func(ctx context.Context, cn *Conn) error
 
-	Protocol         int
-	Username         string
-	Password         string
+	Protocol            int
+	Username            string
+	Password            string
+	CredentialsProvider func() (username string, password string)
+
 	SentinelUsername string
 	SentinelPassword string
 
@@ -82,9 +84,10 @@ func (o *UniversalOptions) Cluster() *ClusterOptions {
 		Dialer:     o.Dialer,
 		OnConnect:  o.OnConnect,
 
-		Protocol: o.Protocol,
-		Username: o.Username,
-		Password: o.Password,
+		Protocol:            o.Protocol,
+		Username:            o.Username,
+		Password:            o.Password,
+		CredentialsProvider: o.CredentialsProvider,
 
 		MaxRedirects:   o.MaxRedirects,
 		ReadOnly:       o.ReadOnly,
@@ -131,10 +134,12 @@ func (o *UniversalOptions) Failover() *FailoverOptions {
 		Dialer:    o.Dialer,
 		OnConnect: o.OnConnect,
 
-		DB:               o.DB,
-		Protocol:         o.Protocol,
-		Username:         o.Username,
-		Password:         o.Password,
+		DB:                  o.DB,
+		Protocol:            o.Protocol,
+		Username:            o.Username,
+		Password:            o.Password,
+		CredentialsProvider: o.CredentialsProvider,
+
 		SentinelUsername: o.SentinelUsername,
 		SentinelPassword: o.SentinelPassword,
 
@@ -176,10 +181,11 @@ func (o *UniversalOptions) Simple() *Options {
 		Dialer:     o.Dialer,
 		OnConnect:  o.OnConnect,
 
-		DB:       o.DB,
-		Protocol: o.Protocol,
-		Username: o.Username,
-		Password: o.Password,
+		DB:                  o.DB,
+		Protocol:            o.Protocol,
+		Username:            o.Username,
+		Password:            o.Password,
+		CredentialsProvider: o.CredentialsProvider,
 
 		MaxRetries:      o.MaxRetries,
 		MinRetryBackoff: o.MinRetryBackoff,


### PR DESCRIPTION
In https://github.com/redis/go-redis/pull/2097 go-redis started to support passing a CredentialsProvider callback to get the username and password when initializing a connection, instead of having to provide them when creating the client. This is very useful in scenarios where you have these credentials stored in a separate service (e.g., AWS Secret Manager or Azure Key Vault) and you want to rotate those credentials periodically.

However, this option was not added in all clients and was not being passed down from the universal client to the concrete clients either. This PR aims to normalize that.

(Note that the CredentialsProviders field was already added to ClusterOptions in https://github.com/redis/go-redis/pull/2791, which is why they are not being touched in this change)