### PR TITLE
fix: flaky ClientKillByFilter test

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Commands", func() {
 
 			killed := client.ClientKillByFilter(ctx, "MAXAGE", "1")
 			Expect(killed.Err()).NotTo(HaveOccurred())
-			Expect(killed.Val()).To(SatisfyAny(Equal(int64(2)), Equal(int64(3)), Equal(int64(4))))
+			Expect(killed.Val()).To(BeNumerically(">=", 2))
 
 			select {
 			case <-done:


### PR DESCRIPTION
We have a flaky test that may kill more than 2 or 3 clients, but was only checking if it kills that amount. Let's just make sure we are killing at least 2 (the blocked one and the one used to call `ClientKillByFilter` 