### PR TITLE
feat(command): add ACL commands, validate module categories exist

### DIFF
--- a/acl_commands.go
+++ b/acl_commands.go
@@ -47,17 +47,13 @@ func (c cmdable) ACLLogReset(ctx context.Context) *StatusCmd {
 }
 
 func (c cmdable) ACLDelUser(ctx context.Context, username string) *IntCmd {
-	args := make([]interface{}, 3, 3)
-	args[0] = "acl"
-	args[1] = "deluser"
-	args[2] = username
-	cmd := NewIntCmd(ctx, args...)
+	cmd := NewIntCmd(ctx, "acl", "deluser", username)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
 func (c cmdable) ACLSetUser(ctx context.Context, username string, rules ...string) *StatusCmd {
-	args := make([]interface{}, 3+len(rules), 3+len(rules))
+	args := make([]interface{}, 3+len(rules))
 	args[0] = "acl"
 	args[1] = "setuser"
 	args[2] = username
@@ -84,8 +80,7 @@ func (c cmdable) ACLCat(ctx context.Context) *StringSliceCmd {
 func (c cmdable) ACLCatArgs(ctx context.Context, options *ACLCatArgs) *StringSliceCmd {
 	// if there is a category passed, build new cmd, if there isn't - use the ACLCat method
 	if options != nil && options.Category != "" {
-		args := []interface{}{"acl", "cat", options.Category}
-		cmd := NewStringSliceCmd(ctx, args...)
+		cmd := NewStringSliceCmd(ctx, "acl", "cat", options.Category)
 		_ = c(ctx, cmd)
 		return cmd
 	}

--- a/acl_commands.go
+++ b/acl_commands.go
@@ -6,6 +6,9 @@ type ACLCmdable interface {
 	ACLDryRun(ctx context.Context, username string, command ...interface{}) *StringCmd
 	ACLLog(ctx context.Context, count int64) *ACLLogCmd
 	ACLLogReset(ctx context.Context) *StatusCmd
+	ACLSetUser(ctx context.Context, username string, rules ...string) *StatusCmd
+	ACLDelUser(ctx context.Context, username string) *IntCmd
+	ACLList(ctx context.Context) *StringSliceCmd
 }
 
 func (c cmdable) ACLDryRun(ctx context.Context, username string, command ...interface{}) *StringCmd {
@@ -30,6 +33,35 @@ func (c cmdable) ACLLog(ctx context.Context, count int64) *ACLLogCmd {
 
 func (c cmdable) ACLLogReset(ctx context.Context) *StatusCmd {
 	cmd := NewStatusCmd(ctx, "acl", "log", "reset")
+	_ = c(ctx, cmd)
+	return cmd
+}
+
+func (c cmdable) ACLDelUser(ctx context.Context, username string) *IntCmd {
+	args := make([]interface{}, 3, 3)
+	args[0] = "acl"
+	args[1] = "deluser"
+	args[2] = username
+	cmd := NewIntCmd(ctx, args...)
+	_ = c(ctx, cmd)
+	return cmd
+}
+
+func (c cmdable) ACLSetUser(ctx context.Context, username string, rules ...string) *StatusCmd {
+	args := make([]interface{}, 3+len(rules), 3+len(rules))
+	args[0] = "acl"
+	args[1] = "setuser"
+	args[2] = username
+	for i, rule := range rules {
+		args[i+3] = rule
+	}
+	cmd := NewStatusCmd(ctx, args...)
+	_ = c(ctx, cmd)
+	return cmd
+}
+
+func (c cmdable) ACLList(ctx context.Context) *StringSliceCmd {
+	cmd := NewStringSliceCmd(ctx, "acl", "list")
 	_ = c(ctx, cmd)
 	return cmd
 }

--- a/acl_commands.go
+++ b/acl_commands.go
@@ -4,11 +4,20 @@ import "context"
 
 type ACLCmdable interface {
 	ACLDryRun(ctx context.Context, username string, command ...interface{}) *StringCmd
+
 	ACLLog(ctx context.Context, count int64) *ACLLogCmd
 	ACLLogReset(ctx context.Context) *StatusCmd
+
 	ACLSetUser(ctx context.Context, username string, rules ...string) *StatusCmd
 	ACLDelUser(ctx context.Context, username string) *IntCmd
 	ACLList(ctx context.Context) *StringSliceCmd
+
+	ACLCat(ctx context.Context) *StringSliceCmd
+	ACLCatArgs(ctx context.Context, options *ACLCatArgs) *StringSliceCmd
+}
+
+type ACLCatArgs struct {
+	Category string
 }
 
 func (c cmdable) ACLDryRun(ctx context.Context, username string, command ...interface{}) *StringCmd {
@@ -64,4 +73,22 @@ func (c cmdable) ACLList(ctx context.Context) *StringSliceCmd {
 	cmd := NewStringSliceCmd(ctx, "acl", "list")
 	_ = c(ctx, cmd)
 	return cmd
+}
+
+func (c cmdable) ACLCat(ctx context.Context) *StringSliceCmd {
+	cmd := NewStringSliceCmd(ctx, "acl", "cat")
+	_ = c(ctx, cmd)
+	return cmd
+}
+
+func (c cmdable) ACLCatArgs(ctx context.Context, options *ACLCatArgs) *StringSliceCmd {
+	// if there is a category passed, build new cmd, if there isn't - use the ACLCat method
+	if options != nil && options.Category != "" {
+		args := []interface{}{"acl", "cat", options.Category}
+		cmd := NewStringSliceCmd(ctx, args...)
+		_ = c(ctx, cmd)
+		return cmd
+	}
+
+	return c.ACLCat(ctx)
 }

--- a/acl_commands_test.go
+++ b/acl_commands_test.go
@@ -21,8 +21,8 @@ var _ = Describe("ACL Users Commands", Label("NonRedisEnterprise"), func() {
 
 	AfterEach(func() {
 		_, err := client.ACLDelUser(context.Background(), TestUserName).Result()
-		Expect(client.Close()).NotTo(HaveOccurred())
 		Expect(err).NotTo(HaveOccurred())
+		Expect(client.Close()).NotTo(HaveOccurred())
 	})
 
 	It("list only default user", func() {
@@ -69,40 +69,106 @@ var _ = Describe("ACL Permissions", Label("NonRedisEnterprise"), func() {
 
 	AfterEach(func() {
 		_, err := client.ACLDelUser(context.Background(), TestUserName).Result()
+		Expect(err).NotTo(HaveOccurred())
 		Expect(client.Close()).NotTo(HaveOccurred())
-		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("list only default user", func() {
-		res, err := client.ACLList(ctx).Result()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(res).To(HaveLen(1))
-		Expect(res[0]).To(ContainSubstring("default"))
-	})
-
-	It("setuser and deluser", func() {
-		res, err := client.ACLList(ctx).Result()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(res).To(HaveLen(1))
-		Expect(res[0]).To(ContainSubstring("default"))
-
-		add, err := client.ACLSetUser(ctx, TestUserName, "nopass", "on", "allkeys", "+set", "+get").Result()
+	It("reset permissions", func() {
+		add, err := client.ACLSetUser(ctx,
+			TestUserName,
+			"reset",
+			"nopass",
+			"on",
+		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(add).To(Equal("OK"))
 
-		resAfter, err := client.ACLList(ctx).Result()
+		connection := client.Conn()
+		authed, err := connection.AuthACL(ctx, TestUserName, "").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resAfter).To(HaveLen(2))
-		Expect(resAfter[1]).To(ContainSubstring(TestUserName))
+		Expect(authed).To(Equal("OK"))
 
-		deletedN, err := client.ACLDelUser(ctx, TestUserName).Result()
-		Expect(err).NotTo(HaveOccurred())
-		Expect(deletedN).To(BeNumerically("==", 1))
+		_, err = connection.Get(ctx, "anykey").Result()
+		Expect(err).To(HaveOccurred())
+	})
 
-		resAfterDeletion, err := client.ACLList(ctx).Result()
+	It("add write permissions", func() {
+		add, err := client.ACLSetUser(ctx,
+			TestUserName,
+			"reset",
+			"nopass",
+			"on",
+			"~*",
+			"+SET",
+		).Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resAfterDeletion).To(HaveLen(1))
-		Expect(resAfterDeletion[0]).To(BeEquivalentTo(res[0]))
+		Expect(add).To(Equal("OK"))
+
+		connection := client.Conn()
+		authed, err := connection.AuthACL(ctx, TestUserName, "").Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(authed).To(Equal("OK"))
+
+		// can write
+		v, err := connection.Set(ctx, "anykey", "anyvalue", 0).Result()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(v).To(Equal("OK"))
+
+		// but can't read
+		value, err := connection.Get(ctx, "anykey").Result()
+		Expect(err).To(HaveOccurred())
+		Expect(value).To(BeEmpty())
+	})
+
+	It("add read permissions", func() {
+		add, err := client.ACLSetUser(ctx,
+			TestUserName,
+			"reset",
+			"nopass",
+			"on",
+			"~*",
+			"+GET",
+		).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(add).To(Equal("OK"))
+
+		connection := client.Conn()
+		authed, err := connection.AuthACL(ctx, TestUserName, "").Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(authed).To(Equal("OK"))
+
+		// can read
+		value, err := connection.Get(ctx, "anykey").Result()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(value).To(Equal("anyvalue"))
+
+		// but can't delete
+		del, err := connection.Del(ctx, "anykey").Result()
+		Expect(err).To(HaveOccurred())
+		Expect(del).ToNot(Equal(1))
+	})
+
+	It("add del permissions", func() {
+		add, err := client.ACLSetUser(ctx,
+			TestUserName,
+			"reset",
+			"nopass",
+			"on",
+			"~*",
+			"+DEL",
+		).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(add).To(Equal("OK"))
+
+		connection := client.Conn()
+		authed, err := connection.AuthACL(ctx, TestUserName, "").Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(authed).To(Equal("OK"))
+
+		// can read
+		del, err := connection.Del(ctx, "anykey").Result()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(del).To(BeEquivalentTo(1))
 	})
 })
 

--- a/acl_commands_test.go
+++ b/acl_commands_test.go
@@ -1,0 +1,60 @@
+package redis_test
+
+import (
+	"context"
+
+	"github.com/redis/go-redis/v9"
+
+	. "github.com/bsm/ginkgo/v2"
+	. "github.com/bsm/gomega"
+)
+
+var TestUserName string = "goredis"
+
+var _ = Describe("ACL Commands", func() {
+	var client *redis.Client
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		client = redis.NewClient(redisOptions())
+	})
+
+	AfterEach(func() {
+		_, err := client.ACLDelUser(context.Background(), TestUserName).Result()
+		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("list only default user", func() {
+		res, err := client.ACLList(ctx).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(HaveLen(1))
+		Expect(res[0]).To(ContainSubstring("default"))
+	})
+
+	It("setuser and deluser", func() {
+		res, err := client.ACLList(ctx).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(HaveLen(1))
+		Expect(res[0]).To(ContainSubstring("default"))
+
+		add, err := client.ACLSetUser(ctx, TestUserName, "nopass", "on", "allkeys", "+set", "+get").Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(add).To(Equal("OK"))
+
+		resAfter, err := client.ACLList(ctx).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resAfter).To(HaveLen(2))
+		Expect(resAfter[1]).To(ContainSubstring(TestUserName))
+
+		deletedN, err := client.ACLDelUser(ctx, TestUserName).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deletedN).To(BeNumerically("==", 1))
+
+		resAfterDeletion, err := client.ACLList(ctx).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resAfterDeletion).To(HaveLen(1))
+		Expect(resAfterDeletion[0]).To(BeEquivalentTo(res[0]))
+	})
+})

--- a/acl_commands_test.go
+++ b/acl_commands_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 var TestUserName string = "goredis"
-
-var _ = Describe("ACL Commands", func() {
+var _ = Describe("ACL Users Commands", Label("NonRedisEnterprise"), func() {
 	var client *redis.Client
 	var ctx context.Context
 
@@ -56,6 +55,68 @@ var _ = Describe("ACL Commands", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resAfterDeletion).To(HaveLen(1))
 		Expect(resAfterDeletion[0]).To(BeEquivalentTo(res[0]))
+	})
+})
+
+var _ = Describe("ACL Permissions", Label("NonRedisEnterprise"), func() {
+	var client *redis.Client
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		client = redis.NewClient(redisOptions())
+	})
+
+	AfterEach(func() {
+		_, err := client.ACLDelUser(context.Background(), TestUserName).Result()
+		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("list only default user", func() {
+		res, err := client.ACLList(ctx).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(HaveLen(1))
+		Expect(res[0]).To(ContainSubstring("default"))
+	})
+
+	It("setuser and deluser", func() {
+		res, err := client.ACLList(ctx).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(HaveLen(1))
+		Expect(res[0]).To(ContainSubstring("default"))
+
+		add, err := client.ACLSetUser(ctx, TestUserName, "nopass", "on", "allkeys", "+set", "+get").Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(add).To(Equal("OK"))
+
+		resAfter, err := client.ACLList(ctx).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resAfter).To(HaveLen(2))
+		Expect(resAfter[1]).To(ContainSubstring(TestUserName))
+
+		deletedN, err := client.ACLDelUser(ctx, TestUserName).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(deletedN).To(BeNumerically("==", 1))
+
+		resAfterDeletion, err := client.ACLList(ctx).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resAfterDeletion).To(HaveLen(1))
+		Expect(resAfterDeletion[0]).To(BeEquivalentTo(res[0]))
+	})
+})
+
+var _ = Describe("ACL Categories", func() {
+	var client *redis.Client
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		client = redis.NewClient(redisOptions())
+	})
+
+	AfterEach(func() {
+		Expect(client.Close()).NotTo(HaveOccurred())
 	})
 
 	It("lists acl categories and subcategories", func() {

--- a/commands_test.go
+++ b/commands_test.go
@@ -2283,6 +2283,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ACL LOG", Label("NonRedisEnterprise"), func() {
+			Expect(client.ACLLogReset(ctx).Err()).NotTo(HaveOccurred())
 			err := client.Do(ctx, "acl", "setuser", "test", ">test", "on", "allkeys", "+get").Err()
 			Expect(err).NotTo(HaveOccurred())
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -211,13 +211,13 @@ var _ = Describe("Commands", func() {
 			select {
 			case <-done:
 				Fail("BLPOP is not blocked.")
-			case <-time.After(2 * time.Second):
+			case <-time.After(1 * time.Second):
 				// ok
 			}
 
 			killed := client.ClientKillByFilter(ctx, "MAXAGE", "1")
 			Expect(killed.Err()).NotTo(HaveOccurred())
-			Expect(killed.Val()).To(SatisfyAny(Equal(int64(2)), Equal(int64(3))))
+			Expect(killed.Val()).To(SatisfyAny(Equal(int64(2)), Equal(int64(3)), Equal(int64(4))))
 
 			select {
 			case <-done:

--- a/commands_test.go
+++ b/commands_test.go
@@ -2228,12 +2228,6 @@ var _ = Describe("Commands", func() {
 			Expect(replace.Val()).To(Equal(int64(1)))
 		})
 
-		It("should acl dryrun", func() {
-			dryRun := client.ACLDryRun(ctx, "default", "get", "randomKey")
-			Expect(dryRun.Err()).NotTo(HaveOccurred())
-			Expect(dryRun.Val()).To(Equal("OK"))
-		})
-
 		It("should fail module loadex", Label("NonRedisEnterprise"), func() {
 			dryRun := client.ModuleLoadex(ctx, &redis.ModuleLoadexConfig{
 				Path: "/path/to/non-existent-library.so",
@@ -2280,56 +2274,6 @@ var _ = Describe("Commands", func() {
 			}
 
 			Expect(args).To(Equal(expectedArgs))
-		})
-
-		It("should ACL LOG", Label("NonRedisEnterprise"), func() {
-			Expect(client.ACLLogReset(ctx).Err()).NotTo(HaveOccurred())
-			err := client.Do(ctx, "acl", "setuser", "test", ">test", "on", "allkeys", "+get").Err()
-			Expect(err).NotTo(HaveOccurred())
-
-			clientAcl := redis.NewClient(redisOptions())
-			clientAcl.Options().Username = "test"
-			clientAcl.Options().Password = "test"
-			clientAcl.Options().DB = 0
-			_ = clientAcl.Set(ctx, "mystring", "foo", 0).Err()
-			_ = clientAcl.HSet(ctx, "myhash", "foo", "bar").Err()
-			_ = clientAcl.SAdd(ctx, "myset", "foo", "bar").Err()
-
-			logEntries, err := client.ACLLog(ctx, 10).Result()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(logEntries)).To(Equal(4))
-
-			for _, entry := range logEntries {
-				Expect(entry.Reason).To(Equal("command"))
-				Expect(entry.Context).To(Equal("toplevel"))
-				Expect(entry.Object).NotTo(BeEmpty())
-				Expect(entry.Username).To(Equal("test"))
-				Expect(entry.AgeSeconds).To(BeNumerically(">=", 0))
-				Expect(entry.ClientInfo).NotTo(BeNil())
-				Expect(entry.EntryID).To(BeNumerically(">=", 0))
-				Expect(entry.TimestampCreated).To(BeNumerically(">=", 0))
-				Expect(entry.TimestampLastUpdated).To(BeNumerically(">=", 0))
-			}
-
-			limitedLogEntries, err := client.ACLLog(ctx, 2).Result()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(limitedLogEntries)).To(Equal(2))
-
-			// cleanup after creating the user
-			err = client.Do(ctx, "acl", "deluser", "test").Err()
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("should ACL LOG RESET", Label("NonRedisEnterprise"), func() {
-			// Call ACL LOG RESET
-			resetCmd := client.ACLLogReset(ctx)
-			Expect(resetCmd.Err()).NotTo(HaveOccurred())
-			Expect(resetCmd.Val()).To(Equal("OK"))
-
-			// Verify that the log is empty after the reset
-			logEntries, err := client.ACLLog(ctx, 10).Result()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(logEntries)).To(Equal(0))
 		})
 	})
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -2313,6 +2313,10 @@ var _ = Describe("Commands", func() {
 			limitedLogEntries, err := client.ACLLog(ctx, 2).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(limitedLogEntries)).To(Equal(2))
+
+			// cleanup after creating the user
+			err = client.Do(ctx, "acl", "deluser", "test").Err()
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should ACL LOG RESET", Label("NonRedisEnterprise"), func() {


### PR DESCRIPTION
- [x] Add ACL SETUSER and ACL DELUSER 
- [x] Add ACL CAT (`ACLCat` and `ACLCatWithArgs` for `ACL CAT [category]`) 
- [x] Validate categories for modules exist in the output of `cat` for redis >=8
- [x] Validate different acl for both commands and categories work for modules 