### PR TITLE
chore: disable verifying golangci configuration

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,3 +22,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6.5.2
+        with:
+          verify: false # disable verifying the configuration since golangci is currently introducing breaking changes in the configuration 
+


### PR DESCRIPTION
`golangci` introduced `version` as a required field in the configuration jsonschema as they just had a major release (https://ldez.github.io/blog/2025/03/23/golangci-lint-v2/). 
The latest jsonshema was picked up by the github action we are using and the config verification failed. 
Skipping the verification of the configuration for now before they release new major version of the github action as well. 