### PR TITLE
Add `(*StatusCmd).Bytes()` method

### DIFF
--- a/command.go
+++ b/command.go
@@ -573,6 +573,10 @@ func (cmd *StatusCmd) Result() (string, error) {
 	return cmd.val, cmd.err
 }
 
+func (cmd *StatusCmd) Bytes() ([]byte, error) {
+	return util.StringToBytes(cmd.val), cmd.err
+}
+
 func (cmd *StatusCmd) String() string {
 	return cmdString(cmd, cmd.val)
 }


### PR DESCRIPTION
When calling `SetArgs` with `Get: true`, it's useful to be able to read the result as bytes rather than a string (in the same way you would with `Get`). However, `SetArgs` returns `*StatusCmd` (which doesn't implement the `Bytes()` method) rather than `*StringCmd` (which does).

This PR adds a `Bytes()` method to `*StatusCmd` to support this use case.