### PR TITLE
feat(tests): validate that ConfigSet and ConfigGet work with Modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ testdata/*
 .DS_Store
 *.tar.gz
 *.dic
+redis8tests.sh

--- a/commands_test.go
+++ b/commands_test.go
@@ -379,8 +379,19 @@ var _ = Describe("Commands", func() {
 			Expect(configSet.Val()).To(Equal("OK"))
 		})
 
+		It("should ConfigGet with Modules", Label("NonRedisEnterprise"), func() {
+			SkipBeforeRedisMajor(8, "config get won't return modules configs before redis 8")
+			configGet := client.ConfigGet(ctx, "*")
+			Expect(configGet.Err()).NotTo(HaveOccurred())
+			Expect(configGet.Val()).To(HaveKey("maxmemory"))
+			Expect(configGet.Val()).To(HaveKey("search-timeout"))
+			Expect(configGet.Val()).To(HaveKey("ts-retention-policy"))
+			Expect(configGet.Val()).To(HaveKey("bf-error-rate"))
+			Expect(configGet.Val()).To(HaveKey("cf-initial-size"))
+		})
+
 		It("should ConfigSet FT DIALECT", func() {
-			SkipBeforeRedisMajor(8, "Config doesn't include modules before Redis 8")
+			SkipBeforeRedisMajor(8, "config doesn't include modules before Redis 8")
 			defaultState, err := client.ConfigGet(ctx, "search-default-dialect").Result()
 			Expect(err).NotTo(HaveOccurred())
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -347,7 +347,7 @@ var _ = Describe("Commands", func() {
 		It("should ConfigGet Modules", func() {
 			SkipBeforeRedisMajor(8, "Config doesn't include modules before Redis 8")
 			expected := map[string]string{
-				"search-*": "search-min-prefix",
+				"search-*": "search-timeout",
 				"ts-*":     "ts-retention-policy",
 				"bf-*":     "bf-error-rate",
 				"cf-*":     "cf-initial-size",

--- a/search_commands.go
+++ b/search_commands.go
@@ -831,20 +831,32 @@ func (c cmdable) FTAlter(ctx context.Context, index string, skipInitialScan bool
 	return cmd
 }
 
-// FTConfigGet - Retrieves the value of a RediSearch configuration parameter.
+// Deprecated: FTConfigGet is deprecated in Redis 8.
+// All configuration will be done with the CONFIG GET command.
+// For more information check [Client.ConfigGet] and [CONFIG GET Documentation]
+//
+// Retrieves the value of a RediSearch configuration parameter.
 // The 'option' parameter specifies the configuration parameter to retrieve.
-// For more information, please refer to the Redis documentation:
-// [FT.CONFIG GET]: (https://redis.io/commands/ft.config-get/)
+// For more information, please refer to the Redis [FT.CONFIG GET] documentation.
+//
+// [CONFIG GET Documentation]: https://redis.io/commands/config-get/
+// [FT.CONFIG GET]: https://redis.io/commands/ft.config-get/
 func (c cmdable) FTConfigGet(ctx context.Context, option string) *MapMapStringInterfaceCmd {
 	cmd := NewMapMapStringInterfaceCmd(ctx, "FT.CONFIG", "GET", option)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
-// FTConfigSet - Sets the value of a RediSearch configuration parameter.
+// Deprecated: FTConfigSet is deprecated in Redis 8.
+// All configuration will be done with the CONFIG SET command.
+// For more information check [Client.ConfigSet] and [CONFIG SET Documentation]
+//
+// Sets the value of a RediSearch configuration parameter.
 // The 'option' parameter specifies the configuration parameter to set, and the 'value' parameter specifies the new value.
-// For more information, please refer to the Redis documentation:
-// [FT.CONFIG SET]: (https://redis.io/commands/ft.config-set/)
+// For more information, please refer to the Redis [FT.CONFIG SET] documentation.
+//
+// [CONFIG SET Documentation]: https://redis.io/commands/config-set/
+// [FT.CONFIG SET]: https://redis.io/commands/ft.config-set/
 func (c cmdable) FTConfigSet(ctx context.Context, option string, value interface{}) *StatusCmd {
 	cmd := NewStatusCmd(ctx, "FT.CONFIG", "SET", option, value)
 	_ = c(ctx, cmd)

--- a/search_commands.go
+++ b/search_commands.go
@@ -831,13 +831,13 @@ func (c cmdable) FTAlter(ctx context.Context, index string, skipInitialScan bool
 	return cmd
 }
 
-// Deprecated: FTConfigGet is deprecated in Redis 8.
-// All configuration will be done with the CONFIG GET command.
-// For more information check [Client.ConfigGet] and [CONFIG GET Documentation]
-//
 // Retrieves the value of a RediSearch configuration parameter.
 // The 'option' parameter specifies the configuration parameter to retrieve.
 // For more information, please refer to the Redis [FT.CONFIG GET] documentation.
+//
+// Deprecated: FTConfigGet is deprecated in Redis 8.
+// All configuration will be done with the CONFIG GET command.
+// For more information check [Client.ConfigGet] and [CONFIG GET Documentation]
 //
 // [CONFIG GET Documentation]: https://redis.io/commands/config-get/
 // [FT.CONFIG GET]: https://redis.io/commands/ft.config-get/
@@ -847,13 +847,13 @@ func (c cmdable) FTConfigGet(ctx context.Context, option string) *MapMapStringIn
 	return cmd
 }
 
-// Deprecated: FTConfigSet is deprecated in Redis 8.
-// All configuration will be done with the CONFIG SET command.
-// For more information check [Client.ConfigSet] and [CONFIG SET Documentation]
-//
 // Sets the value of a RediSearch configuration parameter.
 // The 'option' parameter specifies the configuration parameter to set, and the 'value' parameter specifies the new value.
 // For more information, please refer to the Redis [FT.CONFIG SET] documentation.
+//
+// Deprecated: FTConfigSet is deprecated in Redis 8.
+// All configuration will be done with the CONFIG SET command.
+// For more information check [Client.ConfigSet] and [CONFIG SET Documentation]
 //
 // [CONFIG SET Documentation]: https://redis.io/commands/config-set/
 // [FT.CONFIG SET]: https://redis.io/commands/ft.config-set/

--- a/search_test.go
+++ b/search_test.go
@@ -457,6 +457,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should FTConfigSet and FTConfigGet ", Label("search", "ftconfigget", "ftconfigset", "NonRedisEnterprise"), func() {
+		SkipAfterRedisMajor(7, "FT.CONFIG is moved to Config for redis 8")
 		val, err := client.FTConfigSet(ctx, "TIMEOUT", "100").Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
@@ -1013,6 +1014,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should FTConfigSet and FTConfigGet dialect", Label("search", "ftconfigget", "ftconfigset", "NonRedisEnterprise"), func() {
+		SkipAfterRedisMajor(7, "FT.CONFIG is moved to Config for redis 8")
 		res, err := client.FTConfigSet(ctx, "DEFAULT_DIALECT", "1").Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(BeEquivalentTo("OK"))

--- a/search_test.go
+++ b/search_test.go
@@ -374,9 +374,8 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	// up until redis 8 the default scorer was TFIDF, in redis 8 it is BM25
 	// this test expect redis major version >= 8
 	It("should FTSearch WithScores", Label("search", "ftsearch"), func() {
-		if REDIS_MAJOR_VERSION < 8 {
-			Skip("(redis major version < 8) default scorer is not BM25")
-		}
+		SkipBeforeRedisMajor(8, "default scorer is not BM25")
+
 		text1 := &redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText}
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -418,9 +417,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	// up until redis 8 the default scorer was TFIDF, in redis 8 it is BM25
 	// this test expect redis major version <=7
 	It("should FTSearch WithScores", Label("search", "ftsearch"), func() {
-		if REDIS_MAJOR_VERSION > 7 {
-			Skip("(redis major version > 7) default scorer is not TFIDF")
-		}
+		SkipAfterRedisMajor(7, "default scorer is not TFIDF")
 		text1 := &redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText}
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- [x] Add deprecation warnings
- [x] Test `config set` and `config get` for module keys
- [x] Test `config set search-default-dialect` and then `ft.config get default_dialect`
- [x] Found issue with Resp3 parsing of `ft.config get`, resolved it. Since `ft.config` will be dropped, it was not justified to improve the solution any further. 
- [x] added additional tests, including negative (read only and wrong values) 
- [x] Fixed bug with FT.CONFIG GET command returns error in RESP3 