### PR TITLE
Export connection pool errors for public consumption

### DIFF
--- a/error.go
+++ b/error.go
@@ -15,6 +15,13 @@ import (
 // ErrClosed performs any operation on the closed client will return this error.
 var ErrClosed = pool.ErrClosed
 
+// ErrPoolExhausted is returned from a pool connection method
+// when the maximum number of database connections in the pool has been reached.
+var ErrPoolExhausted = pool.ErrPoolExhausted
+
+// ErrPoolTimeout timed out waiting to get a connection from the connection pool.
+var ErrPoolTimeout = pool.ErrPoolTimeout
+
 // HasErrorPrefix checks if the err is a Redis error and the message contains a prefix.
 func HasErrorPrefix(err error, prefix string) bool {
 	var rErr Error

--- a/export_test.go
+++ b/export_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/redis/go-redis/v9/internal/pool"
 )
 
-var ErrPoolTimeout = pool.ErrPoolTimeout
-
 func (c *baseClient) Pool() pool.Pooler {
 	return c.connPool
 }


### PR DESCRIPTION
The `internal/pool` package has some structured errors:

* `ErrClosed`
* `ErrPoolExhausted`
* `ErrPoolTimeout`

These errors may be propagated to the callsites of top-level commands on the connection. Exposing these errors in the public package layer makes it much easier for external code to detect and classify these errors, e.g. as:

```go
err := ...
if errors.Is(err, redis.ErrPoolTimeout) {
    ...
}
```

This change proposes re-exporting the remaining `ErrPool*` errors, adding to `ErrClosed` which is already re-exported.

See also: #3381