### PR TITLE
fix: better error handling when fetching the master node from the sentinels

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -605,11 +605,11 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 	if masterAddr != "" {
 		return masterAddr, nil
 	}
-	errs := make([]error, len(c.sentinelAddrs))
+	errs := make([]error, 0, len(c.sentinelAddrs))
 	for err := range errCh {
 		errs = append(errs, err)
 	}
-	return "", fmt.Errorf("redis: all sentinels specified in configuration are unreachable: %w", errs)
+	return "", fmt.Errorf("redis: all sentinels specified in configuration are unreachable: %w", errors.Join(errs...))
 }
 
 func (c *sentinelFailover) replicaAddrs(ctx context.Context, useDisconnected bool) ([]string, error) {

--- a/sentinel.go
+++ b/sentinel.go
@@ -606,7 +606,7 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 	if masterAddr != "" {
 		return masterAddr, nil
 	}
-	errs := make([]error, 0, len(c.sentinelAddrs))
+	errs := make([]error, 0, len(errCh))
 	for err := range errCh {
 		errs = append(errs, err)
 	}

--- a/sentinel.go
+++ b/sentinel.go
@@ -602,6 +602,7 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 	}
 
 	wg.Wait()
+	close(errCh)
 	if masterAddr != "" {
 		return masterAddr, nil
 	}


### PR DESCRIPTION
- Make sure all sentinel errors are reported if the `masterAddr` was not resolved.
- Resolving the `masterAddr` concurrently may result in read from `errCh` before read from `done` => first check if the `masterAddr` was resolved, and then proceed to report errors.  