### PR TITLE
SortByWithCount FTSearchOptions fix

### DIFF
--- a/search_commands.go
+++ b/search_commands.go
@@ -1775,7 +1775,7 @@ func FTSearchQuery(query string, options *FTSearchOptions) SearchQuery {
 				}
 			}
 			if options.SortByWithCount {
-				queryArgs = append(queryArgs, "WITHCOUT")
+				queryArgs = append(queryArgs, "WITHCOUNT")
 			}
 		}
 		if options.LimitOffset >= 0 && options.Limit > 0 {

--- a/search_test.go
+++ b/search_test.go
@@ -120,7 +120,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		res2, err := client.FTSearchWithArgs(ctx, "num", "foo", &redis.FTSearchOptions{NoContent: true, SortBy: []redis.FTSearchSortBy{sortBy2}}).Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res2.Total).To(BeEquivalentTo(int64(3)))
+		Expect(res2.Total).To(BeEquivalentTo(int64(0)))
 		Expect(res2.Docs[2].ID).To(BeEquivalentTo("doc1"))
 		Expect(res2.Docs[1].ID).To(BeEquivalentTo("doc2"))
 		Expect(res2.Docs[0].ID).To(BeEquivalentTo("doc3"))

--- a/search_test.go
+++ b/search_test.go
@@ -128,9 +128,6 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		res3, err := client.FTSearchWithArgs(ctx, "num", "foo", &redis.FTSearchOptions{NoContent: true, SortBy: []redis.FTSearchSortBy{sortBy2}, SortByWithCount: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res3.Total).To(BeEquivalentTo(int64(0)))
-		Expect(res3.Docs[2].ID).To(BeEquivalentTo("doc1"))
-		Expect(res3.Docs[1].ID).To(BeEquivalentTo("doc2"))
-		Expect(res3.Docs[0].ID).To(BeEquivalentTo("doc3"))
 
 	})
 

--- a/search_test.go
+++ b/search_test.go
@@ -120,14 +120,14 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		res2, err := client.FTSearchWithArgs(ctx, "num", "foo", &redis.FTSearchOptions{NoContent: true, SortBy: []redis.FTSearchSortBy{sortBy2}}).Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res2.Total).To(BeEquivalentTo(int64(0)))
+		Expect(res2.Total).To(BeEquivalentTo(int64(3)))
 		Expect(res2.Docs[2].ID).To(BeEquivalentTo("doc1"))
 		Expect(res2.Docs[1].ID).To(BeEquivalentTo("doc2"))
 		Expect(res2.Docs[0].ID).To(BeEquivalentTo("doc3"))
 
 		res3, err := client.FTSearchWithArgs(ctx, "num", "foo", &redis.FTSearchOptions{NoContent: true, SortBy: []redis.FTSearchSortBy{sortBy2}, SortByWithCount: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res3.Total).To(BeEquivalentTo(int64(3)))
+		Expect(res3.Total).To(BeEquivalentTo(int64(0)))
 		Expect(res3.Docs[2].ID).To(BeEquivalentTo("doc1"))
 		Expect(res3.Docs[1].ID).To(BeEquivalentTo("doc2"))
 		Expect(res3.Docs[0].ID).To(BeEquivalentTo("doc3"))

--- a/search_test.go
+++ b/search_test.go
@@ -125,6 +125,13 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(res2.Docs[1].ID).To(BeEquivalentTo("doc2"))
 		Expect(res2.Docs[0].ID).To(BeEquivalentTo("doc3"))
 
+		res3, err := client.FTSearchWithArgs(ctx, "num", "foo", &redis.FTSearchOptions{NoContent: true, SortBy: []redis.FTSearchSortBy{sortBy2}, SortByWithCount: true}).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res3.Total).To(BeEquivalentTo(int64(3)))
+		Expect(res3.Docs[2].ID).To(BeEquivalentTo("doc1"))
+		Expect(res3.Docs[1].ID).To(BeEquivalentTo("doc2"))
+		Expect(res3.Docs[0].ID).To(BeEquivalentTo("doc3"))
+
 	})
 
 	It("should FTCreate and FTSearch example", Label("search", "ftcreate", "ftsearch"), func() {


### PR DESCRIPTION
In search_commands.go, if the `SortByWithCount` option is true, the query argument that is added is misspelled. it is currently `WITHCOUT`, but should be `WITHCOUNT`.

`if options.SortByWithCount {
				queryArgs = append(queryArgs, "WITHCOUNT")
			}`
			
This change fixes the spelling.