### PR TITLE
Check for handling errors before returning when querying the sentinel to get the master address.

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -618,6 +618,9 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 		}
 		return "", errors.New("redis: all sentinels specified in configuration are unreachable")
 	case err := <-errCh:
+		if masterAddr != "" {
+			return masterAddr, nil
+		}
 		return "", err
 	}
 }


### PR DESCRIPTION
fix:  https://github.com/redis/go-redis/issues/3172

Supplement the checks for this modification: https://github.com/redis/go-redis/pull/3334