### PR TITLE
Fix: Prevent routing reads to Redis slave nodes in loading state

### DIFF
--- a/osscluster.go
+++ b/osscluster.go
@@ -445,6 +445,14 @@ func (n *clusterNode) SetLastLatencyMeasurement(t time.Time) {
 	}
 }
 
+func (n *clusterNode) Loading() bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := n.Client.Ping(ctx).Err()
+	return err != nil && isLoadingError(err)
+}
+
 //------------------------------------------------------------------------------
 
 type clusterNodes struct {
@@ -754,7 +762,8 @@ func (c *clusterState) slotSlaveNode(slot int) (*clusterNode, error) {
 	case 1:
 		return nodes[0], nil
 	case 2:
-		if slave := nodes[1]; !slave.Failing() {
+		slave := nodes[1]
+		if !slave.Failing() && !slave.Loading() {
 			return slave, nil
 		}
 		return nodes[0], nil
@@ -763,7 +772,7 @@ func (c *clusterState) slotSlaveNode(slot int) (*clusterNode, error) {
 		for i := 0; i < 10; i++ {
 			n := rand.Intn(len(nodes)-1) + 1
 			slave = nodes[n]
-			if !slave.Failing() {
+			if !slave.Failing() && !slave.Loading() {
 				return slave, nil
 			}
 		}


### PR DESCRIPTION
## Problem

When a new slave node is added to a Redis cluster, it enters a loading state while it synchronizes data from its master. If the client has `ReadOnly=true` enabled, it may route read operations to this loading slave node, which can result in nil values or errors being returned to the application.
closes #3222 

## Solution

This PR adds logic to detect when a slave node is in the loading state (by checking for LOADING errors) and temporarily excludes such nodes from the read distribution until they're ready to serve requests.