### PR TITLE
DOC-4449 hash command examples

### DIFF
--- a/doctests/cmds_hash_test.go
+++ b/doctests/cmds_hash_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sort"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -81,7 +82,7 @@ func ExampleClient_hset() {
 		keys = append(keys, key)
 	}
 
-	slices.Sort(keys)
+	sort.Slice(keys, func(i, j int) bool { return i < j })
 
 	for key, _ := range res6 {
 		fmt.Printf("Key: %v, value: %v\n", key, res6[key])
@@ -184,7 +185,7 @@ func ExampleClient_hgetall() {
 		keys = append(keys, key)
 	}
 
-	slices.Sort(keys)
+	sort.Slice(keys, func(i, j int) bool { return i < j })
 
 	for key, _ := range hGetAllResult2 {
 		fmt.Printf("Key: %v, value: %v\n", key, hGetAllResult2[key])

--- a/doctests/cmds_hash_test.go
+++ b/doctests/cmds_hash_test.go
@@ -81,7 +81,7 @@ func ExampleClient_hset() {
 		keys = append(keys, key)
 	}
 
-	sort.Slice(keys, func(i, j int) bool { return i < j })
+	sort.Strings(keys)
 
 	for _, key := range keys {
 		fmt.Printf("Key: %v, value: %v\n", key, res6[key])
@@ -184,7 +184,7 @@ func ExampleClient_hgetall() {
 		keys = append(keys, key)
 	}
 
-	sort.Slice(keys, func(i, j int) bool { return i < j })
+	sort.Strings(keys)
 
 	for _, key := range keys {
 		fmt.Printf("Key: %v, value: %v\n", key, hGetAllResult2[key])
@@ -230,7 +230,7 @@ func ExampleClient_hvals() {
 		panic(err)
 	}
 
-	sort.Slice(hValsResult2, func(i, j int) bool { return i < j })
+	sort.Strings(hValsResult2)
 
 	fmt.Println(hValsResult2) // >>> [Hello World]
 	// STEP_END

--- a/doctests/cmds_hash_test.go
+++ b/doctests/cmds_hash_test.go
@@ -149,7 +149,7 @@ func ExampleClient_hgetall() {
 
 	rdb := redis.NewClient(&redis.Options{
 		Addr:     "localhost:6379",
-		Password: "", // no password docs
+		Password: "", // no password
 		DB:       0,  // use default DB
 	})
 

--- a/doctests/cmds_hash_test.go
+++ b/doctests/cmds_hash_test.go
@@ -5,7 +5,6 @@ package example_commands_test
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sort"
 
 	"github.com/redis/go-redis/v9"
@@ -231,7 +230,7 @@ func ExampleClient_hvals() {
 		panic(err)
 	}
 
-	slices.Sort(hValsResult2)
+	sort.Slice(hValsResult2, func(i, j int) bool { return i < j })
 
 	fmt.Println(hValsResult2) // >>> [Hello World]
 	// STEP_END

--- a/doctests/cmds_hash_test.go
+++ b/doctests/cmds_hash_test.go
@@ -5,6 +5,8 @@ package example_commands_test
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -74,8 +76,16 @@ func ExampleClient_hset() {
 		panic(err)
 	}
 
-	fmt.Println(res6)
-	// >>> map[field1:Hello field2:Hi field3:World]
+	keys := slices.Collect(maps.Keys(res6))
+
+	slices.Sort(keys)
+
+	for key, value := range res6 {
+		fmt.Printf("Key: %v, value: %v\n", key, value)
+	}
+	// >>> Key: field1, value: Hello
+	// >>> Key: field2, value: Hi
+	// >>> Key: field3, value: World
 	// STEP_END
 
 	// Output:
@@ -84,7 +94,9 @@ func ExampleClient_hset() {
 	// 2
 	// Hi
 	// World
-	// map[field1:Hello field2:Hi field3:World]
+	// Key: field1, value: Hello
+	// Key: field2, value: Hi
+	// Key: field3, value: World
 }
 
 func ExampleClient_hget() {
@@ -130,4 +142,93 @@ func ExampleClient_hget() {
 	// 1
 	// foo
 	// redis: nil
+}
+
+func ExampleClient_hgetall() {
+	ctx := context.Background()
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password docs
+		DB:       0,  // use default DB
+	})
+
+	// REMOVE_START
+	rdb.Del(ctx, "myhash")
+	// REMOVE_END
+
+	// STEP_START hgetall
+	hGetAllResult1, err := rdb.HSet(ctx, "myhash",
+		"field1", "Hello",
+		"field2", "World",
+	).Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(hGetAllResult1) // >>> 2
+
+	hGetAllResult2, err := rdb.HGetAll(ctx, "myhash").Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	keys := slices.Collect(maps.Keys(hGetAllResult2))
+
+	slices.Sort(keys)
+
+	for key, value := range hGetAllResult2 {
+		fmt.Printf("Key: %v, value: %v\n", key, value)
+	}
+	// >>> Key: field1, value: Hello
+	// >>> Key: field2, value: World
+	// STEP_END
+
+	// Output:
+	// 2
+	// Key: field1, value: Hello
+	// Key: field2, value: World
+}
+
+func ExampleClient_hvals() {
+	ctx := context.Background()
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password docs
+		DB:       0,  // use default DB
+	})
+
+	// REMOVE_START
+	rdb.Del(ctx, "myhash")
+	// REMOVE_END
+
+	// STEP_START hvals
+	hValsResult1, err := rdb.HSet(ctx, "myhash",
+		"field1", "Hello",
+		"field2", "World",
+	).Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(hValsResult1) // >>> 2
+
+	hValsResult2, err := rdb.HVals(ctx, "myhash").Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	slices.Sort(hValsResult2)
+
+	fmt.Println(hValsResult2) // >>> [Hello World]
+	// STEP_END
+
+	// Output:
+	// 2
+	// [Hello World]
 }

--- a/doctests/cmds_hash_test.go
+++ b/doctests/cmds_hash_test.go
@@ -83,7 +83,7 @@ func ExampleClient_hset() {
 
 	sort.Slice(keys, func(i, j int) bool { return i < j })
 
-	for key, _ := range res6 {
+	for _, key := range keys {
 		fmt.Printf("Key: %v, value: %v\n", key, res6[key])
 	}
 	// >>> Key: field1, value: Hello
@@ -186,7 +186,7 @@ func ExampleClient_hgetall() {
 
 	sort.Slice(keys, func(i, j int) bool { return i < j })
 
-	for key, _ := range hGetAllResult2 {
+	for _, key := range keys {
 		fmt.Printf("Key: %v, value: %v\n", key, hGetAllResult2[key])
 	}
 	// >>> Key: field1, value: Hello

--- a/doctests/cmds_hash_test.go
+++ b/doctests/cmds_hash_test.go
@@ -5,7 +5,6 @@ package example_commands_test
 import (
 	"context"
 	"fmt"
-	"maps"
 	"slices"
 
 	"github.com/redis/go-redis/v9"
@@ -76,12 +75,16 @@ func ExampleClient_hset() {
 		panic(err)
 	}
 
-	keys := slices.Collect(maps.Keys(res6))
+	keys := make([]string, 0, len(res6))
+
+	for key, _ := range res6 {
+		keys = append(keys, key)
+	}
 
 	slices.Sort(keys)
 
-	for key, value := range res6 {
-		fmt.Printf("Key: %v, value: %v\n", key, value)
+	for key, _ := range res6 {
+		fmt.Printf("Key: %v, value: %v\n", key, res6[key])
 	}
 	// >>> Key: field1, value: Hello
 	// >>> Key: field2, value: Hi
@@ -175,12 +178,16 @@ func ExampleClient_hgetall() {
 		panic(err)
 	}
 
-	keys := slices.Collect(maps.Keys(hGetAllResult2))
+	keys := make([]string, 0, len(hGetAllResult2))
+
+	for key, _ := range hGetAllResult2 {
+		keys = append(keys, key)
+	}
 
 	slices.Sort(keys)
 
-	for key, value := range hGetAllResult2 {
-		fmt.Printf("Key: %v, value: %v\n", key, value)
+	for key, _ := range hGetAllResult2 {
+		fmt.Printf("Key: %v, value: %v\n", key, hGetAllResult2[key])
 	}
 	// >>> Key: field1, value: Hello
 	// >>> Key: field2, value: World


### PR DESCRIPTION
[DOC-4449](https://redislabs.atlassian.net/browse/DOC-4449) and [DOC-4454](https://redislabs.atlassian.net/browse/DOC-4454)

I've also made the test for the hset example deterministic by not relying on the order of the hash keys. I originally used the [Collect](https://pkg.go.dev/slices@master#Collect) and [Keys](https://pkg.go.dev/maps#Keys) standard lib functions to do this. However, they have only been added recently (Go 1.23.0), so they don't pass the CI. Let me know if there's a better way to handle this without Collect and Keys.

[DOC-4449]: https://redislabs.atlassian.net/browse/DOC-4449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-4454]: https://redislabs.atlassian.net/browse/DOC-4454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ