### PR TITLE
Set client name in `HELLO` handshake during connection initialization

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -310,7 +310,7 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 
 	// for redis-server versions that do not support the HELLO command,
 	// RESP2 will continue to be used.
-	if err = conn.Hello(ctx, protocol, username, password, "").Err(); err == nil {
+	if err = conn.Hello(ctx, protocol, username, password, c.opt.ClientName).Err(); err == nil {
 		auth = true
 	} else if !isRedisError(err) {
 		// When the server responds with the RESP protocol and the result is not a normal


### PR DESCRIPTION
## Context

Connection initialization consists of 3 independent operations, executed sequentially:

1. Attempt a RESP 3 `HELLO` handshake (ref: https://github.com/redis/go-redis/blob/v9.7.1/redis.go#L313)
2. Pipeline request to set additional properties on the connection, including authentication, DB index, read-only mode, and client name (ref: https://github.com/redis/go-redis/blob/v9.7.1/redis.go#L326)
3. Pipeline request for client library information (ref: https://github.com/redis/go-redis/blob/v9.7.1/redis.go#L362)

The `HELLO` command supports an optional property, `SETNAME`, that allows the client name to be set on the connection at handshake-time, thus making any subsequent `CLIENT SETNAME` unnecesary.

https://redis.io/docs/latest/commands/hello/

## Problem statement

We are running go-redis against a proprietary RESP protocol-compliant server that correctly recognizes and manipulates client names on connections.

The problem with the sequence of 3 operations above is that the client name is not known to the server until completion of step 2. This means that, the client identity is unknown at completion of step 1, and unknown at the start of step 2.

This has caused RESP handshakes to be flagged as coming from unknown clients.

## Proposal

Since the `HELLO` command supports supplying the client name inline, simply pass the client-specified name in the `HELLO` request. This should be supported by any RESP3-compliant servers. This patch is a noop if the client name field is empty.

This does *not* remove `CLIENT SETNAME` from the subsequent pipeline; this is needed for backwards compatibility for RESP2 servers.

This patch solves the problem statement described above because the client identity on the connection will be known at the time `HELLO` completes (assuming a RESP3 client). This allows all subsequent commands (namely, steps 2 and 3 above) to be correctly associated with a client identity.

## Manual test

Against an Elasticache Redis.

First, apply the follwing patch to `go.mod`, in order to include this patch:

```
...

replace (
        github.com/redis/go-redis/v9 v9.7.1 => github.com/LINKIWI/go-redis/v9 v9.0.0-20250309182633-934829e5964b
)
```

Program:

```go
package main

import (
        "context"
        "fmt"
        "time"

        goredis "github.com/redis/go-redis/v9"
)

func main() {
        opts := &goredis.Options{
                Addr:       "<scrubbed>.0001.usw2.cache.amazonaws.com:6379",
                ClientName: "pr-3294",
        }

        rdb := goredis.NewClient(opts)

        for range time.NewTicker(1 * time.Second).C {
                pong, err := rdb.Ping(context.Background()).Result()
                fmt.Println(pong, err)
        }
}
```

Binary execution:

```bash
$ ./ping
PONG <nil>
PONG <nil>
PONG <nil>
PONG <nil>
PONG <nil>
PONG <nil>
PONG <nil>
PONG <nil>
PONG <nil>
PONG <nil>
```

Verify that the client name continues to be set properly by examining `CLIENT LIST`:

```bash
$ echo "client list" | redis-cli -h <scrubbed>.0001.usw2.cache.amazonaws.com | grep pr-3294
id=205685 addr=10.101.66.186:58264 laddr=10.101.254.26:6379 fd=134 name=pr-3294 age=55 idle=1 flags=N db=0 sub=0 psub=0 multi=-1 qbuf=0 qbuf-free=0 argv-mem=0 obl=0 oll=0 omem=0 tot-mem=20496 events=r cmd=ping user=default redir=-1
```