### PR TITLE
Handle invalidate messages from topic __redis__:invalidate

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -409,6 +409,16 @@ func (c *PubSub) newMessage(reply interface{}) (interface{}, error) {
 			return &Pong{
 				Payload: reply[1].(string),
 			}, nil
+		case "invalidate":
+			payload := reply[1].([]interface{})
+			ss := make([]string, len(payload))
+			for i, s := range payload {
+				ss[i] = s.(string)
+			}
+			return &Message{
+				Channel:      "__redis__:invalidate",
+				PayloadSlice: ss,
+			}, nil
 		default:
 			return nil, fmt.Errorf("redis: unsupported pubsub message: %q", kind)
 		}


### PR DESCRIPTION
This pull request handles the "invalidate" messages sent by redis when enabling CLIENT TRACKING and subscribing to topic "\_\_redis\_\_:invalidate" topic.
The invalidated keys are sent on the PayloadSlice field of the redis.Message struct.