### PR TITLE
fix: Fixed issue adding Go 1.22.x and 1.23.x and drop Go 1.19.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,9 +44,6 @@ jobs:
         with:
           files: coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: check the *.sum files location
-        run: ls -la **/*.sum
   
   test-redis-ce:
     name: test-redis-ce

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x]
+        go-version: [1.22.x, 1.23.x]
 
     services:
       redis:
@@ -56,9 +56,6 @@ jobs:
             - "7.2.6"
             - "6.2.16"
           go-version:
-            - "1.19.x"
-            - "1.20.x"
-            - "1.21.x"
             - "1.22.x"
             - "1.23.x"
   

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: "**/*.sum"
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -43,6 +44,9 @@ jobs:
         with:
           files: coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: check the *.sum files location
+        run: ls -la **/*.sum
   
   test-redis-ce:
     name: test-redis-ce
@@ -66,6 +70,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+          cache-dependency-path: "**/*.sum"
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x, 1.23.x]
+        go-version: [1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x]
 
     services:
       redis:
@@ -56,6 +56,7 @@ jobs:
             - "7.2.6"
             - "6.2.16"
           go-version:
+            - "1.19.x"
             - "1.20.x"
             - "1.21.x"
             - "1.22.x"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x, 1.20.x, 1.21.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x, 1.23.x]
 
     services:
       redis:
@@ -56,10 +56,11 @@ jobs:
             - "7.2.6"
             - "6.2.16"
           go-version:
-            - "1.19.x"
             - "1.20.x"
             - "1.21.x"
-
+            - "1.22.x"
+            - "1.23.x"
+  
     steps:
       - name: Set up ${{ matrix.go-version }}
         uses: actions/setup-go@v5
@@ -73,7 +74,7 @@ jobs:
       - name: Set up Docker Compose environment
         run: |
           docker compose --profile all up -d
-      
+    
       - name: Run tests
         env:
           USE_CONTAINERIZED_REDIS: "true"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-          cache-dependency-path: "**/*.sum"
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -67,7 +66,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-          cache-dependency-path: "**/*.sum"
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/doctests.yaml
+++ b/.github/workflows/doctests.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ "1.18",  "1.19",  "1.20", "1.21", "1.22", "1.23" ]
+        go-version: [ "1.22", "1.23" ]
 
     steps:
       - name: Set up ${{ matrix.go-version }}

--- a/.github/workflows/doctests.yaml
+++ b/.github/workflows/doctests.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ "1.18", "1.19", "1.20", "1.21" ]
+        go-version: [ "1.20", "1.21", "1.22", "1.23" ]
 
     steps:
       - name: Set up ${{ matrix.go-version }}

--- a/.github/workflows/doctests.yaml
+++ b/.github/workflows/doctests.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ "1.20", "1.21", "1.22", "1.23" ]
+        go-version: [ "1.18",  "1.19",  "1.20", "1.21", "1.22", "1.23" ]
 
     steps:
       - name: Set up ${{ matrix.go-version }}

--- a/.github/workflows/test-redis-enterprise.yml
+++ b/.github/workflows/test-redis-enterprise.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.21.x]
+        go-version: ["1.21.x", "1.22.x", "1.23.x"]
         re-build: ["7.4.2-54"]
 
     steps:

--- a/.github/workflows/test-redis-enterprise.yml
+++ b/.github/workflows/test-redis-enterprise.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.21.x", "1.22.x", "1.23.x"]
+        go-version: ["1.21.x"]
         re-build: ["7.4.2-54"]
 
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redis/go-redis/v9
 
-go 1.18
+go 1.20
 
 require (
 	github.com/bsm/ginkgo/v2 v2.12.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redis/go-redis/v9
 
-go 1.20
+go 1.18
 
 require (
 	github.com/bsm/ginkgo/v2 v2.12.0


### PR DESCRIPTION
Update Go versions: Add support for Go 1.22.x and 1.23.x in the build.yml workflow, while removing support for the outdated and unsupported Go 1.19.x version. This ensures compatibility with newer Go versions and keeps the build process up-to-date.
#3238