### PR TITLE
add readOnly on failover opts

### DIFF
--- a/universal.go
+++ b/universal.go
@@ -160,6 +160,8 @@ func (o *UniversalOptions) Failover() *FailoverOptions {
 
 		TLSConfig: o.TLSConfig,
 
+		ReplicaOnly:     o.ReadOnly,
+
 		DisableIndentity: o.DisableIndentity,
 		IdentitySuffix:   o.IdentitySuffix,
 		UnstableResp3:    o.UnstableResp3,


### PR DESCRIPTION
fixing issues : 
https://github.com/redis/go-redis/issues/3277

adding ReadOnly for scenarios where you need to connect to read-only replicas is not supported in UniversalClient 

by adding this I can connect to readOnly and Master separately