### PR TITLE
Support Hash-field expiration commands in Pipeline & Fix HExpire HExpireWithArgs expiration

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -2486,27 +2486,27 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HExpire", Label("hash-expiration", "NonRedisEnterprise"), func() {
-			res, err := client.HExpire(ctx, "no_such_key", 10, "field1", "field2", "field3").Result()
+			res, err := client.HExpire(ctx, "no_such_key", 10*time.Second, "field1", "field2", "field3").Result()
 			Expect(err).To(BeNil())
 			for i := 0; i < 100; i++ {
 				sadd := client.HSet(ctx, "myhash", fmt.Sprintf("key%d", i), "hello")
 				Expect(sadd.Err()).NotTo(HaveOccurred())
 			}
 
-			res, err = client.HExpire(ctx, "myhash", 10, "key1", "key2", "key200").Result()
+			res, err = client.HExpire(ctx, "myhash", 10*time.Second, "key1", "key2", "key200").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal([]int64{1, 1, -2}))
 		})
 
 		It("should HPExpire", Label("hash-expiration", "NonRedisEnterprise"), func() {
-			_, err := client.HPExpire(ctx, "no_such_key", 10, "field1", "field2", "field3").Result()
+			_, err := client.HPExpire(ctx, "no_such_key", 10*time.Second, "field1", "field2", "field3").Result()
 			Expect(err).To(BeNil())
 			for i := 0; i < 100; i++ {
 				sadd := client.HSet(ctx, "myhash", fmt.Sprintf("key%d", i), "hello")
 				Expect(sadd.Err()).NotTo(HaveOccurred())
 			}
 
-			res, err := client.HPExpire(ctx, "myhash", 10, "key1", "key2", "key200").Result()
+			res, err := client.HPExpire(ctx, "myhash", 10*time.Second, "key1", "key2", "key200").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal([]int64{1, 1, -2}))
 		})
@@ -2552,7 +2552,7 @@ var _ = Describe("Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal([]int64{-1, -1, -2}))
 
-			res, err = client.HExpire(ctx, "myhash", 10, "key1", "key200").Result()
+			res, err = client.HExpire(ctx, "myhash", 10*time.Second, "key1", "key200").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal([]int64{1, -2}))
 
@@ -2570,7 +2570,7 @@ var _ = Describe("Commands", func() {
 				Expect(sadd.Err()).NotTo(HaveOccurred())
 			}
 
-			res, err := client.HExpire(ctx, "myhash", 10, "key1", "key200").Result()
+			res, err := client.HExpire(ctx, "myhash", 10*time.Second, "key1", "key200").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal([]int64{1, -2}))
 
@@ -2607,7 +2607,7 @@ var _ = Describe("Commands", func() {
 				Expect(sadd.Err()).NotTo(HaveOccurred())
 			}
 
-			res, err := client.HExpire(ctx, "myhash", 10, "key1", "key200").Result()
+			res, err := client.HExpire(ctx, "myhash", 10*time.Second, "key1", "key200").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal([]int64{1, -2}))
 
@@ -2625,7 +2625,7 @@ var _ = Describe("Commands", func() {
 				Expect(sadd.Err()).NotTo(HaveOccurred())
 			}
 
-			res, err := client.HExpire(ctx, "myhash", 10, "key1", "key200").Result()
+			res, err := client.HExpire(ctx, "myhash", 10*time.Second, "key1", "key200").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal([]int64{1, -2}))
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -2488,7 +2488,7 @@ var _ = Describe("Commands", func() {
 		It("should HExpire", Label("hash-expiration", "NonRedisEnterprise"), func() {
 			res, err := client.HExpire(ctx, "no_such_key", 10*time.Second, "field1", "field2", "field3").Result()
 			Expect(err).To(BeNil())
-			Expect(resEmpty).To(BeEquivalentTo([]int64{-2, -2, -2}))
+			Expect(res).To(BeEquivalentTo([]int64{-2, -2, -2}))
 
 			for i := 0; i < 100; i++ {
 				sadd := client.HSet(ctx, "myhash", fmt.Sprintf("key%d", i), "hello")
@@ -2501,16 +2501,16 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HPExpire", Label("hash-expiration", "NonRedisEnterprise"), func() {
-			_, err := client.HPExpire(ctx, "no_such_key", 10*time.Second, "field1", "field2", "field3").Result()
+			res, err := client.HPExpire(ctx, "no_such_key", 10*time.Second, "field1", "field2", "field3").Result()
 			Expect(err).To(BeNil())
-			Expect(resEmpty).To(BeEquivalentTo([]int64{-2, -2, -2}))
+			Expect(res).To(BeEquivalentTo([]int64{-2, -2, -2}))
 
 			for i := 0; i < 100; i++ {
 				sadd := client.HSet(ctx, "myhash", fmt.Sprintf("key%d", i), "hello")
 				Expect(sadd.Err()).NotTo(HaveOccurred())
 			}
 
-			res, err := client.HPExpire(ctx, "myhash", 10*time.Second, "key1", "key2", "key200").Result()
+			res, err = client.HPExpire(ctx, "myhash", 10*time.Second, "key1", "key2", "key200").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(Equal([]int64{1, 1, -2}))
 		})

--- a/hash_commands.go
+++ b/hash_commands.go
@@ -23,6 +23,19 @@ type HashCmdable interface {
 	HVals(ctx context.Context, key string) *StringSliceCmd
 	HRandField(ctx context.Context, key string, count int) *StringSliceCmd
 	HRandFieldWithValues(ctx context.Context, key string, count int) *KeyValueSliceCmd
+	HExpire(ctx context.Context, key string, expiration time.Duration, fields ...string) *IntSliceCmd
+	HExpireWithArgs(ctx context.Context, key string, expiration time.Duration, expirationArgs HExpireArgs, fields ...string) *IntSliceCmd
+	HPExpire(ctx context.Context, key string, expiration time.Duration, fields ...string) *IntSliceCmd
+	HPExpireWithArgs(ctx context.Context, key string, expiration time.Duration, expirationArgs HExpireArgs, fields ...string) *IntSliceCmd
+	HExpireAt(ctx context.Context, key string, tm time.Time, fields ...string) *IntSliceCmd
+	HExpireAtWithArgs(ctx context.Context, key string, tm time.Time, expirationArgs HExpireArgs, fields ...string) *IntSliceCmd
+	HPExpireAt(ctx context.Context, key string, tm time.Time, fields ...string) *IntSliceCmd
+	HPExpireAtWithArgs(ctx context.Context, key string, tm time.Time, expirationArgs HExpireArgs, fields ...string) *IntSliceCmd
+	HPersist(ctx context.Context, key string, fields ...string) *IntSliceCmd
+	HExpireTime(ctx context.Context, key string, fields ...string) *IntSliceCmd
+	HPExpireTime(ctx context.Context, key string, fields ...string) *IntSliceCmd
+	HTTL(ctx context.Context, key string, fields ...string) *IntSliceCmd
+	HPTTL(ctx context.Context, key string, fields ...string) *IntSliceCmd
 }
 
 func (c cmdable) HDel(ctx context.Context, key string, fields ...string) *IntCmd {

--- a/hash_commands.go
+++ b/hash_commands.go
@@ -215,7 +215,7 @@ type HExpireArgs struct {
 // The command constructs an argument list starting with "HEXPIRE", followed by the key, duration, any conditional flags, and the specified fields.
 // For more information - https://redis.io/commands/hexpire/
 func (c cmdable) HExpire(ctx context.Context, key string, expiration time.Duration, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HEXPIRE", key, expiration, "FIELDS", len(fields)}
+	args := []interface{}{"HEXPIRE", key, formatSec(ctx, expiration), "FIELDS", len(fields)}
 
 	for _, field := range fields {
 		args = append(args, field)
@@ -230,7 +230,7 @@ func (c cmdable) HExpire(ctx context.Context, key string, expiration time.Durati
 // The command constructs an argument list starting with "HEXPIRE", followed by the key, duration, any conditional flags, and the specified fields.
 // For more information - https://redis.io/commands/hexpire/
 func (c cmdable) HExpireWithArgs(ctx context.Context, key string, expiration time.Duration, expirationArgs HExpireArgs, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HEXPIRE", key, expiration}
+	args := []interface{}{"HEXPIRE", key, formatSec(ctx, expiration)}
 
 	// only if one argument is true, we can add it to the args
 	// if more than one argument is true, it will cause an error


### PR DESCRIPTION
#2991 Supports Hash-field expiration commands, it will be useful to support that in Pipeline.
Also Fix `HExpire` `HExpireWithArgs` expiration, convert it to seconds