### PR TITLE
Fix FT.Search Limit argument and add CountOnly argument for limit 0 0

### DIFF
--- a/search_commands.go
+++ b/search_commands.go
@@ -320,6 +320,7 @@ type FTSearchOptions struct {
 	SortByWithCount bool
 	LimitOffset     int
 	Limit           int
+	CountOnly       bool
 	Params          map[string]interface{}
 	DialectVersion  int
 }
@@ -1954,8 +1955,12 @@ func (c cmdable) FTSearchWithArgs(ctx context.Context, index string, query strin
 				args = append(args, "WITHCOUNT")
 			}
 		}
-		if options.LimitOffset >= 0 && options.Limit > 0 {
-			args = append(args, "LIMIT", options.LimitOffset, options.Limit)
+		if options.CountOnly {
+			args = append(args, "LIMIT", 0, 0)
+		} else {
+			if options.LimitOffset >= 0 && options.Limit > 0 || options.LimitOffset > 0 && options.Limit == 0 {
+				args = append(args, "LIMIT", options.LimitOffset, options.Limit)
+			}
 		}
 		if options.Params != nil {
 			args = append(args, "PARAMS", len(options.Params)*2)

--- a/search_commands.go
+++ b/search_commands.go
@@ -320,7 +320,7 @@ type FTSearchOptions struct {
 	SortByWithCount bool
 	LimitOffset     int
 	Limit           int
-	// You can use LIMIT 0 0 to count the number of documents in the result set without actually returning them.
+	// CountOnly sets LIMIT 0 0 to get the count - number of documents in the result set without actually returning the result set.
 	// When using this option, the Limit and LimitOffset options are ignored.
 	CountOnly      bool
 	Params         map[string]interface{}

--- a/search_commands.go
+++ b/search_commands.go
@@ -320,9 +320,11 @@ type FTSearchOptions struct {
 	SortByWithCount bool
 	LimitOffset     int
 	Limit           int
-	CountOnly       bool
-	Params          map[string]interface{}
-	DialectVersion  int
+	// You can use LIMIT 0 0 to count the number of documents in the result set without actually returning them.
+	// When using this option, the Limit and LimitOffset options are ignored.
+	CountOnly      bool
+	Params         map[string]interface{}
+	DialectVersion int
 }
 
 type FTSynDumpResult struct {

--- a/search_test.go
+++ b/search_test.go
@@ -1683,6 +1683,44 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(resUint8.Docs[0].ID).To(BeEquivalentTo("doc1"))
 	})
 
+	It("should test ft.search with CountOnly param", Label("search", "ftsearch"), func() {
+		val, err := client.FTCreate(ctx, "txtIndex", &redis.FTCreateOptions{},
+			&redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText},
+		).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(val).To(BeEquivalentTo("OK"))
+		WaitForIndexing(client, "txtIndex")
+
+		_, err = client.HSet(ctx, "doc1", "txt", "hello world").Result()
+		Expect(err).NotTo(HaveOccurred())
+		_, err = client.HSet(ctx, "doc2", "txt", "hello go").Result()
+		Expect(err).NotTo(HaveOccurred())
+		_, err = client.HSet(ctx, "doc3", "txt", "hello redis").Result()
+		Expect(err).NotTo(HaveOccurred())
+
+		optsCountOnly := &redis.FTSearchOptions{
+			CountOnly:      true,
+			LimitOffset:    0,
+			Limit:          2, // even though we limit to 2, with count-only no docs are returned
+			DialectVersion: 2,
+		}
+		resCountOnly, err := client.FTSearchWithArgs(ctx, "txtIndex", "hello", optsCountOnly).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resCountOnly.Total).To(BeEquivalentTo(3))
+		Expect(len(resCountOnly.Docs)).To(BeEquivalentTo(0))
+
+		optsLimit := &redis.FTSearchOptions{
+			CountOnly:      false,
+			LimitOffset:    0,
+			Limit:          2, // we expect to get 2 documents even though total count is 3
+			DialectVersion: 2,
+		}
+		resLimit, err := client.FTSearchWithArgs(ctx, "txtIndex", "hello", optsLimit).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resLimit.Total).To(BeEquivalentTo(3))
+		Expect(len(resLimit.Docs)).To(BeEquivalentTo(2))
+	})
+
 })
 
 func _assert_geosearch_result(result *redis.FTSearchResult, expectedDocIDs []string) {


### PR DESCRIPTION
Adding a new boolean flag, CountOnly, to the FTSearchOptions struct to decouple count-only behavior from the default limit parameters.
Previously, it wasn't possible to input 0 0 for LimitOffset and Limit  Now, with the CountOnly flag, users can explicitly signal a count-only query.
When CountOnly is set to true, the FT.SEARCH command builder appends LIMIT 0 0, ensuring that only the total count of matching documents is returned. When CountOnly is false, the provided LimitOffset and Limit values are used as usual. 