### PR TITLE
Recognize byte slice for key argument in cluster client hash slot computation

### DIFF
--- a/command.go
+++ b/command.go
@@ -167,6 +167,8 @@ func (cmd *baseCmd) stringArg(pos int) string {
 	switch v := arg.(type) {
 	case string:
 		return v
+	case []byte:
+		return string(v)
 	default:
 		// TODO: consider using appendArg
 		return fmt.Sprint(v)


### PR DESCRIPTION
This PR is mildly related to #3048.

The cluster client uses the command type to determine the expected key position in the command arguments slice to compute the hash slot. This enables the client to properly send the command to the node that owns that slot, according to the cached cluster topology state.

For generic commands assembled with the `Do()` API, the logic falls back to assuming the key is at position 1. Though this is a reasonable assumption, it depends on the argument to be of `string` type; `[]byte` type arguments are not converted to strings, which results in an incorrect slot computation, thus forcing (in most cases) a double round trip caused by response to a `MOVED` redirection.

This PR adds a `[]byte` type case for key string serialization, so that the generic commands passed as byte slices yield the correct cluster hash slot.