### PR TITLE
Rename XPendingExt RetryCount to DeliveredTimes to avoid ambiguity

### DIFF
--- a/command.go
+++ b/command.go
@@ -1741,10 +1741,10 @@ func (cmd *XPendingCmd) readReply(rd *proto.Reader) error {
 //------------------------------------------------------------------------------
 
 type XPendingExt struct {
-	ID         string
-	Consumer   string
-	Idle       time.Duration
-	RetryCount int64
+	ID             string
+	Consumer       string
+	Idle           time.Duration
+	DeliveredTimes int64
 }
 
 type XPendingExtCmd struct {
@@ -1805,7 +1805,7 @@ func (cmd *XPendingExtCmd) readReply(rd *proto.Reader) error {
 		}
 		cmd.val[i].Idle = time.Duration(idle) * time.Millisecond
 
-		if cmd.val[i].RetryCount, err = rd.ReadInt(); err != nil && err != Nil {
+		if cmd.val[i].DeliveredTimes, err = rd.ReadInt(); err != nil && err != Nil {
 			return err
 		}
 	}

--- a/commands_test.go
+++ b/commands_test.go
@@ -6063,9 +6063,9 @@ var _ = Describe("Commands", func() {
 					infoExt[i].Idle = 0
 				}
 				Expect(infoExt).To(Equal([]redis.XPendingExt{
-					{ID: "1-0", Consumer: "consumer", Idle: 0, RetryCount: 1},
-					{ID: "2-0", Consumer: "consumer", Idle: 0, RetryCount: 1},
-					{ID: "3-0", Consumer: "consumer", Idle: 0, RetryCount: 1},
+					{ID: "1-0", Consumer: "consumer", Idle: 0, DeliveredTimes: 1},
+					{ID: "2-0", Consumer: "consumer", Idle: 0, DeliveredTimes: 1},
+					{ID: "3-0", Consumer: "consumer", Idle: 0, DeliveredTimes: 1},
 				}))
 
 				args.Idle = 72 * time.Hour


### PR DESCRIPTION
https://github.com/redis/go-redis/discussions/3075