### PR TITLE
fix: Fix panic caused when arg is nil

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -81,6 +81,8 @@ func appendArg(dst []interface{}, arg interface{}) []interface{} {
 		return dst
 	case time.Time, time.Duration, encoding.BinaryMarshaler, net.IP:
 		return append(dst, arg)
+	case nil:
+		return dst
 	default:
 		// scan struct field
 		v := reflect.ValueOf(arg)


### PR DESCRIPTION
script := `return redis.call('get', KEYS[1])`
keys := []string{"key"}
// When the args parameter is set to nil, it will cause a program panic
// As with the modified appendArg function, when entering the default branch and arg is nil, this code will cause pain
// painc: reflect: call of re reflect.Value.Type on zero Value
// if v.Type().Kind() == reflect.Ptr 
vals, err := rdb.Eval(ctx, script, keys, nil).Result()
if err != nil {
    panic(err)
}
fmt.Println("vals", vals)