### PR TITLE
Order slices of strings to be sure what the output of Println in doctests will be.

### DIFF
--- a/doctests/sets_example_test.go
+++ b/doctests/sets_example_test.go
@@ -216,8 +216,9 @@ func ExampleClient_saddsmembers() {
 		panic(err)
 	}
 
-	// Sort the strings in the slice to make sure the output is alphabetical 
+	// Sort the strings in the slice to make sure the output is lexicographical 
 	sort.Strings(res10)
+
 	fmt.Println(res10) // >>> [bike:1 bike:2 bike:3]
 	// STEP_END
 
@@ -298,7 +299,7 @@ func ExampleClient_sdiff() {
 	}
 
 
-	// Sort the strings in the slice to make sure the output is alphabetical 
+	// Sort the strings in the slice to make sure the output is lexicographical 
 	sort.Strings(res13)
 
 	fmt.Println(res13) // >>> [bike:2 bike:3]
@@ -356,7 +357,7 @@ func ExampleClient_multisets() {
 		panic(err)
 	}
 
-	// Sort the strings in the slice to make sure the output is alphabetical 
+	// Sort the strings in the slice to make sure the output is lexicographical 
 	sort.Strings(res15)
 
 	fmt.Println(res15) // >>> [bike:1 bike:2 bike:3 bike:4]
@@ -383,7 +384,7 @@ func ExampleClient_multisets() {
 		panic(err)
 	}
 
-	// Sort the strings in the slice to make sure the output is alphabetical 
+	// Sort the strings in the slice to make sure the output is lexicographical 
 	sort.Strings(res18)
 
 	fmt.Println(res18) // >>> [bike:2 bike:3]

--- a/doctests/sets_example_test.go
+++ b/doctests/sets_example_test.go
@@ -5,6 +5,7 @@ package example_commands_test
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -215,6 +216,8 @@ func ExampleClient_saddsmembers() {
 		panic(err)
 	}
 
+	// Sort the strings in the slice to make sure the output is alphabetical 
+	sort.Strings(res10)
 	fmt.Println(res10) // >>> [bike:1 bike:2 bike:3]
 	// STEP_END
 
@@ -294,6 +297,10 @@ func ExampleClient_sdiff() {
 		panic(err)
 	}
 
+
+	// Sort the strings in the slice to make sure the output is alphabetical 
+	sort.Strings(res13)
+
 	fmt.Println(res13) // >>> [bike:2 bike:3]
 	// STEP_END
 
@@ -349,6 +356,9 @@ func ExampleClient_multisets() {
 		panic(err)
 	}
 
+	// Sort the strings in the slice to make sure the output is alphabetical 
+	sort.Strings(res15)
+
 	fmt.Println(res15) // >>> [bike:1 bike:2 bike:3 bike:4]
 
 	res16, err := rdb.SDiff(ctx, "bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy").Result()
@@ -372,6 +382,9 @@ func ExampleClient_multisets() {
 	if err != nil {
 		panic(err)
 	}
+
+	// Sort the strings in the slice to make sure the output is alphabetical 
+	sort.Strings(res18)
 
 	fmt.Println(res18) // >>> [bike:2 bike:3]
 	// STEP_END


### PR DESCRIPTION
While executing the tests locally some failed due to slices not being returned in the order that was expected. Ordering the result before printing fixes this.