### PR TITLE
chore: add Go 1.22.x for CI coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x, 1.20.x, 1.21.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x]
 
     services:
       redis:

--- a/.github/workflows/doctests.yaml
+++ b/.github/workflows/doctests.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ "1.18", "1.19", "1.20", "1.21" ]
+        go-version: [ "1.18", "1.19", "1.20", "1.21", "1.22" ]
 
     steps:
       - name: Set up ${{ matrix.go-version }}

--- a/.github/workflows/test-redis-enterprise.yml
+++ b/.github/workflows/test-redis-enterprise.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.22.x]
         re-build: ["7.4.2-54"]
 
     steps:


### PR DESCRIPTION
Similar to #2697, adds support for Go 1.22.x. Also, as per the README,
go-redis supports the 2 last Go versions so remove 1.19.x from
`build.yml`.