### PR TITLE
feat: support Elasticache cluster mode by setting IsClusterMode in config

### DIFF
--- a/universal.go
+++ b/universal.go
@@ -69,6 +69,9 @@ type UniversalOptions struct {
 	DisableIndentity bool
 	IdentitySuffix   string
 	UnstableResp3    bool
+
+	// IsClusterMode can be used when only one Addrs is provided (e.g. Elasticache supports setting up cluster mode with configuration endpoint).
+	IsClusterMode bool
 }
 
 // Cluster returns cluster options created from the universal options.
@@ -244,7 +247,7 @@ var (
 func NewUniversalClient(opts *UniversalOptions) UniversalClient {
 	if opts.MasterName != "" {
 		return NewFailoverClient(opts.Failover())
-	} else if len(opts.Addrs) > 1 {
+	} else if len(opts.Addrs) > 1 || opts.IsClusterMode {
 		return NewClusterClient(opts.Cluster())
 	}
 	return NewClient(opts.Simple())

--- a/universal_test.go
+++ b/universal_test.go
@@ -60,4 +60,21 @@ var _ = Describe("UniversalClient", func() {
 		a := func() { client.FTInfo(ctx, "all").Result() }
 		Expect(a).ToNot(Panic())
 	})
+
+	It("should connect to clusters if IsClusterMode is set even if only a single address is provided", Label("NonRedisEnterprise"), func() {
+		client = redis.NewUniversalClient(&redis.UniversalOptions{
+			Addrs:         []string{cluster.addrs()[0]},
+			IsClusterMode: true,
+		})
+		_, ok := client.(*redis.ClusterClient)
+		Expect(ok).To(BeTrue(), "expected a ClusterClient")
+	})
+
+	It("should return all slots after instantiating UniversalClient with IsClusterMode", Label("NonRedisEnterprise"), func() {
+		client = redis.NewUniversalClient(&redis.UniversalOptions{
+			Addrs:         []string{cluster.addrs()[0]},
+			IsClusterMode: true,
+		})
+		Expect(client.ClusterSlots(ctx).Val()).To(HaveLen(3))
+	})
 })


### PR DESCRIPTION
- This is required because Elasticache supports setting up cluster mode with configuration endpoint. So the check len(Addrs) > 1 is not enough for determining cluster mode.
- If IsClusterMode is true, the client will be created as a cluster client.