### PR TITLE
Ensure context isn't exhausted via concurrent query as opposed to sentinel query

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -570,44 +570,32 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 		masterAddr string
 		wg         sync.WaitGroup
 		once       sync.Once
-		done       = make(chan struct{})
 	)
 
 	for i, sentinelAddr := range c.sentinelAddrs {
 		wg.Add(1)
 		go func(i int, addr string) {
 			defer wg.Done()
-			select {
-			case <-done:
+			sentinelCli := NewSentinelClient(c.opt.sentinelOptions(addr))
+			addrVal, err := sentinelCli.GetMasterAddrByName(ctx, c.opt.MasterName).Result()
+			if err != nil {
+				internal.Logger.Printf(ctx, "sentinel: GetMasterAddrByName addr=%s, master=%q failed: %s",
+					addr, c.opt.MasterName, err)
+				_ = sentinelCli.Close()
 				return
-			default:
-				sentinelCli := NewSentinelClient(c.opt.sentinelOptions(addr))
-				addrVal, err := sentinelCli.GetMasterAddrByName(ctx, c.opt.MasterName).Result()
-				if err != nil {
-					internal.Logger.Printf(ctx, "sentinel: GetMasterAddrByName addr=%s, master=%q failed: %s",
-						addr, c.opt.MasterName, err)
-					_ = sentinelCli.Close()
-					return
-				}
-
-				once.Do(func() {
-					masterAddr = net.JoinHostPort(addrVal[0], addrVal[1])
-					// Push working sentinel to the top
-					c.sentinelAddrs[0], c.sentinelAddrs[i] = c.sentinelAddrs[i], c.sentinelAddrs[0]
-					c.setSentinel(ctx, sentinelCli)
-					internal.Logger.Printf(ctx, "sentinel: selected addr=%s masterAddr=%s", addr, masterAddr)
-					close(done)
-				})
 			}
+
+			once.Do(func() {
+				masterAddr = net.JoinHostPort(addrVal[0], addrVal[1])
+				// Push working sentinel to the top
+				c.sentinelAddrs[0], c.sentinelAddrs[i] = c.sentinelAddrs[i], c.sentinelAddrs[0]
+				c.setSentinel(ctx, sentinelCli)
+				internal.Logger.Printf(ctx, "sentinel: selected addr=%s masterAddr=%s", addr, masterAddr)
+			})
 		}(i, sentinelAddr)
 	}
 
-	go func() {
-		wg.Wait()
-		once.Do(func() { close(done) })
-	}()
-
-	<-done
+	wg.Wait()
 
 	if masterAddr != "" {
 		return masterAddr, nil

--- a/sentinel.go
+++ b/sentinel.go
@@ -540,7 +540,6 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return "", err
 			}
-			// Continue on other errors
 			internal.Logger.Printf(ctx, "sentinel: GetMasterAddrByName name=%q failed: %s",
 				c.opt.MasterName, err)
 		} else {
@@ -558,7 +557,6 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return "", err
 			}
-			// Continue on other errors
 			internal.Logger.Printf(ctx, "sentinel: GetMasterAddrByName name=%q failed: %s",
 				c.opt.MasterName, err)
 		} else {
@@ -566,28 +564,52 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 		}
 	}
 
+	var (
+		masterAddr string
+		wg         sync.WaitGroup
+		once       sync.Once
+		done       = make(chan struct{})
+	)
+
 	for i, sentinelAddr := range c.sentinelAddrs {
-		sentinel := NewSentinelClient(c.opt.sentinelOptions(sentinelAddr))
+		wg.Add(1)
+		go func(i int, addr string) {
+			defer wg.Done()
+			select {
+			case <-done:
+				return
+			default:
+				sentinelCli := NewSentinelClient(c.opt.sentinelOptions(addr))
+				addrVal, err := sentinelCli.GetMasterAddrByName(ctx, c.opt.MasterName).Result()
+				if err != nil {
+					internal.Logger.Printf(ctx, "sentinel: GetMasterAddrByName addr=%s, master=%q failed: %s",
+						addr, c.opt.MasterName, err)
+					_ = sentinelCli.Close()
+					return
+				}
 
-		masterAddr, err := sentinel.GetMasterAddrByName(ctx, c.opt.MasterName).Result()
-		if err != nil {
-			_ = sentinel.Close()
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return "", err
+				once.Do(func() {
+					masterAddr = net.JoinHostPort(addrVal[0], addrVal[1])
+					// Push working sentinel to the top
+					c.sentinelAddrs[0], c.sentinelAddrs[i] = c.sentinelAddrs[i], c.sentinelAddrs[0]
+					c.setSentinel(ctx, sentinelCli)
+					internal.Logger.Printf(ctx, "sentinel: selected addr=%s masterAddr=%s", addr, masterAddr)
+					close(done)
+				})
 			}
-			internal.Logger.Printf(ctx, "sentinel: GetMasterAddrByName master=%q failed: %s",
-				c.opt.MasterName, err)
-			continue
-		}
-
-		// Push working sentinel to the top.
-		c.sentinelAddrs[0], c.sentinelAddrs[i] = c.sentinelAddrs[i], c.sentinelAddrs[0]
-		c.setSentinel(ctx, sentinel)
-
-		addr := net.JoinHostPort(masterAddr[0], masterAddr[1])
-		return addr, nil
+		}(i, sentinelAddr)
 	}
 
+	go func() {
+		wg.Wait()
+		once.Do(func() { close(done) })
+	}()
+
+	<-done
+
+	if masterAddr != "" {
+		return masterAddr, nil
+	}
 	return "", errors.New("redis: all sentinels specified in configuration are unreachable")
 }
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -540,6 +540,7 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return "", err
 			}
+			// Continue on other errors
 			internal.Logger.Printf(ctx, "sentinel: GetMasterAddrByName name=%q failed: %s",
 				c.opt.MasterName, err)
 		} else {
@@ -557,6 +558,7 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				return "", err
 			}
+			// Continue on other errors
 			internal.Logger.Printf(ctx, "sentinel: GetMasterAddrByName name=%q failed: %s",
 				c.opt.MasterName, err)
 		} else {

--- a/sentinel.go
+++ b/sentinel.go
@@ -573,6 +573,9 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 		errCh      = make(chan error, len(c.sentinelAddrs))
 	)
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	for i, sentinelAddr := range c.sentinelAddrs {
 		wg.Add(1)
 		go func(i int, addr string) {
@@ -597,6 +600,7 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 				c.sentinelAddrs[0], c.sentinelAddrs[i] = c.sentinelAddrs[i], c.sentinelAddrs[0]
 				c.setSentinel(ctx, sentinelCli)
 				internal.Logger.Printf(ctx, "sentinel: selected addr=%s masterAddr=%s", addr, masterAddr)
+				cancel()
 			})
 		}(i, sentinelAddr)
 	}

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -32,6 +32,24 @@ var _ = Describe("Sentinel PROTO 2", func() {
 	})
 })
 
+var _ = Describe("Sentinel resolution", func() {
+	It("should resolve master without context exhaustion", func() {
+		shortCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+
+		client := redis.NewFailoverClient(&redis.FailoverOptions{
+			MasterName:    sentinelName,
+			SentinelAddrs: sentinelAddrs,
+			MaxRetries: -1,
+		})
+
+		err := client.Ping(shortCtx).Err()
+		Expect(err).NotTo(HaveOccurred(), "expected master to resolve without context exhaustion")
+
+		_ = client.Close()
+	})
+})
+
 var _ = Describe("Sentinel", func() {
 	var client *redis.Client
 	var master *redis.Client

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -3,6 +3,7 @@ package redis_test
 import (
 	"context"
 	"net"
+	"time"
 
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"


### PR DESCRIPTION
Switch from sequential sentinel query to concurrent query to avoid context exhaustion and connect to new master redis after redis failover