### PR TITLE
move regexp.MustCompile close to call

### DIFF
--- a/command.go
+++ b/command.go
@@ -5484,10 +5484,6 @@ func (cmd *InfoCmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
-var (
-	moduleRe = regexp.MustCompile(`module:name=(.+?),(.+)$`)
-)
-
 func (cmd *InfoCmd) readReply(rd *proto.Reader) error {
 	val, err := rd.ReadString()
 	if err != nil {
@@ -5506,6 +5502,7 @@ func (cmd *InfoCmd) readReply(rd *proto.Reader) error {
 			cmd.val[section] = make(map[string]string)
 		} else if line != "" {
 			if section == "Modules" {
+				moduleRe := regexp.MustCompile(`module:name=(.+?),(.+)$`)
 				kv := moduleRe.FindStringSubmatch(line)
 				if len(kv) == 3 {
 					cmd.val[section][kv[1]] = kv[2]

--- a/command.go
+++ b/command.go
@@ -5484,6 +5484,10 @@ func (cmd *InfoCmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
+var (
+	moduleRe = regexp.MustCompile(`module:name=(.+?),(.+)$`)
+)
+
 func (cmd *InfoCmd) readReply(rd *proto.Reader) error {
 	val, err := rd.ReadString()
 	if err != nil {
@@ -5492,8 +5496,6 @@ func (cmd *InfoCmd) readReply(rd *proto.Reader) error {
 
 	section := ""
 	scanner := bufio.NewScanner(strings.NewReader(val))
-	moduleRe := regexp.MustCompile(`module:name=(.+?),(.+)$`)
-
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, "#") {


### PR DESCRIPTION
I'm validating an idea for my linter. I checked the top 2500 projects on github and found this.

All project result can be found here -> https://github.com/alingse/sundrylint/issues/7

I think move the `regexp.MustCompile` out has two advantages

1. Performance benefits
2. Fail early with faulty regexp string
