### PR TITLE
Test agains Redis 8.0-RC1

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -25,7 +25,7 @@ runs:
         
         # Mapping of redis version to redis testing containers
         declare -A redis_version_mapping=(
-          ["8.0-M05"]="8.0-M05-pre"
+          ["8.0-RC1"]="8.0-RC1-pre"
           ["7.4.2"]="rs-7.4.0-v2"
           ["7.2.7"]="rs-7.2.0-v14"
         )

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         redis-version:
-          - "8.0-M05" # 8.0 milestone 5
+          - "8.0-RC1" # 8.0 RC1
           - "7.4.2" # should use redis stack 7.4
         go-version:
           - "1.23.x"
@@ -43,7 +43,7 @@ jobs:
           
           # Mapping of redis version to redis testing containers
           declare -A redis_version_mapping=(
-            ["8.0-M05"]="8.0-M05-pre"
+            ["8.0-RC1"]="8.0-RC1-pre"
             ["7.4.2"]="rs-7.4.0-v2"
           )
           if [[ -v redis_version_mapping[$REDIS_VERSION] ]]; then
@@ -72,7 +72,7 @@ jobs:
         fail-fast: false
         matrix:
           redis-version:
-            - "8.0-M05" # 8.0 milestone 5
+            - "8.0-RC1" # 8.0 RC1
             - "7.4.2" # should use redis stack 7.4
             - "7.2.7" # should redis stack 7.2
           go-version:

--- a/search_test.go
+++ b/search_test.go
@@ -381,7 +381,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	// up until redis 8 the default scorer was TFIDF, in redis 8 it is BM25
 	// this test expect redis major version >= 8
 	It("should FTSearch WithScores", Label("search", "ftsearch"), func() {
-		SkipBeforeRedisVersion(7.9, "default scorer is not BM25")
+		SkipBeforeRedisVersion(7.9, "default scorer is not BM25STD")
 
 		text1 := &redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText}
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1).Result()


### PR DESCRIPTION
- Update docker mappings to use the `RC1-pre` image for Redis 8 CE 