### PR TITLE
fix: Fixed issue with context cancelled error leading to connection spikes on Primary instances

### DIFF
--- a/error.go
+++ b/error.go
@@ -38,6 +38,15 @@ type Error interface {
 
 var _ Error = proto.RedisError("")
 
+func isContextError(err error) bool {
+	switch err {
+	case context.Canceled, context.DeadlineExceeded:
+		return true
+	default:
+		return false
+	}
+}
+
 func shouldRetry(err error, retryTimeout bool) bool {
 	switch err {
 	case io.EOF, io.ErrUnexpectedEOF:

--- a/osscluster.go
+++ b/osscluster.go
@@ -1350,7 +1350,9 @@ func (c *ClusterClient) processPipelineNode(
 	_ = node.Client.withProcessPipelineHook(ctx, cmds, func(ctx context.Context, cmds []Cmder) error {
 		cn, err := node.Client.getConn(ctx)
 		if err != nil {
-			node.MarkAsFailing()
+			if !isContextError(err) {
+				node.MarkAsFailing()
+			}
 			_ = c.mapCmdsByNode(ctx, failedCmds, cmds)
 			setCmdsErr(cmds, err)
 			return err

--- a/osscluster_test.go
+++ b/osscluster_test.go
@@ -561,9 +561,10 @@ var _ = Describe("ClusterClient", func() {
 					ctx, cancel := context.WithCancel(context.Background())
 					cancel()
 					pipe.Set(ctx, "A", "A_value", 0)
-					cmds, err := pipe.Exec(ctx)
-					Expect(cmds).To(HaveLen(1))
-					Expect(err).To(Equal(context.Canceled))
+					_, err := pipe.Exec(ctx)
+
+					Expect(err).To(HaveOccurred())
+					Expect(errors.Is(err, context.Canceled)).To(BeTrue())
 
 					clientNodes, _ := client.Nodes(ctx, "A")
 


### PR DESCRIPTION
Issue: After upgrading from 9.5.1 to 9.7.0, we noticed the spikes in connections to Master/ Primary nodes and also reads are happening from Master nodes. Also noticed increase in pool_conn_total_current metrics. 

Environment: AWS Cloud, Elasticache Redis with Cluster Mode

Cause: After debugging, we noticed that nodes are marked as failed when the `context.Cancelled` error is raised https://github.com/redis/go-redis/blob/930d904205691ff06104fcc3ac108177077def35/osscluster.go#L1324.  This is introduced in v9.5.2. 

We tested this by deploying the change from my Fork and noticed improvements. Elasticache Cluster Current Connections Screenshot:
![image](https://github.com/user-attachments/assets/1c476cba-c5a4-4234-97f1-98ea6d914530)

FYI: My first PR to go-redis. Happy to fix if any concerns. 
