### PR TITLE
Use correct slot for COUNTKEYSINSLOT command

### DIFF
--- a/internal_test.go
+++ b/internal_test.go
@@ -352,3 +352,27 @@ var _ = Describe("withConn", func() {
 		Expect(client.connPool.Len()).To(Equal(1))
 	})
 })
+
+var _ = Describe("ClusterClient", func() {
+	var client *ClusterClient
+
+	BeforeEach(func() {
+		client = &ClusterClient{}
+	})
+
+	Describe("cmdSlot", func() {
+		It("select slot from args for GETKEYSINSLOT command", func() {
+			cmd := NewStringSliceCmd(ctx, "cluster", "getkeysinslot", 100, 200)
+
+			slot := client.cmdSlot(context.Background(), cmd)
+			Expect(slot).To(Equal(100))
+		})
+
+		It("select slot from args for COUNTKEYSINSLOT command", func() {
+			cmd := NewStringSliceCmd(ctx, "cluster", "countkeysinslot", 100)
+
+			slot := client.cmdSlot(context.Background(), cmd)
+			Expect(slot).To(Equal(100))
+		})
+	})
+})

--- a/osscluster.go
+++ b/osscluster.go
@@ -1856,7 +1856,7 @@ func (c *ClusterClient) cmdInfo(ctx context.Context, name string) *CommandInfo {
 
 func (c *ClusterClient) cmdSlot(ctx context.Context, cmd Cmder) int {
 	args := cmd.Args()
-	if args[0] == "cluster" && args[1] == "getkeysinslot" {
+	if args[0] == "cluster" && (args[1] == "getkeysinslot" || args[1] == "countkeysinslot") {
 		return args[2].(int)
 	}
 


### PR DESCRIPTION
Added selection of the correct slot for the CLUSTER COUNTKEYSINSLOT command based on the argument.
This allows to make a request for the number of keys in a slot not for all shards, but for the necessary one.