### PR TITLE
feat(options): Add skip_verify param

### DIFF
--- a/options.go
+++ b/options.go
@@ -487,6 +487,9 @@ func setupConnParams(u *url.URL, o *Options) (*Options, error) {
 	if q.err != nil {
 		return nil, q.err
 	}
+	if o.TLSConfig != nil && q.has("skip_verify") {
+		o.TLSConfig.InsecureSkipVerify = q.bool("skip_verify")
+	}
 
 	// any parameters left?
 	if r := q.remaining(); len(r) > 0 {

--- a/options_test.go
+++ b/options_test.go
@@ -31,6 +31,9 @@ func TestParseURL(t *testing.T) {
 			url: "rediss://localhost:123",
 			o:   &Options{Addr: "localhost:123", TLSConfig: &tls.Config{ /* no deep comparison */ }},
 		}, {
+			url: "rediss://localhost:123/?skip_verify=true",
+			o:   &Options{Addr: "localhost:123", TLSConfig: &tls.Config{InsecureSkipVerify: true}},
+		}, {
 			url: "redis://:bar@localhost:123",
 			o:   &Options{Addr: "localhost:123", Password: "bar"},
 		}, {


### PR DESCRIPTION
When parsing a URL, add a "skip_verify" query param to disable TLS certificate verification.

Inspired by various Go drivers:

* ClickHouse: https://github.com/ClickHouse/clickhouse-go/blob/v2.30.0/clickhouse_options.go#L259
* MongoDB: https://github.com/mongodb/mongo-go-driver/blob/v2.0.0/x/mongo/driver/connstring/connstring.go#L609
* MySQL: https://github.com/go-sql-driver/mysql/blob/v1.8.1/dsn.go#L175