### PR TITLE
Attempt to Close Sentinel when the NewFailoverClusterClient is Closed.

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -825,7 +825,7 @@ func NewFailoverClusterClient(failoverOpt *FailoverOptions) *ClusterClient {
 		}
 		return slots, nil
 	}
-
+	opt.OnClose = failover.Close
 	c := NewClusterClient(opt)
 
 	failover.mu.Lock()


### PR DESCRIPTION
We should have a means to reclaim the sentinels' connection resources established by NewFailoverClusterClient.