### PR TITLE
fix: add unstableresp3 to cluster client

### DIFF
--- a/options.go
+++ b/options.go
@@ -154,7 +154,7 @@ type Options struct {
 	// Add suffix to client name. Default is empty.
 	IdentitySuffix string
 
-	// Enable Unstable mode for Redis Search module with RESP3.
+	// UnstableResp3 enables Unstable mode for Redis Search module with RESP3.
 	UnstableResp3 bool
 }
 

--- a/osscluster.go
+++ b/osscluster.go
@@ -94,6 +94,9 @@ type ClusterOptions struct {
 	DisableIndentity bool // Disable set-lib on connect. Default is false.
 
 	IdentitySuffix string // Add suffix to client name. Default is empty.
+
+	// UnstableResp3 enables Unstable mode for Redis Search module with RESP3.
+	UnstableResp3 bool
 }
 
 func (opt *ClusterOptions) init() {

--- a/osscluster.go
+++ b/osscluster.go
@@ -311,7 +311,8 @@ func (opt *ClusterOptions) clientOptions() *Options {
 		// much use for ClusterSlots config).  This means we cannot execute the
 		// READONLY command against that node -- setting readOnly to false in such
 		// situations in the options below will prevent that from happening.
-		readOnly: opt.ReadOnly && opt.ClusterSlots == nil,
+		readOnly:      opt.ReadOnly && opt.ClusterSlots == nil,
+		UnstableResp3: opt.UnstableResp3,
 	}
 }
 

--- a/universal.go
+++ b/universal.go
@@ -115,6 +115,7 @@ func (o *UniversalOptions) Cluster() *ClusterOptions {
 
 		DisableIndentity: o.DisableIndentity,
 		IdentitySuffix:   o.IdentitySuffix,
+		UnstableResp3:    o.UnstableResp3,
 	}
 }
 

--- a/universal_test.go
+++ b/universal_test.go
@@ -39,8 +39,19 @@ var _ = Describe("UniversalClient", func() {
 		Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
 	})
 
-	It("should connect to clusters with unstableresp3", Label("NonRedisEnterprise"), func() {
+	It("connect to clusters with UniversalClient and UnstableResp3", Label("NonRedisEnterprise"), func() {
 		client = redis.NewUniversalClient(&redis.UniversalOptions{
+			Addrs:         cluster.addrs(),
+			Protocol:      3,
+			UnstableResp3: true,
+		})
+		Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+		a := func() { client.FTInfo(ctx, "all").Result() }
+		Expect(a).ToNot(Panic())
+	})
+
+	It("connect to clusters with ClusterClient and UnstableResp3", Label("NonRedisEnterprise"), func() {
+		client = redis.NewClusterClient(&redis.ClusterOptions{
 			Addrs:         cluster.addrs(),
 			Protocol:      3,
 			UnstableResp3: true,

--- a/universal_test.go
+++ b/universal_test.go
@@ -46,7 +46,7 @@ var _ = Describe("UniversalClient", func() {
 			UnstableResp3: true,
 		})
 		Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
-		_, err := client.FTInfo(ctx, "test").Result()
+		_, err := client.FTInfo(ctx, "all").Result()
 		Expect(err).ToNot(HaveOccurred())
 	})
 })

--- a/universal_test.go
+++ b/universal_test.go
@@ -46,7 +46,7 @@ var _ = Describe("UniversalClient", func() {
 			UnstableResp3: true,
 		})
 		Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
-		_, err := client.FTInfo(ctx, "all").Result()
-		Expect(err).ToNot(HaveOccurred())
+		a := func() { client.FTInfo(ctx, "all").Result() }
+		Expect(a).ToNot(Panic())
 	})
 })

--- a/universal_test.go
+++ b/universal_test.go
@@ -38,4 +38,15 @@ var _ = Describe("UniversalClient", func() {
 		})
 		Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
 	})
+
+	It("should connect to clusters with unstableresp3", Label("NonRedisEnterprise"), func() {
+		client = redis.NewUniversalClient(&redis.UniversalOptions{
+			Addrs:         cluster.addrs(),
+			Protocol:      3,
+			UnstableResp3: true,
+		})
+		Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+		_, err := client.FTInfo(ctx, "test").Result()
+		Expect(err).ToNot(HaveOccurred())
+	})
 })


### PR DESCRIPTION
fixes https://github.com/redis/go-redis/issues/3261