### PR TITLE
Remove direct read from TLS underlying conn

### DIFF
--- a/internal/pool/conn_check.go
+++ b/internal/pool/conn_check.go
@@ -3,7 +3,6 @@
 package pool
 
 import (
-	"crypto/tls"
 	"errors"
 	"io"
 	"net"
@@ -17,10 +16,6 @@ func connCheck(conn net.Conn) error {
 	// Reset previous timeout.
 	_ = conn.SetDeadline(time.Time{})
 
-	// Check if tls.Conn.
-	if c, ok := conn.(*tls.Conn); ok {
-		conn = c.NetConn()
-	}
 	sysConn, ok := conn.(syscall.Conn)
 	if !ok {
 		return nil

--- a/internal/pool/conn_check_test.go
+++ b/internal/pool/conn_check_test.go
@@ -3,7 +3,6 @@
 package pool
 
 import (
-	"crypto/tls"
 	"net"
 	"net/http/httptest"
 	"time"
@@ -15,16 +14,11 @@ import (
 var _ = Describe("tests conn_check with real conns", func() {
 	var ts *httptest.Server
 	var conn net.Conn
-	var tlsConn *tls.Conn
 	var err error
 
 	BeforeEach(func() {
 		ts = httptest.NewServer(nil)
 		conn, err = net.DialTimeout(ts.Listener.Addr().Network(), ts.Listener.Addr().String(), time.Second)
-		Expect(err).NotTo(HaveOccurred())
-		tlsTestServer := httptest.NewUnstartedServer(nil)
-		tlsTestServer.StartTLS()
-		tlsConn, err = tls.DialWithDialer(&net.Dialer{Timeout: time.Second}, tlsTestServer.Listener.Addr().Network(), tlsTestServer.Listener.Addr().String(), &tls.Config{InsecureSkipVerify: true})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -39,21 +33,9 @@ var _ = Describe("tests conn_check with real conns", func() {
 		Expect(connCheck(conn)).To(HaveOccurred())
 	})
 
-	It("good tls conn check", func() {
-		Expect(connCheck(tlsConn)).NotTo(HaveOccurred())
-
-		Expect(tlsConn.Close()).NotTo(HaveOccurred())
-		Expect(connCheck(tlsConn)).To(HaveOccurred())
-	})
-
 	It("bad conn check", func() {
 		Expect(conn.Close()).NotTo(HaveOccurred())
 		Expect(connCheck(conn)).To(HaveOccurred())
-	})
-
-	It("bad tls conn check", func() {
-		Expect(tlsConn.Close()).NotTo(HaveOccurred())
-		Expect(connCheck(tlsConn)).To(HaveOccurred())
 	})
 
 	It("check conn deadline", func() {


### PR DESCRIPTION
Addresses #3137.

This essentially reverts https://github.com/redis/go-redis/commit/0858ed24e6d08c1940bcb86ccbf8913c761d9ec0, to avoid corrupting TLS sessions by directly reading from the underlying `net.Conn`. This is blocking upgrades to `> 9.5.2` if using TLS.

`conn_check.go` is quite different on the [v9.6 branch](https://github.com/redis/go-redis/blob/v9.6/internal/pool/conn_check.go) ([it changed here](https://github.com/redis/go-redis/pull/3066/files)), should I open another PR to fix that as well?