### PR TITLE
Backport #3138 to v9.6

### DIFF
--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -3,7 +3,6 @@ package pool
 import (
 	"bufio"
 	"context"
-	"crypto/tls"
 	"net"
 	"sync/atomic"
 	"syscall"
@@ -64,9 +63,6 @@ func (cn *Conn) setSysConn() {
 	conn := cn.netConn
 	if conn == nil {
 		return
-	}
-	if tlsConn, ok := conn.(*tls.Conn); ok {
-		conn = tlsConn.NetConn()
 	}
 
 	if sysConn, ok := conn.(syscall.Conn); ok {


### PR DESCRIPTION
This backports #3138 (related to https://github.com/redis/go-redis/issues/3137) to v9.6 branch. Code changed quite a bit and it's a little trickier to follow but the change should effectively be the same.