### PR TITLE
DOC-5111 added hash search examples

### DIFF
--- a/doctests/home_json_example_test.go
+++ b/doctests/home_json_example_test.go
@@ -227,3 +227,107 @@ func ExampleClient_search_json() {
 	// London - 1
 	// Tel Aviv - 2
 }
+
+func ExampleClient_search_hash() {
+	ctx := context.Background()
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password docs
+		DB:       0,  // use default DB
+		Protocol: 2,
+	})
+
+	// REMOVE_START
+	rdb.Del(ctx, "huser:1", "huser:2", "huser:3")
+	rdb.FTDropIndex(ctx, "hash-idx:users")
+	// REMOVE_END
+
+	// STEP_START make_hash_index
+	_, err := rdb.FTCreate(
+		ctx,
+		"hash-idx:users",
+		// Options:
+		&redis.FTCreateOptions{
+			OnHash: true,
+			Prefix: []interface{}{"huser:"},
+		},
+		// Index schema fields:
+		&redis.FieldSchema{
+			FieldName: "name",
+			FieldType: redis.SearchFieldTypeText,
+		},
+		&redis.FieldSchema{
+			FieldName: "city",
+			FieldType: redis.SearchFieldTypeTag,
+		},
+		&redis.FieldSchema{
+			FieldName: "age",
+			FieldType: redis.SearchFieldTypeNumeric,
+		},
+	).Result()
+
+	if err != nil {
+		panic(err)
+	}
+	// STEP_END
+
+	user1 := map[string]interface{}{
+		"name":  "Paul John",
+		"email": "paul.john@example.com",
+		"age":   42,
+		"city":  "London",
+	}
+
+	user2 := map[string]interface{}{
+		"name":  "Eden Zamir",
+		"email": "eden.zamir@example.com",
+		"age":   29,
+		"city":  "Tel Aviv",
+	}
+
+	user3 := map[string]interface{}{
+		"name":  "Paul Zamir",
+		"email": "paul.zamir@example.com",
+		"age":   35,
+		"city":  "Tel Aviv",
+	}
+
+	// STEP_START add_hash_data
+	_, err = rdb.HSet(ctx, "huser:1", user1).Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = rdb.HSet(ctx, "huser:2", user2).Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = rdb.HSet(ctx, "huser:3", user3).Result()
+
+	if err != nil {
+		panic(err)
+	}
+	// STEP_END
+
+	// STEP_START query1_hash
+	findPaulHashResult, err := rdb.FTSearch(
+		ctx,
+		"hash-idx:users",
+		"Paul @age:[30 40]",
+	).Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(findPaulHashResult)
+	// >>> {1 [{huser:3 <nil> <nil> <nil> map[age:35 city:Tel Aviv...
+	// STEP_END
+
+	// Output:
+	// {1 [{huser:3 <nil> <nil> <nil> map[age:35 city:Tel Aviv email:paul.zamir@example.com name:Paul Zamir]}]}
+}


### PR DESCRIPTION
[DOC-5111](https://redislabs.atlassian.net/browse/DOC-5111)

This is to extend the examples in [this page](https://redis.io/docs/latest/develop/clients/go/queryjson/) to include hash search. The text of the page will also be reworked a bit to explain the differences with hashes.

[DOC-5111]: https://redislabs.atlassian.net/browse/DOC-5111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ