### PR TITLE
Add ConnChecker to customize conn health check

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -68,6 +68,7 @@ type Options struct {
 	MaxActiveConns  int
 	ConnMaxIdleTime time.Duration
 	ConnMaxLifetime time.Duration
+	ConnChecker     func(net.Conn) error
 }
 
 type lastDialErrorWrap struct {
@@ -511,6 +512,12 @@ func (p *ConnPool) isHealthyConn(cn *Conn) bool {
 
 	if connCheck(cn.netConn) != nil {
 		return false
+	}
+
+	if p.cfg.ConnChecker != nil {
+		if err := p.cfg.ConnChecker(cn.netConn); err != nil {
+			return false
+		}
 	}
 
 	cn.SetUsedAt(now)

--- a/options.go
+++ b/options.go
@@ -139,6 +139,9 @@ type Options struct {
 	// Default is to not close idle connections.
 	ConnMaxLifetime time.Duration
 
+	// ConnChecker checks the health of a connection before returning it to the client.
+	ConnChecker func(net.Conn) error
+
 	// TLS Config to use. When set, TLS will be negotiated.
 	TLSConfig *tls.Config
 
@@ -520,5 +523,6 @@ func newConnPool(
 		MaxActiveConns:  opt.MaxActiveConns,
 		ConnMaxIdleTime: opt.ConnMaxIdleTime,
 		ConnMaxLifetime: opt.ConnMaxLifetime,
+		ConnChecker:     opt.ConnChecker,
 	})
 }


### PR DESCRIPTION
**Allow user to customize conn health check.**

One of the scenario we met is that we'd like to drain some proxy node before upgrading. If we'd like to take down some node, instructions could be sent to clients to drop connections to these nodes.