### PR TITLE
Fix keyword SEPARATOR typo in FT.CREATE command

### DIFF
--- a/search_commands.go
+++ b/search_commands.go
@@ -1004,7 +1004,7 @@ func (c cmdable) FTCreate(ctx context.Context, index string, options *FTCreateOp
 			args = append(args, "WEIGHT", schema.Weight)
 		}
 		if schema.Seperator != "" {
-			args = append(args, "SEPERATOR", schema.Seperator)
+			args = append(args, "SEPARATOR", schema.Seperator)
 		}
 		if schema.CaseSensitive {
 			args = append(args, "CASESENSITIVE")


### PR DESCRIPTION
Fix #3150