### PR TITLE
fix(command): add missing `io-thread` key in `client info`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.rdb
 testdata/*
-dockers/
 .idea/
 .DS_Store
 *.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dockers/
 *.rdb
 testdata/*
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.rdb
 testdata/*
+dockers/
 .idea/
 .DS_Store
 *.tar.gz

--- a/command.go
+++ b/command.go
@@ -5114,6 +5114,7 @@ type ClientInfo struct {
 	OutputListLength   int           // oll, output list length (replies are queued in this list when the buffer is full)
 	OutputMemory       int           // omem, output buffer memory usage
 	TotalMemory        int           // tot-mem, total memory consumed by this client in its various buffers
+	IoThread           int           // io-thread id
 	Events             string        // file descriptor events (see below)
 	LastCmd            string        // cmd, last command played
 	User               string        // the authenticated username of the client
@@ -5292,6 +5293,8 @@ func parseClientInfo(txt string) (info *ClientInfo, err error) {
 			info.LibName = val
 		case "lib-ver":
 			info.LibVer = val
+		case "io-thread":
+			info.IoThread, err = strconv.Atoi(val)
 		default:
 			return nil, fmt.Errorf("redis: unexpected client info key(%s)", key)
 		}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 services:
 
   redis-stanalone:
-    image: redislabs/client-libs-test:8.0-M02
+    image: redislabs/client-libs-test:8.0-M03
     container_name: redis-standalone
     environment:
       - REDIS_CLUSTER=no

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 services:
 
   redis-stanalone:
-    image: redislabs/client-libs-test:8.0-M03
+    image: redislabs/client-libs-test:8.0-M02
     container_name: redis-standalone
     environment:
       - REDIS_CLUSTER=no

--- a/main_test.go
+++ b/main_test.go
@@ -118,7 +118,8 @@ var _ = BeforeSuite(func() {
 			sentinelSlave2Port, "--slaveof", "127.0.0.1", sentinelMasterPort)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(startCluster(ctx, cluster)).NotTo(HaveOccurred())
+		err = startCluster(ctx, cluster)
+		Expect(err).NotTo(HaveOccurred())
 	} else {
 		redisPort = rediStackPort
 		redisAddr = rediStackAddr


### PR DESCRIPTION
Redis 8.0 introduces new key `io-thread` in the response
for `client info`. The key needs to be parsed. If an unknown key
is observed, the client will return an error.

This PR also introduces the 8.0-M3 build in the docker compose and a small improvement to the readability. 