### PR TITLE
Handle IPv6 in isMovedError

### DIFF
--- a/error.go
+++ b/error.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strings"
 
+	"github.com/redis/go-redis/v9/internal"
 	"github.com/redis/go-redis/v9/internal/pool"
 	"github.com/redis/go-redis/v9/internal/proto"
 )
@@ -129,7 +130,9 @@ func isMovedError(err error) (moved bool, ask bool, addr string) {
 	if ind == -1 {
 		return false, false, ""
 	}
+
 	addr = s[ind+1:]
+	addr = internal.GetAddr(addr)
 	return
 }
 

--- a/internal/util.go
+++ b/internal/util.go
@@ -67,20 +67,17 @@ func ReplaceSpaces(s string) string {
 }
 
 func GetAddr(addr string) string {
-	ind := strings.LastIndex(addr, ":")
+	ind := strings.LastIndexByte(addr, ':')
 	if ind == -1 {
 		return ""
 	}
 
-	port := addr[ind+1:]
-	host := addr[:ind]
-	if string(host[0]) == "[" && string(host[len(host)-1]) == "]" {
-		host = host[1 : len(host)-1]
+	if strings.IndexByte(addr, '.') != -1 {
+		return addr
 	}
 
-	if net.ParseIP(host) == nil {
-		return ""
+	if addr[0] == '[' {
+		return addr
 	}
-
-	return net.JoinHostPort(host, port)
+	return net.JoinHostPort(addr[:ind], addr[ind+1:])
 }

--- a/internal/util.go
+++ b/internal/util.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"net"
 	"strings"
 	"time"
 
@@ -63,4 +64,23 @@ func ReplaceSpaces(s string) string {
 	}
 
 	return builder.String()
+}
+
+func GetAddr(addr string) string {
+	ind := strings.LastIndex(addr, ":")
+	if ind == -1 {
+		return ""
+	}
+
+	port := addr[ind+1:]
+	host := addr[:ind]
+	if string(host[0]) == "[" && string(host[len(host)-1]) == "]" {
+		host = host[1 : len(host)-1]
+	}
+
+	if net.ParseIP(host) == nil {
+		return ""
+	}
+
+	return net.JoinHostPort(host, port)
 }

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -51,3 +51,24 @@ func TestIsLower(t *testing.T) {
 		Expect(isLower(str)).To(BeTrue())
 	})
 }
+
+func TestGetAddr(t *testing.T) {
+	It("getAddr", func() {
+		str := "127.0.0.1:1234"
+		Expect(GetAddr(str)).To(Equal(str))
+
+		str = "[::1]:1234"
+		Expect(GetAddr(str)).To(Equal(str))
+
+		str = "[fd01:abcd::7d03]:6379"
+		Expect(GetAddr(str)).To(Equal(str))
+
+		Expect(GetAddr("::1:1234")).To(Equal("[::1]:1234"))
+
+		Expect(GetAddr("fd01:abcd::7d03:6379")).To(Equal("[fd01:abcd::7d03]:6379"))
+
+		Expect(GetAddr("127.0.0.1")).To(Equal(""))
+
+		Expect(GetAddr("127")).To(Equal(""))
+	})
+}


### PR DESCRIPTION
If the address in the error is an IPv6 address it adds squared brackets around the host part of the address.