### PR TITLE
rewrite interface{} to any

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ For example:
 		"idx:bicycle",
 		"@pickup_zone:[CONTAINS $bike]",
 		&redis.FTSearchOptions{
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"bike": "POINT(-0.1278 51.5074)",
 			},
 			DialectVersion: 3,

--- a/acl_commands.go
+++ b/acl_commands.go
@@ -3,7 +3,7 @@ package redis
 import "context"
 
 type ACLCmdable interface {
-	ACLDryRun(ctx context.Context, username string, command ...interface{}) *StringCmd
+	ACLDryRun(ctx context.Context, username string, command ...any) *StringCmd
 
 	ACLLog(ctx context.Context, count int64) *ACLLogCmd
 	ACLLogReset(ctx context.Context) *StatusCmd
@@ -20,8 +20,8 @@ type ACLCatArgs struct {
 	Category string
 }
 
-func (c cmdable) ACLDryRun(ctx context.Context, username string, command ...interface{}) *StringCmd {
-	args := make([]interface{}, 0, 3+len(command))
+func (c cmdable) ACLDryRun(ctx context.Context, username string, command ...any) *StringCmd {
+	args := make([]any, 0, 3+len(command))
 	args = append(args, "acl", "dryrun", username)
 	args = append(args, command...)
 	cmd := NewStringCmd(ctx, args...)
@@ -30,7 +30,7 @@ func (c cmdable) ACLDryRun(ctx context.Context, username string, command ...inte
 }
 
 func (c cmdable) ACLLog(ctx context.Context, count int64) *ACLLogCmd {
-	args := make([]interface{}, 0, 3)
+	args := make([]any, 0, 3)
 	args = append(args, "acl", "log")
 	if count > 0 {
 		args = append(args, count)
@@ -53,7 +53,7 @@ func (c cmdable) ACLDelUser(ctx context.Context, username string) *IntCmd {
 }
 
 func (c cmdable) ACLSetUser(ctx context.Context, username string, rules ...string) *StatusCmd {
-	args := make([]interface{}, 3+len(rules))
+	args := make([]any, 3+len(rules))
 	args[0] = "acl"
 	args[1] = "setuser"
 	args[2] = username

--- a/acl_commands_test.go
+++ b/acl_commands_test.go
@@ -430,7 +430,7 @@ var _ = Describe("ACL Categories", func() {
 			"tdigest":    "tdigest.rank",
 			"timeseries": "ts.range",
 		}
-		var cats []interface{}
+		var cats []any
 
 		for cat, subitem := range aclTestCase {
 			cats = append(cats, cat)

--- a/bench_decode_test.go
+++ b/bench_decode_test.go
@@ -219,7 +219,7 @@ func respString(b *testing.B, stub ClientStubFunc) {
 
 func respArray(b *testing.B, stub ClientStubFunc) {
 	rdb := stub([]byte("*3\r\n$5\r\nhello\r\n:10\r\n+OK\r\n"))
-	var val []interface{}
+	var val []any
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/bitmap_commands.go
+++ b/bitmap_commands.go
@@ -15,8 +15,8 @@ type BitMapCmdable interface {
 	BitOpNot(ctx context.Context, destKey string, key string) *IntCmd
 	BitPos(ctx context.Context, key string, bit int64, pos ...int64) *IntCmd
 	BitPosSpan(ctx context.Context, key string, bit int8, start, end int64, span string) *IntCmd
-	BitField(ctx context.Context, key string, values ...interface{}) *IntSliceCmd
-	BitFieldRO(ctx context.Context, key string, values ...interface{}) *IntSliceCmd
+	BitField(ctx context.Context, key string, values ...any) *IntSliceCmd
+	BitFieldRO(ctx context.Context, key string, values ...any) *IntSliceCmd
 }
 
 func (c cmdable) GetBit(ctx context.Context, key string, offset int64) *IntCmd {
@@ -66,7 +66,7 @@ func (c cmdable) BitCount(ctx context.Context, key string, bitCount *BitCount) *
 }
 
 func (c cmdable) bitOp(ctx context.Context, op, destKey string, keys ...string) *IntCmd {
-	args := make([]interface{}, 3+len(keys))
+	args := make([]any, 3+len(keys))
 	args[0] = "bitop"
 	args[1] = op
 	args[2] = destKey
@@ -97,7 +97,7 @@ func (c cmdable) BitOpNot(ctx context.Context, destKey string, key string) *IntC
 // BitPos is an API before Redis version 7.0, cmd: bitpos key bit start end
 // if you need the `byte | bit` parameter, please use `BitPosSpan`.
 func (c cmdable) BitPos(ctx context.Context, key string, bit int64, pos ...int64) *IntCmd {
-	args := make([]interface{}, 3+len(pos))
+	args := make([]any, 3+len(pos))
 	args[0] = "bitpos"
 	args[1] = key
 	args[2] = bit
@@ -131,9 +131,9 @@ func (c cmdable) BitPosSpan(ctx context.Context, key string, bit int8, start, en
 // BitField accepts multiple values:
 //   - BitField("set", "i1", "offset1", "value1","cmd2", "type2", "offset2", "value2")
 //   - BitField([]string{"cmd1", "type1", "offset1", "value1","cmd2", "type2", "offset2", "value2"})
-//   - BitField([]interface{}{"cmd1", "type1", "offset1", "value1","cmd2", "type2", "offset2", "value2"})
-func (c cmdable) BitField(ctx context.Context, key string, values ...interface{}) *IntSliceCmd {
-	args := make([]interface{}, 2, 2+len(values))
+//   - BitField([]any{"cmd1", "type1", "offset1", "value1","cmd2", "type2", "offset2", "value2"})
+func (c cmdable) BitField(ctx context.Context, key string, values ...any) *IntSliceCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "bitfield"
 	args[1] = key
 	args = appendArgs(args, values)
@@ -145,8 +145,8 @@ func (c cmdable) BitField(ctx context.Context, key string, values ...interface{}
 // BitFieldRO - Read-only variant of the BITFIELD command.
 // It is like the original BITFIELD but only accepts GET subcommand and can safely be used in read-only replicas.
 // - BitFieldRO(ctx, key, "<Encoding0>", "<Offset0>", "<Encoding1>","<Offset1>")
-func (c cmdable) BitFieldRO(ctx context.Context, key string, values ...interface{}) *IntSliceCmd {
-	args := make([]interface{}, 2, 2+len(values))
+func (c cmdable) BitFieldRO(ctx context.Context, key string, values ...any) *IntSliceCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "BITFIELD_RO"
 	args[1] = key
 	if len(values)%2 != 0 {

--- a/cluster_commands.go
+++ b/cluster_commands.go
@@ -127,7 +127,7 @@ func (c cmdable) ClusterCountKeysInSlot(ctx context.Context, slot int) *IntCmd {
 }
 
 func (c cmdable) ClusterDelSlots(ctx context.Context, slots ...int) *StatusCmd {
-	args := make([]interface{}, 2+len(slots))
+	args := make([]any, 2+len(slots))
 	args[0] = "cluster"
 	args[1] = "delslots"
 	for i, slot := range slots {
@@ -166,7 +166,7 @@ func (c cmdable) ClusterFailover(ctx context.Context) *StatusCmd {
 }
 
 func (c cmdable) ClusterAddSlots(ctx context.Context, slots ...int) *StatusCmd {
-	args := make([]interface{}, 2+len(slots))
+	args := make([]any, 2+len(slots))
 	args[0] = "cluster"
 	args[1] = "addslots"
 	for i, num := range slots {

--- a/command.go
+++ b/command.go
@@ -28,7 +28,7 @@ type Cmder interface {
 
 	// all args of the command.
 	// e.g. "set k v ex 10" -> "[set k v ex 10]".
-	Args() []interface{}
+	Args() []any
 
 	// format request and response string.
 	// e.g. "set k v ex 10" -> "set k v ex 10: OK", "get k" -> "get k: v".
@@ -98,7 +98,7 @@ func cmdFirstKeyPos(cmd Cmder) int {
 	return 1
 }
 
-func cmdString(cmd Cmder, val interface{}) string {
+func cmdString(cmd Cmder, val any) string {
 	b := make([]byte, 0, 64)
 
 	for i, arg := range cmd.Args() {
@@ -123,10 +123,10 @@ func cmdString(cmd Cmder, val interface{}) string {
 
 type baseCmd struct {
 	ctx          context.Context
-	args         []interface{}
+	args         []any
 	err          error
 	keyPos       int8
-	rawVal       interface{}
+	rawVal       any
 	_readTimeout *time.Duration
 }
 
@@ -155,7 +155,7 @@ func (cmd *baseCmd) FullName() string {
 	}
 }
 
-func (cmd *baseCmd) Args() []interface{} {
+func (cmd *baseCmd) Args() []any {
 	return cmd.args
 }
 
@@ -209,10 +209,10 @@ func (cmd *baseCmd) readRawReply(rd *proto.Reader) (err error) {
 type Cmd struct {
 	baseCmd
 
-	val interface{}
+	val any
 }
 
-func NewCmd(ctx context.Context, args ...interface{}) *Cmd {
+func NewCmd(ctx context.Context, args ...any) *Cmd {
 	return &Cmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -225,15 +225,15 @@ func (cmd *Cmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
-func (cmd *Cmd) SetVal(val interface{}) {
+func (cmd *Cmd) SetVal(val any) {
 	cmd.val = val
 }
 
-func (cmd *Cmd) Val() interface{} {
+func (cmd *Cmd) Val() any {
 	return cmd.val
 }
 
-func (cmd *Cmd) Result() (interface{}, error) {
+func (cmd *Cmd) Result() (any, error) {
 	return cmd.val, cmd.err
 }
 
@@ -244,7 +244,7 @@ func (cmd *Cmd) Text() (string, error) {
 	return toString(cmd.val)
 }
 
-func toString(val interface{}) (string, error) {
+func toString(val any) (string, error) {
 	switch val := val.(type) {
 	case string:
 		return val, nil
@@ -276,7 +276,7 @@ func (cmd *Cmd) Int64() (int64, error) {
 	return toInt64(cmd.val)
 }
 
-func toInt64(val interface{}) (int64, error) {
+func toInt64(val any) (int64, error) {
 	switch val := val.(type) {
 	case int64:
 		return val, nil
@@ -295,7 +295,7 @@ func (cmd *Cmd) Uint64() (uint64, error) {
 	return toUint64(cmd.val)
 }
 
-func toUint64(val interface{}) (uint64, error) {
+func toUint64(val any) (uint64, error) {
 	switch val := val.(type) {
 	case int64:
 		return uint64(val), nil
@@ -314,7 +314,7 @@ func (cmd *Cmd) Float32() (float32, error) {
 	return toFloat32(cmd.val)
 }
 
-func toFloat32(val interface{}) (float32, error) {
+func toFloat32(val any) (float32, error) {
 	switch val := val.(type) {
 	case int64:
 		return float32(val), nil
@@ -337,7 +337,7 @@ func (cmd *Cmd) Float64() (float64, error) {
 	return toFloat64(cmd.val)
 }
 
-func toFloat64(val interface{}) (float64, error) {
+func toFloat64(val any) (float64, error) {
 	switch val := val.(type) {
 	case int64:
 		return float64(val), nil
@@ -356,7 +356,7 @@ func (cmd *Cmd) Bool() (bool, error) {
 	return toBool(cmd.val)
 }
 
-func toBool(val interface{}) (bool, error) {
+func toBool(val any) (bool, error) {
 	switch val := val.(type) {
 	case bool:
 		return val, nil
@@ -370,12 +370,12 @@ func toBool(val interface{}) (bool, error) {
 	}
 }
 
-func (cmd *Cmd) Slice() ([]interface{}, error) {
+func (cmd *Cmd) Slice() ([]any, error) {
 	if cmd.err != nil {
 		return nil, cmd.err
 	}
 	switch val := cmd.val.(type) {
-	case []interface{}:
+	case []any:
 		return val, nil
 	default:
 		return nil, fmt.Errorf("redis: unexpected type=%T for Slice", val)
@@ -494,12 +494,12 @@ func (cmd *Cmd) readReply(rd *proto.Reader) (err error) {
 type SliceCmd struct {
 	baseCmd
 
-	val []interface{}
+	val []any
 }
 
 var _ Cmder = (*SliceCmd)(nil)
 
-func NewSliceCmd(ctx context.Context, args ...interface{}) *SliceCmd {
+func NewSliceCmd(ctx context.Context, args ...any) *SliceCmd {
 	return &SliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -508,15 +508,15 @@ func NewSliceCmd(ctx context.Context, args ...interface{}) *SliceCmd {
 	}
 }
 
-func (cmd *SliceCmd) SetVal(val []interface{}) {
+func (cmd *SliceCmd) SetVal(val []any) {
 	cmd.val = val
 }
 
-func (cmd *SliceCmd) Val() []interface{} {
+func (cmd *SliceCmd) Val() []any {
 	return cmd.val
 }
 
-func (cmd *SliceCmd) Result() ([]interface{}, error) {
+func (cmd *SliceCmd) Result() ([]any, error) {
 	return cmd.val, cmd.err
 }
 
@@ -526,14 +526,14 @@ func (cmd *SliceCmd) String() string {
 
 // Scan scans the results from the map into a destination struct. The map keys
 // are matched in the Redis struct fields by the `redis:"field"` tag.
-func (cmd *SliceCmd) Scan(dst interface{}) error {
+func (cmd *SliceCmd) Scan(dst any) error {
 	if cmd.err != nil {
 		return cmd.err
 	}
 
 	// Pass the list of keys and values.
 	// Skip the first two args for: HMGET key
-	var args []interface{}
+	var args []any
 	if cmd.args[0] == "hmget" {
 		args = cmd.args[2:]
 	} else {
@@ -559,7 +559,7 @@ type StatusCmd struct {
 
 var _ Cmder = (*StatusCmd)(nil)
 
-func NewStatusCmd(ctx context.Context, args ...interface{}) *StatusCmd {
+func NewStatusCmd(ctx context.Context, args ...any) *StatusCmd {
 	return &StatusCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -603,7 +603,7 @@ type IntCmd struct {
 
 var _ Cmder = (*IntCmd)(nil)
 
-func NewIntCmd(ctx context.Context, args ...interface{}) *IntCmd {
+func NewIntCmd(ctx context.Context, args ...any) *IntCmd {
 	return &IntCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -647,7 +647,7 @@ type IntSliceCmd struct {
 
 var _ Cmder = (*IntSliceCmd)(nil)
 
-func NewIntSliceCmd(ctx context.Context, args ...interface{}) *IntSliceCmd {
+func NewIntSliceCmd(ctx context.Context, args ...any) *IntSliceCmd {
 	return &IntSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -697,7 +697,7 @@ type DurationCmd struct {
 
 var _ Cmder = (*DurationCmd)(nil)
 
-func NewDurationCmd(ctx context.Context, precision time.Duration, args ...interface{}) *DurationCmd {
+func NewDurationCmd(ctx context.Context, precision time.Duration, args ...any) *DurationCmd {
 	return &DurationCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -749,7 +749,7 @@ type TimeCmd struct {
 
 var _ Cmder = (*TimeCmd)(nil)
 
-func NewTimeCmd(ctx context.Context, args ...interface{}) *TimeCmd {
+func NewTimeCmd(ctx context.Context, args ...any) *TimeCmd {
 	return &TimeCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -800,7 +800,7 @@ type BoolCmd struct {
 
 var _ Cmder = (*BoolCmd)(nil)
 
-func NewBoolCmd(ctx context.Context, args ...interface{}) *BoolCmd {
+func NewBoolCmd(ctx context.Context, args ...any) *BoolCmd {
 	return &BoolCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -847,7 +847,7 @@ type StringCmd struct {
 
 var _ Cmder = (*StringCmd)(nil)
 
-func NewStringCmd(ctx context.Context, args ...interface{}) *StringCmd {
+func NewStringCmd(ctx context.Context, args ...any) *StringCmd {
 	return &StringCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -925,7 +925,7 @@ func (cmd *StringCmd) Time() (time.Time, error) {
 	return time.Parse(time.RFC3339Nano, cmd.Val())
 }
 
-func (cmd *StringCmd) Scan(val interface{}) error {
+func (cmd *StringCmd) Scan(val any) error {
 	if cmd.err != nil {
 		return cmd.err
 	}
@@ -951,7 +951,7 @@ type FloatCmd struct {
 
 var _ Cmder = (*FloatCmd)(nil)
 
-func NewFloatCmd(ctx context.Context, args ...interface{}) *FloatCmd {
+func NewFloatCmd(ctx context.Context, args ...any) *FloatCmd {
 	return &FloatCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -991,7 +991,7 @@ type FloatSliceCmd struct {
 
 var _ Cmder = (*FloatSliceCmd)(nil)
 
-func NewFloatSliceCmd(ctx context.Context, args ...interface{}) *FloatSliceCmd {
+func NewFloatSliceCmd(ctx context.Context, args ...any) *FloatSliceCmd {
 	return &FloatSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1046,7 +1046,7 @@ type StringSliceCmd struct {
 
 var _ Cmder = (*StringSliceCmd)(nil)
 
-func NewStringSliceCmd(ctx context.Context, args ...interface{}) *StringSliceCmd {
+func NewStringSliceCmd(ctx context.Context, args ...any) *StringSliceCmd {
 	return &StringSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1071,7 +1071,7 @@ func (cmd *StringSliceCmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
-func (cmd *StringSliceCmd) ScanSlice(container interface{}) error {
+func (cmd *StringSliceCmd) ScanSlice(container any) error {
 	return proto.ScanSlice(cmd.Val(), container)
 }
 
@@ -1109,7 +1109,7 @@ type KeyValueSliceCmd struct {
 
 var _ Cmder = (*KeyValueSliceCmd)(nil)
 
-func NewKeyValueSliceCmd(ctx context.Context, args ...interface{}) *KeyValueSliceCmd {
+func NewKeyValueSliceCmd(ctx context.Context, args ...any) *KeyValueSliceCmd {
 	return &KeyValueSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1198,7 +1198,7 @@ type BoolSliceCmd struct {
 
 var _ Cmder = (*BoolSliceCmd)(nil)
 
-func NewBoolSliceCmd(ctx context.Context, args ...interface{}) *BoolSliceCmd {
+func NewBoolSliceCmd(ctx context.Context, args ...any) *BoolSliceCmd {
 	return &BoolSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1247,7 +1247,7 @@ type MapStringStringCmd struct {
 
 var _ Cmder = (*MapStringStringCmd)(nil)
 
-func NewMapStringStringCmd(ctx context.Context, args ...interface{}) *MapStringStringCmd {
+func NewMapStringStringCmd(ctx context.Context, args ...any) *MapStringStringCmd {
 	return &MapStringStringCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1274,7 +1274,7 @@ func (cmd *MapStringStringCmd) String() string {
 
 // Scan scans the results from the map into a destination struct. The map keys
 // are matched in the Redis struct fields by the `redis:"field"` tag.
-func (cmd *MapStringStringCmd) Scan(dest interface{}) error {
+func (cmd *MapStringStringCmd) Scan(dest any) error {
 	if cmd.err != nil {
 		return cmd.err
 	}
@@ -1326,7 +1326,7 @@ type MapStringIntCmd struct {
 
 var _ Cmder = (*MapStringIntCmd)(nil)
 
-func NewMapStringIntCmd(ctx context.Context, args ...interface{}) *MapStringIntCmd {
+func NewMapStringIntCmd(ctx context.Context, args ...any) *MapStringIntCmd {
 	return &MapStringIntCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1376,10 +1376,10 @@ func (cmd *MapStringIntCmd) readReply(rd *proto.Reader) error {
 // ------------------------------------------------------------------------------
 type MapStringSliceInterfaceCmd struct {
 	baseCmd
-	val map[string][]interface{}
+	val map[string][]any
 }
 
-func NewMapStringSliceInterfaceCmd(ctx context.Context, args ...interface{}) *MapStringSliceInterfaceCmd {
+func NewMapStringSliceInterfaceCmd(ctx context.Context, args ...any) *MapStringSliceInterfaceCmd {
 	return &MapStringSliceInterfaceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1392,15 +1392,15 @@ func (cmd *MapStringSliceInterfaceCmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
-func (cmd *MapStringSliceInterfaceCmd) SetVal(val map[string][]interface{}) {
+func (cmd *MapStringSliceInterfaceCmd) SetVal(val map[string][]any) {
 	cmd.val = val
 }
 
-func (cmd *MapStringSliceInterfaceCmd) Result() (map[string][]interface{}, error) {
+func (cmd *MapStringSliceInterfaceCmd) Result() (map[string][]any, error) {
 	return cmd.val, cmd.err
 }
 
-func (cmd *MapStringSliceInterfaceCmd) Val() map[string][]interface{} {
+func (cmd *MapStringSliceInterfaceCmd) Val() map[string][]any {
 	return cmd.val
 }
 
@@ -1410,7 +1410,7 @@ func (cmd *MapStringSliceInterfaceCmd) readReply(rd *proto.Reader) (err error) {
 		return err
 	}
 
-	cmd.val = make(map[string][]interface{})
+	cmd.val = make(map[string][]any)
 
 	switch readType {
 	case proto.RespMap:
@@ -1427,7 +1427,7 @@ func (cmd *MapStringSliceInterfaceCmd) readReply(rd *proto.Reader) (err error) {
 			if err != nil {
 				return err
 			}
-			cmd.val[k] = make([]interface{}, nn)
+			cmd.val[k] = make([]any, nn)
 			for j := 0; j < nn; j++ {
 				value, err := rd.ReadReply()
 				if err != nil {
@@ -1454,7 +1454,7 @@ func (cmd *MapStringSliceInterfaceCmd) readReply(rd *proto.Reader) (err error) {
 			if err != nil {
 				return err
 			}
-			cmd.val[key] = make([]interface{}, 0, itemLen-1)
+			cmd.val[key] = make([]any, 0, itemLen-1)
 			for j := 1; j < itemLen; j++ {
 				// Read the inner array for timestamp-value pairs
 				data, err := rd.ReadReply()
@@ -1479,7 +1479,7 @@ type StringStructMapCmd struct {
 
 var _ Cmder = (*StringStructMapCmd)(nil)
 
-func NewStringStructMapCmd(ctx context.Context, args ...interface{}) *StringStructMapCmd {
+func NewStringStructMapCmd(ctx context.Context, args ...any) *StringStructMapCmd {
 	return &StringStructMapCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1525,7 +1525,7 @@ func (cmd *StringStructMapCmd) readReply(rd *proto.Reader) error {
 
 type XMessage struct {
 	ID     string
-	Values map[string]interface{}
+	Values map[string]any
 }
 
 type XMessageSliceCmd struct {
@@ -1536,7 +1536,7 @@ type XMessageSliceCmd struct {
 
 var _ Cmder = (*XMessageSliceCmd)(nil)
 
-func NewXMessageSliceCmd(ctx context.Context, args ...interface{}) *XMessageSliceCmd {
+func NewXMessageSliceCmd(ctx context.Context, args ...any) *XMessageSliceCmd {
 	return &XMessageSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1604,13 +1604,13 @@ func readXMessage(rd *proto.Reader) (XMessage, error) {
 	}, nil
 }
 
-func stringInterfaceMapParser(rd *proto.Reader) (map[string]interface{}, error) {
+func stringInterfaceMapParser(rd *proto.Reader) (map[string]any, error) {
 	n, err := rd.ReadMapLen()
 	if err != nil {
 		return nil, err
 	}
 
-	m := make(map[string]interface{}, n)
+	m := make(map[string]any, n)
 	for i := 0; i < n; i++ {
 		key, err := rd.ReadString()
 		if err != nil {
@@ -1642,7 +1642,7 @@ type XStreamSliceCmd struct {
 
 var _ Cmder = (*XStreamSliceCmd)(nil)
 
-func NewXStreamSliceCmd(ctx context.Context, args ...interface{}) *XStreamSliceCmd {
+func NewXStreamSliceCmd(ctx context.Context, args ...any) *XStreamSliceCmd {
 	return &XStreamSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1715,7 +1715,7 @@ type XPendingCmd struct {
 
 var _ Cmder = (*XPendingCmd)(nil)
 
-func NewXPendingCmd(ctx context.Context, args ...interface{}) *XPendingCmd {
+func NewXPendingCmd(ctx context.Context, args ...any) *XPendingCmd {
 	return &XPendingCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1798,7 +1798,7 @@ type XPendingExtCmd struct {
 
 var _ Cmder = (*XPendingExtCmd)(nil)
 
-func NewXPendingExtCmd(ctx context.Context, args ...interface{}) *XPendingExtCmd {
+func NewXPendingExtCmd(ctx context.Context, args ...any) *XPendingExtCmd {
 	return &XPendingExtCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1868,7 +1868,7 @@ type XAutoClaimCmd struct {
 
 var _ Cmder = (*XAutoClaimCmd)(nil)
 
-func NewXAutoClaimCmd(ctx context.Context, args ...interface{}) *XAutoClaimCmd {
+func NewXAutoClaimCmd(ctx context.Context, args ...any) *XAutoClaimCmd {
 	return &XAutoClaimCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1938,7 +1938,7 @@ type XAutoClaimJustIDCmd struct {
 
 var _ Cmder = (*XAutoClaimJustIDCmd)(nil)
 
-func NewXAutoClaimJustIDCmd(ctx context.Context, args ...interface{}) *XAutoClaimJustIDCmd {
+func NewXAutoClaimJustIDCmd(ctx context.Context, args ...any) *XAutoClaimJustIDCmd {
 	return &XAutoClaimJustIDCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -2025,7 +2025,7 @@ func NewXInfoConsumersCmd(ctx context.Context, stream string, group string) *XIn
 	return &XInfoConsumersCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
-			args: []interface{}{"xinfo", "consumers", stream, group},
+			args: []any{"xinfo", "consumers", stream, group},
 		},
 	}
 }
@@ -2115,7 +2115,7 @@ func NewXInfoGroupsCmd(ctx context.Context, stream string) *XInfoGroupsCmd {
 	return &XInfoGroupsCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
-			args: []interface{}{"xinfo", "groups", stream},
+			args: []any{"xinfo", "groups", stream},
 		},
 	}
 }
@@ -2230,7 +2230,7 @@ func NewXInfoStreamCmd(ctx context.Context, stream string) *XInfoStreamCmd {
 	return &XInfoStreamCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
-			args: []interface{}{"xinfo", "stream", stream},
+			args: []any{"xinfo", "stream", stream},
 		},
 	}
 }
@@ -2373,7 +2373,7 @@ type XInfoStreamConsumerPending struct {
 
 var _ Cmder = (*XInfoStreamFullCmd)(nil)
 
-func NewXInfoStreamFullCmd(ctx context.Context, args ...interface{}) *XInfoStreamFullCmd {
+func NewXInfoStreamFullCmd(ctx context.Context, args ...any) *XInfoStreamFullCmd {
 	return &XInfoStreamFullCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -2672,7 +2672,7 @@ type ZSliceCmd struct {
 
 var _ Cmder = (*ZSliceCmd)(nil)
 
-func NewZSliceCmd(ctx context.Context, args ...interface{}) *ZSliceCmd {
+func NewZSliceCmd(ctx context.Context, args ...any) *ZSliceCmd {
 	return &ZSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -2750,7 +2750,7 @@ type ZWithKeyCmd struct {
 
 var _ Cmder = (*ZWithKeyCmd)(nil)
 
-func NewZWithKeyCmd(ctx context.Context, args ...interface{}) *ZWithKeyCmd {
+func NewZWithKeyCmd(ctx context.Context, args ...any) *ZWithKeyCmd {
 	return &ZWithKeyCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -2807,7 +2807,7 @@ type ScanCmd struct {
 
 var _ Cmder = (*ScanCmd)(nil)
 
-func NewScanCmd(ctx context.Context, process cmdable, args ...interface{}) *ScanCmd {
+func NewScanCmd(ctx context.Context, process cmdable, args ...any) *ScanCmd {
 	return &ScanCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -2888,7 +2888,7 @@ type ClusterSlotsCmd struct {
 
 var _ Cmder = (*ClusterSlotsCmd)(nil)
 
-func NewClusterSlotsCmd(ctx context.Context, args ...interface{}) *ClusterSlotsCmd {
+func NewClusterSlotsCmd(ctx context.Context, args ...any) *ClusterSlotsCmd {
 	return &ClusterSlotsCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3041,7 +3041,7 @@ type GeoLocationCmd struct {
 
 var _ Cmder = (*GeoLocationCmd)(nil)
 
-func NewGeoLocationCmd(ctx context.Context, q *GeoRadiusQuery, args ...interface{}) *GeoLocationCmd {
+func NewGeoLocationCmd(ctx context.Context, q *GeoRadiusQuery, args ...any) *GeoLocationCmd {
 	return &GeoLocationCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3051,7 +3051,7 @@ func NewGeoLocationCmd(ctx context.Context, q *GeoRadiusQuery, args ...interface
 	}
 }
 
-func geoLocationArgs(q *GeoRadiusQuery, args ...interface{}) []interface{} {
+func geoLocationArgs(q *GeoRadiusQuery, args ...any) []any {
 	args = append(args, q.Radius)
 	if q.Unit != "" {
 		args = append(args, q.Unit)
@@ -3197,7 +3197,7 @@ type GeoSearchStoreQuery struct {
 	StoreDist bool
 }
 
-func geoSearchLocationArgs(q *GeoSearchLocationQuery, args []interface{}) []interface{} {
+func geoSearchLocationArgs(q *GeoSearchLocationQuery, args []any) []any {
 	args = geoSearchArgs(&q.GeoSearchQuery, args)
 
 	if q.WithCoord {
@@ -3213,7 +3213,7 @@ func geoSearchLocationArgs(q *GeoSearchLocationQuery, args []interface{}) []inte
 	return args
 }
 
-func geoSearchArgs(q *GeoSearchQuery, args []interface{}) []interface{} {
+func geoSearchArgs(q *GeoSearchQuery, args []any) []any {
 	if q.Member != "" {
 		args = append(args, "frommember", q.Member)
 	} else {
@@ -3256,7 +3256,7 @@ type GeoSearchLocationCmd struct {
 var _ Cmder = (*GeoSearchLocationCmd)(nil)
 
 func NewGeoSearchLocationCmd(
-	ctx context.Context, opt *GeoSearchLocationQuery, args ...interface{},
+	ctx context.Context, opt *GeoSearchLocationQuery, args ...any,
 ) *GeoSearchLocationCmd {
 	return &GeoSearchLocationCmd{
 		baseCmd: baseCmd{
@@ -3348,7 +3348,7 @@ type GeoPosCmd struct {
 
 var _ Cmder = (*GeoPosCmd)(nil)
 
-func NewGeoPosCmd(ctx context.Context, args ...interface{}) *GeoPosCmd {
+func NewGeoPosCmd(ctx context.Context, args ...any) *GeoPosCmd {
 	return &GeoPosCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3429,7 +3429,7 @@ type CommandsInfoCmd struct {
 
 var _ Cmder = (*CommandsInfoCmd)(nil)
 
-func NewCommandsInfoCmd(ctx context.Context, args ...interface{}) *CommandsInfoCmd {
+func NewCommandsInfoCmd(ctx context.Context, args ...any) *CommandsInfoCmd {
 	return &CommandsInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3618,7 +3618,7 @@ type SlowLogCmd struct {
 
 var _ Cmder = (*SlowLogCmd)(nil)
 
-func NewSlowLogCmd(ctx context.Context, args ...interface{}) *SlowLogCmd {
+func NewSlowLogCmd(ctx context.Context, args ...any) *SlowLogCmd {
 	return &SlowLogCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3712,12 +3712,12 @@ func (cmd *SlowLogCmd) readReply(rd *proto.Reader) error {
 type MapStringInterfaceCmd struct {
 	baseCmd
 
-	val map[string]interface{}
+	val map[string]any
 }
 
 var _ Cmder = (*MapStringInterfaceCmd)(nil)
 
-func NewMapStringInterfaceCmd(ctx context.Context, args ...interface{}) *MapStringInterfaceCmd {
+func NewMapStringInterfaceCmd(ctx context.Context, args ...any) *MapStringInterfaceCmd {
 	return &MapStringInterfaceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3726,15 +3726,15 @@ func NewMapStringInterfaceCmd(ctx context.Context, args ...interface{}) *MapStri
 	}
 }
 
-func (cmd *MapStringInterfaceCmd) SetVal(val map[string]interface{}) {
+func (cmd *MapStringInterfaceCmd) SetVal(val map[string]any) {
 	cmd.val = val
 }
 
-func (cmd *MapStringInterfaceCmd) Val() map[string]interface{} {
+func (cmd *MapStringInterfaceCmd) Val() map[string]any {
 	return cmd.val
 }
 
-func (cmd *MapStringInterfaceCmd) Result() (map[string]interface{}, error) {
+func (cmd *MapStringInterfaceCmd) Result() (map[string]any, error) {
 	return cmd.val, cmd.err
 }
 
@@ -3748,7 +3748,7 @@ func (cmd *MapStringInterfaceCmd) readReply(rd *proto.Reader) error {
 		return err
 	}
 
-	cmd.val = make(map[string]interface{}, n)
+	cmd.val = make(map[string]any, n)
 	for i := 0; i < n; i++ {
 		k, err := rd.ReadString()
 		if err != nil {
@@ -3781,7 +3781,7 @@ type MapStringStringSliceCmd struct {
 
 var _ Cmder = (*MapStringStringSliceCmd)(nil)
 
-func NewMapStringStringSliceCmd(ctx context.Context, args ...interface{}) *MapStringStringSliceCmd {
+func NewMapStringStringSliceCmd(ctx context.Context, args ...any) *MapStringStringSliceCmd {
 	return &MapStringStringSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3837,13 +3837,13 @@ func (cmd *MapStringStringSliceCmd) readReply(rd *proto.Reader) error {
 
 // -----------------------------------------------------------------------
 
-// MapMapStringInterfaceCmd represents a command that returns a map of strings to interface{}.
+// MapMapStringInterfaceCmd represents a command that returns a map of strings to any.
 type MapMapStringInterfaceCmd struct {
 	baseCmd
-	val map[string]interface{}
+	val map[string]any
 }
 
-func NewMapMapStringInterfaceCmd(ctx context.Context, args ...interface{}) *MapMapStringInterfaceCmd {
+func NewMapMapStringInterfaceCmd(ctx context.Context, args ...any) *MapMapStringInterfaceCmd {
 	return &MapMapStringInterfaceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3856,15 +3856,15 @@ func (cmd *MapMapStringInterfaceCmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
-func (cmd *MapMapStringInterfaceCmd) SetVal(val map[string]interface{}) {
+func (cmd *MapMapStringInterfaceCmd) SetVal(val map[string]any) {
 	cmd.val = val
 }
 
-func (cmd *MapMapStringInterfaceCmd) Result() (map[string]interface{}, error) {
+func (cmd *MapMapStringInterfaceCmd) Result() (map[string]any, error) {
 	return cmd.val, cmd.err
 }
 
-func (cmd *MapMapStringInterfaceCmd) Val() map[string]interface{} {
+func (cmd *MapMapStringInterfaceCmd) Val() map[string]any {
 	return cmd.val
 }
 
@@ -3874,10 +3874,10 @@ func (cmd *MapMapStringInterfaceCmd) readReply(rd *proto.Reader) (err error) {
 	if err != nil {
 		return err
 	}
-	resultMap := map[string]interface{}{}
+	resultMap := map[string]any{}
 
 	switch midResponse := data.(type) {
-	case map[interface{}]interface{}: // resp3 will return map
+	case map[any]any: // resp3 will return map
 		for k, v := range midResponse {
 			stringKey, ok := k.(string)
 			if !ok {
@@ -3885,10 +3885,10 @@ func (cmd *MapMapStringInterfaceCmd) readReply(rd *proto.Reader) (err error) {
 			}
 			resultMap[stringKey] = v
 		}
-	case []interface{}: // resp2 will return array of arrays
+	case []any: // resp2 will return array of arrays
 		n := len(midResponse)
 		for i := 0; i < n; i++ {
-			finalArr, ok := midResponse[i].([]interface{}) // final array that we need to transform to map
+			finalArr, ok := midResponse[i].([]any) // final array that we need to transform to map
 			if !ok {
 				return fmt.Errorf("redis: unexpected response %#v", data)
 			}
@@ -3918,12 +3918,12 @@ func (cmd *MapMapStringInterfaceCmd) readReply(rd *proto.Reader) (err error) {
 type MapStringInterfaceSliceCmd struct {
 	baseCmd
 
-	val []map[string]interface{}
+	val []map[string]any
 }
 
 var _ Cmder = (*MapStringInterfaceSliceCmd)(nil)
 
-func NewMapStringInterfaceSliceCmd(ctx context.Context, args ...interface{}) *MapStringInterfaceSliceCmd {
+func NewMapStringInterfaceSliceCmd(ctx context.Context, args ...any) *MapStringInterfaceSliceCmd {
 	return &MapStringInterfaceSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3932,15 +3932,15 @@ func NewMapStringInterfaceSliceCmd(ctx context.Context, args ...interface{}) *Ma
 	}
 }
 
-func (cmd *MapStringInterfaceSliceCmd) SetVal(val []map[string]interface{}) {
+func (cmd *MapStringInterfaceSliceCmd) SetVal(val []map[string]any) {
 	cmd.val = val
 }
 
-func (cmd *MapStringInterfaceSliceCmd) Val() []map[string]interface{} {
+func (cmd *MapStringInterfaceSliceCmd) Val() []map[string]any {
 	return cmd.val
 }
 
-func (cmd *MapStringInterfaceSliceCmd) Result() ([]map[string]interface{}, error) {
+func (cmd *MapStringInterfaceSliceCmd) Result() ([]map[string]any, error) {
 	return cmd.val, cmd.err
 }
 
@@ -3954,13 +3954,13 @@ func (cmd *MapStringInterfaceSliceCmd) readReply(rd *proto.Reader) error {
 		return err
 	}
 
-	cmd.val = make([]map[string]interface{}, n)
+	cmd.val = make([]map[string]any, n)
 	for i := 0; i < n; i++ {
 		nn, err := rd.ReadMapLen()
 		if err != nil {
 			return err
 		}
-		cmd.val[i] = make(map[string]interface{}, nn)
+		cmd.val[i] = make(map[string]any, nn)
 		for f := 0; f < nn; f++ {
 			k, err := rd.ReadString()
 			if err != nil {
@@ -3989,7 +3989,7 @@ type KeyValuesCmd struct {
 
 var _ Cmder = (*KeyValuesCmd)(nil)
 
-func NewKeyValuesCmd(ctx context.Context, args ...interface{}) *KeyValuesCmd {
+func NewKeyValuesCmd(ctx context.Context, args ...any) *KeyValuesCmd {
 	return &KeyValuesCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -4051,7 +4051,7 @@ type ZSliceWithKeyCmd struct {
 
 var _ Cmder = (*ZSliceWithKeyCmd)(nil)
 
-func NewZSliceWithKeyCmd(ctx context.Context, args ...interface{}) *ZSliceWithKeyCmd {
+func NewZSliceWithKeyCmd(ctx context.Context, args ...any) *ZSliceWithKeyCmd {
 	return &ZSliceWithKeyCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -4144,7 +4144,7 @@ type FunctionListCmd struct {
 
 var _ Cmder = (*FunctionListCmd)(nil)
 
-func NewFunctionListCmd(ctx context.Context, args ...interface{}) *FunctionListCmd {
+func NewFunctionListCmd(ctx context.Context, args ...any) *FunctionListCmd {
 	return &FunctionListCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -4325,7 +4325,7 @@ type FunctionStatsCmd struct {
 
 var _ Cmder = (*FunctionStatsCmd)(nil)
 
-func NewFunctionStatsCmd(ctx context.Context, args ...interface{}) *FunctionStatsCmd {
+func NewFunctionStatsCmd(ctx context.Context, args ...any) *FunctionStatsCmd {
 	return &FunctionStatsCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -4543,7 +4543,7 @@ type LCSCmd struct {
 }
 
 func NewLCSCmd(ctx context.Context, q *LCSQuery) *LCSCmd {
-	args := make([]interface{}, 3, 7)
+	args := make([]any, 3, 7)
 	args[0] = "lcs"
 	args[1] = q.Key1
 	args[2] = q.Key2
@@ -4691,7 +4691,7 @@ type KeyFlagsCmd struct {
 
 var _ Cmder = (*KeyFlagsCmd)(nil)
 
-func NewKeyFlagsCmd(ctx context.Context, args ...interface{}) *KeyFlagsCmd {
+func NewKeyFlagsCmd(ctx context.Context, args ...any) *KeyFlagsCmd {
 	return &KeyFlagsCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -4773,7 +4773,7 @@ type ClusterLinksCmd struct {
 
 var _ Cmder = (*ClusterLinksCmd)(nil)
 
-func NewClusterLinksCmd(ctx context.Context, args ...interface{}) *ClusterLinksCmd {
+func NewClusterLinksCmd(ctx context.Context, args ...any) *ClusterLinksCmd {
 	return &ClusterLinksCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -4875,7 +4875,7 @@ type ClusterShardsCmd struct {
 
 var _ Cmder = (*ClusterShardsCmd)(nil)
 
-func NewClusterShardsCmd(ctx context.Context, args ...interface{}) *ClusterShardsCmd {
+func NewClusterShardsCmd(ctx context.Context, args ...any) *ClusterShardsCmd {
 	return &ClusterShardsCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -5008,7 +5008,7 @@ type RankWithScoreCmd struct {
 
 var _ Cmder = (*RankWithScoreCmd)(nil)
 
-func NewRankWithScoreCmd(ctx context.Context, args ...interface{}) *RankWithScoreCmd {
+func NewRankWithScoreCmd(ctx context.Context, args ...any) *RankWithScoreCmd {
 	return &RankWithScoreCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -5156,7 +5156,7 @@ type ClientInfoCmd struct {
 
 var _ Cmder = (*ClientInfoCmd)(nil)
 
-func NewClientInfoCmd(ctx context.Context, args ...interface{}) *ClientInfoCmd {
+func NewClientInfoCmd(ctx context.Context, args ...any) *ClientInfoCmd {
 	return &ClientInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -5354,7 +5354,7 @@ type ACLLogCmd struct {
 
 var _ Cmder = (*ACLLogCmd)(nil)
 
-func NewACLLogCmd(ctx context.Context, args ...interface{}) *ACLLogCmd {
+func NewACLLogCmd(ctx context.Context, args ...any) *ACLLogCmd {
 	return &ACLLogCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -5465,7 +5465,7 @@ type InfoCmd struct {
 
 var _ Cmder = (*InfoCmd)(nil)
 
-func NewInfoCmd(ctx context.Context, args ...interface{}) *InfoCmd {
+func NewInfoCmd(ctx context.Context, args ...any) *InfoCmd {
 	return &InfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -5554,7 +5554,7 @@ func newMonitorCmd(ctx context.Context, ch chan string) *MonitorCmd {
 	return &MonitorCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
-			args: []interface{}{"monitor"},
+			args: []any{"monitor"},
 		},
 		ch:     ch,
 		status: monitorStatusIdle,

--- a/commands.go
+++ b/commands.go
@@ -50,7 +50,7 @@ func formatSec(ctx context.Context, dur time.Duration) int64 {
 	return int64(dur / time.Second)
 }
 
-func appendArgs(dst, src []interface{}) []interface{} {
+func appendArgs(dst, src []any) []any {
 	if len(src) == 1 {
 		return appendArg(dst, src[0])
 	}
@@ -59,17 +59,17 @@ func appendArgs(dst, src []interface{}) []interface{} {
 	return dst
 }
 
-func appendArg(dst []interface{}, arg interface{}) []interface{} {
+func appendArg(dst []any, arg any) []any {
 	switch arg := arg.(type) {
 	case []string:
 		for _, s := range arg {
 			dst = append(dst, s)
 		}
 		return dst
-	case []interface{}:
+	case []any:
 		dst = append(dst, arg...)
 		return dst
-	case map[string]interface{}:
+	case map[string]any:
 		for k, v := range arg {
 			dst = append(dst, k, v)
 		}
@@ -103,7 +103,7 @@ func appendArg(dst []interface{}, arg interface{}) []interface{} {
 }
 
 // appendStructField appends the field and value held by the structure v to dst, and returns the appended dst.
-func appendStructField(dst []interface{}, v reflect.Value) []interface{} {
+func appendStructField(dst []any, v reflect.Value) []any {
 	typ := v.Type()
 	for i := 0; i < typ.NumField(); i++ {
 		tag := typ.Field(i).Tag.Get("redis")
@@ -174,10 +174,10 @@ type Cmdable interface {
 
 	Command(ctx context.Context) *CommandsInfoCmd
 	CommandList(ctx context.Context, filter *FilterBy) *StringSliceCmd
-	CommandGetKeys(ctx context.Context, commands ...interface{}) *StringSliceCmd
-	CommandGetKeysAndFlags(ctx context.Context, commands ...interface{}) *KeyFlagsCmd
+	CommandGetKeys(ctx context.Context, commands ...any) *StringSliceCmd
+	CommandGetKeysAndFlags(ctx context.Context, commands ...any) *KeyFlagsCmd
 	ClientGetName(ctx context.Context) *StringCmd
-	Echo(ctx context.Context, message interface{}) *StringCmd
+	Echo(ctx context.Context, message any) *StringCmd
 	Ping(ctx context.Context) *StatusCmd
 	Quit(ctx context.Context) *StatusCmd
 	Unlink(ctx context.Context, keys ...string) *IntCmd
@@ -343,7 +343,7 @@ func (info LibraryInfo) Validate() error {
 func (c statefulCmdable) Hello(ctx context.Context,
 	ver int, username, password, clientName string,
 ) *MapStringInterfaceCmd {
-	args := make([]interface{}, 0, 7)
+	args := make([]any, 0, 7)
 	args = append(args, "hello", ver)
 	if password != "" {
 		if username != "" {
@@ -376,7 +376,7 @@ type FilterBy struct {
 }
 
 func (c cmdable) CommandList(ctx context.Context, filter *FilterBy) *StringSliceCmd {
-	args := make([]interface{}, 0, 5)
+	args := make([]any, 0, 5)
 	args = append(args, "command", "list")
 	if filter != nil {
 		if filter.Module != "" {
@@ -392,8 +392,8 @@ func (c cmdable) CommandList(ctx context.Context, filter *FilterBy) *StringSlice
 	return cmd
 }
 
-func (c cmdable) CommandGetKeys(ctx context.Context, commands ...interface{}) *StringSliceCmd {
-	args := make([]interface{}, 2+len(commands))
+func (c cmdable) CommandGetKeys(ctx context.Context, commands ...any) *StringSliceCmd {
+	args := make([]any, 2+len(commands))
 	args[0] = "command"
 	args[1] = "getkeys"
 	copy(args[2:], commands)
@@ -402,8 +402,8 @@ func (c cmdable) CommandGetKeys(ctx context.Context, commands ...interface{}) *S
 	return cmd
 }
 
-func (c cmdable) CommandGetKeysAndFlags(ctx context.Context, commands ...interface{}) *KeyFlagsCmd {
-	args := make([]interface{}, 2+len(commands))
+func (c cmdable) CommandGetKeysAndFlags(ctx context.Context, commands ...any) *KeyFlagsCmd {
+	args := make([]any, 2+len(commands))
 	args[0] = "command"
 	args[1] = "getkeysandflags"
 	copy(args[2:], commands)
@@ -419,7 +419,7 @@ func (c cmdable) ClientGetName(ctx context.Context) *StringCmd {
 	return cmd
 }
 
-func (c cmdable) Echo(ctx context.Context, message interface{}) *StringCmd {
+func (c cmdable) Echo(ctx context.Context, message any) *StringCmd {
 	cmd := NewStringCmd(ctx, "echo", message)
 	_ = c(ctx, cmd)
 	return cmd
@@ -431,7 +431,7 @@ func (c cmdable) Ping(ctx context.Context) *StatusCmd {
 	return cmd
 }
 
-func (c cmdable) Do(ctx context.Context, args ...interface{}) *Cmd {
+func (c cmdable) Do(ctx context.Context, args ...any) *Cmd {
 	cmd := NewCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -465,7 +465,7 @@ func (c cmdable) ClientKill(ctx context.Context, ipPort string) *StatusCmd {
 //
 //	CLIENT KILL <option> [value] ... <option> [value]
 func (c cmdable) ClientKillByFilter(ctx context.Context, keys ...string) *IntCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]any, 2+len(keys))
 	args[0] = "client"
 	args[1] = "kill"
 	for i, key := range keys {
@@ -575,7 +575,7 @@ func (c cmdable) FlushDBAsync(ctx context.Context) *StatusCmd {
 }
 
 func (c cmdable) Info(ctx context.Context, sections ...string) *StringCmd {
-	args := make([]interface{}, 1+len(sections))
+	args := make([]any, 1+len(sections))
 	args[0] = "info"
 	for i, section := range sections {
 		args[i+1] = section
@@ -586,7 +586,7 @@ func (c cmdable) Info(ctx context.Context, sections ...string) *StringCmd {
 }
 
 func (c cmdable) InfoMap(ctx context.Context, sections ...string) *InfoCmd {
-	args := make([]interface{}, 1+len(sections))
+	args := make([]any, 1+len(sections))
 	args[0] = "info"
 	for i, section := range sections {
 		args[i+1] = section
@@ -609,11 +609,11 @@ func (c cmdable) Save(ctx context.Context) *StatusCmd {
 }
 
 func (c cmdable) shutdown(ctx context.Context, modifier string) *StatusCmd {
-	var args []interface{}
+	var args []any
 	if modifier == "" {
-		args = []interface{}{"shutdown"}
+		args = []any{"shutdown"}
 	} else {
-		args = []interface{}{"shutdown", modifier}
+		args = []any{"shutdown", modifier}
 	}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -671,7 +671,7 @@ func (c cmdable) DebugObject(ctx context.Context, key string) *StringCmd {
 }
 
 func (c cmdable) MemoryUsage(ctx context.Context, key string, samples ...int) *IntCmd {
-	args := []interface{}{"memory", "usage", key}
+	args := []any{"memory", "usage", key}
 	if len(samples) > 0 {
 		if len(samples) != 1 {
 			panic("MemoryUsage expects single sample count")
@@ -690,12 +690,12 @@ func (c cmdable) MemoryUsage(ctx context.Context, key string, samples ...int) *I
 // `MODULE LOADEX path [CONFIG name value [CONFIG name value ...]] [ARGS args [args ...]]`
 type ModuleLoadexConfig struct {
 	Path string
-	Conf map[string]interface{}
-	Args []interface{}
+	Conf map[string]any
+	Args []any
 }
 
-func (c *ModuleLoadexConfig) toArgs() []interface{} {
-	args := make([]interface{}, 3, 3+len(c.Conf)*3+len(c.Args)*2)
+func (c *ModuleLoadexConfig) toArgs() []any {
+	args := make([]any, 3, 3+len(c.Conf)*3+len(c.Args)*2)
 	args[0] = "MODULE"
 	args[1] = "LOADEX"
 	args[2] = c.Path

--- a/commands_test.go
+++ b/commands_test.go
@@ -409,7 +409,7 @@ var _ = Describe("Commands", func() {
 
 			defDialect, err := client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "3"}))
+			Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "3"}))
 
 			resGet, err := client.ConfigGet(ctx, "search-default-dialect").Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -422,7 +422,7 @@ var _ = Describe("Commands", func() {
 
 			defDialect, err = client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "2"}))
+			Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "2"}))
 
 			// set to 1
 			res, err = client.ConfigSet(ctx, "search-default-dialect", "1").Result()
@@ -431,7 +431,7 @@ var _ = Describe("Commands", func() {
 
 			defDialect, err = client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "1"}))
+			Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "1"}))
 
 			resGet, err = client.ConfigGet(ctx, "search-default-dialect").Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -1190,7 +1190,7 @@ var _ = Describe("Commands", func() {
 					Get: []string{"object_*"},
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(els).To(Equal([]interface{}{nil, "value2", nil}))
+				Expect(els).To(Equal([]any{nil, "value2", nil}))
 			}
 		})
 
@@ -1743,29 +1743,29 @@ var _ = Describe("Commands", func() {
 
 			mGet := client.MGet(ctx, "key1", "key2", "_")
 			Expect(mGet.Err()).NotTo(HaveOccurred())
-			Expect(mGet.Val()).To(Equal([]interface{}{"hello1", "hello2", nil}))
+			Expect(mGet.Val()).To(Equal([]any{"hello1", "hello2", nil}))
 
 			// MSet struct
 			type set struct {
 				Set1 string                 `redis:"set1"`
 				Set2 int16                  `redis:"set2"`
 				Set3 time.Duration          `redis:"set3"`
-				Set4 interface{}            `redis:"set4"`
-				Set5 map[string]interface{} `redis:"-"`
+				Set4 any            `redis:"set4"`
+				Set5 map[string]any `redis:"-"`
 			}
 			mSet = client.MSet(ctx, &set{
 				Set1: "val1",
 				Set2: 1024,
 				Set3: 2 * time.Millisecond,
 				Set4: nil,
-				Set5: map[string]interface{}{"k1": 1},
+				Set5: map[string]any{"k1": 1},
 			})
 			Expect(mSet.Err()).NotTo(HaveOccurred())
 			Expect(mSet.Val()).To(Equal("OK"))
 
 			mGet = client.MGet(ctx, "set1", "set2", "set3", "set4")
 			Expect(mGet.Err()).NotTo(HaveOccurred())
-			Expect(mGet.Val()).To(Equal([]interface{}{
+			Expect(mGet.Val()).To(Equal([]any{
 				"val1",
 				"1024",
 				strconv.Itoa(int(2 * time.Millisecond.Nanoseconds())),
@@ -1813,15 +1813,15 @@ var _ = Describe("Commands", func() {
 				Set1 string                 `redis:"set1"`
 				Set2 int16                  `redis:"set2"`
 				Set3 time.Duration          `redis:"set3"`
-				Set4 interface{}            `redis:"set4"`
-				Set5 map[string]interface{} `redis:"-"`
+				Set4 any            `redis:"set4"`
+				Set5 map[string]any `redis:"-"`
 			}
 			mSetNX = client.MSetNX(ctx, &set{
 				Set1: "val1",
 				Set2: 1024,
 				Set3: 2 * time.Millisecond,
 				Set4: nil,
-				Set5: map[string]interface{}{"k1": 1},
+				Set5: map[string]any{"k1": 1},
 			})
 			Expect(mSetNX.Err()).NotTo(HaveOccurred())
 			Expect(mSetNX.Val()).To(Equal(true))
@@ -2292,10 +2292,10 @@ var _ = Describe("Commands", func() {
 		It("should fail module loadex", Label("NonRedisEnterprise"), func() {
 			dryRun := client.ModuleLoadex(ctx, &redis.ModuleLoadexConfig{
 				Path: "/path/to/non-existent-library.so",
-				Conf: map[string]interface{}{
+				Conf: map[string]any{
 					"param1": "value1",
 				},
-				Args: []interface{}{
+				Args: []any{
 					"arg1",
 				},
 			})
@@ -2306,10 +2306,10 @@ var _ = Describe("Commands", func() {
 		It("converts the module loadex configuration to a slice of arguments correctly", func() {
 			conf := &redis.ModuleLoadexConfig{
 				Path: "/path/to/your/module.so",
-				Conf: map[string]interface{}{
+				Conf: map[string]any{
 					"param1": "value1",
 				},
-				Args: []interface{}{
+				Args: []any{
 					"arg1",
 					"arg2",
 					3,
@@ -2319,7 +2319,7 @@ var _ = Describe("Commands", func() {
 			args := conf.ToArgs()
 
 			// Test if the arguments are in the correct order
-			expectedArgs := []interface{}{
+			expectedArgs := []any{
 				"MODULE",
 				"LOADEX",
 				"/path/to/your/module.so",
@@ -2500,11 +2500,11 @@ var _ = Describe("Commands", func() {
 
 			vals, err := client.HMGet(ctx, "hash", "key1", "key2", "_").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vals).To(Equal([]interface{}{"hello1", "hello2", nil}))
+			Expect(vals).To(Equal([]any{"hello1", "hello2", nil}))
 		})
 
 		It("should HSet", func() {
-			ok, err := client.HSet(ctx, "hash", map[string]interface{}{
+			ok, err := client.HSet(ctx, "hash", map[string]any{
 				"key1": "hello1",
 				"key2": "hello2",
 			}).Result()
@@ -2539,8 +2539,8 @@ var _ = Describe("Commands", func() {
 				Set1 string                 `redis:"set1"`
 				Set2 int16                  `redis:"set2"`
 				Set3 time.Duration          `redis:"set3"`
-				Set4 interface{}            `redis:"set4"`
-				Set5 map[string]interface{} `redis:"-"`
+				Set4 any            `redis:"set4"`
+				Set5 map[string]any `redis:"-"`
 				Set6 string                 `redis:"set6,omitempty"`
 			}
 
@@ -2549,14 +2549,14 @@ var _ = Describe("Commands", func() {
 				Set2: 1024,
 				Set3: 2 * time.Millisecond,
 				Set4: nil,
-				Set5: map[string]interface{}{"k1": 1},
+				Set5: map[string]any{"k1": 1},
 			})
 			Expect(hSet.Err()).NotTo(HaveOccurred())
 			Expect(hSet.Val()).To(Equal(int64(4)))
 
 			hMGet := client.HMGet(ctx, "hash", "set1", "set2", "set3", "set4", "set5", "set6")
 			Expect(hMGet.Err()).NotTo(HaveOccurred())
-			Expect(hMGet.Val()).To(Equal([]interface{}{
+			Expect(hMGet.Val()).To(Equal([]any{
 				"val1",
 				"1024",
 				strconv.Itoa(int(2 * time.Millisecond.Nanoseconds())),
@@ -2574,7 +2574,7 @@ var _ = Describe("Commands", func() {
 
 			hMGet = client.HMGet(ctx, "hash2", "set1", "set6")
 			Expect(hMGet.Err()).NotTo(HaveOccurred())
-			Expect(hMGet.Val()).To(Equal([]interface{}{
+			Expect(hMGet.Val()).To(Equal([]any{
 				"val2",
 				"val",
 			}))
@@ -3014,7 +3014,7 @@ var _ = Describe("Commands", func() {
 
 			values, err := client.HMGet(ctx, "myhash", "f1", "f2").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(values).To(Equal([]interface{}{"val1", "val2"}))
+			Expect(values).To(Equal([]any{"val1", "val2"}))
 		})
 	})
 
@@ -6045,16 +6045,16 @@ var _ = Describe("Commands", func() {
 			id, err := client.XAdd(ctx, &redis.XAddArgs{
 				Stream: "stream",
 				ID:     "1-0",
-				Values: map[string]interface{}{"uno": "un"},
+				Values: map[string]any{"uno": "un"},
 			}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(id).To(Equal("1-0"))
 
-			// Values supports []interface{}.
+			// Values supports []any.
 			id, err = client.XAdd(ctx, &redis.XAddArgs{
 				Stream: "stream",
 				ID:     "2-0",
-				Values: []interface{}{"dos", "deux"},
+				Values: []any{"dos", "deux"},
 			}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(id).To(Equal("2-0"))
@@ -6096,17 +6096,17 @@ var _ = Describe("Commands", func() {
 		It("should XAdd", func() {
 			id, err := client.XAdd(ctx, &redis.XAddArgs{
 				Stream: "stream",
-				Values: map[string]interface{}{"quatro": "quatre"},
+				Values: map[string]any{"quatro": "quatre"},
 			}).Result()
 			Expect(err).NotTo(HaveOccurred())
 
 			vals, err := client.XRange(ctx, "stream", "-", "+").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vals).To(Equal([]redis.XMessage{
-				{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
-				{ID: id, Values: map[string]interface{}{"quatro": "quatre"}},
+				{ID: "1-0", Values: map[string]any{"uno": "un"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
+				{ID: id, Values: map[string]any{"quatro": "quatre"}},
 			}))
 		})
 
@@ -6114,14 +6114,14 @@ var _ = Describe("Commands", func() {
 			id, err := client.XAdd(ctx, &redis.XAddArgs{
 				Stream: "stream",
 				MaxLen: 1,
-				Values: map[string]interface{}{"quatro": "quatre"},
+				Values: map[string]any{"quatro": "quatre"},
 			}).Result()
 			Expect(err).NotTo(HaveOccurred())
 
 			vals, err := client.XRange(ctx, "stream", "-", "+").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vals).To(Equal([]redis.XMessage{
-				{ID: id, Values: map[string]interface{}{"quatro": "quatre"}},
+				{ID: id, Values: map[string]any{"quatro": "quatre"}},
 			}))
 		})
 
@@ -6130,7 +6130,7 @@ var _ = Describe("Commands", func() {
 				Stream: "stream",
 				MinID:  "5-0",
 				ID:     "4-0",
-				Values: map[string]interface{}{"quatro": "quatre"},
+				Values: map[string]any{"quatro": "quatre"},
 			}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(id).To(Equal("4-0"))
@@ -6156,23 +6156,23 @@ var _ = Describe("Commands", func() {
 			msgs, err := client.XRange(ctx, "stream", "-", "+").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+				{ID: "1-0", Values: map[string]any{"uno": "un"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 			}))
 
 			msgs, err = client.XRange(ctx, "stream", "2", "+").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 			}))
 
 			msgs, err = client.XRange(ctx, "stream", "-", "2").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+				{ID: "1-0", Values: map[string]any{"uno": "un"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 			}))
 		})
 
@@ -6180,20 +6180,20 @@ var _ = Describe("Commands", func() {
 			msgs, err := client.XRangeN(ctx, "stream", "-", "+", 2).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+				{ID: "1-0", Values: map[string]any{"uno": "un"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 			}))
 
 			msgs, err = client.XRangeN(ctx, "stream", "2", "+", 1).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 			}))
 
 			msgs, err = client.XRangeN(ctx, "stream", "-", "2", 1).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
+				{ID: "1-0", Values: map[string]any{"uno": "un"}},
 			}))
 		})
 
@@ -6201,16 +6201,16 @@ var _ = Describe("Commands", func() {
 			msgs, err := client.XRevRange(ctx, "stream", "+", "-").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-				{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+				{ID: "1-0", Values: map[string]any{"uno": "un"}},
 			}))
 
 			msgs, err = client.XRevRange(ctx, "stream", "+", "2").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 			}))
 		})
 
@@ -6218,14 +6218,14 @@ var _ = Describe("Commands", func() {
 			msgs, err := client.XRevRangeN(ctx, "stream", "+", "-", 2).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 			}))
 
 			msgs, err = client.XRevRangeN(ctx, "stream", "+", "2", 1).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 			}))
 		})
 
@@ -6236,9 +6236,9 @@ var _ = Describe("Commands", func() {
 				{
 					Stream: "stream",
 					Messages: []redis.XMessage{
-						{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-						{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-						{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+						{ID: "1-0", Values: map[string]any{"uno": "un"}},
+						{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+						{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 					},
 				},
 			}))
@@ -6258,8 +6258,8 @@ var _ = Describe("Commands", func() {
 				{
 					Stream: "stream",
 					Messages: []redis.XMessage{
-						{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-						{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+						{ID: "1-0", Values: map[string]any{"uno": "un"}},
+						{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 					},
 				},
 			}))
@@ -6284,7 +6284,7 @@ var _ = Describe("Commands", func() {
 				{
 					Stream: "stream",
 					Messages: []redis.XMessage{
-						{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+						{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 					},
 				},
 			}))
@@ -6301,13 +6301,13 @@ var _ = Describe("Commands", func() {
 				{
 					Stream: "stream",
 					Messages: []redis.XMessage{
-						{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+						{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 					},
 				},
 				{
 					Stream: "stream",
 					Messages: []redis.XMessage{
-						{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+						{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 					},
 				},
 			}))
@@ -6323,7 +6323,7 @@ var _ = Describe("Commands", func() {
 				id, err := client.XAdd(ctx, &redis.XAddArgs{
 					Stream: "empty",
 					ID:     "4-0",
-					Values: map[string]interface{}{"quatro": "quatre"},
+					Values: map[string]any{"quatro": "quatre"},
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(id).To(Equal("4-0"))
@@ -6341,7 +6341,7 @@ var _ = Describe("Commands", func() {
 				{
 					Stream: "empty",
 					Messages: []redis.XMessage{
-						{ID: "4-0", Values: map[string]interface{}{"quatro": "quatre"}},
+						{ID: "4-0", Values: map[string]any{"quatro": "quatre"}},
 					},
 				},
 			}))
@@ -6362,9 +6362,9 @@ var _ = Describe("Commands", func() {
 					{
 						Stream: "stream",
 						Messages: []redis.XMessage{
-							{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-							{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-							{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+							{ID: "1-0", Values: map[string]any{"uno": "un"}},
+							{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+							{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 						},
 					},
 				}))
@@ -6391,9 +6391,9 @@ var _ = Describe("Commands", func() {
 					{
 						Stream: "stream",
 						Messages: []redis.XMessage{
-							{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
+							{ID: "1-0", Values: map[string]any{"uno": "un"}},
 							{ID: "2-0", Values: nil},
-							{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+							{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 						},
 					},
 				}))
@@ -6472,10 +6472,10 @@ var _ = Describe("Commands", func() {
 				Expect(start).To(Equal("3-0"))
 				Expect(msgs).To(Equal([]redis.XMessage{{
 					ID:     "1-0",
-					Values: map[string]interface{}{"uno": "un"},
+					Values: map[string]any{"uno": "un"},
 				}, {
 					ID:     "2-0",
-					Values: map[string]interface{}{"dos": "deux"},
+					Values: map[string]any{"dos": "deux"},
 				}}))
 
 				xca.Start = start
@@ -6484,7 +6484,7 @@ var _ = Describe("Commands", func() {
 				Expect(start).To(Equal("0-0"))
 				Expect(msgs).To(Equal([]redis.XMessage{{
 					ID:     "3-0",
-					Values: map[string]interface{}{"tres": "troix"},
+					Values: map[string]any{"tres": "troix"},
 				}}))
 
 				ids, start, err := client.XAutoClaimJustID(ctx, xca).Result()
@@ -6503,13 +6503,13 @@ var _ = Describe("Commands", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(msgs).To(Equal([]redis.XMessage{{
 					ID:     "1-0",
-					Values: map[string]interface{}{"uno": "un"},
+					Values: map[string]any{"uno": "un"},
 				}, {
 					ID:     "2-0",
-					Values: map[string]interface{}{"dos": "deux"},
+					Values: map[string]any{"dos": "deux"},
 				}, {
 					ID:     "3-0",
-					Values: map[string]interface{}{"tres": "troix"},
+					Values: map[string]any{"tres": "troix"},
 				}}))
 
 				ids, err := client.XClaimJustID(ctx, &redis.XClaimArgs{
@@ -6545,8 +6545,8 @@ var _ = Describe("Commands", func() {
 					{
 						Stream: "stream",
 						Messages: []redis.XMessage{
-							{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-							{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+							{ID: "1-0", Values: map[string]any{"uno": "un"}},
+							{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 						},
 					},
 				}))
@@ -6561,7 +6561,7 @@ var _ = Describe("Commands", func() {
 					{
 						Stream: "stream",
 						Messages: []redis.XMessage{
-							{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+							{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 						},
 					},
 				}))
@@ -6579,8 +6579,8 @@ var _ = Describe("Commands", func() {
 					{
 						Stream: "stream",
 						Messages: []redis.XMessage{
-							{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-							{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+							{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+							{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 						},
 					},
 				}))
@@ -6611,11 +6611,11 @@ var _ = Describe("Commands", func() {
 					EntriesAdded:      3,
 					FirstEntry: redis.XMessage{
 						ID:     "1-0",
-						Values: map[string]interface{}{"uno": "un"},
+						Values: map[string]any{"uno": "un"},
 					},
 					LastEntry: redis.XMessage{
 						ID:     "3-0",
-						Values: map[string]interface{}{"tres": "troix"},
+						Values: map[string]any{"tres": "troix"},
 					},
 					RecordedFirstEntryID: "1-0",
 				}))
@@ -7209,9 +7209,9 @@ var _ = Describe("Commands", func() {
 
 	Describe("marshaling/unmarshaling", func() {
 		type convTest struct {
-			value  interface{}
+			value  any
 			wanted string
-			dest   interface{}
+			dest   any
 		}
 
 		convTests := []convTest{
@@ -7284,7 +7284,7 @@ var _ = Describe("Commands", func() {
 				"hello",
 			).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vals).To(Equal([]interface{}{"key", "hello"}))
+			Expect(vals).To(Equal([]any{"key", "hello"}))
 		})
 
 		It("returns all values after an error", func() {
@@ -7294,7 +7294,7 @@ var _ = Describe("Commands", func() {
 				nil,
 			).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vals).To(Equal([]interface{}{int64(12), proto.RedisError("error"), "abc"}))
+			Expect(vals).To(Equal([]any{int64(12), proto.RedisError("error"), "abc"}))
 		})
 
 		It("returns empty values when args are nil", func() {
@@ -7318,7 +7318,7 @@ var _ = Describe("Commands", func() {
 				"hello",
 			).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vals).To(Equal([]interface{}{"key", "hello"}))
+			Expect(vals).To(Equal([]any{"key", "hello"}))
 		})
 
 		It("returns all values after an error", func() {
@@ -7328,7 +7328,7 @@ var _ = Describe("Commands", func() {
 				nil,
 			).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vals).To(Equal([]interface{}{int64(12), proto.RedisError("error"), "abc"}))
+			Expect(vals).To(Equal([]any{int64(12), proto.RedisError("error"), "abc"}))
 		})
 
 		It("returns empty values when args are nil", func() {
@@ -7718,7 +7718,7 @@ func (n *numberStruct) ScanRedis(str string) error {
 	return json.Unmarshal([]byte(str), n)
 }
 
-func deref(viface interface{}) interface{} {
+func deref(viface any) any {
 	v := reflect.ValueOf(viface)
 	for v.Kind() == reflect.Ptr {
 		v = v.Elem()

--- a/doctests/geo_index_test.go
+++ b/doctests/geo_index_test.go
@@ -34,7 +34,7 @@ func ExampleClient_geoindex() {
 		"productidx",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"product:"},
+			Prefix: []any{"product:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.location",
@@ -51,7 +51,7 @@ func ExampleClient_geoindex() {
 	// STEP_END
 
 	// STEP_START add_geo_json
-	prd46885 := map[string]interface{}{
+	prd46885 := map[string]any{
 		"description": "Navy Blue Slippers",
 		"price":       45.99,
 		"city":        "Denver",
@@ -66,7 +66,7 @@ func ExampleClient_geoindex() {
 
 	fmt.Println(gjResult1) // >>> OK
 
-	prd46886 := map[string]interface{}{
+	prd46886 := map[string]any{
 		"description": "Bright Green Socks",
 		"price":       25.50,
 		"city":        "Fort Collins",
@@ -99,7 +99,7 @@ func ExampleClient_geoindex() {
 	geomCreateResult, err := rdb.FTCreate(ctx, "geomidx",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"shape:"},
+			Prefix: []any{"shape:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.name",
@@ -122,7 +122,7 @@ func ExampleClient_geoindex() {
 	// STEP_END
 
 	// STEP_START add_gshape_json
-	shape1 := map[string]interface{}{
+	shape1 := map[string]any{
 		"name": "Green Square",
 		"geom": "POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))",
 	}
@@ -135,7 +135,7 @@ func ExampleClient_geoindex() {
 
 	fmt.Println(gmjResult1) // >>> OK
 
-	shape2 := map[string]interface{}{
+	shape2 := map[string]any{
 		"name": "Red Rectangle",
 		"geom": "POLYGON ((2 2.5, 2 3.5, 3.5 3.5, 3.5 2.5, 2 2.5))",
 	}
@@ -148,7 +148,7 @@ func ExampleClient_geoindex() {
 
 	fmt.Println(gmjResult2) // >>> OK
 
-	shape3 := map[string]interface{}{
+	shape3 := map[string]any{
 		"name": "Blue Triangle",
 		"geom": "POLYGON ((3.5 1, 3.75 2, 4 1, 3.5 1))",
 	}
@@ -161,7 +161,7 @@ func ExampleClient_geoindex() {
 
 	fmt.Println(gmjResult3) // >>> OK
 
-	shape4 := map[string]interface{}{
+	shape4 := map[string]any{
 		"name": "Purple Point",
 		"geom": "POINT (2 2)",
 	}
@@ -179,7 +179,7 @@ func ExampleClient_geoindex() {
 	geomQueryResult, err := rdb.FTSearchWithArgs(ctx, "geomidx",
 		"(-@name:(Green Square) @geom:[WITHIN $qshape])",
 		&redis.FTSearchOptions{
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"qshape": "POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))",
 			},
 			DialectVersion: 4,

--- a/doctests/home_json_example_test.go
+++ b/doctests/home_json_example_test.go
@@ -33,21 +33,21 @@ func ExampleClient_search_json() {
 	// REMOVE_END
 
 	// STEP_START create_data
-	user1 := map[string]interface{}{
+	user1 := map[string]any{
 		"name":  "Paul John",
 		"email": "paul.john@example.com",
 		"age":   42,
 		"city":  "London",
 	}
 
-	user2 := map[string]interface{}{
+	user2 := map[string]any{
 		"name":  "Eden Zamir",
 		"email": "eden.zamir@example.com",
 		"age":   29,
 		"city":  "Tel Aviv",
 	}
 
-	user3 := map[string]interface{}{
+	user3 := map[string]any{
 		"name":  "Paul Zamir",
 		"email": "paul.zamir@example.com",
 		"age":   35,
@@ -62,7 +62,7 @@ func ExampleClient_search_json() {
 		// Options:
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"user:"},
+			Prefix: []any{"user:"},
 		},
 		// Index schema fields:
 		&redis.FieldSchema{
@@ -182,7 +182,7 @@ func ExampleClient_search_json() {
 	aggOptions := redis.FTAggregateOptions{
 		GroupBy: []redis.FTAggregateGroupBy{
 			{
-				Fields: []interface{}{"@city"},
+				Fields: []any{"@city"},
 				Reduce: []redis.FTAggregateReducer{
 					{
 						Reducer: redis.SearchCount,
@@ -250,7 +250,7 @@ func ExampleClient_search_hash() {
 		// Options:
 		&redis.FTCreateOptions{
 			OnHash: true,
-			Prefix: []interface{}{"huser:"},
+			Prefix: []any{"huser:"},
 		},
 		// Index schema fields:
 		&redis.FieldSchema{
@@ -272,21 +272,21 @@ func ExampleClient_search_hash() {
 	}
 	// STEP_END
 
-	user1 := map[string]interface{}{
+	user1 := map[string]any{
 		"name":  "Paul John",
 		"email": "paul.john@example.com",
 		"age":   42,
 		"city":  "London",
 	}
 
-	user2 := map[string]interface{}{
+	user2 := map[string]any{
 		"name":  "Eden Zamir",
 		"email": "eden.zamir@example.com",
 		"age":   29,
 		"city":  "Tel Aviv",
 	}
 
-	user3 := map[string]interface{}{
+	user3 := map[string]any{
 		"name":  "Paul Zamir",
 		"email": "paul.zamir@example.com",
 		"age":   35,

--- a/doctests/json_tutorial_test.go
+++ b/doctests/json_tutorial_test.go
@@ -187,9 +187,9 @@ func ExampleClient_arr() {
 
 	// STEP_START arr
 	res11, err := rdb.JSONSet(ctx, "newbike", "$",
-		[]interface{}{
+		[]any{
 			"Deimos",
-			map[string]interface{}{"crashes": 0},
+			map[string]any{"crashes": 0},
 			nil,
 		},
 	).Result()
@@ -255,7 +255,7 @@ func ExampleClient_arr2() {
 	// REMOVE_END
 
 	// STEP_START arr2
-	res16, err := rdb.JSONSet(ctx, "riders", "$", []interface{}{}).Result()
+	res16, err := rdb.JSONSet(ctx, "riders", "$", []any{}).Result()
 
 	if err != nil {
 		panic(err)
@@ -361,7 +361,7 @@ func ExampleClient_obj() {
 
 	// STEP_START obj
 	res25, err := rdb.JSONSet(ctx, "bike:1", "$",
-		map[string]interface{}{
+		map[string]any{
 			"model": "Deimos",
 			"brand": "Ergonom",
 			"price": 4972,
@@ -397,10 +397,10 @@ func ExampleClient_obj() {
 	// [[brand model price]]
 }
 
-var inventory_json = map[string]interface{}{
-	"inventory": map[string]interface{}{
-		"mountain_bikes": []interface{}{
-			map[string]interface{}{
+var inventory_json = map[string]any{
+	"inventory": map[string]any{
+		"mountain_bikes": []any{
+			map[string]any{
 				"id":    "bike:1",
 				"model": "Phoebe",
 				"description": "This is a mid-travel trail slayer that is a fantastic " +
@@ -409,10 +409,10 @@ var inventory_json = map[string]interface{}{
 					"mudguards and a rack too.  This is the bike for the rider who wants " +
 					"trail manners with low fuss ownership.",
 				"price":  1920,
-				"specs":  map[string]interface{}{"material": "carbon", "weight": 13.1},
-				"colors": []interface{}{"black", "silver"},
+				"specs":  map[string]any{"material": "carbon", "weight": 13.1},
+				"colors": []any{"black", "silver"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":    "bike:2",
 				"model": "Quaoar",
 				"description": "Redesigned for the 2020 model year, this bike " +
@@ -422,10 +422,10 @@ var inventory_json = map[string]interface{}{
 					"and tear. All in all it's an impressive package for the price, " +
 					"making it very competitive.",
 				"price":  2072,
-				"specs":  map[string]interface{}{"material": "aluminium", "weight": 7.9},
-				"colors": []interface{}{"black", "white"},
+				"specs":  map[string]any{"material": "aluminium", "weight": 7.9},
+				"colors": []any{"black", "white"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":    "bike:3",
 				"model": "Weywot",
 				"description": "This bike gives kids aged six years and older " +
@@ -435,11 +435,11 @@ var inventory_json = map[string]interface{}{
 					"ability. If you're after a budget option, this is one of the best " +
 					"bikes you could get.",
 				"price": 3264,
-				"specs": map[string]interface{}{"material": "alloy", "weight": 13.8},
+				"specs": map[string]any{"material": "alloy", "weight": 13.8},
 			},
 		},
-		"commuter_bikes": []interface{}{
-			map[string]interface{}{
+		"commuter_bikes": []any{
+			map[string]any{
 				"id":    "bike:4",
 				"model": "Salacia",
 				"description": "This bike is a great option for anyone who just " +
@@ -448,10 +448,10 @@ var inventory_json = map[string]interface{}{
 					"bank and delivers craved performance.  It\u2019s for the rider " +
 					"who wants both efficiency and capability.",
 				"price":  1475,
-				"specs":  map[string]interface{}{"material": "aluminium", "weight": 16.6},
-				"colors": []interface{}{"black", "silver"},
+				"specs":  map[string]any{"material": "aluminium", "weight": 16.6},
+				"colors": []any{"black", "silver"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":    "bike:5",
 				"model": "Mimas",
 				"description": "A real joy to ride, this bike got very high " +
@@ -463,7 +463,7 @@ var inventory_json = map[string]interface{}{
 					"conveniently placed thumb throttle. Put it all together and you " +
 					"get a bike that helps redefine what can be done for this price.",
 				"price": 3941,
-				"specs": map[string]interface{}{"material": "alloy", "weight": 11.6},
+				"specs": map[string]any{"material": "alloy", "weight": 11.6},
 			},
 		},
 	},
@@ -483,10 +483,10 @@ func ExampleClient_setbikes() {
 	// REMOVE_END
 
 	// STEP_START set_bikes
-	var inventory_json = map[string]interface{}{
-		"inventory": map[string]interface{}{
-			"mountain_bikes": []interface{}{
-				map[string]interface{}{
+	var inventory_json = map[string]any{
+		"inventory": map[string]any{
+			"mountain_bikes": []any{
+				map[string]any{
 					"id":    "bike:1",
 					"model": "Phoebe",
 					"description": "This is a mid-travel trail slayer that is a fantastic " +
@@ -495,10 +495,10 @@ func ExampleClient_setbikes() {
 						"mudguards and a rack too.  This is the bike for the rider who wants " +
 						"trail manners with low fuss ownership.",
 					"price":  1920,
-					"specs":  map[string]interface{}{"material": "carbon", "weight": 13.1},
-					"colors": []interface{}{"black", "silver"},
+					"specs":  map[string]any{"material": "carbon", "weight": 13.1},
+					"colors": []any{"black", "silver"},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "bike:2",
 					"model": "Quaoar",
 					"description": "Redesigned for the 2020 model year, this bike " +
@@ -508,10 +508,10 @@ func ExampleClient_setbikes() {
 						"and tear. All in all it's an impressive package for the price, " +
 						"making it very competitive.",
 					"price":  2072,
-					"specs":  map[string]interface{}{"material": "aluminium", "weight": 7.9},
-					"colors": []interface{}{"black", "white"},
+					"specs":  map[string]any{"material": "aluminium", "weight": 7.9},
+					"colors": []any{"black", "white"},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "bike:3",
 					"model": "Weywot",
 					"description": "This bike gives kids aged six years and older " +
@@ -521,11 +521,11 @@ func ExampleClient_setbikes() {
 						"ability. If you're after a budget option, this is one of the best " +
 						"bikes you could get.",
 					"price": 3264,
-					"specs": map[string]interface{}{"material": "alloy", "weight": 13.8},
+					"specs": map[string]any{"material": "alloy", "weight": 13.8},
 				},
 			},
-			"commuter_bikes": []interface{}{
-				map[string]interface{}{
+			"commuter_bikes": []any{
+				map[string]any{
 					"id":    "bike:4",
 					"model": "Salacia",
 					"description": "This bike is a great option for anyone who just " +
@@ -534,10 +534,10 @@ func ExampleClient_setbikes() {
 						"bank and delivers craved performance.  It\u2019s for the rider " +
 						"who wants both efficiency and capability.",
 					"price":  1475,
-					"specs":  map[string]interface{}{"material": "aluminium", "weight": 16.6},
-					"colors": []interface{}{"black", "silver"},
+					"specs":  map[string]any{"material": "aluminium", "weight": 16.6},
+					"colors": []any{"black", "silver"},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "bike:5",
 					"model": "Mimas",
 					"description": "A real joy to ride, this bike got very high " +
@@ -549,7 +549,7 @@ func ExampleClient_setbikes() {
 						"conveniently placed thumb throttle. Put it all together and you " +
 						"get a bike that helps redefine what can be done for this price.",
 					"price": 3941,
-					"specs": map[string]interface{}{"material": "alloy", "weight": 11.6},
+					"specs": map[string]any{"material": "alloy", "weight": 11.6},
 				},
 			},
 		},

--- a/doctests/query_agg_test.go
+++ b/doctests/query_agg_test.go
@@ -30,7 +30,7 @@ func ExampleClient_query_agg() {
 	_, err := rdb.FTCreate(ctx, "idx:bicycle",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"bicycle:"},
+			Prefix: []any{"bicycle:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.brand",
@@ -63,7 +63,7 @@ func ExampleClient_query_agg() {
 		panic(err)
 	}
 
-	exampleJsons := []map[string]interface{}{
+	exampleJsons := []map[string]any{
 		{
 			"pickup_zone": "POLYGON((-74.0610 40.7578, -73.9510 40.7578, -73.9510 40.6678, " +
 				"-74.0610 40.6678, -74.0610 40.7578))",
@@ -282,11 +282,11 @@ func ExampleClient_query_agg() {
 			},
 			GroupBy: []redis.FTAggregateGroupBy{
 				{
-					Fields: []interface{}{"@condition"},
+					Fields: []any{"@condition"},
 					Reduce: []redis.FTAggregateReducer{
 						{
 							Reducer: redis.SearchSum,
-							Args:    []interface{}{"@price_category"},
+							Args:    []any{"@price_category"},
 							As:      "num_affordable",
 						},
 					},
@@ -331,7 +331,7 @@ func ExampleClient_query_agg() {
 			},
 			GroupBy: []redis.FTAggregateGroupBy{
 				{
-					Fields: []interface{}{"@type"},
+					Fields: []any{"@type"},
 					Reduce: []redis.FTAggregateReducer{
 						{
 							Reducer: redis.SearchCount,
@@ -368,11 +368,11 @@ func ExampleClient_query_agg() {
 			},
 			GroupBy: []redis.FTAggregateGroupBy{
 				{
-					Fields: []interface{}{"@condition"},
+					Fields: []any{"@condition"},
 					Reduce: []redis.FTAggregateReducer{
 						{
 							Reducer: redis.SearchToList,
-							Args:    []interface{}{"__key"},
+							Args:    []any{"__key"},
 							As:      "bicycles",
 						},
 					},
@@ -393,7 +393,7 @@ func ExampleClient_query_agg() {
 	})
 
 	for _, row := range res4.Rows {
-		rowBikes := row.Fields["bicycles"].([]interface{})
+		rowBikes := row.Fields["bicycles"].([]any)
 		bikes := make([]string, len(rowBikes))
 
 		for i, rowBike := range rowBikes {

--- a/doctests/query_em_test.go
+++ b/doctests/query_em_test.go
@@ -32,7 +32,7 @@ func ExampleClient_query_em() {
 	_, err := rdb.FTCreate(ctx, "idx:bicycle",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"bicycle:"},
+			Prefix: []any{"bicycle:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.brand",
@@ -65,7 +65,7 @@ func ExampleClient_query_em() {
 		panic(err)
 	}
 
-	exampleJsons := []map[string]interface{}{
+	exampleJsons := []map[string]any{
 		{
 			"pickup_zone": "POLYGON((-74.0610 40.7578, -73.9510 40.7578, -73.9510 40.6678, " +
 				"-74.0610 40.6678, -74.0610 40.7578))",
@@ -298,7 +298,7 @@ func ExampleClient_query_em() {
 		"idx:email",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"key:"},
+			Prefix: []any{"key:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.email",
@@ -314,7 +314,7 @@ func ExampleClient_query_em() {
 	fmt.Println(res4) // >>> OK
 
 	res5, err := rdb.JSONSet(ctx, "key:1", "$",
-		map[string]interface{}{
+		map[string]any{
 			"email": "test@redis.com",
 		},
 	).Result()

--- a/doctests/query_ft_test.go
+++ b/doctests/query_ft_test.go
@@ -30,7 +30,7 @@ func ExampleClient_query_ft() {
 	_, err := rdb.FTCreate(ctx, "idx:bicycle",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"bicycle:"},
+			Prefix: []any{"bicycle:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.brand",
@@ -63,7 +63,7 @@ func ExampleClient_query_ft() {
 		panic(err)
 	}
 
-	exampleJsons := []map[string]interface{}{
+	exampleJsons := []map[string]any{
 		{
 			"pickup_zone": "POLYGON((-74.0610 40.7578, -73.9510 40.7578, -73.9510 40.6678, " +
 				"-74.0610 40.6678, -74.0610 40.7578))",

--- a/doctests/query_geo_test.go
+++ b/doctests/query_geo_test.go
@@ -29,7 +29,7 @@ func ExampleClient_query_geo() {
 	_, err := rdb.FTCreate(ctx, "idx:bicycle",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"bicycle:"},
+			Prefix: []any{"bicycle:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.brand",
@@ -73,7 +73,7 @@ func ExampleClient_query_geo() {
 		panic(err)
 	}
 
-	exampleJsons := []map[string]interface{}{
+	exampleJsons := []map[string]any{
 		{
 			"pickup_zone": "POLYGON((-74.0610 40.7578, -73.9510 40.7578, -73.9510 40.6678, " +
 				"-74.0610 40.6678, -74.0610 40.7578))",
@@ -237,7 +237,7 @@ func ExampleClient_query_geo() {
 	res1, err := rdb.FTSearchWithArgs(ctx,
 		"idx:bicycle", "@store_location:[$lon $lat $radius $units]",
 		&redis.FTSearchOptions{
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"lon":    -0.1778,
 				"lat":    51.5524,
 				"radius": 20,
@@ -264,7 +264,7 @@ func ExampleClient_query_geo() {
 		"idx:bicycle",
 		"@pickup_zone:[CONTAINS $bike]",
 		&redis.FTSearchOptions{
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"bike": "POINT(-0.1278 51.5074)",
 			},
 			DialectVersion: 3,
@@ -288,7 +288,7 @@ func ExampleClient_query_geo() {
 		"idx:bicycle",
 		"@pickup_zone:[WITHIN $europe]",
 		&redis.FTSearchOptions{
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"europe": "POLYGON((-25 35, 40 35, 40 70, -25 70, -25 35))",
 			},
 			DialectVersion: 3,

--- a/doctests/query_range_test.go
+++ b/doctests/query_range_test.go
@@ -28,7 +28,7 @@ func ExampleClient_query_range() {
 	_, err := rdb.FTCreate(ctx, "idx:bicycle",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"bicycle:"},
+			Prefix: []any{"bicycle:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.brand",
@@ -61,7 +61,7 @@ func ExampleClient_query_range() {
 		panic(err)
 	}
 
-	exampleJsons := []map[string]interface{}{
+	exampleJsons := []map[string]any{
 		{
 			"pickup_zone": "POLYGON((-74.0610 40.7578, -73.9510 40.7578, -73.9510 40.6678, " +
 				"-74.0610 40.6678, -74.0610 40.7578))",

--- a/doctests/stream_tutorial_test.go
+++ b/doctests/stream_tutorial_test.go
@@ -12,7 +12,7 @@ import (
 // HIDE_END
 
 // REMOVE_START
-func UNUSED(v ...interface{}) {}
+func UNUSED(v ...any) {}
 
 // REMOVE_END
 
@@ -34,7 +34,7 @@ func ExampleClient_xadd() {
 	// STEP_START xadd
 	res1, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Castilla",
 			"speed":       30.2,
 			"position":    1,
@@ -50,7 +50,7 @@ func ExampleClient_xadd() {
 
 	res2, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Norem",
 			"speed":       28.8,
 			"position":    3,
@@ -66,7 +66,7 @@ func ExampleClient_xadd() {
 
 	res3, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Prickett",
 			"speed":       29.7,
 			"position":    2,
@@ -114,7 +114,7 @@ func ExampleClient_racefrance1() {
 
 	_, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Castilla",
 			"speed":       30.2,
 			"position":    1,
@@ -129,7 +129,7 @@ func ExampleClient_racefrance1() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Norem",
 			"speed":       28.8,
 			"position":    3,
@@ -144,7 +144,7 @@ func ExampleClient_racefrance1() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Prickett",
 			"speed":       29.7,
 			"position":    2,
@@ -186,7 +186,7 @@ func ExampleClient_racefrance1() {
 	// STEP_START xadd_2
 	res6, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Castilla",
 			"speed":       29.9,
 			"position":    1,
@@ -239,7 +239,7 @@ func ExampleClient_raceusa() {
 	// STEP_START xadd_id
 	res8, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:usa",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"racer": "Castilla",
 		},
 		ID: "0-1",
@@ -253,7 +253,7 @@ func ExampleClient_raceusa() {
 
 	res9, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:usa",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"racer": "Norem",
 		},
 		ID: "0-2",
@@ -268,7 +268,7 @@ func ExampleClient_raceusa() {
 
 	// STEP_START xadd_bad_id
 	res10, err := rdb.XAdd(ctx, &redis.XAddArgs{
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"racer": "Prickett",
 		},
 		ID: "0-1",
@@ -283,7 +283,7 @@ func ExampleClient_raceusa() {
 	// STEP_START xadd_7
 	res11, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:usa",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"racer": "Prickett",
 		},
 		ID: "0-*",
@@ -323,7 +323,7 @@ func ExampleClient_racefrance2() {
 
 	_, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Castilla",
 			"speed":       30.2,
 			"position":    1,
@@ -338,7 +338,7 @@ func ExampleClient_racefrance2() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Norem",
 			"speed":       28.8,
 			"position":    3,
@@ -353,7 +353,7 @@ func ExampleClient_racefrance2() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Prickett",
 			"speed":       29.7,
 			"position":    2,
@@ -368,7 +368,7 @@ func ExampleClient_racefrance2() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Castilla",
 			"speed":       29.9,
 			"position":    1,
@@ -493,7 +493,7 @@ func ExampleClient_xgroupcreate() {
 
 	_, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Castilla",
 			"speed":       30.2,
 			"position":    1,
@@ -577,7 +577,7 @@ func ExampleClient_xgroupread() {
 	// STEP_START xgroup_read
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Castilla"},
+		Values: map[string]any{"rider": "Castilla"},
 	}).Result()
 	// >>> 1692632639151-0
 
@@ -587,7 +587,7 @@ func ExampleClient_xgroupread() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Royce"},
+		Values: map[string]any{"rider": "Royce"},
 	}).Result()
 	// >>> 1692632647899-0
 
@@ -597,7 +597,7 @@ func ExampleClient_xgroupread() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Sam-Bodden"},
+		Values: map[string]any{"rider": "Sam-Bodden"},
 	}).Result()
 	// >>> 1692632662819-0
 
@@ -607,7 +607,7 @@ func ExampleClient_xgroupread() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Prickett"},
+		Values: map[string]any{"rider": "Prickett"},
 	}).Result()
 	// >>> 1692632670501-0
 
@@ -617,7 +617,7 @@ func ExampleClient_xgroupread() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Norem"},
+		Values: map[string]any{"rider": "Norem"},
 	}).Result()
 	// >>> 1692632678249-0
 
@@ -684,7 +684,7 @@ func ExampleClient_raceitaly() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Castilla"},
+		Values: map[string]any{"rider": "Castilla"},
 		ID:     "1692632639151-0",
 	}).Result()
 
@@ -694,7 +694,7 @@ func ExampleClient_raceitaly() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Royce"},
+		Values: map[string]any{"rider": "Royce"},
 		ID:     "1692632647899-0",
 	}).Result()
 
@@ -704,7 +704,7 @@ func ExampleClient_raceitaly() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Sam-Bodden"},
+		Values: map[string]any{"rider": "Sam-Bodden"},
 		ID:     "1692632662819-0",
 	}).Result()
 
@@ -714,7 +714,7 @@ func ExampleClient_raceitaly() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Prickett"},
+		Values: map[string]any{"rider": "Prickett"},
 		ID:     "1692632670501-0",
 	}).Result()
 
@@ -724,7 +724,7 @@ func ExampleClient_raceitaly() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Norem"},
+		Values: map[string]any{"rider": "Norem"},
 		ID:     "1692632678249-0",
 	}).Result()
 
@@ -926,7 +926,7 @@ func ExampleClient_raceitaly() {
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
 		MaxLen: 2,
-		Values: map[string]interface{}{"rider": "Jones"},
+		Values: map[string]any{"rider": "Jones"},
 	},
 	).Result()
 
@@ -937,7 +937,7 @@ func ExampleClient_raceitaly() {
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
 		MaxLen: 2,
-		Values: map[string]interface{}{"rider": "Wood"},
+		Values: map[string]any{"rider": "Wood"},
 	},
 	).Result()
 
@@ -948,7 +948,7 @@ func ExampleClient_raceitaly() {
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
 		MaxLen: 2,
-		Values: map[string]interface{}{"rider": "Henshaw"},
+		Values: map[string]any{"rider": "Henshaw"},
 	},
 	).Result()
 
@@ -1035,7 +1035,7 @@ func ExampleClient_xdel() {
 	_, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
 		MaxLen: 2,
-		Values: map[string]interface{}{"rider": "Wood"},
+		Values: map[string]any{"rider": "Wood"},
 		ID:     "1692633198206-0",
 	},
 	).Result()
@@ -1047,7 +1047,7 @@ func ExampleClient_xdel() {
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
 		MaxLen: 2,
-		Values: map[string]interface{}{"rider": "Henshaw"},
+		Values: map[string]any{"rider": "Henshaw"},
 		ID:     "1692633208557-0",
 	},
 	).Result()

--- a/export_test.go
+++ b/export_test.go
@@ -99,7 +99,7 @@ func (c *Ring) ShardByName(name string) *ringShard {
 	return shard
 }
 
-func (c *ModuleLoadexConfig) ToArgs() []interface{} {
+func (c *ModuleLoadexConfig) ToArgs() []any {
 	return c.toArgs()
 }
 

--- a/extra/rediscmd/rediscmd.go
+++ b/extra/rediscmd/rediscmd.go
@@ -61,7 +61,7 @@ func AppendCmd(b []byte, cmd redis.Cmder) []byte {
 	return b
 }
 
-func appendArg(b []byte, v interface{}) []byte {
+func appendArg(b []byte, v any) []byte {
 	switch v := v.(type) {
 	case nil:
 		return append(b, "<nil>"...)

--- a/extra/redisotel/tracing_test.go
+++ b/extra/redisotel/tracing_test.go
@@ -386,7 +386,7 @@ func TestTracingHook_ProcessPipelineHook_LongCommands(t *testing.T) {
 	}
 }
 
-func assertEqual(t *testing.T, expected, actual interface{}) {
+func assertEqual(t *testing.T, expected, actual any) {
 	t.Helper()
 	if expected != actual {
 		t.Fatalf("expected %v, got %v", expected, actual)

--- a/generic_commands.go
+++ b/generic_commands.go
@@ -47,7 +47,7 @@ type GenericCmdable interface {
 }
 
 func (c cmdable) Del(ctx context.Context, keys ...string) *IntCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "del"
 	for i, key := range keys {
 		args[1+i] = key
@@ -58,7 +58,7 @@ func (c cmdable) Del(ctx context.Context, keys ...string) *IntCmd {
 }
 
 func (c cmdable) Unlink(ctx context.Context, keys ...string) *IntCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "unlink"
 	for i, key := range keys {
 		args[1+i] = key
@@ -75,7 +75,7 @@ func (c cmdable) Dump(ctx context.Context, key string) *StringCmd {
 }
 
 func (c cmdable) Exists(ctx context.Context, keys ...string) *IntCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "exists"
 	for i, key := range keys {
 		args[1+i] = key
@@ -108,7 +108,7 @@ func (c cmdable) ExpireLT(ctx context.Context, key string, expiration time.Durat
 func (c cmdable) expire(
 	ctx context.Context, key string, expiration time.Duration, mode string,
 ) *BoolCmd {
-	args := make([]interface{}, 3, 4)
+	args := make([]any, 3, 4)
 	args[0] = "expire"
 	args[1] = key
 	args[2] = formatSec(ctx, expiration)
@@ -270,8 +270,8 @@ type Sort struct {
 	Alpha         bool
 }
 
-func (sort *Sort) args(command, key string) []interface{} {
-	args := []interface{}{command, key}
+func (sort *Sort) args(command, key string) []any {
+	args := []any{command, key}
 
 	if sort.By != "" {
 		args = append(args, "by", sort.By)
@@ -320,7 +320,7 @@ func (c cmdable) SortInterfaces(ctx context.Context, key string, sort *Sort) *Sl
 }
 
 func (c cmdable) Touch(ctx context.Context, keys ...string) *IntCmd {
-	args := make([]interface{}, len(keys)+1)
+	args := make([]any, len(keys)+1)
 	args[0] = "touch"
 	for i, key := range keys {
 		args[i+1] = key
@@ -343,7 +343,7 @@ func (c cmdable) Type(ctx context.Context, key string) *StatusCmd {
 }
 
 func (c cmdable) Copy(ctx context.Context, sourceKey, destKey string, db int, replace bool) *IntCmd {
-	args := []interface{}{"copy", sourceKey, destKey, "DB", db}
+	args := []any{"copy", sourceKey, destKey, "DB", db}
 	if replace {
 		args = append(args, "REPLACE")
 	}
@@ -355,7 +355,7 @@ func (c cmdable) Copy(ctx context.Context, sourceKey, destKey string, db int, re
 //------------------------------------------------------------------------------
 
 func (c cmdable) Scan(ctx context.Context, cursor uint64, match string, count int64) *ScanCmd {
-	args := []interface{}{"scan", cursor}
+	args := []any{"scan", cursor}
 	if match != "" {
 		args = append(args, "match", match)
 	}
@@ -368,7 +368,7 @@ func (c cmdable) Scan(ctx context.Context, cursor uint64, match string, count in
 }
 
 func (c cmdable) ScanType(ctx context.Context, cursor uint64, match string, count int64, keyType string) *ScanCmd {
-	args := []interface{}{"scan", cursor}
+	args := []any{"scan", cursor}
 	if match != "" {
 		args = append(args, "match", match)
 	}

--- a/geo_commands.go
+++ b/geo_commands.go
@@ -20,7 +20,7 @@ type GeoCmdable interface {
 }
 
 func (c cmdable) GeoAdd(ctx context.Context, key string, geoLocation ...*GeoLocation) *IntCmd {
-	args := make([]interface{}, 2+3*len(geoLocation))
+	args := make([]any, 2+3*len(geoLocation))
 	args[0] = "geoadd"
 	args[1] = key
 	for i, eachLoc := range geoLocation {
@@ -88,7 +88,7 @@ func (c cmdable) GeoRadiusByMemberStore(
 }
 
 func (c cmdable) GeoSearch(ctx context.Context, key string, q *GeoSearchQuery) *StringSliceCmd {
-	args := make([]interface{}, 0, 13)
+	args := make([]any, 0, 13)
 	args = append(args, "geosearch", key)
 	args = geoSearchArgs(q, args)
 	cmd := NewStringSliceCmd(ctx, args...)
@@ -99,7 +99,7 @@ func (c cmdable) GeoSearch(ctx context.Context, key string, q *GeoSearchQuery) *
 func (c cmdable) GeoSearchLocation(
 	ctx context.Context, key string, q *GeoSearchLocationQuery,
 ) *GeoSearchLocationCmd {
-	args := make([]interface{}, 0, 16)
+	args := make([]any, 0, 16)
 	args = append(args, "geosearch", key)
 	args = geoSearchLocationArgs(q, args)
 	cmd := NewGeoSearchLocationCmd(ctx, q, args...)
@@ -108,7 +108,7 @@ func (c cmdable) GeoSearchLocation(
 }
 
 func (c cmdable) GeoSearchStore(ctx context.Context, key, store string, q *GeoSearchStoreQuery) *IntCmd {
-	args := make([]interface{}, 0, 15)
+	args := make([]any, 0, 15)
 	args = append(args, "geosearchstore", store, key)
 	args = geoSearchArgs(&q.GeoSearchQuery, args)
 	if q.StoreDist {
@@ -131,7 +131,7 @@ func (c cmdable) GeoDist(
 }
 
 func (c cmdable) GeoHash(ctx context.Context, key string, members ...string) *StringSliceCmd {
-	args := make([]interface{}, 2+len(members))
+	args := make([]any, 2+len(members))
 	args[0] = "geohash"
 	args[1] = key
 	for i, member := range members {
@@ -143,7 +143,7 @@ func (c cmdable) GeoHash(ctx context.Context, key string, members ...string) *St
 }
 
 func (c cmdable) GeoPos(ctx context.Context, key string, members ...string) *GeoPosCmd {
-	args := make([]interface{}, 2+len(members))
+	args := make([]any, 2+len(members))
 	args[0] = "geopos"
 	args[1] = key
 	for i, member := range members {

--- a/hash_commands.go
+++ b/hash_commands.go
@@ -18,11 +18,11 @@ type HashCmdable interface {
 	HKeys(ctx context.Context, key string) *StringSliceCmd
 	HLen(ctx context.Context, key string) *IntCmd
 	HMGet(ctx context.Context, key string, fields ...string) *SliceCmd
-	HSet(ctx context.Context, key string, values ...interface{}) *IntCmd
-	HMSet(ctx context.Context, key string, values ...interface{}) *BoolCmd
+	HSet(ctx context.Context, key string, values ...any) *IntCmd
+	HMSet(ctx context.Context, key string, values ...any) *BoolCmd
 	HSetEX(ctx context.Context, key string, fieldsAndValues ...string) *IntCmd
 	HSetEXWithArgs(ctx context.Context, key string, options *HSetEXOptions, fieldsAndValues ...string) *IntCmd
-	HSetNX(ctx context.Context, key, field string, value interface{}) *BoolCmd
+	HSetNX(ctx context.Context, key, field string, value any) *BoolCmd
 	HScan(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd
 	HScanNoValues(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd
 	HVals(ctx context.Context, key string) *StringSliceCmd
@@ -45,7 +45,7 @@ type HashCmdable interface {
 }
 
 func (c cmdable) HDel(ctx context.Context, key string, fields ...string) *IntCmd {
-	args := make([]interface{}, 2+len(fields))
+	args := make([]any, 2+len(fields))
 	args[0] = "hdel"
 	args[1] = key
 	for i, field := range fields {
@@ -99,9 +99,9 @@ func (c cmdable) HLen(ctx context.Context, key string) *IntCmd {
 }
 
 // HMGet returns the values for the specified fields in the hash stored at key.
-// It returns an interface{} to distinguish between empty string and nil value.
+// It returns an any to distinguish between empty string and nil value.
 func (c cmdable) HMGet(ctx context.Context, key string, fields ...string) *SliceCmd {
-	args := make([]interface{}, 2+len(fields))
+	args := make([]any, 2+len(fields))
 	args[0] = "hmget"
 	args[1] = key
 	for i, field := range fields {
@@ -118,7 +118,7 @@ func (c cmdable) HMGet(ctx context.Context, key string, fields ...string) *Slice
 //
 //   - HSet("myhash", []string{"key1", "value1", "key2", "value2"})
 //
-//   - HSet("myhash", map[string]interface{}{"key1": "value1", "key2": "value2"})
+//   - HSet("myhash", map[string]any{"key1": "value1", "key2": "value2"})
 //
 //     Playing struct With "redis" tag.
 //     type MyHash struct { Key1 string `redis:"key1"`; Key2 int `redis:"key2"` }
@@ -136,8 +136,8 @@ func (c cmdable) HMGet(ctx context.Context, key string, fields ...string) *Slice
 // redis-docs: https://redis.io/commands/hset (Starting with Redis version 4.0.0: Accepts multiple field and value arguments.)
 // If you are using a Struct type and the number of fields is greater than one,
 // you will receive an error similar to "ERR wrong number of arguments", you can use HMSet as a substitute.
-func (c cmdable) HSet(ctx context.Context, key string, values ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(values))
+func (c cmdable) HSet(ctx context.Context, key string, values ...any) *IntCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "hset"
 	args[1] = key
 	args = appendArgs(args, values)
@@ -147,8 +147,8 @@ func (c cmdable) HSet(ctx context.Context, key string, values ...interface{}) *I
 }
 
 // HMSet is a deprecated version of HSet left for compatibility with Redis 3.
-func (c cmdable) HMSet(ctx context.Context, key string, values ...interface{}) *BoolCmd {
-	args := make([]interface{}, 2, 2+len(values))
+func (c cmdable) HMSet(ctx context.Context, key string, values ...any) *BoolCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "hmset"
 	args[1] = key
 	args = appendArgs(args, values)
@@ -157,7 +157,7 @@ func (c cmdable) HMSet(ctx context.Context, key string, values ...interface{}) *
 	return cmd
 }
 
-func (c cmdable) HSetNX(ctx context.Context, key, field string, value interface{}) *BoolCmd {
+func (c cmdable) HSetNX(ctx context.Context, key, field string, value any) *BoolCmd {
 	cmd := NewBoolCmd(ctx, "hsetnx", key, field, value)
 	_ = c(ctx, cmd)
 	return cmd
@@ -184,7 +184,7 @@ func (c cmdable) HRandFieldWithValues(ctx context.Context, key string, count int
 }
 
 func (c cmdable) HScan(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd {
-	args := []interface{}{"hscan", key, cursor}
+	args := []any{"hscan", key, cursor}
 	if match != "" {
 		args = append(args, "match", match)
 	}
@@ -202,7 +202,7 @@ func (c cmdable) HStrLen(ctx context.Context, key, field string) *IntCmd {
 	return cmd
 }
 func (c cmdable) HScanNoValues(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd {
-	args := []interface{}{"hscan", key, cursor}
+	args := []any{"hscan", key, cursor}
 	if match != "" {
 		args = append(args, "match", match)
 	}
@@ -229,7 +229,7 @@ type HExpireArgs struct {
 //
 // [HEXPIRE Documentation]: https://redis.io/commands/hexpire/
 func (c cmdable) HExpire(ctx context.Context, key string, expiration time.Duration, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HEXPIRE", key, formatSec(ctx, expiration), "FIELDS", len(fields)}
+	args := []any{"HEXPIRE", key, formatSec(ctx, expiration), "FIELDS", len(fields)}
 
 	for _, field := range fields {
 		args = append(args, field)
@@ -247,7 +247,7 @@ func (c cmdable) HExpire(ctx context.Context, key string, expiration time.Durati
 //
 // [HEXPIRE Documentation]: https://redis.io/commands/hexpire/
 func (c cmdable) HExpireWithArgs(ctx context.Context, key string, expiration time.Duration, expirationArgs HExpireArgs, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HEXPIRE", key, formatSec(ctx, expiration)}
+	args := []any{"HEXPIRE", key, formatSec(ctx, expiration)}
 
 	// only if one argument is true, we can add it to the args
 	// if more than one argument is true, it will cause an error
@@ -279,7 +279,7 @@ func (c cmdable) HExpireWithArgs(ctx context.Context, key string, expiration tim
 //
 // [HPEXPIRE Documentation]: https://redis.io/commands/hpexpire/
 func (c cmdable) HPExpire(ctx context.Context, key string, expiration time.Duration, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HPEXPIRE", key, formatMs(ctx, expiration), "FIELDS", len(fields)}
+	args := []any{"HPEXPIRE", key, formatMs(ctx, expiration), "FIELDS", len(fields)}
 
 	for _, field := range fields {
 		args = append(args, field)
@@ -297,7 +297,7 @@ func (c cmdable) HPExpire(ctx context.Context, key string, expiration time.Durat
 //
 // [HPEXPIRE Documentation]: https://redis.io/commands/hpexpire/
 func (c cmdable) HPExpireWithArgs(ctx context.Context, key string, expiration time.Duration, expirationArgs HExpireArgs, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HPEXPIRE", key, formatMs(ctx, expiration)}
+	args := []any{"HPEXPIRE", key, formatMs(ctx, expiration)}
 
 	// only if one argument is true, we can add it to the args
 	// if more than one argument is true, it will cause an error
@@ -330,7 +330,7 @@ func (c cmdable) HPExpireWithArgs(ctx context.Context, key string, expiration ti
 // [HExpireAt Documentation]: https://redis.io/commands/hexpireat/
 func (c cmdable) HExpireAt(ctx context.Context, key string, tm time.Time, fields ...string) *IntSliceCmd {
 
-	args := []interface{}{"HEXPIREAT", key, tm.Unix(), "FIELDS", len(fields)}
+	args := []any{"HEXPIREAT", key, tm.Unix(), "FIELDS", len(fields)}
 
 	for _, field := range fields {
 		args = append(args, field)
@@ -341,7 +341,7 @@ func (c cmdable) HExpireAt(ctx context.Context, key string, tm time.Time, fields
 }
 
 func (c cmdable) HExpireAtWithArgs(ctx context.Context, key string, tm time.Time, expirationArgs HExpireArgs, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HEXPIREAT", key, tm.Unix()}
+	args := []any{"HEXPIREAT", key, tm.Unix()}
 
 	// only if one argument is true, we can add it to the args
 	// if more than one argument is true, it will cause an error
@@ -372,7 +372,7 @@ func (c cmdable) HExpireAtWithArgs(ctx context.Context, key string, tm time.Time
 //
 // [HExpireAt Documentation]: https://redis.io/commands/hexpireat/
 func (c cmdable) HPExpireAt(ctx context.Context, key string, tm time.Time, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HPEXPIREAT", key, tm.UnixNano() / int64(time.Millisecond), "FIELDS", len(fields)}
+	args := []any{"HPEXPIREAT", key, tm.UnixNano() / int64(time.Millisecond), "FIELDS", len(fields)}
 
 	for _, field := range fields {
 		args = append(args, field)
@@ -383,7 +383,7 @@ func (c cmdable) HPExpireAt(ctx context.Context, key string, tm time.Time, field
 }
 
 func (c cmdable) HPExpireAtWithArgs(ctx context.Context, key string, tm time.Time, expirationArgs HExpireArgs, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HPEXPIREAT", key, tm.UnixNano() / int64(time.Millisecond)}
+	args := []any{"HPEXPIREAT", key, tm.UnixNano() / int64(time.Millisecond)}
 
 	// only if one argument is true, we can add it to the args
 	// if more than one argument is true, it will cause an error
@@ -415,7 +415,7 @@ func (c cmdable) HPExpireAtWithArgs(ctx context.Context, key string, tm time.Tim
 //
 // [HPersist Documentation]: https://redis.io/commands/hpersist/
 func (c cmdable) HPersist(ctx context.Context, key string, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HPERSIST", key, "FIELDS", len(fields)}
+	args := []any{"HPERSIST", key, "FIELDS", len(fields)}
 
 	for _, field := range fields {
 		args = append(args, field)
@@ -434,7 +434,7 @@ func (c cmdable) HPersist(ctx context.Context, key string, fields ...string) *In
 // [HExpireTime Documentation]: https://redis.io/commands/hexpiretime/
 // For more information - https://redis.io/commands/hexpiretime/
 func (c cmdable) HExpireTime(ctx context.Context, key string, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HEXPIRETIME", key, "FIELDS", len(fields)}
+	args := []any{"HEXPIRETIME", key, "FIELDS", len(fields)}
 
 	for _, field := range fields {
 		args = append(args, field)
@@ -453,7 +453,7 @@ func (c cmdable) HExpireTime(ctx context.Context, key string, fields ...string) 
 // [HExpireTime Documentation]: https://redis.io/commands/hexpiretime/
 // For more information - https://redis.io/commands/hexpiretime/
 func (c cmdable) HPExpireTime(ctx context.Context, key string, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HPEXPIRETIME", key, "FIELDS", len(fields)}
+	args := []any{"HPEXPIRETIME", key, "FIELDS", len(fields)}
 
 	for _, field := range fields {
 		args = append(args, field)
@@ -471,7 +471,7 @@ func (c cmdable) HPExpireTime(ctx context.Context, key string, fields ...string)
 //
 // [HTTL Documentation]: https://redis.io/commands/httl/
 func (c cmdable) HTTL(ctx context.Context, key string, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HTTL", key, "FIELDS", len(fields)}
+	args := []any{"HTTL", key, "FIELDS", len(fields)}
 
 	for _, field := range fields {
 		args = append(args, field)
@@ -490,7 +490,7 @@ func (c cmdable) HTTL(ctx context.Context, key string, fields ...string) *IntSli
 // [HPTTL Documentation]: https://redis.io/commands/hpttl/
 // For more information - https://redis.io/commands/hpttl/
 func (c cmdable) HPTTL(ctx context.Context, key string, fields ...string) *IntSliceCmd {
-	args := []interface{}{"HPTTL", key, "FIELDS", len(fields)}
+	args := []any{"HPTTL", key, "FIELDS", len(fields)}
 
 	for _, field := range fields {
 		args = append(args, field)
@@ -501,7 +501,7 @@ func (c cmdable) HPTTL(ctx context.Context, key string, fields ...string) *IntSl
 }
 
 func (c cmdable) HGetDel(ctx context.Context, key string, fields ...string) *StringSliceCmd {
-	args := []interface{}{"HGETDEL", key, "FIELDS", len(fields)}
+	args := []any{"HGETDEL", key, "FIELDS", len(fields)}
 	for _, field := range fields {
 		args = append(args, field)
 	}
@@ -511,7 +511,7 @@ func (c cmdable) HGetDel(ctx context.Context, key string, fields ...string) *Str
 }
 
 func (c cmdable) HGetEX(ctx context.Context, key string, fields ...string) *StringSliceCmd {
-	args := []interface{}{"HGETEX", key, "FIELDS", len(fields)}
+	args := []any{"HGETEX", key, "FIELDS", len(fields)}
 	for _, field := range fields {
 		args = append(args, field)
 	}
@@ -537,7 +537,7 @@ type HGetEXOptions struct {
 }
 
 func (c cmdable) HGetEXWithArgs(ctx context.Context, key string, options *HGetEXOptions, fields ...string) *StringSliceCmd {
-	args := []interface{}{"HGETEX", key}
+	args := []any{"HGETEX", key}
 	if options.ExpirationType != "" {
 		args = append(args, string(options.ExpirationType))
 		if options.ExpirationType != HGetEXExpirationPERSIST {
@@ -579,7 +579,7 @@ type HSetEXOptions struct {
 }
 
 func (c cmdable) HSetEX(ctx context.Context, key string, fieldsAndValues ...string) *IntCmd {
-	args := []interface{}{"HSETEX", key, "FIELDS", len(fieldsAndValues) / 2}
+	args := []any{"HSETEX", key, "FIELDS", len(fieldsAndValues) / 2}
 	for _, field := range fieldsAndValues {
 		args = append(args, field)
 	}
@@ -590,7 +590,7 @@ func (c cmdable) HSetEX(ctx context.Context, key string, fieldsAndValues ...stri
 }
 
 func (c cmdable) HSetEXWithArgs(ctx context.Context, key string, options *HSetEXOptions, fieldsAndValues ...string) *IntCmd {
-	args := []interface{}{"HSETEX", key}
+	args := []any{"HSETEX", key}
 	if options.Condition != "" {
 		args = append(args, string(options.Condition))
 	}

--- a/hyperloglog_commands.go
+++ b/hyperloglog_commands.go
@@ -3,13 +3,13 @@ package redis
 import "context"
 
 type HyperLogLogCmdable interface {
-	PFAdd(ctx context.Context, key string, els ...interface{}) *IntCmd
+	PFAdd(ctx context.Context, key string, els ...any) *IntCmd
 	PFCount(ctx context.Context, keys ...string) *IntCmd
 	PFMerge(ctx context.Context, dest string, keys ...string) *StatusCmd
 }
 
-func (c cmdable) PFAdd(ctx context.Context, key string, els ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(els))
+func (c cmdable) PFAdd(ctx context.Context, key string, els ...any) *IntCmd {
+	args := make([]any, 2, 2+len(els))
 	args[0] = "pfadd"
 	args[1] = key
 	args = appendArgs(args, els)
@@ -19,7 +19,7 @@ func (c cmdable) PFAdd(ctx context.Context, key string, els ...interface{}) *Int
 }
 
 func (c cmdable) PFCount(ctx context.Context, keys ...string) *IntCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "pfcount"
 	for i, key := range keys {
 		args[1+i] = key
@@ -30,7 +30,7 @@ func (c cmdable) PFCount(ctx context.Context, keys ...string) *IntCmd {
 }
 
 func (c cmdable) PFMerge(ctx context.Context, dest string, keys ...string) *StatusCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]any, 2+len(keys))
 	args[0] = "pfmerge"
 	args[1] = dest
 	for i, key := range keys {

--- a/internal/arg.go
+++ b/internal/arg.go
@@ -8,7 +8,7 @@ import (
 	"github.com/redis/go-redis/v9/internal/util"
 )
 
-func AppendArg(b []byte, v interface{}) []byte {
+func AppendArg(b []byte, v any) []byte {
 	switch v := v.(type) {
 	case nil:
 		return append(b, "<nil>"...)

--- a/internal/customvet/checks/setval/setval.go
+++ b/internal/customvet/checks/setval/setval.go
@@ -12,7 +12,7 @@ var Analyzer = &analysis.Analyzer{
 	Name: "setval",
 	Doc:  "find Cmder types that are missing a SetVal method",
 
-	Run: func(pass *analysis.Pass) (interface{}, error) {
+	Run: func(pass *analysis.Pass) (any, error) {
 		cmderTypes := make(map[string]token.Pos)
 		typesWithSetValMethod := make(map[string]bool)
 

--- a/internal/customvet/checks/setval/setval.go
+++ b/internal/customvet/checks/setval/setval.go
@@ -12,7 +12,7 @@ var Analyzer = &analysis.Analyzer{
 	Name: "setval",
 	Doc:  "find Cmder types that are missing a SetVal method",
 
-	Run: func(pass *analysis.Pass) (any, error) {
+	Run: func(pass *analysis.Pass) (interface{}, error) {
 		cmderTypes := make(map[string]token.Pos)
 		typesWithSetValMethod := make(map[string]bool)
 

--- a/internal/hscan/hscan.go
+++ b/internal/hscan/hscan.go
@@ -52,7 +52,7 @@ var (
 	globalStructMap = newStructMap()
 )
 
-func Struct(dst interface{}) (StructValue, error) {
+func Struct(dst any) (StructValue, error) {
 	v := reflect.ValueOf(dst)
 
 	// The destination to scan into should be a struct pointer.
@@ -73,7 +73,7 @@ func Struct(dst interface{}) (StructValue, error) {
 
 // Scan scans the results from a key-value Redis map result set to a destination struct.
 // The Redis keys are matched to the struct's field with the `redis` tag.
-func Scan(dst interface{}, keys []interface{}, vals []interface{}) error {
+func Scan(dst any, keys []any, vals []any) error {
 	if len(keys) != len(vals) {
 		return errors.New("args should have the same number of keys and vals")
 	}

--- a/internal/hscan/hscan_test.go
+++ b/internal/hscan/hscan_test.go
@@ -48,7 +48,7 @@ type TimeData struct {
 	Time *TimeRFC3339Nano `redis:"login"`
 }
 
-type i []interface{}
+type i []any
 
 func TestGinkgoSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -66,7 +66,7 @@ var _ = Describe("Scan", func() {
 		Expect(Scan(&d, i{"key"}, i{"1", "2"})).To(HaveOccurred())
 		Expect(Scan(nil, i{"key", "1"}, i{})).To(HaveOccurred())
 
-		var m map[string]interface{}
+		var m map[string]any
 		Expect(Scan(&m, i{"key"}, i{"1"})).To(HaveOccurred())
 		Expect(Scan(data{}, i{"key"}, i{"1"})).To(HaveOccurred())
 		Expect(Scan(data{}, i{"key", "string"}, i{nil, nil})).To(HaveOccurred())

--- a/internal/log.go
+++ b/internal/log.go
@@ -8,14 +8,14 @@ import (
 )
 
 type Logging interface {
-	Printf(ctx context.Context, format string, v ...interface{})
+	Printf(ctx context.Context, format string, v ...any)
 }
 
 type logger struct {
 	log *log.Logger
 }
 
-func (l *logger) Printf(ctx context.Context, format string, v ...interface{}) {
+func (l *logger) Printf(ctx context.Context, format string, v ...any) {
 	_ = l.log.Output(2, fmt.Sprintf(format, v...))
 }
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -24,7 +24,7 @@ var (
 )
 
 var timers = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		t := time.NewTimer(time.Hour)
 		t.Stop()
 		return t

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -151,7 +151,7 @@ func (r *Reader) readLine() ([]byte, error) {
 	return b[:len(b)-2], nil
 }
 
-func (r *Reader) ReadReply() (interface{}, error) {
+func (r *Reader) ReadReply() (any, error) {
 	line, err := r.ReadLine()
 	if err != nil {
 		return nil, err
@@ -239,13 +239,13 @@ func (r *Reader) readVerb(line []byte) (string, error) {
 	return s[4:], nil
 }
 
-func (r *Reader) readSlice(line []byte) ([]interface{}, error) {
+func (r *Reader) readSlice(line []byte) ([]any, error) {
 	n, err := replyLen(line)
 	if err != nil {
 		return nil, err
 	}
 
-	val := make([]interface{}, n)
+	val := make([]any, n)
 	for i := 0; i < len(val); i++ {
 		v, err := r.ReadReply()
 		if err != nil {
@@ -264,12 +264,12 @@ func (r *Reader) readSlice(line []byte) ([]interface{}, error) {
 	return val, nil
 }
 
-func (r *Reader) readMap(line []byte) (map[interface{}]interface{}, error) {
+func (r *Reader) readMap(line []byte) (map[any]any, error) {
 	n, err := replyLen(line)
 	if err != nil {
 		return nil, err
 	}
-	m := make(map[interface{}]interface{}, n)
+	m := make(map[any]any, n)
 	for i := 0; i < n; i++ {
 		k, err := r.ReadReply()
 		if err != nil {
@@ -402,7 +402,7 @@ func (r *Reader) ReadBool() (bool, error) {
 	return s == "OK" || s == "1" || s == "true", nil
 }
 
-func (r *Reader) ReadSlice() ([]interface{}, error) {
+func (r *Reader) ReadSlice() ([]any, error) {
 	line, err := r.ReadLine()
 	if err != nil {
 		return nil, err

--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -13,7 +13,7 @@ import (
 // Scan parses bytes `b` to `v` with appropriate type.
 //
 //nolint:gocyclo
-func Scan(b []byte, v interface{}) error {
+func Scan(b []byte, v any) error {
 	switch v := v.(type) {
 	case nil:
 		return fmt.Errorf("redis: Scan(nil)")
@@ -126,7 +126,7 @@ func Scan(b []byte, v interface{}) error {
 	}
 }
 
-func ScanSlice(data []string, slice interface{}) error {
+func ScanSlice(data []string, slice any) error {
 	v := reflect.ValueOf(slice)
 	if !v.IsValid() {
 		return fmt.Errorf("redis: ScanSlice(nil)")

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -34,7 +34,7 @@ func NewWriter(wr writer) *Writer {
 	}
 }
 
-func (w *Writer) WriteArgs(args []interface{}) error {
+func (w *Writer) WriteArgs(args []any) error {
 	if err := w.WriteByte(RespArray); err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func (w *Writer) writeLen(n int) error {
 	return err
 }
 
-func (w *Writer) WriteArg(v interface{}) error {
+func (w *Writer) WriteArg(v any) error {
 	switch v := v.(type) {
 	case nil:
 		return w.string("")

--- a/internal/proto/writer_test.go
+++ b/internal/proto/writer_test.go
@@ -33,7 +33,7 @@ var _ = Describe("WriteBuffer", func() {
 	})
 
 	It("should write args", func() {
-		err := wr.WriteArgs([]interface{}{
+		err := wr.WriteArgs([]any{
 			"string",
 			12,
 			34.56,
@@ -55,14 +55,14 @@ var _ = Describe("WriteBuffer", func() {
 
 	It("should append time", func() {
 		tm := time.Date(2019, 1, 1, 9, 45, 10, 222125, time.UTC)
-		err := wr.WriteArgs([]interface{}{tm})
+		err := wr.WriteArgs([]any{tm})
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(buf.Len()).To(Equal(41))
 	})
 
 	It("should append marshalable args", func() {
-		err := wr.WriteArgs([]interface{}{&MyType{}})
+		err := wr.WriteArgs([]any{&MyType{}})
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(buf.Len()).To(Equal(15))
@@ -70,7 +70,7 @@ var _ = Describe("WriteBuffer", func() {
 
 	It("should append net.IP", func() {
 		ip := net.ParseIP("192.168.1.1")
-		err := wr.WriteArgs([]interface{}{ip})
+		err := wr.WriteArgs([]any{ip})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(buf.String()).To(Equal(fmt.Sprintf("*1\r\n$16\r\n%s\r\n", bytes.NewBuffer(ip))))
 	})
@@ -92,7 +92,7 @@ func (discard) WriteByte(c byte) error {
 
 func BenchmarkWriteBuffer_Append(b *testing.B) {
 	buf := proto.NewWriter(discard{})
-	args := []interface{}{"hello", "world", "foo", "bar"}
+	args := []any{"hello", "world", "foo", "bar"}
 
 	for i := 0; i < b.N; i++ {
 		err := buf.WriteArgs(args)

--- a/internal/util.go
+++ b/internal/util.go
@@ -68,7 +68,7 @@ func GetAddr(addr string) string {
 	return net.JoinHostPort(addr[:ind], addr[ind+1:])
 }
 
-func ToInteger(val interface{}) int {
+func ToInteger(val any) int {
 	switch v := val.(type) {
 	case int:
 		return v
@@ -82,7 +82,7 @@ func ToInteger(val interface{}) int {
 	}
 }
 
-func ToFloat(val interface{}) float64 {
+func ToFloat(val any) float64 {
 	switch v := val.(type) {
 	case float64:
 		return v
@@ -94,15 +94,15 @@ func ToFloat(val interface{}) float64 {
 	}
 }
 
-func ToString(val interface{}) string {
+func ToString(val any) string {
 	if str, ok := val.(string); ok {
 		return str
 	}
 	return ""
 }
 
-func ToStringSlice(val interface{}) []string {
-	if arr, ok := val.([]interface{}); ok {
+func ToStringSlice(val any) []string {
+	if arr, ok := val.([]any); ok {
 		result := make([]string, len(arr))
 		for i, v := range arr {
 			result[i] = ToString(v)

--- a/json.go
+++ b/json.go
@@ -12,10 +12,10 @@ import (
 // -------------------------------------------
 
 type JSONCmdable interface {
-	JSONArrAppend(ctx context.Context, key, path string, values ...interface{}) *IntSliceCmd
-	JSONArrIndex(ctx context.Context, key, path string, value ...interface{}) *IntSliceCmd
-	JSONArrIndexWithArgs(ctx context.Context, key, path string, options *JSONArrIndexArgs, value ...interface{}) *IntSliceCmd
-	JSONArrInsert(ctx context.Context, key, path string, index int64, values ...interface{}) *IntSliceCmd
+	JSONArrAppend(ctx context.Context, key, path string, values ...any) *IntSliceCmd
+	JSONArrIndex(ctx context.Context, key, path string, value ...any) *IntSliceCmd
+	JSONArrIndexWithArgs(ctx context.Context, key, path string, options *JSONArrIndexArgs, value ...any) *IntSliceCmd
+	JSONArrInsert(ctx context.Context, key, path string, index int64, values ...any) *IntSliceCmd
 	JSONArrLen(ctx context.Context, key, path string) *IntSliceCmd
 	JSONArrPop(ctx context.Context, key, path string, index int) *StringSliceCmd
 	JSONArrTrim(ctx context.Context, key, path string) *IntSliceCmd
@@ -28,13 +28,13 @@ type JSONCmdable interface {
 	JSONGetWithArgs(ctx context.Context, key string, options *JSONGetArgs, paths ...string) *JSONCmd
 	JSONMerge(ctx context.Context, key, path string, value string) *StatusCmd
 	JSONMSetArgs(ctx context.Context, docs []JSONSetArgs) *StatusCmd
-	JSONMSet(ctx context.Context, params ...interface{}) *StatusCmd
+	JSONMSet(ctx context.Context, params ...any) *StatusCmd
 	JSONMGet(ctx context.Context, path string, keys ...string) *JSONSliceCmd
 	JSONNumIncrBy(ctx context.Context, key, path string, value float64) *JSONCmd
 	JSONObjKeys(ctx context.Context, key, path string) *SliceCmd
 	JSONObjLen(ctx context.Context, key, path string) *IntPointerSliceCmd
-	JSONSet(ctx context.Context, key, path string, value interface{}) *StatusCmd
-	JSONSetMode(ctx context.Context, key, path string, value interface{}, mode string) *StatusCmd
+	JSONSet(ctx context.Context, key, path string, value any) *StatusCmd
+	JSONSetMode(ctx context.Context, key, path string, value any, mode string) *StatusCmd
 	JSONStrAppend(ctx context.Context, key, path, value string) *IntPointerSliceCmd
 	JSONStrLen(ctx context.Context, key, path string) *IntPointerSliceCmd
 	JSONToggle(ctx context.Context, key, path string) *IntPointerSliceCmd
@@ -44,7 +44,7 @@ type JSONCmdable interface {
 type JSONSetArgs struct {
 	Key   string
 	Path  string
-	Value interface{}
+	Value any
 }
 
 type JSONArrIndexArgs struct {
@@ -60,12 +60,12 @@ type JSONArrTrimArgs struct {
 type JSONCmd struct {
 	baseCmd
 	val      string
-	expanded interface{}
+	expanded any
 }
 
 var _ Cmder = (*JSONCmd)(nil)
 
-func newJSONCmd(ctx context.Context, args ...interface{}) *JSONCmd {
+func newJSONCmd(ctx context.Context, args ...any) *JSONCmd {
 	return &JSONCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -100,7 +100,7 @@ func (cmd *JSONCmd) Result() (string, error) {
 	return cmd.Val(), cmd.Err()
 }
 
-func (cmd *JSONCmd) Expanded() (interface{}, error) {
+func (cmd *JSONCmd) Expanded() (any, error) {
 	if len(cmd.val) != 0 && cmd.expanded == nil {
 		err := json.Unmarshal([]byte(cmd.val), &cmd.expanded)
 		if err != nil {
@@ -127,7 +127,7 @@ func (cmd *JSONCmd) readReply(rd *proto.Reader) error {
 			return err
 		}
 
-		expanded := make([]interface{}, size)
+		expanded := make([]any, size)
 
 		for i := 0; i < size; i++ {
 			if expanded[i], err = rd.ReadReply(); err != nil {
@@ -153,10 +153,10 @@ func (cmd *JSONCmd) readReply(rd *proto.Reader) error {
 
 type JSONSliceCmd struct {
 	baseCmd
-	val []interface{}
+	val []any
 }
 
-func NewJSONSliceCmd(ctx context.Context, args ...interface{}) *JSONSliceCmd {
+func NewJSONSliceCmd(ctx context.Context, args ...any) *JSONSliceCmd {
 	return &JSONSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -169,15 +169,15 @@ func (cmd *JSONSliceCmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
-func (cmd *JSONSliceCmd) SetVal(val []interface{}) {
+func (cmd *JSONSliceCmd) SetVal(val []any) {
 	cmd.val = val
 }
 
-func (cmd *JSONSliceCmd) Val() []interface{} {
+func (cmd *JSONSliceCmd) Val() []any {
 	return cmd.val
 }
 
-func (cmd *JSONSliceCmd) Result() ([]interface{}, error) {
+func (cmd *JSONSliceCmd) Result() ([]any, error) {
 	return cmd.val, cmd.err
 }
 
@@ -194,7 +194,7 @@ func (cmd *JSONSliceCmd) readReply(rd *proto.Reader) error {
 		if err != nil {
 			return nil
 		} else {
-			cmd.val = response.([]interface{})
+			cmd.val = response.([]any)
 		}
 
 	} else {
@@ -202,7 +202,7 @@ func (cmd *JSONSliceCmd) readReply(rd *proto.Reader) error {
 		if err != nil {
 			return err
 		}
-		cmd.val = make([]interface{}, n)
+		cmd.val = make([]any, n)
 		for i := 0; i < len(cmd.val); i++ {
 			switch s, err := rd.ReadString(); {
 			case err == Nil:
@@ -230,7 +230,7 @@ type IntPointerSliceCmd struct {
 }
 
 // NewIntPointerSliceCmd initialises an IntPointerSliceCmd
-func NewIntPointerSliceCmd(ctx context.Context, args ...interface{}) *IntPointerSliceCmd {
+func NewIntPointerSliceCmd(ctx context.Context, args ...any) *IntPointerSliceCmd {
 	return &IntPointerSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -278,8 +278,8 @@ func (cmd *IntPointerSliceCmd) readReply(rd *proto.Reader) error {
 
 // JSONArrAppend adds the provided JSON values to the end of the array at the given path.
 // For more information, see https://redis.io/commands/json.arrappend
-func (c cmdable) JSONArrAppend(ctx context.Context, key, path string, values ...interface{}) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRAPPEND", key, path}
+func (c cmdable) JSONArrAppend(ctx context.Context, key, path string, values ...any) *IntSliceCmd {
+	args := []any{"JSON.ARRAPPEND", key, path}
 	args = append(args, values...)
 	cmd := NewIntSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -288,8 +288,8 @@ func (c cmdable) JSONArrAppend(ctx context.Context, key, path string, values ...
 
 // JSONArrIndex searches for the first occurrence of the provided JSON value in the array at the given path.
 // For more information, see https://redis.io/commands/json.arrindex
-func (c cmdable) JSONArrIndex(ctx context.Context, key, path string, value ...interface{}) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRINDEX", key, path}
+func (c cmdable) JSONArrIndex(ctx context.Context, key, path string, value ...any) *IntSliceCmd {
+	args := []any{"JSON.ARRINDEX", key, path}
 	args = append(args, value...)
 	cmd := NewIntSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -299,8 +299,8 @@ func (c cmdable) JSONArrIndex(ctx context.Context, key, path string, value ...in
 // JSONArrIndexWithArgs searches for the first occurrence of a JSON value in an array while allowing the start and
 // stop options to be provided.
 // For more information, see https://redis.io/commands/json.arrindex
-func (c cmdable) JSONArrIndexWithArgs(ctx context.Context, key, path string, options *JSONArrIndexArgs, value ...interface{}) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRINDEX", key, path}
+func (c cmdable) JSONArrIndexWithArgs(ctx context.Context, key, path string, options *JSONArrIndexArgs, value ...any) *IntSliceCmd {
+	args := []any{"JSON.ARRINDEX", key, path}
 	args = append(args, value...)
 
 	if options != nil {
@@ -316,8 +316,8 @@ func (c cmdable) JSONArrIndexWithArgs(ctx context.Context, key, path string, opt
 
 // JSONArrInsert inserts the JSON values into the array at the specified path before the index (shifts to the right).
 // For more information, see https://redis.io/commands/json.arrinsert
-func (c cmdable) JSONArrInsert(ctx context.Context, key, path string, index int64, values ...interface{}) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRINSERT", key, path, index}
+func (c cmdable) JSONArrInsert(ctx context.Context, key, path string, index int64, values ...any) *IntSliceCmd {
+	args := []any{"JSON.ARRINSERT", key, path, index}
 	args = append(args, values...)
 	cmd := NewIntSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -327,7 +327,7 @@ func (c cmdable) JSONArrInsert(ctx context.Context, key, path string, index int6
 // JSONArrLen reports the length of the JSON array at the specified path in the given key.
 // For more information, see https://redis.io/commands/json.arrlen
 func (c cmdable) JSONArrLen(ctx context.Context, key, path string) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRLEN", key, path}
+	args := []any{"JSON.ARRLEN", key, path}
 	cmd := NewIntSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -336,7 +336,7 @@ func (c cmdable) JSONArrLen(ctx context.Context, key, path string) *IntSliceCmd 
 // JSONArrPop removes and returns an element from the specified index in the array.
 // For more information, see https://redis.io/commands/json.arrpop
 func (c cmdable) JSONArrPop(ctx context.Context, key, path string, index int) *StringSliceCmd {
-	args := []interface{}{"JSON.ARRPOP", key, path, index}
+	args := []any{"JSON.ARRPOP", key, path, index}
 	cmd := NewStringSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -345,7 +345,7 @@ func (c cmdable) JSONArrPop(ctx context.Context, key, path string, index int) *S
 // JSONArrTrim trims an array to contain only the specified inclusive range of elements.
 // For more information, see https://redis.io/commands/json.arrtrim
 func (c cmdable) JSONArrTrim(ctx context.Context, key, path string) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRTRIM", key, path}
+	args := []any{"JSON.ARRTRIM", key, path}
 	cmd := NewIntSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -354,7 +354,7 @@ func (c cmdable) JSONArrTrim(ctx context.Context, key, path string) *IntSliceCmd
 // JSONArrTrimWithArgs trims an array to contain only the specified inclusive range of elements.
 // For more information, see https://redis.io/commands/json.arrtrim
 func (c cmdable) JSONArrTrimWithArgs(ctx context.Context, key, path string, options *JSONArrTrimArgs) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRTRIM", key, path}
+	args := []any{"JSON.ARRTRIM", key, path}
 
 	if options != nil {
 		args = append(args, options.Start)
@@ -371,7 +371,7 @@ func (c cmdable) JSONArrTrimWithArgs(ctx context.Context, key, path string, opti
 // JSONClear clears container values (arrays/objects) and sets numeric values to 0.
 // For more information, see https://redis.io/commands/json.clear
 func (c cmdable) JSONClear(ctx context.Context, key, path string) *IntCmd {
-	args := []interface{}{"JSON.CLEAR", key, path}
+	args := []any{"JSON.CLEAR", key, path}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -386,7 +386,7 @@ func (c cmdable) JSONDebugMemory(ctx context.Context, key, path string) *IntCmd 
 // JSONDel deletes a value.
 // For more information, see https://redis.io/commands/json.del
 func (c cmdable) JSONDel(ctx context.Context, key, path string) *IntCmd {
-	args := []interface{}{"JSON.DEL", key, path}
+	args := []any{"JSON.DEL", key, path}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -395,7 +395,7 @@ func (c cmdable) JSONDel(ctx context.Context, key, path string) *IntCmd {
 // JSONForget deletes a value.
 // For more information, see https://redis.io/commands/json.forget
 func (c cmdable) JSONForget(ctx context.Context, key, path string) *IntCmd {
-	args := []interface{}{"JSON.FORGET", key, path}
+	args := []any{"JSON.FORGET", key, path}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -406,7 +406,7 @@ func (c cmdable) JSONForget(ctx context.Context, key, path string) *IntCmd {
 // internal strings unprocessed by default (see Val())
 // For more information - https://redis.io/commands/json.get/
 func (c cmdable) JSONGet(ctx context.Context, key string, paths ...string) *JSONCmd {
-	args := make([]interface{}, len(paths)+2)
+	args := make([]any, len(paths)+2)
 	args[0] = "JSON.GET"
 	args[1] = key
 	for n, path := range paths {
@@ -428,7 +428,7 @@ type JSONGetArgs struct {
 // Indention, NewLine and Space
 // For more information - https://redis.io/commands/json.get/
 func (c cmdable) JSONGetWithArgs(ctx context.Context, key string, options *JSONGetArgs, paths ...string) *JSONCmd {
-	args := []interface{}{"JSON.GET", key}
+	args := []any{"JSON.GET", key}
 	if options != nil {
 		if options.Indent != "" {
 			args = append(args, "INDENT", options.Indent)
@@ -451,7 +451,7 @@ func (c cmdable) JSONGetWithArgs(ctx context.Context, key string, options *JSONG
 // JSONMerge merges a given JSON value into matching paths.
 // For more information, see https://redis.io/commands/json.merge
 func (c cmdable) JSONMerge(ctx context.Context, key, path string, value string) *StatusCmd {
-	args := []interface{}{"JSON.MERGE", key, path, value}
+	args := []any{"JSON.MERGE", key, path, value}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -462,7 +462,7 @@ func (c cmdable) JSONMerge(ctx context.Context, key, path string, value string) 
 // to follow the pattern of having the last argument be variable.
 // For more information, see https://redis.io/commands/json.mget
 func (c cmdable) JSONMGet(ctx context.Context, path string, keys ...string) *JSONSliceCmd {
-	args := make([]interface{}, len(keys)+1)
+	args := make([]any, len(keys)+1)
 	args[0] = "JSON.MGET"
 	for n, key := range keys {
 		args[n+1] = key
@@ -476,7 +476,7 @@ func (c cmdable) JSONMGet(ctx context.Context, path string, keys ...string) *JSO
 // JSONMSetArgs sets or updates one or more JSON values according to the specified key-path-value triplets.
 // For more information, see https://redis.io/commands/json.mset
 func (c cmdable) JSONMSetArgs(ctx context.Context, docs []JSONSetArgs) *StatusCmd {
-	args := []interface{}{"JSON.MSET"}
+	args := []any{"JSON.MSET"}
 	for _, doc := range docs {
 		args = append(args, doc.Key, doc.Path, doc.Value)
 	}
@@ -485,8 +485,8 @@ func (c cmdable) JSONMSetArgs(ctx context.Context, docs []JSONSetArgs) *StatusCm
 	return cmd
 }
 
-func (c cmdable) JSONMSet(ctx context.Context, params ...interface{}) *StatusCmd {
-	args := []interface{}{"JSON.MSET"}
+func (c cmdable) JSONMSet(ctx context.Context, params ...any) *StatusCmd {
+	args := []any{"JSON.MSET"}
 	args = append(args, params...)
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -496,7 +496,7 @@ func (c cmdable) JSONMSet(ctx context.Context, params ...interface{}) *StatusCmd
 // JSONNumIncrBy increments the number value stored at the specified path by the provided number.
 // For more information, see https://redis.io/docs/latest/commands/json.numincrby/
 func (c cmdable) JSONNumIncrBy(ctx context.Context, key, path string, value float64) *JSONCmd {
-	args := []interface{}{"JSON.NUMINCRBY", key, path, value}
+	args := []any{"JSON.NUMINCRBY", key, path, value}
 	cmd := newJSONCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -505,7 +505,7 @@ func (c cmdable) JSONNumIncrBy(ctx context.Context, key, path string, value floa
 // JSONObjKeys returns the keys in the object that's referenced by the specified path.
 // For more information, see https://redis.io/commands/json.objkeys
 func (c cmdable) JSONObjKeys(ctx context.Context, key, path string) *SliceCmd {
-	args := []interface{}{"JSON.OBJKEYS", key, path}
+	args := []any{"JSON.OBJKEYS", key, path}
 	cmd := NewSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -514,7 +514,7 @@ func (c cmdable) JSONObjKeys(ctx context.Context, key, path string) *SliceCmd {
 // JSONObjLen reports the number of keys in the JSON object at the specified path in the given key.
 // For more information, see https://redis.io/commands/json.objlen
 func (c cmdable) JSONObjLen(ctx context.Context, key, path string) *IntPointerSliceCmd {
-	args := []interface{}{"JSON.OBJLEN", key, path}
+	args := []any{"JSON.OBJLEN", key, path}
 	cmd := NewIntPointerSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -524,7 +524,7 @@ func (c cmdable) JSONObjLen(ctx context.Context, key, path string) *IntPointerSl
 // can be marshaled to JSON (using encoding/JSON) unless the argument is a string or a []byte when we assume that
 // it can be passed directly as JSON.
 // For more information, see https://redis.io/commands/json.set
-func (c cmdable) JSONSet(ctx context.Context, key, path string, value interface{}) *StatusCmd {
+func (c cmdable) JSONSet(ctx context.Context, key, path string, value any) *StatusCmd {
 	return c.JSONSetMode(ctx, key, path, value, "")
 }
 
@@ -532,7 +532,7 @@ func (c cmdable) JSONSet(ctx context.Context, key, path string, value interface{
 // (the mode value must be "XX" or "NX"). The value must be something that can be marshaled to JSON (using encoding/JSON) unless
 // the argument is a string or []byte when we assume that it can be passed directly as JSON.
 // For more information, see https://redis.io/commands/json.set
-func (c cmdable) JSONSetMode(ctx context.Context, key, path string, value interface{}, mode string) *StatusCmd {
+func (c cmdable) JSONSetMode(ctx context.Context, key, path string, value any, mode string) *StatusCmd {
 	var bytes []byte
 	var err error
 	switch v := value.(type) {
@@ -543,7 +543,7 @@ func (c cmdable) JSONSetMode(ctx context.Context, key, path string, value interf
 	default:
 		bytes, err = json.Marshal(v)
 	}
-	args := []interface{}{"JSON.SET", key, path, util.BytesToString(bytes)}
+	args := []any{"JSON.SET", key, path, util.BytesToString(bytes)}
 	if mode != "" {
 		switch strings.ToUpper(mode) {
 		case "XX", "NX":
@@ -565,7 +565,7 @@ func (c cmdable) JSONSetMode(ctx context.Context, key, path string, value interf
 // JSONStrAppend appends the JSON-string values to the string at the specified path.
 // For more information, see https://redis.io/commands/json.strappend
 func (c cmdable) JSONStrAppend(ctx context.Context, key, path, value string) *IntPointerSliceCmd {
-	args := []interface{}{"JSON.STRAPPEND", key, path, value}
+	args := []any{"JSON.STRAPPEND", key, path, value}
 	cmd := NewIntPointerSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -574,7 +574,7 @@ func (c cmdable) JSONStrAppend(ctx context.Context, key, path, value string) *In
 // JSONStrLen reports the length of the JSON String at the specified path in the given key.
 // For more information, see https://redis.io/commands/json.strlen
 func (c cmdable) JSONStrLen(ctx context.Context, key, path string) *IntPointerSliceCmd {
-	args := []interface{}{"JSON.STRLEN", key, path}
+	args := []any{"JSON.STRLEN", key, path}
 	cmd := NewIntPointerSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -583,7 +583,7 @@ func (c cmdable) JSONStrLen(ctx context.Context, key, path string) *IntPointerSl
 // JSONToggle toggles a Boolean value stored at the specified path.
 // For more information, see https://redis.io/commands/json.toggle
 func (c cmdable) JSONToggle(ctx context.Context, key, path string) *IntPointerSliceCmd {
-	args := []interface{}{"JSON.TOGGLE", key, path}
+	args := []any{"JSON.TOGGLE", key, path}
 	cmd := NewIntPointerSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -592,7 +592,7 @@ func (c cmdable) JSONToggle(ctx context.Context, key, path string) *IntPointerSl
 // JSONType reports the type of JSON value at the specified path.
 // For more information, see https://redis.io/commands/json.type
 func (c cmdable) JSONType(ctx context.Context, key, path string) *JSONSliceCmd {
-	args := []interface{}{"JSON.TYPE", key, path}
+	args := []any{"JSON.TYPE", key, path}
 	cmd := NewJSONSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd

--- a/json_test.go
+++ b/json_test.go
@@ -297,11 +297,11 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 
 				res, err := client.JSONMGet(ctx, "$", "mset1").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(res).To(Equal([]interface{}{`[{"a":1}]`}))
+				Expect(res).To(Equal([]any{`[{"a":1}]`}))
 
 				res, err = client.JSONMGet(ctx, "$", "mset1", "mset2").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(res).To(Equal([]interface{}{`[{"a":1}]`, "[2]"}))
+				Expect(res).To(Equal([]any{`[{"a":1}]`, "[2]"}))
 
 				_, err = client.JSONMSet(ctx, "mset1", "$.a", 2, "mset3", "$", `[1]`).Result()
 				Expect(err).NotTo(HaveOccurred())
@@ -333,15 +333,15 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 
 				iRes, err := client.JSONMGet(ctx, "$..a", "doc1").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(iRes).To(Equal([]interface{}{`[1,3,""]`}))
+				Expect(iRes).To(Equal([]any{`[1,3,""]`}))
 
 				iRes, err = client.JSONMGet(ctx, "$..a", "doc1", "doc2").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(iRes).To(Equal([]interface{}{`[1,3,""]`, `[4,6,[""]]`}))
+				Expect(iRes).To(Equal([]any{`[1,3,""]`, `[4,6,[""]]`}))
 
 				iRes, err = client.JSONMGet(ctx, "$..a", "non_existing_doc", "non_existing_doc1").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(iRes).To(Equal([]interface{}{nil, nil}))
+				Expect(iRes).To(Equal([]any{nil, nil}))
 			})
 		})
 
@@ -562,7 +562,7 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 				cmd2 := client.JSONObjKeys(ctx, "objkeys1", "$..*")
 				Expect(cmd2.Err()).NotTo(HaveOccurred())
 				Expect(cmd2.Val()).To(HaveLen(7))
-				Expect(cmd2.Val()).To(Equal([]interface{}{nil, []interface{}{"a"}, nil, nil, nil, nil, nil}))
+				Expect(cmd2.Val()).To(Equal([]any{nil, []any{"a"}, nil, nil, nil, nil, nil}))
 			})
 
 			It("should JSONObjKeys with $", Label("json.objkeys", "json"), func() {
@@ -577,15 +577,15 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 
 				cmd2, err := client.JSONObjKeys(ctx, "objkeys1", "$.nested1.a").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cmd2).To(Equal([]interface{}{[]interface{}{"foo", "bar"}}))
+				Expect(cmd2).To(Equal([]any{[]any{"foo", "bar"}}))
 
 				cmd2, err = client.JSONObjKeys(ctx, "objkeys1", ".*.a").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cmd2).To(Equal([]interface{}{"foo", "bar"}))
+				Expect(cmd2).To(Equal([]any{"foo", "bar"}))
 
 				cmd2, err = client.JSONObjKeys(ctx, "objkeys1", ".nested2.a").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cmd2).To(Equal([]interface{}{"baz"}))
+				Expect(cmd2).To(Equal([]any{"baz"}))
 
 				_, err = client.JSONObjKeys(ctx, "non_existing_doc", "..a").Result()
 				Expect(err).To(HaveOccurred())
@@ -670,7 +670,7 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 				Expect(cmd2.Err()).NotTo(HaveOccurred())
 				Expect(cmd2.Val()).To(HaveLen(1))
 				// RESP2 v RESP3
-				Expect(cmd2.Val()[0]).To(Or(Equal([]interface{}{"boolean"}), Equal("boolean")))
+				Expect(cmd2.Val()[0]).To(Or(Equal([]any{"boolean"}), Equal("boolean")))
 			})
 		})
 	}
@@ -706,27 +706,27 @@ var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
 				})
 
 				It("should perform complex JSON and RediSearch operations", func() {
-					jsonDoc := map[string]interface{}{
-						"person": map[string]interface{}{
+					jsonDoc := map[string]any{
+						"person": map[string]any{
 							"name":   "Alice",
 							"age":    30,
 							"status": true,
-							"address": map[string]interface{}{
+							"address": map[string]any{
 								"city":     "Wonderland",
 								"postcode": "12345",
 							},
-							"contacts": []map[string]interface{}{
+							"contacts": []map[string]any{
 								{"type": "email", "value": "alice@example.com"},
 								{"type": "phone", "value": "+123456789"},
 								{"type": "fax", "value": "+987654321"},
 							},
-							"friends": []map[string]interface{}{
+							"friends": []map[string]any{
 								{"name": "Bob", "age": 35, "status": true},
 								{"name": "Charlie", "age": 28, "status": false},
 							},
 						},
-						"settings": map[string]interface{}{
-							"notifications": map[string]interface{}{
+						"settings": map[string]any{
+							"notifications": map[string]any{
 								"email":  true,
 								"sms":    false,
 								"alerts": []string{"low battery", "door open"},
@@ -765,7 +765,7 @@ var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
 					arrTrimCmd := client.JSONArrTrimWithArgs(ctx, "person:1", "$.person.friends", &redis.JSONArrTrimArgs{Start: start, Stop: &stop})
 					Expect(arrTrimCmd.Err()).NotTo(HaveOccurred(), "JSON.ARRTRIM failed")
 
-					mergeData := map[string]interface{}{
+					mergeData := map[string]any{
 						"status":    false,
 						"nickname":  "WonderAlice",
 						"lastLogin": time.Now().Format(time.RFC3339),
@@ -776,7 +776,7 @@ var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
 					typeCmd := client.JSONType(ctx, "person:1", "$.person.nickname")
 					nicknameType, err := typeCmd.Result()
 					Expect(err).NotTo(HaveOccurred(), "JSON.TYPE failed")
-					Expect(nicknameType[0]).To(Equal([]interface{}{"string"}), "JSON.TYPE mismatch for nickname")
+					Expect(nicknameType[0]).To(Equal([]any{"string"}), "JSON.TYPE mismatch for nickname")
 
 					createIndexCmd := client.Do(ctx, "FT.CREATE", "person_idx", "ON", "JSON",
 						"PREFIX", "1", "person:", "SCHEMA",
@@ -811,7 +811,7 @@ var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
 })
 
 // Helper function to marshal data into JSON for comparisons
-func jsonMustMarshal(v interface{}) string {
+func jsonMustMarshal(v any) string {
 	bytes, err := json.Marshal(v)
 	Expect(err).NotTo(HaveOccurred())
 	return string(bytes)

--- a/list_commands.go
+++ b/list_commands.go
@@ -12,32 +12,32 @@ type ListCmdable interface {
 	BRPop(ctx context.Context, timeout time.Duration, keys ...string) *StringSliceCmd
 	BRPopLPush(ctx context.Context, source, destination string, timeout time.Duration) *StringCmd
 	LIndex(ctx context.Context, key string, index int64) *StringCmd
-	LInsert(ctx context.Context, key, op string, pivot, value interface{}) *IntCmd
-	LInsertBefore(ctx context.Context, key string, pivot, value interface{}) *IntCmd
-	LInsertAfter(ctx context.Context, key string, pivot, value interface{}) *IntCmd
+	LInsert(ctx context.Context, key, op string, pivot, value any) *IntCmd
+	LInsertBefore(ctx context.Context, key string, pivot, value any) *IntCmd
+	LInsertAfter(ctx context.Context, key string, pivot, value any) *IntCmd
 	LLen(ctx context.Context, key string) *IntCmd
 	LMPop(ctx context.Context, direction string, count int64, keys ...string) *KeyValuesCmd
 	LPop(ctx context.Context, key string) *StringCmd
 	LPopCount(ctx context.Context, key string, count int) *StringSliceCmd
 	LPos(ctx context.Context, key string, value string, args LPosArgs) *IntCmd
 	LPosCount(ctx context.Context, key string, value string, count int64, args LPosArgs) *IntSliceCmd
-	LPush(ctx context.Context, key string, values ...interface{}) *IntCmd
-	LPushX(ctx context.Context, key string, values ...interface{}) *IntCmd
+	LPush(ctx context.Context, key string, values ...any) *IntCmd
+	LPushX(ctx context.Context, key string, values ...any) *IntCmd
 	LRange(ctx context.Context, key string, start, stop int64) *StringSliceCmd
-	LRem(ctx context.Context, key string, count int64, value interface{}) *IntCmd
-	LSet(ctx context.Context, key string, index int64, value interface{}) *StatusCmd
+	LRem(ctx context.Context, key string, count int64, value any) *IntCmd
+	LSet(ctx context.Context, key string, index int64, value any) *StatusCmd
 	LTrim(ctx context.Context, key string, start, stop int64) *StatusCmd
 	RPop(ctx context.Context, key string) *StringCmd
 	RPopCount(ctx context.Context, key string, count int) *StringSliceCmd
 	RPopLPush(ctx context.Context, source, destination string) *StringCmd
-	RPush(ctx context.Context, key string, values ...interface{}) *IntCmd
-	RPushX(ctx context.Context, key string, values ...interface{}) *IntCmd
+	RPush(ctx context.Context, key string, values ...any) *IntCmd
+	RPushX(ctx context.Context, key string, values ...any) *IntCmd
 	LMove(ctx context.Context, source, destination, srcpos, destpos string) *StringCmd
 	BLMove(ctx context.Context, source, destination, srcpos, destpos string, timeout time.Duration) *StringCmd
 }
 
 func (c cmdable) BLPop(ctx context.Context, timeout time.Duration, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 1+len(keys)+1)
+	args := make([]any, 1+len(keys)+1)
 	args[0] = "blpop"
 	for i, key := range keys {
 		args[1+i] = key
@@ -50,7 +50,7 @@ func (c cmdable) BLPop(ctx context.Context, timeout time.Duration, keys ...strin
 }
 
 func (c cmdable) BLMPop(ctx context.Context, timeout time.Duration, direction string, count int64, keys ...string) *KeyValuesCmd {
-	args := make([]interface{}, 3+len(keys), 6+len(keys))
+	args := make([]any, 3+len(keys), 6+len(keys))
 	args[0] = "blmpop"
 	args[1] = formatSec(ctx, timeout)
 	args[2] = len(keys)
@@ -65,7 +65,7 @@ func (c cmdable) BLMPop(ctx context.Context, timeout time.Duration, direction st
 }
 
 func (c cmdable) BRPop(ctx context.Context, timeout time.Duration, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 1+len(keys)+1)
+	args := make([]any, 1+len(keys)+1)
 	args[0] = "brpop"
 	for i, key := range keys {
 		args[1+i] = key
@@ -100,7 +100,7 @@ func (c cmdable) LIndex(ctx context.Context, key string, index int64) *StringCmd
 // direction: left or right, count: > 0
 // example: client.LMPop(ctx, "left", 3, "key1", "key2")
 func (c cmdable) LMPop(ctx context.Context, direction string, count int64, keys ...string) *KeyValuesCmd {
-	args := make([]interface{}, 2+len(keys), 5+len(keys))
+	args := make([]any, 2+len(keys), 5+len(keys))
 	args[0] = "lmpop"
 	args[1] = len(keys)
 	for i, key := range keys {
@@ -112,19 +112,19 @@ func (c cmdable) LMPop(ctx context.Context, direction string, count int64, keys 
 	return cmd
 }
 
-func (c cmdable) LInsert(ctx context.Context, key, op string, pivot, value interface{}) *IntCmd {
+func (c cmdable) LInsert(ctx context.Context, key, op string, pivot, value any) *IntCmd {
 	cmd := NewIntCmd(ctx, "linsert", key, op, pivot, value)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
-func (c cmdable) LInsertBefore(ctx context.Context, key string, pivot, value interface{}) *IntCmd {
+func (c cmdable) LInsertBefore(ctx context.Context, key string, pivot, value any) *IntCmd {
 	cmd := NewIntCmd(ctx, "linsert", key, "before", pivot, value)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
-func (c cmdable) LInsertAfter(ctx context.Context, key string, pivot, value interface{}) *IntCmd {
+func (c cmdable) LInsertAfter(ctx context.Context, key string, pivot, value any) *IntCmd {
 	cmd := NewIntCmd(ctx, "linsert", key, "after", pivot, value)
 	_ = c(ctx, cmd)
 	return cmd
@@ -153,7 +153,7 @@ type LPosArgs struct {
 }
 
 func (c cmdable) LPos(ctx context.Context, key string, value string, a LPosArgs) *IntCmd {
-	args := []interface{}{"lpos", key, value}
+	args := []any{"lpos", key, value}
 	if a.Rank != 0 {
 		args = append(args, "rank", a.Rank)
 	}
@@ -167,7 +167,7 @@ func (c cmdable) LPos(ctx context.Context, key string, value string, a LPosArgs)
 }
 
 func (c cmdable) LPosCount(ctx context.Context, key string, value string, count int64, a LPosArgs) *IntSliceCmd {
-	args := []interface{}{"lpos", key, value, "count", count}
+	args := []any{"lpos", key, value, "count", count}
 	if a.Rank != 0 {
 		args = append(args, "rank", a.Rank)
 	}
@@ -179,8 +179,8 @@ func (c cmdable) LPosCount(ctx context.Context, key string, value string, count 
 	return cmd
 }
 
-func (c cmdable) LPush(ctx context.Context, key string, values ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(values))
+func (c cmdable) LPush(ctx context.Context, key string, values ...any) *IntCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "lpush"
 	args[1] = key
 	args = appendArgs(args, values)
@@ -189,8 +189,8 @@ func (c cmdable) LPush(ctx context.Context, key string, values ...interface{}) *
 	return cmd
 }
 
-func (c cmdable) LPushX(ctx context.Context, key string, values ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(values))
+func (c cmdable) LPushX(ctx context.Context, key string, values ...any) *IntCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "lpushx"
 	args[1] = key
 	args = appendArgs(args, values)
@@ -211,13 +211,13 @@ func (c cmdable) LRange(ctx context.Context, key string, start, stop int64) *Str
 	return cmd
 }
 
-func (c cmdable) LRem(ctx context.Context, key string, count int64, value interface{}) *IntCmd {
+func (c cmdable) LRem(ctx context.Context, key string, count int64, value any) *IntCmd {
 	cmd := NewIntCmd(ctx, "lrem", key, count, value)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
-func (c cmdable) LSet(ctx context.Context, key string, index int64, value interface{}) *StatusCmd {
+func (c cmdable) LSet(ctx context.Context, key string, index int64, value any) *StatusCmd {
 	cmd := NewStatusCmd(ctx, "lset", key, index, value)
 	_ = c(ctx, cmd)
 	return cmd
@@ -253,8 +253,8 @@ func (c cmdable) RPopLPush(ctx context.Context, source, destination string) *Str
 	return cmd
 }
 
-func (c cmdable) RPush(ctx context.Context, key string, values ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(values))
+func (c cmdable) RPush(ctx context.Context, key string, values ...any) *IntCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "rpush"
 	args[1] = key
 	args = appendArgs(args, values)
@@ -263,8 +263,8 @@ func (c cmdable) RPush(ctx context.Context, key string, values ...interface{}) *
 	return cmd
 }
 
-func (c cmdable) RPushX(ctx context.Context, key string, values ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(values))
+func (c cmdable) RPushX(ctx context.Context, key string, values ...any) *IntCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "rpushx"
 	args[1] = key
 	args = appendArgs(args, values)

--- a/osscluster_commands.go
+++ b/osscluster_commands.go
@@ -69,7 +69,7 @@ func (c *ClusterClient) ScriptFlush(ctx context.Context) *StatusCmd {
 }
 
 func (c *ClusterClient) ScriptExists(ctx context.Context, hashes ...string) *BoolSliceCmd {
-	args := make([]interface{}, 2+len(hashes))
+	args := make([]any, 2+len(hashes))
 	args[0] = "script"
 	args[1] = "exists"
 	for i, hash := range hashes {

--- a/pipeline.go
+++ b/pipeline.go
@@ -28,7 +28,7 @@ type Pipeliner interface {
 
 	// Do is an API for executing any command.
 	// If a certain Redis command is not yet supported, you can use Do to execute it.
-	Do(ctx context.Context, args ...interface{}) *Cmd
+	Do(ctx context.Context, args ...any) *Cmd
 
 	// Process is to put the commands to be executed into the pipeline buffer.
 	Process(ctx context.Context, cmd Cmder) error
@@ -64,7 +64,7 @@ func (c *Pipeline) Len() int {
 }
 
 // Do queues the custom command for later execution.
-func (c *Pipeline) Do(ctx context.Context, args ...interface{}) *Cmd {
+func (c *Pipeline) Do(ctx context.Context, args ...any) *Cmd {
 	cmd := NewCmd(ctx, args...)
 	if len(args) == 0 {
 		cmd.SetErr(errors.New("redis: please enter the command to be executed"))

--- a/probabilistic.go
+++ b/probabilistic.go
@@ -8,9 +8,9 @@ import (
 )
 
 type ProbabilisticCmdable interface {
-	BFAdd(ctx context.Context, key string, element interface{}) *BoolCmd
+	BFAdd(ctx context.Context, key string, element any) *BoolCmd
 	BFCard(ctx context.Context, key string) *IntCmd
-	BFExists(ctx context.Context, key string, element interface{}) *BoolCmd
+	BFExists(ctx context.Context, key string, element any) *BoolCmd
 	BFInfo(ctx context.Context, key string) *BFInfoCmd
 	BFInfoArg(ctx context.Context, key, option string) *BFInfoCmd
 	BFInfoCapacity(ctx context.Context, key string) *BFInfoCmd
@@ -18,48 +18,48 @@ type ProbabilisticCmdable interface {
 	BFInfoFilters(ctx context.Context, key string) *BFInfoCmd
 	BFInfoItems(ctx context.Context, key string) *BFInfoCmd
 	BFInfoExpansion(ctx context.Context, key string) *BFInfoCmd
-	BFInsert(ctx context.Context, key string, options *BFInsertOptions, elements ...interface{}) *BoolSliceCmd
-	BFMAdd(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd
-	BFMExists(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd
+	BFInsert(ctx context.Context, key string, options *BFInsertOptions, elements ...any) *BoolSliceCmd
+	BFMAdd(ctx context.Context, key string, elements ...any) *BoolSliceCmd
+	BFMExists(ctx context.Context, key string, elements ...any) *BoolSliceCmd
 	BFReserve(ctx context.Context, key string, errorRate float64, capacity int64) *StatusCmd
 	BFReserveExpansion(ctx context.Context, key string, errorRate float64, capacity, expansion int64) *StatusCmd
 	BFReserveNonScaling(ctx context.Context, key string, errorRate float64, capacity int64) *StatusCmd
 	BFReserveWithArgs(ctx context.Context, key string, options *BFReserveOptions) *StatusCmd
 	BFScanDump(ctx context.Context, key string, iterator int64) *ScanDumpCmd
-	BFLoadChunk(ctx context.Context, key string, iterator int64, data interface{}) *StatusCmd
+	BFLoadChunk(ctx context.Context, key string, iterator int64, data any) *StatusCmd
 
-	CFAdd(ctx context.Context, key string, element interface{}) *BoolCmd
-	CFAddNX(ctx context.Context, key string, element interface{}) *BoolCmd
-	CFCount(ctx context.Context, key string, element interface{}) *IntCmd
-	CFDel(ctx context.Context, key string, element interface{}) *BoolCmd
-	CFExists(ctx context.Context, key string, element interface{}) *BoolCmd
+	CFAdd(ctx context.Context, key string, element any) *BoolCmd
+	CFAddNX(ctx context.Context, key string, element any) *BoolCmd
+	CFCount(ctx context.Context, key string, element any) *IntCmd
+	CFDel(ctx context.Context, key string, element any) *BoolCmd
+	CFExists(ctx context.Context, key string, element any) *BoolCmd
 	CFInfo(ctx context.Context, key string) *CFInfoCmd
-	CFInsert(ctx context.Context, key string, options *CFInsertOptions, elements ...interface{}) *BoolSliceCmd
-	CFInsertNX(ctx context.Context, key string, options *CFInsertOptions, elements ...interface{}) *IntSliceCmd
-	CFMExists(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd
+	CFInsert(ctx context.Context, key string, options *CFInsertOptions, elements ...any) *BoolSliceCmd
+	CFInsertNX(ctx context.Context, key string, options *CFInsertOptions, elements ...any) *IntSliceCmd
+	CFMExists(ctx context.Context, key string, elements ...any) *BoolSliceCmd
 	CFReserve(ctx context.Context, key string, capacity int64) *StatusCmd
 	CFReserveWithArgs(ctx context.Context, key string, options *CFReserveOptions) *StatusCmd
 	CFReserveExpansion(ctx context.Context, key string, capacity int64, expansion int64) *StatusCmd
 	CFReserveBucketSize(ctx context.Context, key string, capacity int64, bucketsize int64) *StatusCmd
 	CFReserveMaxIterations(ctx context.Context, key string, capacity int64, maxiterations int64) *StatusCmd
 	CFScanDump(ctx context.Context, key string, iterator int64) *ScanDumpCmd
-	CFLoadChunk(ctx context.Context, key string, iterator int64, data interface{}) *StatusCmd
+	CFLoadChunk(ctx context.Context, key string, iterator int64, data any) *StatusCmd
 
-	CMSIncrBy(ctx context.Context, key string, elements ...interface{}) *IntSliceCmd
+	CMSIncrBy(ctx context.Context, key string, elements ...any) *IntSliceCmd
 	CMSInfo(ctx context.Context, key string) *CMSInfoCmd
 	CMSInitByDim(ctx context.Context, key string, width, height int64) *StatusCmd
 	CMSInitByProb(ctx context.Context, key string, errorRate, probability float64) *StatusCmd
 	CMSMerge(ctx context.Context, destKey string, sourceKeys ...string) *StatusCmd
 	CMSMergeWithWeight(ctx context.Context, destKey string, sourceKeys map[string]int64) *StatusCmd
-	CMSQuery(ctx context.Context, key string, elements ...interface{}) *IntSliceCmd
+	CMSQuery(ctx context.Context, key string, elements ...any) *IntSliceCmd
 
-	TopKAdd(ctx context.Context, key string, elements ...interface{}) *StringSliceCmd
-	TopKCount(ctx context.Context, key string, elements ...interface{}) *IntSliceCmd
-	TopKIncrBy(ctx context.Context, key string, elements ...interface{}) *StringSliceCmd
+	TopKAdd(ctx context.Context, key string, elements ...any) *StringSliceCmd
+	TopKCount(ctx context.Context, key string, elements ...any) *IntSliceCmd
+	TopKIncrBy(ctx context.Context, key string, elements ...any) *StringSliceCmd
 	TopKInfo(ctx context.Context, key string) *TopKInfoCmd
 	TopKList(ctx context.Context, key string) *StringSliceCmd
 	TopKListWithCount(ctx context.Context, key string) *MapStringIntCmd
-	TopKQuery(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd
+	TopKQuery(ctx context.Context, key string, elements ...any) *BoolSliceCmd
 	TopKReserve(ctx context.Context, key string, k int64) *StatusCmd
 	TopKReserveWithOptions(ctx context.Context, key string, k int64, width, depth int64, decay float64) *StatusCmd
 
@@ -115,7 +115,7 @@ type CFInsertOptions struct {
 // for the initial specified capacity and with an upper bound error_rate.
 // For more information - https://redis.io/commands/bf.reserve/
 func (c cmdable) BFReserve(ctx context.Context, key string, errorRate float64, capacity int64) *StatusCmd {
-	args := []interface{}{"BF.RESERVE", key, errorRate, capacity}
+	args := []any{"BF.RESERVE", key, errorRate, capacity}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -126,7 +126,7 @@ func (c cmdable) BFReserve(ctx context.Context, key string, errorRate float64, c
 // This function also allows for specifying an expansion rate for the filter.
 // For more information - https://redis.io/commands/bf.reserve/
 func (c cmdable) BFReserveExpansion(ctx context.Context, key string, errorRate float64, capacity, expansion int64) *StatusCmd {
-	args := []interface{}{"BF.RESERVE", key, errorRate, capacity, "EXPANSION", expansion}
+	args := []any{"BF.RESERVE", key, errorRate, capacity, "EXPANSION", expansion}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -137,7 +137,7 @@ func (c cmdable) BFReserveExpansion(ctx context.Context, key string, errorRate f
 // This function also allows for specifying that the filter should not scale.
 // For more information - https://redis.io/commands/bf.reserve/
 func (c cmdable) BFReserveNonScaling(ctx context.Context, key string, errorRate float64, capacity int64) *StatusCmd {
-	args := []interface{}{"BF.RESERVE", key, errorRate, capacity, "NONSCALING"}
+	args := []any{"BF.RESERVE", key, errorRate, capacity, "NONSCALING"}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -148,7 +148,7 @@ func (c cmdable) BFReserveNonScaling(ctx context.Context, key string, errorRate 
 // This function also allows for specifying additional options such as expansion rate and non-scaling behavior.
 // For more information - https://redis.io/commands/bf.reserve/
 func (c cmdable) BFReserveWithArgs(ctx context.Context, key string, options *BFReserveOptions) *StatusCmd {
-	args := []interface{}{"BF.RESERVE", key}
+	args := []any{"BF.RESERVE", key}
 	if options != nil {
 		args = append(args, options.Error, options.Capacity)
 		if options.Expansion != 0 {
@@ -165,8 +165,8 @@ func (c cmdable) BFReserveWithArgs(ctx context.Context, key string, options *BFR
 
 // BFAdd adds an item to a Bloom filter.
 // For more information - https://redis.io/commands/bf.add/
-func (c cmdable) BFAdd(ctx context.Context, key string, element interface{}) *BoolCmd {
-	args := []interface{}{"BF.ADD", key, element}
+func (c cmdable) BFAdd(ctx context.Context, key string, element any) *BoolCmd {
+	args := []any{"BF.ADD", key, element}
 	cmd := NewBoolCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -177,7 +177,7 @@ func (c cmdable) BFAdd(ctx context.Context, key string, element interface{}) *Bo
 // (items that caused at least one bit to be set in at least one sub-filter).
 // For more information - https://redis.io/commands/bf.card/
 func (c cmdable) BFCard(ctx context.Context, key string) *IntCmd {
-	args := []interface{}{"BF.CARD", key}
+	args := []any{"BF.CARD", key}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -185,8 +185,8 @@ func (c cmdable) BFCard(ctx context.Context, key string) *IntCmd {
 
 // BFExists determines whether a given item was added to a Bloom filter.
 // For more information - https://redis.io/commands/bf.exists/
-func (c cmdable) BFExists(ctx context.Context, key string, element interface{}) *BoolCmd {
-	args := []interface{}{"BF.EXISTS", key, element}
+func (c cmdable) BFExists(ctx context.Context, key string, element any) *BoolCmd {
+	args := []any{"BF.EXISTS", key, element}
 	cmd := NewBoolCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -194,8 +194,8 @@ func (c cmdable) BFExists(ctx context.Context, key string, element interface{}) 
 
 // BFLoadChunk restores a Bloom filter previously saved using BF.SCANDUMP.
 // For more information - https://redis.io/commands/bf.loadchunk/
-func (c cmdable) BFLoadChunk(ctx context.Context, key string, iterator int64, data interface{}) *StatusCmd {
-	args := []interface{}{"BF.LOADCHUNK", key, iterator, data}
+func (c cmdable) BFLoadChunk(ctx context.Context, key string, iterator int64, data any) *StatusCmd {
+	args := []any{"BF.LOADCHUNK", key, iterator, data}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -205,7 +205,7 @@ func (c cmdable) BFLoadChunk(ctx context.Context, key string, iterator int64, da
 // This command is useful for large Bloom filters that cannot fit into the DUMP and RESTORE model.
 // For more information - https://redis.io/commands/bf.scandump/
 func (c cmdable) BFScanDump(ctx context.Context, key string, iterator int64) *ScanDumpCmd {
-	args := []interface{}{"BF.SCANDUMP", key, iterator}
+	args := []any{"BF.SCANDUMP", key, iterator}
 	cmd := newScanDumpCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -222,7 +222,7 @@ type ScanDumpCmd struct {
 	val ScanDump
 }
 
-func newScanDumpCmd(ctx context.Context, args ...interface{}) *ScanDumpCmd {
+func newScanDumpCmd(ctx context.Context, args ...any) *ScanDumpCmd {
 	return &ScanDumpCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -273,7 +273,7 @@ func (cmd *ScanDumpCmd) readReply(rd *proto.Reader) (err error) {
 // Returns information about a Bloom filter.
 // For more information - https://redis.io/commands/bf.info/
 func (c cmdable) BFInfo(ctx context.Context, key string) *BFInfoCmd {
-	args := []interface{}{"BF.INFO", key}
+	args := []any{"BF.INFO", key}
 	cmd := NewBFInfoCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -293,7 +293,7 @@ type BFInfoCmd struct {
 	val BFInfo
 }
 
-func NewBFInfoCmd(ctx context.Context, args ...interface{}) *BFInfoCmd {
+func NewBFInfoCmd(ctx context.Context, args ...any) *BFInfoCmd {
 	return &BFInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -421,7 +421,7 @@ func (c cmdable) BFInfoExpansion(ctx context.Context, key string) *BFInfoCmd {
 // BFInfoArg returns information about a specific option of a Bloom filter.
 // For more information - https://redis.io/commands/bf.info/
 func (c cmdable) BFInfoArg(ctx context.Context, key, option string) *BFInfoCmd {
-	args := []interface{}{"BF.INFO", key, option}
+	args := []any{"BF.INFO", key, option}
 	cmd := NewBFInfoCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -431,8 +431,8 @@ func (c cmdable) BFInfoArg(ctx context.Context, key, option string) *BFInfoCmd {
 // This function also allows for specifying additional options such as:
 // capacity, error rate, expansion rate, and non-scaling behavior.
 // For more information - https://redis.io/commands/bf.insert/
-func (c cmdable) BFInsert(ctx context.Context, key string, options *BFInsertOptions, elements ...interface{}) *BoolSliceCmd {
-	args := []interface{}{"BF.INSERT", key}
+func (c cmdable) BFInsert(ctx context.Context, key string, options *BFInsertOptions, elements ...any) *BoolSliceCmd {
+	args := []any{"BF.INSERT", key}
 	if options != nil {
 		if options.Capacity != 0 {
 			args = append(args, "CAPACITY", options.Capacity)
@@ -461,8 +461,8 @@ func (c cmdable) BFInsert(ctx context.Context, key string, options *BFInsertOpti
 // BFMAdd adds multiple elements to a Bloom filter.
 // Returns an array of booleans indicating whether each element was added to the filter or not.
 // For more information - https://redis.io/commands/bf.madd/
-func (c cmdable) BFMAdd(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd {
-	args := []interface{}{"BF.MADD", key}
+func (c cmdable) BFMAdd(ctx context.Context, key string, elements ...any) *BoolSliceCmd {
+	args := []any{"BF.MADD", key}
 	args = append(args, elements...)
 	cmd := NewBoolSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -472,8 +472,8 @@ func (c cmdable) BFMAdd(ctx context.Context, key string, elements ...interface{}
 // BFMExists check if multiple elements exist in a Bloom filter.
 // Returns an array of booleans indicating whether each element exists in the filter or not.
 // For more information - https://redis.io/commands/bf.mexists/
-func (c cmdable) BFMExists(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd {
-	args := []interface{}{"BF.MEXISTS", key}
+func (c cmdable) BFMExists(ctx context.Context, key string, elements ...any) *BoolSliceCmd {
+	args := []any{"BF.MEXISTS", key}
 	args = append(args, elements...)
 
 	cmd := NewBoolSliceCmd(ctx, args...)
@@ -488,7 +488,7 @@ func (c cmdable) BFMExists(ctx context.Context, key string, elements ...interfac
 // CFReserve creates an empty Cuckoo filter with the specified capacity.
 // For more information - https://redis.io/commands/cf.reserve/
 func (c cmdable) CFReserve(ctx context.Context, key string, capacity int64) *StatusCmd {
-	args := []interface{}{"CF.RESERVE", key, capacity}
+	args := []any{"CF.RESERVE", key, capacity}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -497,7 +497,7 @@ func (c cmdable) CFReserve(ctx context.Context, key string, capacity int64) *Sta
 // CFReserveExpansion creates an empty Cuckoo filter with the specified capacity and expansion rate.
 // For more information - https://redis.io/commands/cf.reserve/
 func (c cmdable) CFReserveExpansion(ctx context.Context, key string, capacity int64, expansion int64) *StatusCmd {
-	args := []interface{}{"CF.RESERVE", key, capacity, "EXPANSION", expansion}
+	args := []any{"CF.RESERVE", key, capacity, "EXPANSION", expansion}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -506,7 +506,7 @@ func (c cmdable) CFReserveExpansion(ctx context.Context, key string, capacity in
 // CFReserveBucketSize creates an empty Cuckoo filter with the specified capacity and bucket size.
 // For more information - https://redis.io/commands/cf.reserve/
 func (c cmdable) CFReserveBucketSize(ctx context.Context, key string, capacity int64, bucketsize int64) *StatusCmd {
-	args := []interface{}{"CF.RESERVE", key, capacity, "BUCKETSIZE", bucketsize}
+	args := []any{"CF.RESERVE", key, capacity, "BUCKETSIZE", bucketsize}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -515,7 +515,7 @@ func (c cmdable) CFReserveBucketSize(ctx context.Context, key string, capacity i
 // CFReserveMaxIterations creates an empty Cuckoo filter with the specified capacity and maximum number of iterations.
 // For more information - https://redis.io/commands/cf.reserve/
 func (c cmdable) CFReserveMaxIterations(ctx context.Context, key string, capacity int64, maxiterations int64) *StatusCmd {
-	args := []interface{}{"CF.RESERVE", key, capacity, "MAXITERATIONS", maxiterations}
+	args := []any{"CF.RESERVE", key, capacity, "MAXITERATIONS", maxiterations}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -525,7 +525,7 @@ func (c cmdable) CFReserveMaxIterations(ctx context.Context, key string, capacit
 // This function allows for specifying additional options such as bucket size and maximum number of iterations.
 // For more information - https://redis.io/commands/cf.reserve/
 func (c cmdable) CFReserveWithArgs(ctx context.Context, key string, options *CFReserveOptions) *StatusCmd {
-	args := []interface{}{"CF.RESERVE", key, options.Capacity}
+	args := []any{"CF.RESERVE", key, options.Capacity}
 	if options.BucketSize != 0 {
 		args = append(args, "BUCKETSIZE", options.BucketSize)
 	}
@@ -543,8 +543,8 @@ func (c cmdable) CFReserveWithArgs(ctx context.Context, key string, options *CFR
 // CFAdd adds an element to a Cuckoo filter.
 // Returns true if the element was added to the filter or false if it already exists in the filter.
 // For more information - https://redis.io/commands/cf.add/
-func (c cmdable) CFAdd(ctx context.Context, key string, element interface{}) *BoolCmd {
-	args := []interface{}{"CF.ADD", key, element}
+func (c cmdable) CFAdd(ctx context.Context, key string, element any) *BoolCmd {
+	args := []any{"CF.ADD", key, element}
 	cmd := NewBoolCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -553,8 +553,8 @@ func (c cmdable) CFAdd(ctx context.Context, key string, element interface{}) *Bo
 // CFAddNX adds an element to a Cuckoo filter only if it does not already exist in the filter.
 // Returns true if the element was added to the filter or false if it already exists in the filter.
 // For more information - https://redis.io/commands/cf.addnx/
-func (c cmdable) CFAddNX(ctx context.Context, key string, element interface{}) *BoolCmd {
-	args := []interface{}{"CF.ADDNX", key, element}
+func (c cmdable) CFAddNX(ctx context.Context, key string, element any) *BoolCmd {
+	args := []any{"CF.ADDNX", key, element}
 	cmd := NewBoolCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -562,8 +562,8 @@ func (c cmdable) CFAddNX(ctx context.Context, key string, element interface{}) *
 
 // CFCount returns an estimate of the number of times an element may be in a Cuckoo Filter.
 // For more information - https://redis.io/commands/cf.count/
-func (c cmdable) CFCount(ctx context.Context, key string, element interface{}) *IntCmd {
-	args := []interface{}{"CF.COUNT", key, element}
+func (c cmdable) CFCount(ctx context.Context, key string, element any) *IntCmd {
+	args := []any{"CF.COUNT", key, element}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -571,8 +571,8 @@ func (c cmdable) CFCount(ctx context.Context, key string, element interface{}) *
 
 // CFDel deletes an item once from the cuckoo filter.
 // For more information - https://redis.io/commands/cf.del/
-func (c cmdable) CFDel(ctx context.Context, key string, element interface{}) *BoolCmd {
-	args := []interface{}{"CF.DEL", key, element}
+func (c cmdable) CFDel(ctx context.Context, key string, element any) *BoolCmd {
+	args := []any{"CF.DEL", key, element}
 	cmd := NewBoolCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -580,8 +580,8 @@ func (c cmdable) CFDel(ctx context.Context, key string, element interface{}) *Bo
 
 // CFExists determines whether an item may exist in the Cuckoo Filter or not.
 // For more information - https://redis.io/commands/cf.exists/
-func (c cmdable) CFExists(ctx context.Context, key string, element interface{}) *BoolCmd {
-	args := []interface{}{"CF.EXISTS", key, element}
+func (c cmdable) CFExists(ctx context.Context, key string, element any) *BoolCmd {
+	args := []any{"CF.EXISTS", key, element}
 	cmd := NewBoolCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -589,8 +589,8 @@ func (c cmdable) CFExists(ctx context.Context, key string, element interface{}) 
 
 // CFLoadChunk restores a filter previously saved using SCANDUMP.
 // For more information - https://redis.io/commands/cf.loadchunk/
-func (c cmdable) CFLoadChunk(ctx context.Context, key string, iterator int64, data interface{}) *StatusCmd {
-	args := []interface{}{"CF.LOADCHUNK", key, iterator, data}
+func (c cmdable) CFLoadChunk(ctx context.Context, key string, iterator int64, data any) *StatusCmd {
+	args := []any{"CF.LOADCHUNK", key, iterator, data}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -599,7 +599,7 @@ func (c cmdable) CFLoadChunk(ctx context.Context, key string, iterator int64, da
 // CFScanDump begins an incremental save of the cuckoo filter.
 // For more information - https://redis.io/commands/cf.scandump/
 func (c cmdable) CFScanDump(ctx context.Context, key string, iterator int64) *ScanDumpCmd {
-	args := []interface{}{"CF.SCANDUMP", key, iterator}
+	args := []any{"CF.SCANDUMP", key, iterator}
 	cmd := newScanDumpCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -622,7 +622,7 @@ type CFInfoCmd struct {
 	val CFInfo
 }
 
-func NewCFInfoCmd(ctx context.Context, args ...interface{}) *CFInfoCmd {
+func NewCFInfoCmd(ctx context.Context, args ...any) *CFInfoCmd {
 	return &CFInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -695,7 +695,7 @@ func (cmd *CFInfoCmd) readReply(rd *proto.Reader) (err error) {
 // CFInfo returns information about a Cuckoo filter.
 // For more information - https://redis.io/commands/cf.info/
 func (c cmdable) CFInfo(ctx context.Context, key string) *CFInfoCmd {
-	args := []interface{}{"CF.INFO", key}
+	args := []any{"CF.INFO", key}
 	cmd := NewCFInfoCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -705,8 +705,8 @@ func (c cmdable) CFInfo(ctx context.Context, key string) *CFInfoCmd {
 // This function also allows for specifying additional options such as capacity, error rate, expansion rate, and non-scaling behavior.
 // Returns an array of booleans indicating whether each element was added to the filter or not.
 // For more information - https://redis.io/commands/cf.insert/
-func (c cmdable) CFInsert(ctx context.Context, key string, options *CFInsertOptions, elements ...interface{}) *BoolSliceCmd {
-	args := []interface{}{"CF.INSERT", key}
+func (c cmdable) CFInsert(ctx context.Context, key string, options *CFInsertOptions, elements ...any) *BoolSliceCmd {
+	args := []any{"CF.INSERT", key}
 	args = c.getCfInsertWithArgs(args, options, elements...)
 
 	cmd := NewBoolSliceCmd(ctx, args...)
@@ -719,8 +719,8 @@ func (c cmdable) CFInsert(ctx context.Context, key string, options *CFInsertOpti
 // capacity, error rate, expansion rate, and non-scaling behavior.
 // Returns an array of integers indicating whether each element was added to the filter or not.
 // For more information - https://redis.io/commands/cf.insertnx/
-func (c cmdable) CFInsertNX(ctx context.Context, key string, options *CFInsertOptions, elements ...interface{}) *IntSliceCmd {
-	args := []interface{}{"CF.INSERTNX", key}
+func (c cmdable) CFInsertNX(ctx context.Context, key string, options *CFInsertOptions, elements ...any) *IntSliceCmd {
+	args := []any{"CF.INSERTNX", key}
 	args = c.getCfInsertWithArgs(args, options, elements...)
 
 	cmd := NewIntSliceCmd(ctx, args...)
@@ -728,7 +728,7 @@ func (c cmdable) CFInsertNX(ctx context.Context, key string, options *CFInsertOp
 	return cmd
 }
 
-func (c cmdable) getCfInsertWithArgs(args []interface{}, options *CFInsertOptions, elements ...interface{}) []interface{} {
+func (c cmdable) getCfInsertWithArgs(args []any, options *CFInsertOptions, elements ...any) []any {
 	if options != nil {
 		if options.Capacity != 0 {
 			args = append(args, "CAPACITY", options.Capacity)
@@ -746,8 +746,8 @@ func (c cmdable) getCfInsertWithArgs(args []interface{}, options *CFInsertOption
 // CFMExists check if multiple elements exist in a Cuckoo filter.
 // Returns an array of booleans indicating whether each element exists in the filter or not.
 // For more information - https://redis.io/commands/cf.mexists/
-func (c cmdable) CFMExists(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd {
-	args := []interface{}{"CF.MEXISTS", key}
+func (c cmdable) CFMExists(ctx context.Context, key string, elements ...any) *BoolSliceCmd {
+	args := []any{"CF.MEXISTS", key}
 	args = append(args, elements...)
 	cmd := NewBoolSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -761,8 +761,8 @@ func (c cmdable) CFMExists(ctx context.Context, key string, elements ...interfac
 // CMSIncrBy increments the count of one or more items in a Count-Min Sketch filter.
 // Returns an array of integers representing the updated count of each item.
 // For more information - https://redis.io/commands/cms.incrby/
-func (c cmdable) CMSIncrBy(ctx context.Context, key string, elements ...interface{}) *IntSliceCmd {
-	args := make([]interface{}, 2, 2+len(elements))
+func (c cmdable) CMSIncrBy(ctx context.Context, key string, elements ...any) *IntSliceCmd {
+	args := make([]any, 2, 2+len(elements))
 	args[0] = "CMS.INCRBY"
 	args[1] = key
 	args = appendArgs(args, elements)
@@ -784,7 +784,7 @@ type CMSInfoCmd struct {
 	val CMSInfo
 }
 
-func NewCMSInfoCmd(ctx context.Context, args ...interface{}) *CMSInfoCmd {
+func NewCMSInfoCmd(ctx context.Context, args ...any) *CMSInfoCmd {
 	return &CMSInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -846,7 +846,7 @@ func (cmd *CMSInfoCmd) readReply(rd *proto.Reader) (err error) {
 // CMSInfo returns information about a Count-Min Sketch filter.
 // For more information - https://redis.io/commands/cms.info/
 func (c cmdable) CMSInfo(ctx context.Context, key string) *CMSInfoCmd {
-	args := []interface{}{"CMS.INFO", key}
+	args := []any{"CMS.INFO", key}
 	cmd := NewCMSInfoCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -855,7 +855,7 @@ func (c cmdable) CMSInfo(ctx context.Context, key string) *CMSInfoCmd {
 // CMSInitByDim creates an empty Count-Min Sketch filter with the specified dimensions.
 // For more information - https://redis.io/commands/cms.initbydim/
 func (c cmdable) CMSInitByDim(ctx context.Context, key string, width, depth int64) *StatusCmd {
-	args := []interface{}{"CMS.INITBYDIM", key, width, depth}
+	args := []any{"CMS.INITBYDIM", key, width, depth}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -864,7 +864,7 @@ func (c cmdable) CMSInitByDim(ctx context.Context, key string, width, depth int6
 // CMSInitByProb creates an empty Count-Min Sketch filter with the specified error rate and probability.
 // For more information - https://redis.io/commands/cms.initbyprob/
 func (c cmdable) CMSInitByProb(ctx context.Context, key string, errorRate, probability float64) *StatusCmd {
-	args := []interface{}{"CMS.INITBYPROB", key, errorRate, probability}
+	args := []any{"CMS.INITBYPROB", key, errorRate, probability}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -876,7 +876,7 @@ func (c cmdable) CMSInitByProb(ctx context.Context, key string, errorRate, proba
 // Returns OK on success or an error if the filters could not be merged.
 // For more information - https://redis.io/commands/cms.merge/
 func (c cmdable) CMSMerge(ctx context.Context, destKey string, sourceKeys ...string) *StatusCmd {
-	args := []interface{}{"CMS.MERGE", destKey, len(sourceKeys)}
+	args := []any{"CMS.MERGE", destKey, len(sourceKeys)}
 	for _, s := range sourceKeys {
 		args = append(args, s)
 	}
@@ -891,12 +891,12 @@ func (c cmdable) CMSMerge(ctx context.Context, destKey string, sourceKeys ...str
 // Returns OK on success or an error if the filters could not be merged.
 // For more information - https://redis.io/commands/cms.merge/
 func (c cmdable) CMSMergeWithWeight(ctx context.Context, destKey string, sourceKeys map[string]int64) *StatusCmd {
-	args := make([]interface{}, 0, 4+(len(sourceKeys)*2+1))
+	args := make([]any, 0, 4+(len(sourceKeys)*2+1))
 	args = append(args, "CMS.MERGE", destKey, len(sourceKeys))
 
 	if len(sourceKeys) > 0 {
-		sk := make([]interface{}, len(sourceKeys))
-		sw := make([]interface{}, len(sourceKeys))
+		sk := make([]any, len(sourceKeys))
+		sw := make([]any, len(sourceKeys))
 
 		i := 0
 		for k, w := range sourceKeys {
@@ -917,8 +917,8 @@ func (c cmdable) CMSMergeWithWeight(ctx context.Context, destKey string, sourceK
 
 // CMSQuery returns count for item(s).
 // For more information - https://redis.io/commands/cms.query/
-func (c cmdable) CMSQuery(ctx context.Context, key string, elements ...interface{}) *IntSliceCmd {
-	args := []interface{}{"CMS.QUERY", key}
+func (c cmdable) CMSQuery(ctx context.Context, key string, elements ...any) *IntSliceCmd {
+	args := []any{"CMS.QUERY", key}
 	args = append(args, elements...)
 	cmd := NewIntSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -932,8 +932,8 @@ func (c cmdable) CMSQuery(ctx context.Context, key string, elements ...interface
 // TopKAdd adds one or more elements to a Top-K filter.
 // Returns an array of strings representing the items that were removed from the filter, if any.
 // For more information - https://redis.io/commands/topk.add/
-func (c cmdable) TopKAdd(ctx context.Context, key string, elements ...interface{}) *StringSliceCmd {
-	args := make([]interface{}, 2, 2+len(elements))
+func (c cmdable) TopKAdd(ctx context.Context, key string, elements ...any) *StringSliceCmd {
+	args := make([]any, 2, 2+len(elements))
 	args[0] = "TOPK.ADD"
 	args[1] = key
 	args = appendArgs(args, elements)
@@ -946,7 +946,7 @@ func (c cmdable) TopKAdd(ctx context.Context, key string, elements ...interface{
 // TopKReserve creates an empty Top-K filter with the specified number of top items to keep.
 // For more information - https://redis.io/commands/topk.reserve/
 func (c cmdable) TopKReserve(ctx context.Context, key string, k int64) *StatusCmd {
-	args := []interface{}{"TOPK.RESERVE", key, k}
+	args := []any{"TOPK.RESERVE", key, k}
 
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -957,7 +957,7 @@ func (c cmdable) TopKReserve(ctx context.Context, key string, k int64) *StatusCm
 // This function allows for specifying additional options such as width, depth and decay.
 // For more information - https://redis.io/commands/topk.reserve/
 func (c cmdable) TopKReserveWithOptions(ctx context.Context, key string, k int64, width, depth int64, decay float64) *StatusCmd {
-	args := []interface{}{"TOPK.RESERVE", key, k, width, depth, decay}
+	args := []any{"TOPK.RESERVE", key, k, width, depth, decay}
 
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -977,7 +977,7 @@ type TopKInfoCmd struct {
 	val TopKInfo
 }
 
-func NewTopKInfoCmd(ctx context.Context, args ...interface{}) *TopKInfoCmd {
+func NewTopKInfoCmd(ctx context.Context, args ...any) *TopKInfoCmd {
 	return &TopKInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1041,7 +1041,7 @@ func (cmd *TopKInfoCmd) readReply(rd *proto.Reader) (err error) {
 // TopKInfo returns information about a Top-K filter.
 // For more information - https://redis.io/commands/topk.info/
 func (c cmdable) TopKInfo(ctx context.Context, key string) *TopKInfoCmd {
-	args := []interface{}{"TOPK.INFO", key}
+	args := []any{"TOPK.INFO", key}
 
 	cmd := NewTopKInfoCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1051,8 +1051,8 @@ func (c cmdable) TopKInfo(ctx context.Context, key string) *TopKInfoCmd {
 // TopKQuery check if multiple elements exist in a Top-K filter.
 // Returns an array of booleans indicating whether each element exists in the filter or not.
 // For more information - https://redis.io/commands/topk.query/
-func (c cmdable) TopKQuery(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd {
-	args := make([]interface{}, 2, 2+len(elements))
+func (c cmdable) TopKQuery(ctx context.Context, key string, elements ...any) *BoolSliceCmd {
+	args := make([]any, 2, 2+len(elements))
 	args[0] = "TOPK.QUERY"
 	args[1] = key
 	args = appendArgs(args, elements)
@@ -1064,8 +1064,8 @@ func (c cmdable) TopKQuery(ctx context.Context, key string, elements ...interfac
 
 // TopKCount returns an estimate of the number of times an item may be in a Top-K filter.
 // For more information - https://redis.io/commands/topk.count/
-func (c cmdable) TopKCount(ctx context.Context, key string, elements ...interface{}) *IntSliceCmd {
-	args := make([]interface{}, 2, 2+len(elements))
+func (c cmdable) TopKCount(ctx context.Context, key string, elements ...any) *IntSliceCmd {
+	args := make([]any, 2, 2+len(elements))
 	args[0] = "TOPK.COUNT"
 	args[1] = key
 	args = appendArgs(args, elements)
@@ -1077,8 +1077,8 @@ func (c cmdable) TopKCount(ctx context.Context, key string, elements ...interfac
 
 // TopKIncrBy increases the count of one or more items in a Top-K filter.
 // For more information - https://redis.io/commands/topk.incrby/
-func (c cmdable) TopKIncrBy(ctx context.Context, key string, elements ...interface{}) *StringSliceCmd {
-	args := make([]interface{}, 2, 2+len(elements))
+func (c cmdable) TopKIncrBy(ctx context.Context, key string, elements ...any) *StringSliceCmd {
+	args := make([]any, 2, 2+len(elements))
 	args[0] = "TOPK.INCRBY"
 	args[1] = key
 	args = appendArgs(args, elements)
@@ -1091,7 +1091,7 @@ func (c cmdable) TopKIncrBy(ctx context.Context, key string, elements ...interfa
 // TopKList returns all items in Top-K list.
 // For more information - https://redis.io/commands/topk.list/
 func (c cmdable) TopKList(ctx context.Context, key string) *StringSliceCmd {
-	args := []interface{}{"TOPK.LIST", key}
+	args := []any{"TOPK.LIST", key}
 
 	cmd := NewStringSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1101,7 +1101,7 @@ func (c cmdable) TopKList(ctx context.Context, key string) *StringSliceCmd {
 // TopKListWithCount returns all items in Top-K list with their respective count.
 // For more information - https://redis.io/commands/topk.list/
 func (c cmdable) TopKListWithCount(ctx context.Context, key string) *MapStringIntCmd {
-	args := []interface{}{"TOPK.LIST", key, "WITHCOUNT"}
+	args := []any{"TOPK.LIST", key, "WITHCOUNT"}
 
 	cmd := NewMapStringIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1116,7 +1116,7 @@ func (c cmdable) TopKListWithCount(ctx context.Context, key string) *MapStringIn
 // Returns OK on success or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.add/
 func (c cmdable) TDigestAdd(ctx context.Context, key string, elements ...float64) *StatusCmd {
-	args := make([]interface{}, 2+len(elements))
+	args := make([]any, 2+len(elements))
 	args[0] = "TDIGEST.ADD"
 	args[1] = key
 
@@ -1134,7 +1134,7 @@ func (c cmdable) TDigestAdd(ctx context.Context, key string, elements ...float64
 // Returns an array of floats representing the values at the specified ranks or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.byrank/
 func (c cmdable) TDigestByRank(ctx context.Context, key string, rank ...uint64) *FloatSliceCmd {
-	args := make([]interface{}, 2+len(rank))
+	args := make([]any, 2+len(rank))
 	args[0] = "TDIGEST.BYRANK"
 	args[1] = key
 
@@ -1152,7 +1152,7 @@ func (c cmdable) TDigestByRank(ctx context.Context, key string, rank ...uint64) 
 // Returns an array of floats representing the values at the specified ranks or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.byrevrank/
 func (c cmdable) TDigestByRevRank(ctx context.Context, key string, rank ...uint64) *FloatSliceCmd {
-	args := make([]interface{}, 2+len(rank))
+	args := make([]any, 2+len(rank))
 	args[0] = "TDIGEST.BYREVRANK"
 	args[1] = key
 
@@ -1170,7 +1170,7 @@ func (c cmdable) TDigestByRevRank(ctx context.Context, key string, rank ...uint6
 // Returns an array of floats representing the CDF values for each element or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.cdf/
 func (c cmdable) TDigestCDF(ctx context.Context, key string, elements ...float64) *FloatSliceCmd {
-	args := make([]interface{}, 2+len(elements))
+	args := make([]any, 2+len(elements))
 	args[0] = "TDIGEST.CDF"
 	args[1] = key
 
@@ -1187,7 +1187,7 @@ func (c cmdable) TDigestCDF(ctx context.Context, key string, elements ...float64
 // Returns OK on success or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.create/
 func (c cmdable) TDigestCreate(ctx context.Context, key string) *StatusCmd {
-	args := []interface{}{"TDIGEST.CREATE", key}
+	args := []any{"TDIGEST.CREATE", key}
 
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1199,7 +1199,7 @@ func (c cmdable) TDigestCreate(ctx context.Context, key string) *StatusCmd {
 // Returns OK on success or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.create/
 func (c cmdable) TDigestCreateWithCompression(ctx context.Context, key string, compression int64) *StatusCmd {
-	args := []interface{}{"TDIGEST.CREATE", key, "COMPRESSION", compression}
+	args := []any{"TDIGEST.CREATE", key, "COMPRESSION", compression}
 
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1224,7 +1224,7 @@ type TDigestInfoCmd struct {
 	val TDigestInfo
 }
 
-func NewTDigestInfoCmd(ctx context.Context, args ...interface{}) *TDigestInfoCmd {
+func NewTDigestInfoCmd(ctx context.Context, args ...any) *TDigestInfoCmd {
 	return &TDigestInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1298,7 +1298,7 @@ func (cmd *TDigestInfoCmd) readReply(rd *proto.Reader) (err error) {
 // TDigestInfo returns information about a t-Digest data structure.
 // For more information - https://redis.io/commands/tdigest.info/
 func (c cmdable) TDigestInfo(ctx context.Context, key string) *TDigestInfoCmd {
-	args := []interface{}{"TDIGEST.INFO", key}
+	args := []any{"TDIGEST.INFO", key}
 
 	cmd := NewTDigestInfoCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1308,7 +1308,7 @@ func (c cmdable) TDigestInfo(ctx context.Context, key string) *TDigestInfoCmd {
 // TDigestMax returns the maximum value from a t-Digest data structure.
 // For more information - https://redis.io/commands/tdigest.max/
 func (c cmdable) TDigestMax(ctx context.Context, key string) *FloatCmd {
-	args := []interface{}{"TDIGEST.MAX", key}
+	args := []any{"TDIGEST.MAX", key}
 
 	cmd := NewFloatCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1325,7 +1325,7 @@ type TDigestMergeOptions struct {
 // Returns OK on success or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.merge/
 func (c cmdable) TDigestMerge(ctx context.Context, destKey string, options *TDigestMergeOptions, sourceKeys ...string) *StatusCmd {
-	args := []interface{}{"TDIGEST.MERGE", destKey, len(sourceKeys)}
+	args := []any{"TDIGEST.MERGE", destKey, len(sourceKeys)}
 
 	for _, sourceKey := range sourceKeys {
 		args = append(args, sourceKey)
@@ -1348,7 +1348,7 @@ func (c cmdable) TDigestMerge(ctx context.Context, destKey string, options *TDig
 // TDigestMin returns the minimum value from a t-Digest data structure.
 // For more information - https://redis.io/commands/tdigest.min/
 func (c cmdable) TDigestMin(ctx context.Context, key string) *FloatCmd {
-	args := []interface{}{"TDIGEST.MIN", key}
+	args := []any{"TDIGEST.MIN", key}
 
 	cmd := NewFloatCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1360,7 +1360,7 @@ func (c cmdable) TDigestMin(ctx context.Context, key string) *FloatCmd {
 // Returns an array of floats representing the quantile values for each element or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.quantile/
 func (c cmdable) TDigestQuantile(ctx context.Context, key string, elements ...float64) *FloatSliceCmd {
-	args := make([]interface{}, 2+len(elements))
+	args := make([]any, 2+len(elements))
 	args[0] = "TDIGEST.QUANTILE"
 	args[1] = key
 
@@ -1378,7 +1378,7 @@ func (c cmdable) TDigestQuantile(ctx context.Context, key string, elements ...fl
 // Returns an array of integers representing the rank values for each element or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.rank/
 func (c cmdable) TDigestRank(ctx context.Context, key string, values ...float64) *IntSliceCmd {
-	args := make([]interface{}, 2+len(values))
+	args := make([]any, 2+len(values))
 	args[0] = "TDIGEST.RANK"
 	args[1] = key
 
@@ -1395,7 +1395,7 @@ func (c cmdable) TDigestRank(ctx context.Context, key string, values ...float64)
 // Returns OK on success or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.reset/
 func (c cmdable) TDigestReset(ctx context.Context, key string) *StatusCmd {
-	args := []interface{}{"TDIGEST.RESET", key}
+	args := []any{"TDIGEST.RESET", key}
 
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1407,7 +1407,7 @@ func (c cmdable) TDigestReset(ctx context.Context, key string) *StatusCmd {
 // Returns an array of integers representing the reverse rank values for each element or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.revrank/
 func (c cmdable) TDigestRevRank(ctx context.Context, key string, values ...float64) *IntSliceCmd {
-	args := make([]interface{}, 2+len(values))
+	args := make([]any, 2+len(values))
 	args[0] = "TDIGEST.REVRANK"
 	args[1] = key
 
@@ -1425,7 +1425,7 @@ func (c cmdable) TDigestRevRank(ctx context.Context, key string, values ...float
 // Returns a float representing the trimmed mean value or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.trimmed_mean/
 func (c cmdable) TDigestTrimmedMean(ctx context.Context, key string, lowCutQuantile, highCutQuantile float64) *FloatCmd {
-	args := []interface{}{"TDIGEST.TRIMMED_MEAN", key, lowCutQuantile, highCutQuantile}
+	args := []any{"TDIGEST.TRIMMED_MEAN", key, lowCutQuantile, highCutQuantile}
 
 	cmd := NewFloatCmd(ctx, args...)
 	_ = c(ctx, cmd)

--- a/pubsub_commands.go
+++ b/pubsub_commands.go
@@ -3,8 +3,8 @@ package redis
 import "context"
 
 type PubSubCmdable interface {
-	Publish(ctx context.Context, channel string, message interface{}) *IntCmd
-	SPublish(ctx context.Context, channel string, message interface{}) *IntCmd
+	Publish(ctx context.Context, channel string, message any) *IntCmd
+	SPublish(ctx context.Context, channel string, message any) *IntCmd
 	PubSubChannels(ctx context.Context, pattern string) *StringSliceCmd
 	PubSubNumSub(ctx context.Context, channels ...string) *MapStringIntCmd
 	PubSubNumPat(ctx context.Context) *IntCmd
@@ -13,20 +13,20 @@ type PubSubCmdable interface {
 }
 
 // Publish posts the message to the channel.
-func (c cmdable) Publish(ctx context.Context, channel string, message interface{}) *IntCmd {
+func (c cmdable) Publish(ctx context.Context, channel string, message any) *IntCmd {
 	cmd := NewIntCmd(ctx, "publish", channel, message)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
-func (c cmdable) SPublish(ctx context.Context, channel string, message interface{}) *IntCmd {
+func (c cmdable) SPublish(ctx context.Context, channel string, message any) *IntCmd {
 	cmd := NewIntCmd(ctx, "spublish", channel, message)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
 func (c cmdable) PubSubChannels(ctx context.Context, pattern string) *StringSliceCmd {
-	args := []interface{}{"pubsub", "channels"}
+	args := []any{"pubsub", "channels"}
 	if pattern != "*" {
 		args = append(args, pattern)
 	}
@@ -36,7 +36,7 @@ func (c cmdable) PubSubChannels(ctx context.Context, pattern string) *StringSlic
 }
 
 func (c cmdable) PubSubNumSub(ctx context.Context, channels ...string) *MapStringIntCmd {
-	args := make([]interface{}, 2+len(channels))
+	args := make([]any, 2+len(channels))
 	args[0] = "pubsub"
 	args[1] = "numsub"
 	for i, channel := range channels {
@@ -48,7 +48,7 @@ func (c cmdable) PubSubNumSub(ctx context.Context, channels ...string) *MapStrin
 }
 
 func (c cmdable) PubSubShardChannels(ctx context.Context, pattern string) *StringSliceCmd {
-	args := []interface{}{"pubsub", "shardchannels"}
+	args := []any{"pubsub", "shardchannels"}
 	if pattern != "*" {
 		args = append(args, pattern)
 	}
@@ -58,7 +58,7 @@ func (c cmdable) PubSubShardChannels(ctx context.Context, pattern string) *Strin
 }
 
 func (c cmdable) PubSubShardNumSub(ctx context.Context, channels ...string) *MapStringIntCmd {
-	args := make([]interface{}, 2+len(channels))
+	args := make([]any, 2+len(channels))
 	args[0] = "pubsub"
 	args[1] = "shardnumsub"
 	for i, channel := range channels {

--- a/result.go
+++ b/result.go
@@ -3,7 +3,7 @@ package redis
 import "time"
 
 // NewCmdResult returns a Cmd initialised with val and err for testing.
-func NewCmdResult(val interface{}, err error) *Cmd {
+func NewCmdResult(val any, err error) *Cmd {
 	var cmd Cmd
 	cmd.val = val
 	cmd.SetErr(err)
@@ -11,7 +11,7 @@ func NewCmdResult(val interface{}, err error) *Cmd {
 }
 
 // NewSliceResult returns a SliceCmd initialised with val and err for testing.
-func NewSliceResult(val []interface{}, err error) *SliceCmd {
+func NewSliceResult(val []any, err error) *SliceCmd {
 	var cmd SliceCmd
 	cmd.val = val
 	cmd.SetErr(err)

--- a/script.go
+++ b/script.go
@@ -8,10 +8,10 @@ import (
 )
 
 type Scripter interface {
-	Eval(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd
-	EvalSha(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd
-	EvalRO(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd
-	EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd
+	Eval(ctx context.Context, script string, keys []string, args ...any) *Cmd
+	EvalSha(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd
+	EvalRO(ctx context.Context, script string, keys []string, args ...any) *Cmd
+	EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd
 	ScriptExists(ctx context.Context, hashes ...string) *BoolSliceCmd
 	ScriptLoad(ctx context.Context, script string) *StringCmd
 }
@@ -47,25 +47,25 @@ func (s *Script) Exists(ctx context.Context, c Scripter) *BoolSliceCmd {
 	return c.ScriptExists(ctx, s.hash)
 }
 
-func (s *Script) Eval(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
+func (s *Script) Eval(ctx context.Context, c Scripter, keys []string, args ...any) *Cmd {
 	return c.Eval(ctx, s.src, keys, args...)
 }
 
-func (s *Script) EvalRO(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
+func (s *Script) EvalRO(ctx context.Context, c Scripter, keys []string, args ...any) *Cmd {
 	return c.EvalRO(ctx, s.src, keys, args...)
 }
 
-func (s *Script) EvalSha(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
+func (s *Script) EvalSha(ctx context.Context, c Scripter, keys []string, args ...any) *Cmd {
 	return c.EvalSha(ctx, s.hash, keys, args...)
 }
 
-func (s *Script) EvalShaRO(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
+func (s *Script) EvalShaRO(ctx context.Context, c Scripter, keys []string, args ...any) *Cmd {
 	return c.EvalShaRO(ctx, s.hash, keys, args...)
 }
 
 // Run optimistically uses EVALSHA to run the script. If script does not exist
 // it is retried using EVAL.
-func (s *Script) Run(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
+func (s *Script) Run(ctx context.Context, c Scripter, keys []string, args ...any) *Cmd {
 	r := s.EvalSha(ctx, c, keys, args...)
 	if HasErrorPrefix(r.Err(), "NOSCRIPT") {
 		return s.Eval(ctx, c, keys, args...)
@@ -75,7 +75,7 @@ func (s *Script) Run(ctx context.Context, c Scripter, keys []string, args ...int
 
 // RunRO optimistically uses EVALSHA_RO to run the script. If script does not exist
 // it is retried using EVAL_RO.
-func (s *Script) RunRO(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
+func (s *Script) RunRO(ctx context.Context, c Scripter, keys []string, args ...any) *Cmd {
 	r := s.EvalShaRO(ctx, c, keys, args...)
 	if HasErrorPrefix(r.Err(), "NOSCRIPT") {
 		return s.EvalRO(ctx, c, keys, args...)

--- a/scripting_commands.go
+++ b/scripting_commands.go
@@ -3,10 +3,10 @@ package redis
 import "context"
 
 type ScriptingFunctionsCmdable interface {
-	Eval(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd
-	EvalSha(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd
-	EvalRO(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd
-	EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd
+	Eval(ctx context.Context, script string, keys []string, args ...any) *Cmd
+	EvalSha(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd
+	EvalRO(ctx context.Context, script string, keys []string, args ...any) *Cmd
+	EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd
 	ScriptExists(ctx context.Context, hashes ...string) *BoolSliceCmd
 	ScriptFlush(ctx context.Context) *StatusCmd
 	ScriptKill(ctx context.Context) *StatusCmd
@@ -22,29 +22,29 @@ type ScriptingFunctionsCmdable interface {
 	FunctionDump(ctx context.Context) *StringCmd
 	FunctionRestore(ctx context.Context, libDump string) *StringCmd
 	FunctionStats(ctx context.Context) *FunctionStatsCmd
-	FCall(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd
-	FCallRo(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd
-	FCallRO(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd
+	FCall(ctx context.Context, function string, keys []string, args ...any) *Cmd
+	FCallRo(ctx context.Context, function string, keys []string, args ...any) *Cmd
+	FCallRO(ctx context.Context, function string, keys []string, args ...any) *Cmd
 }
 
-func (c cmdable) Eval(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) Eval(ctx context.Context, script string, keys []string, args ...any) *Cmd {
 	return c.eval(ctx, "eval", script, keys, args...)
 }
 
-func (c cmdable) EvalRO(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) EvalRO(ctx context.Context, script string, keys []string, args ...any) *Cmd {
 	return c.eval(ctx, "eval_ro", script, keys, args...)
 }
 
-func (c cmdable) EvalSha(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) EvalSha(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd {
 	return c.eval(ctx, "evalsha", sha1, keys, args...)
 }
 
-func (c cmdable) EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd {
 	return c.eval(ctx, "evalsha_ro", sha1, keys, args...)
 }
 
-func (c cmdable) eval(ctx context.Context, name, payload string, keys []string, args ...interface{}) *Cmd {
-	cmdArgs := make([]interface{}, 3+len(keys), 3+len(keys)+len(args))
+func (c cmdable) eval(ctx context.Context, name, payload string, keys []string, args ...any) *Cmd {
+	cmdArgs := make([]any, 3+len(keys), 3+len(keys)+len(args))
 	cmdArgs[0] = name
 	cmdArgs[1] = payload
 	cmdArgs[2] = len(keys)
@@ -64,7 +64,7 @@ func (c cmdable) eval(ctx context.Context, name, payload string, keys []string, 
 }
 
 func (c cmdable) ScriptExists(ctx context.Context, hashes ...string) *BoolSliceCmd {
-	args := make([]interface{}, 2+len(hashes))
+	args := make([]any, 2+len(hashes))
 	args[0] = "script"
 	args[1] = "exists"
 	for i, hash := range hashes {
@@ -143,7 +143,7 @@ func (c cmdable) FunctionFlushAsync(ctx context.Context) *StringCmd {
 }
 
 func (c cmdable) FunctionList(ctx context.Context, q FunctionListQuery) *FunctionListCmd {
-	args := make([]interface{}, 2, 5)
+	args := make([]any, 2, 5)
 	args[0] = "function"
 	args[1] = "list"
 	if q.LibraryNamePattern != "" {
@@ -175,7 +175,7 @@ func (c cmdable) FunctionStats(ctx context.Context) *FunctionStatsCmd {
 	return cmd
 }
 
-func (c cmdable) FCall(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) FCall(ctx context.Context, function string, keys []string, args ...any) *Cmd {
 	cmdArgs := fcallArgs("fcall", function, keys, args...)
 	cmd := NewCmd(ctx, cmdArgs...)
 	if len(keys) > 0 {
@@ -187,11 +187,11 @@ func (c cmdable) FCall(ctx context.Context, function string, keys []string, args
 
 // FCallRo this function simply calls FCallRO,
 // Deprecated: to maintain convention FCallRO.
-func (c cmdable) FCallRo(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) FCallRo(ctx context.Context, function string, keys []string, args ...any) *Cmd {
 	return c.FCallRO(ctx, function, keys, args...)
 }
 
-func (c cmdable) FCallRO(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) FCallRO(ctx context.Context, function string, keys []string, args ...any) *Cmd {
 	cmdArgs := fcallArgs("fcall_ro", function, keys, args...)
 	cmd := NewCmd(ctx, cmdArgs...)
 	if len(keys) > 0 {
@@ -201,8 +201,8 @@ func (c cmdable) FCallRO(ctx context.Context, function string, keys []string, ar
 	return cmd
 }
 
-func fcallArgs(command string, function string, keys []string, args ...interface{}) []interface{} {
-	cmdArgs := make([]interface{}, 3+len(keys), 3+len(keys)+len(args))
+func fcallArgs(command string, function string, keys []string, args ...any) []any {
+	cmdArgs := make([]any, 3+len(keys), 3+len(keys)+len(args))
 	cmdArgs[0] = command
 	cmdArgs[1] = function
 	cmdArgs[2] = len(keys)

--- a/search_commands.go
+++ b/search_commands.go
@@ -16,14 +16,14 @@ type SearchCmdable interface {
 	FTAliasAdd(ctx context.Context, index string, alias string) *StatusCmd
 	FTAliasDel(ctx context.Context, alias string) *StatusCmd
 	FTAliasUpdate(ctx context.Context, index string, alias string) *StatusCmd
-	FTAlter(ctx context.Context, index string, skipInitialScan bool, definition []interface{}) *StatusCmd
+	FTAlter(ctx context.Context, index string, skipInitialScan bool, definition []any) *StatusCmd
 	FTConfigGet(ctx context.Context, option string) *MapMapStringInterfaceCmd
-	FTConfigSet(ctx context.Context, option string, value interface{}) *StatusCmd
+	FTConfigSet(ctx context.Context, option string, value any) *StatusCmd
 	FTCreate(ctx context.Context, index string, options *FTCreateOptions, schema ...*FieldSchema) *StatusCmd
 	FTCursorDel(ctx context.Context, index string, cursorId int) *StatusCmd
 	FTCursorRead(ctx context.Context, index string, cursorId int, count int) *MapStringInterfaceCmd
-	FTDictAdd(ctx context.Context, dict string, term ...interface{}) *IntCmd
-	FTDictDel(ctx context.Context, dict string, term ...interface{}) *IntCmd
+	FTDictAdd(ctx context.Context, dict string, term ...any) *IntCmd
+	FTDictDel(ctx context.Context, dict string, term ...any) *IntCmd
 	FTDictDump(ctx context.Context, dict string) *StringSliceCmd
 	FTDropIndex(ctx context.Context, index string) *StatusCmd
 	FTDropIndexWithArgs(ctx context.Context, index string, options *FTDropIndexOptions) *StatusCmd
@@ -35,15 +35,15 @@ type SearchCmdable interface {
 	FTSearch(ctx context.Context, index string, query string) *FTSearchCmd
 	FTSearchWithArgs(ctx context.Context, index string, query string, options *FTSearchOptions) *FTSearchCmd
 	FTSynDump(ctx context.Context, index string) *FTSynDumpCmd
-	FTSynUpdate(ctx context.Context, index string, synGroupId interface{}, terms []interface{}) *StatusCmd
-	FTSynUpdateWithArgs(ctx context.Context, index string, synGroupId interface{}, options *FTSynUpdateOptions, terms []interface{}) *StatusCmd
+	FTSynUpdate(ctx context.Context, index string, synGroupId any, terms []any) *StatusCmd
+	FTSynUpdateWithArgs(ctx context.Context, index string, synGroupId any, options *FTSynUpdateOptions, terms []any) *StatusCmd
 	FTTagVals(ctx context.Context, index string, field string) *StringSliceCmd
 }
 
 type FTCreateOptions struct {
 	OnHash          bool
 	OnJSON          bool
-	Prefix          []interface{}
+	Prefix          []any
 	Filter          string
 	DefaultLanguage string
 	LanguageField   string
@@ -56,7 +56,7 @@ type FTCreateOptions struct {
 	NoHL            bool
 	NoFields        bool
 	NoFreqs         bool
-	StopWords       []interface{}
+	StopWords       []any
 	SkipInitialScan bool
 }
 
@@ -210,12 +210,12 @@ func (t SearchFieldType) String() string {
 // Please follow https://redis.io/docs/interact/search-and-query/search/aggregations/#supported-groupby-reducers for more information.
 type FTAggregateReducer struct {
 	Reducer SearchAggregator
-	Args    []interface{}
+	Args    []any
 	As      string
 }
 
 type FTAggregateGroupBy struct {
-	Fields []interface{}
+	Fields []any
 	Reduce []FTAggregateReducer
 }
 
@@ -261,15 +261,15 @@ type FTAggregateOptions struct {
 	Filter            string
 	WithCursor        bool
 	WithCursorOptions *FTAggregateWithCursor
-	Params            map[string]interface{}
+	Params            map[string]any
 	// Dialect 1,3 and 4 are deprecated since redis 8.0
 	DialectVersion int
 }
 
 type FTSearchFilter struct {
-	FieldName interface{}
-	Min       interface{}
-	Max       interface{}
+	FieldName any
+	Min       any
+	Max       any
 }
 
 type FTSearchGeoFilter struct {
@@ -303,8 +303,8 @@ type FTSearchOptions struct {
 	WithSortKeys bool
 	Filters      []FTSearchFilter
 	GeoFilter    []FTSearchGeoFilter
-	InKeys       []interface{}
-	InFields     []interface{}
+	InKeys       []any
+	InFields     []any
 	Return       []FTSearchReturn
 	Slop         int
 	Timeout      int
@@ -325,7 +325,7 @@ type FTSearchOptions struct {
 	// CountOnly sets LIMIT 0 0 to get the count - number of documents in the result set without actually returning the result set.
 	// When using this option, the Limit and LimitOffset options are ignored.
 	CountOnly bool
-	Params    map[string]interface{}
+	Params    map[string]any
 	// Dialect 1,3 and 4 are deprecated since redis 8.0
 	DialectVersion int
 }
@@ -346,7 +346,7 @@ type FTAggregateResult struct {
 }
 
 type AggregateRow struct {
-	Fields map[string]interface{}
+	Fields map[string]any
 }
 
 type AggregateCmd struct {
@@ -450,7 +450,7 @@ type FTSpellCheckOptions struct {
 type FTSpellCheckTerms struct {
 	Inclusion  string // Either "INCLUDE" or "EXCLUDE"
 	Dictionary string
-	Terms      []interface{}
+	Terms      []any
 }
 
 type SpellCheckResult struct {
@@ -476,7 +476,7 @@ type Document struct {
 	Fields  map[string]string
 }
 
-type AggregateQuery []interface{}
+type AggregateQuery []any
 
 // FT_List - Lists all the existing indexes in the database.
 // For more information, please refer to the Redis documentation:
@@ -492,14 +492,14 @@ func (c cmdable) FT_List(ctx context.Context) *StringSliceCmd {
 // For more information, please refer to the Redis documentation:
 // [FT.AGGREGATE]: (https://redis.io/commands/ft.aggregate/)
 func (c cmdable) FTAggregate(ctx context.Context, index string, query string) *MapStringInterfaceCmd {
-	args := []interface{}{"FT.AGGREGATE", index, query}
+	args := []any{"FT.AGGREGATE", index, query}
 	cmd := NewMapStringInterfaceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
 func FTAggregateQuery(query string, options *FTAggregateOptions) AggregateQuery {
-	queryArgs := []interface{}{query}
+	queryArgs := []any{query}
 	if options != nil {
 		if options.Verbatim {
 			queryArgs = append(queryArgs, "VERBATIM")
@@ -566,7 +566,7 @@ func FTAggregateQuery(query string, options *FTAggregateOptions) AggregateQuery 
 		}
 		if options.SortBy != nil {
 			queryArgs = append(queryArgs, "SORTBY")
-			sortByOptions := []interface{}{}
+			sortByOptions := []any{}
 			for _, sortBy := range options.SortBy {
 				sortByOptions = append(sortByOptions, sortBy.FieldName)
 				if sortBy.Asc && sortBy.Desc {
@@ -618,7 +618,7 @@ func FTAggregateQuery(query string, options *FTAggregateOptions) AggregateQuery 
 	return queryArgs
 }
 
-func ProcessAggregateResult(data []interface{}) (*FTAggregateResult, error) {
+func ProcessAggregateResult(data []any) (*FTAggregateResult, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("no data returned")
 	}
@@ -630,12 +630,12 @@ func ProcessAggregateResult(data []interface{}) (*FTAggregateResult, error) {
 
 	rows := make([]AggregateRow, 0, len(data)-1)
 	for _, row := range data[1:] {
-		fields, ok := row.([]interface{})
+		fields, ok := row.([]any)
 		if !ok {
 			return nil, fmt.Errorf("invalid row format")
 		}
 
-		rowMap := make(map[string]interface{})
+		rowMap := make(map[string]any)
 		for i := 0; i < len(fields); i += 2 {
 			key, ok := fields[i].(string)
 			if !ok {
@@ -654,7 +654,7 @@ func ProcessAggregateResult(data []interface{}) (*FTAggregateResult, error) {
 	return result, nil
 }
 
-func NewAggregateCmd(ctx context.Context, args ...interface{}) *AggregateCmd {
+func NewAggregateCmd(ctx context.Context, args ...any) *AggregateCmd {
 	return &AggregateCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -675,11 +675,11 @@ func (cmd *AggregateCmd) Result() (*FTAggregateResult, error) {
 	return cmd.val, cmd.err
 }
 
-func (cmd *AggregateCmd) RawVal() interface{} {
+func (cmd *AggregateCmd) RawVal() any {
 	return cmd.rawVal
 }
 
-func (cmd *AggregateCmd) RawResult() (interface{}, error) {
+func (cmd *AggregateCmd) RawResult() (any, error) {
 	return cmd.rawVal, cmd.err
 }
 
@@ -705,7 +705,7 @@ func (cmd *AggregateCmd) readReply(rd *proto.Reader) (err error) {
 // For more information, please refer to the Redis documentation:
 // [FT.AGGREGATE]: (https://redis.io/commands/ft.aggregate/)
 func (c cmdable) FTAggregateWithArgs(ctx context.Context, index string, query string, options *FTAggregateOptions) *AggregateCmd {
-	args := []interface{}{"FT.AGGREGATE", index, query}
+	args := []any{"FT.AGGREGATE", index, query}
 	if options != nil {
 		if options.Verbatim {
 			args = append(args, "VERBATIM")
@@ -766,7 +766,7 @@ func (c cmdable) FTAggregateWithArgs(ctx context.Context, index string, query st
 		}
 		if options.SortBy != nil {
 			args = append(args, "SORTBY")
-			sortByOptions := []interface{}{}
+			sortByOptions := []any{}
 			for _, sortBy := range options.SortBy {
 				sortByOptions = append(sortByOptions, sortBy.FieldName)
 				if sortBy.Asc && sortBy.Desc {
@@ -825,7 +825,7 @@ func (c cmdable) FTAggregateWithArgs(ctx context.Context, index string, query st
 // For more information, please refer to the Redis documentation:
 // [FT.ALIASADD]: (https://redis.io/commands/ft.aliasadd/)
 func (c cmdable) FTAliasAdd(ctx context.Context, index string, alias string) *StatusCmd {
-	args := []interface{}{"FT.ALIASADD", alias, index}
+	args := []any{"FT.ALIASADD", alias, index}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -857,8 +857,8 @@ func (c cmdable) FTAliasUpdate(ctx context.Context, index string, alias string) 
 // The 'definition' parameter specifies the new definition for the index.
 // For more information, please refer to the Redis documentation:
 // [FT.ALTER]: (https://redis.io/commands/ft.alter/)
-func (c cmdable) FTAlter(ctx context.Context, index string, skipInitialScan bool, definition []interface{}) *StatusCmd {
-	args := []interface{}{"FT.ALTER", index}
+func (c cmdable) FTAlter(ctx context.Context, index string, skipInitialScan bool, definition []any) *StatusCmd {
+	args := []any{"FT.ALTER", index}
 	if skipInitialScan {
 		args = append(args, "SKIPINITIALSCAN")
 	}
@@ -895,7 +895,7 @@ func (c cmdable) FTConfigGet(ctx context.Context, option string) *MapMapStringIn
 //
 // [CONFIG SET Documentation]: https://redis.io/commands/config-set/
 // [FT.CONFIG SET]: https://redis.io/commands/ft.config-set/
-func (c cmdable) FTConfigSet(ctx context.Context, option string, value interface{}) *StatusCmd {
+func (c cmdable) FTConfigSet(ctx context.Context, option string, value any) *StatusCmd {
 	cmd := NewStatusCmd(ctx, "FT.CONFIG", "SET", option, value)
 	_ = c(ctx, cmd)
 	return cmd
@@ -909,7 +909,7 @@ func (c cmdable) FTConfigSet(ctx context.Context, option string, value interface
 // For more information, please refer to the Redis documentation:
 // [FT.CREATE]: (https://redis.io/commands/ft.create/)
 func (c cmdable) FTCreate(ctx context.Context, index string, options *FTCreateOptions, schema ...*FieldSchema) *StatusCmd {
-	args := []interface{}{"FT.CREATE", index}
+	args := []any{"FT.CREATE", index}
 	if options != nil {
 		if options.OnHash && !options.OnJSON {
 			args = append(args, "ON", "HASH")
@@ -993,7 +993,7 @@ func (c cmdable) FTCreate(ctx context.Context, index string, options *FTCreateOp
 				if schema.VectorArgs.FlatOptions.Type == "" || schema.VectorArgs.FlatOptions.Dim == 0 || schema.VectorArgs.FlatOptions.DistanceMetric == "" {
 					panic("FT.CREATE: Type, Dim and DistanceMetric are required for VECTOR FLAT")
 				}
-				flatArgs := []interface{}{
+				flatArgs := []any{
 					"TYPE", schema.VectorArgs.FlatOptions.Type,
 					"DIM", schema.VectorArgs.FlatOptions.Dim,
 					"DISTANCE_METRIC", schema.VectorArgs.FlatOptions.DistanceMetric,
@@ -1012,7 +1012,7 @@ func (c cmdable) FTCreate(ctx context.Context, index string, options *FTCreateOp
 				if schema.VectorArgs.HNSWOptions.Type == "" || schema.VectorArgs.HNSWOptions.Dim == 0 || schema.VectorArgs.HNSWOptions.DistanceMetric == "" {
 					panic("FT.CREATE: Type, Dim and DistanceMetric are required for VECTOR HNSW")
 				}
-				hnswArgs := []interface{}{
+				hnswArgs := []any{
 					"TYPE", schema.VectorArgs.HNSWOptions.Type,
 					"DIM", schema.VectorArgs.HNSWOptions.Dim,
 					"DISTANCE_METRIC", schema.VectorArgs.HNSWOptions.DistanceMetric,
@@ -1097,7 +1097,7 @@ func (c cmdable) FTCursorDel(ctx context.Context, index string, cursorId int) *S
 // For more information, please refer to the Redis documentation:
 // [FT.CURSOR READ]: (https://redis.io/commands/ft.cursor-read/)
 func (c cmdable) FTCursorRead(ctx context.Context, index string, cursorId int, count int) *MapStringInterfaceCmd {
-	args := []interface{}{"FT.CURSOR", "READ", index, cursorId}
+	args := []any{"FT.CURSOR", "READ", index, cursorId}
 	if count > 0 {
 		args = append(args, "COUNT", count)
 	}
@@ -1110,8 +1110,8 @@ func (c cmdable) FTCursorRead(ctx context.Context, index string, cursorId int, c
 // The 'dict' parameter specifies the dictionary to which to add the terms, and the 'term' parameter specifies the terms to add.
 // For more information, please refer to the Redis documentation:
 // [FT.DICTADD]: (https://redis.io/commands/ft.dictadd/)
-func (c cmdable) FTDictAdd(ctx context.Context, dict string, term ...interface{}) *IntCmd {
-	args := []interface{}{"FT.DICTADD", dict}
+func (c cmdable) FTDictAdd(ctx context.Context, dict string, term ...any) *IntCmd {
+	args := []any{"FT.DICTADD", dict}
 	args = append(args, term...)
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1122,8 +1122,8 @@ func (c cmdable) FTDictAdd(ctx context.Context, dict string, term ...interface{}
 // The 'dict' parameter specifies the dictionary from which to delete the terms, and the 'term' parameter specifies the terms to delete.
 // For more information, please refer to the Redis documentation:
 // [FT.DICTDEL]: (https://redis.io/commands/ft.dictdel/)
-func (c cmdable) FTDictDel(ctx context.Context, dict string, term ...interface{}) *IntCmd {
-	args := []interface{}{"FT.DICTDEL", dict}
+func (c cmdable) FTDictDel(ctx context.Context, dict string, term ...any) *IntCmd {
+	args := []any{"FT.DICTDEL", dict}
 	args = append(args, term...)
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1145,7 +1145,7 @@ func (c cmdable) FTDictDump(ctx context.Context, dict string) *StringSliceCmd {
 // For more information, please refer to the Redis documentation:
 // [FT.DROPINDEX]: (https://redis.io/commands/ft.dropindex/)
 func (c cmdable) FTDropIndex(ctx context.Context, index string) *StatusCmd {
-	args := []interface{}{"FT.DROPINDEX", index}
+	args := []any{"FT.DROPINDEX", index}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -1156,7 +1156,7 @@ func (c cmdable) FTDropIndex(ctx context.Context, index string) *StatusCmd {
 // For more information, please refer to the Redis documentation:
 // [FT.DROPINDEX]: (https://redis.io/commands/ft.dropindex/)
 func (c cmdable) FTDropIndexWithArgs(ctx context.Context, index string, options *FTDropIndexOptions) *StatusCmd {
-	args := []interface{}{"FT.DROPINDEX", index}
+	args := []any{"FT.DROPINDEX", index}
 	if options != nil {
 		if options.DeleteDocs {
 			args = append(args, "DD")
@@ -1182,7 +1182,7 @@ func (c cmdable) FTExplain(ctx context.Context, index string, query string) *Str
 // For more information, please refer to the Redis documentation:
 // [FT.EXPLAIN]: (https://redis.io/commands/ft.explain/)
 func (c cmdable) FTExplainWithArgs(ctx context.Context, index string, query string, options *FTExplainOptions) *StringCmd {
-	args := []interface{}{"FT.EXPLAIN", index, query}
+	args := []any{"FT.EXPLAIN", index, query}
 	if options.Dialect != "" {
 		args = append(args, "DIALECT", options.Dialect)
 	} else {
@@ -1199,10 +1199,10 @@ func (c cmdable) FTExplainCli(ctx context.Context, key, path string) error {
 	panic("not implemented")
 }
 
-func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
+func parseFTInfo(data map[string]any) (FTInfoResult, error) {
 	var ftInfo FTInfoResult
 	// Manually parse each field from the map
-	if indexErrors, ok := data["Index Errors"].([]interface{}); ok {
+	if indexErrors, ok := data["Index Errors"].([]any); ok {
 		ftInfo.IndexErrors = IndexErrors{
 			IndexingFailures:     internal.ToInteger(indexErrors[1]),
 			LastIndexingError:    internal.ToString(indexErrors[3]),
@@ -1210,9 +1210,9 @@ func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
 		}
 	}
 
-	if attributes, ok := data["attributes"].([]interface{}); ok {
+	if attributes, ok := data["attributes"].([]any); ok {
 		for _, attr := range attributes {
-			if attrMap, ok := attr.([]interface{}); ok {
+			if attrMap, ok := attr.([]any); ok {
 				att := FTAttribute{}
 				for i := 0; i < len(attrMap); i++ {
 					if internal.ToLower(internal.ToString(attrMap[i])) == "attribute" {
@@ -1269,7 +1269,7 @@ func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
 	ftInfo.BytesPerRecordAvg = internal.ToString(data["bytes_per_record_avg"])
 	ftInfo.Cleaning = internal.ToInteger(data["cleaning"])
 
-	if cursorStats, ok := data["cursor_stats"].([]interface{}); ok {
+	if cursorStats, ok := data["cursor_stats"].([]any); ok {
 		ftInfo.CursorStats = CursorStats{
 			GlobalIdle:    internal.ToInteger(cursorStats[1]),
 			GlobalTotal:   internal.ToInteger(cursorStats[3]),
@@ -1278,7 +1278,7 @@ func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
 		}
 	}
 
-	if dialectStats, ok := data["dialect_stats"].([]interface{}); ok {
+	if dialectStats, ok := data["dialect_stats"].([]any); ok {
 		ftInfo.DialectStats = make(map[string]int)
 		for i := 0; i < len(dialectStats); i += 2 {
 			ftInfo.DialectStats[internal.ToString(dialectStats[i])] = internal.ToInteger(dialectStats[i+1])
@@ -1287,23 +1287,23 @@ func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
 
 	ftInfo.DocTableSizeMB = internal.ToFloat(data["doc_table_size_mb"])
 
-	if fieldStats, ok := data["field statistics"].([]interface{}); ok {
+	if fieldStats, ok := data["field statistics"].([]any); ok {
 		for _, stat := range fieldStats {
-			if statMap, ok := stat.([]interface{}); ok {
+			if statMap, ok := stat.([]any); ok {
 				ftInfo.FieldStatistics = append(ftInfo.FieldStatistics, FieldStatistic{
 					Identifier: internal.ToString(statMap[1]),
 					Attribute:  internal.ToString(statMap[3]),
 					IndexErrors: IndexErrors{
-						IndexingFailures:     internal.ToInteger(statMap[5].([]interface{})[1]),
-						LastIndexingError:    internal.ToString(statMap[5].([]interface{})[3]),
-						LastIndexingErrorKey: internal.ToString(statMap[5].([]interface{})[5]),
+						IndexingFailures:     internal.ToInteger(statMap[5].([]any)[1]),
+						LastIndexingError:    internal.ToString(statMap[5].([]any)[3]),
+						LastIndexingErrorKey: internal.ToString(statMap[5].([]any)[5]),
 					},
 				})
 			}
 		}
 	}
 
-	if gcStats, ok := data["gc_stats"].([]interface{}); ok {
+	if gcStats, ok := data["gc_stats"].([]any); ok {
 		ftInfo.GCStats = GCStats{}
 		for i := 0; i < len(gcStats); i += 2 {
 			if internal.ToLower(internal.ToString(gcStats[i])) == "bytes_collected" {
@@ -1340,7 +1340,7 @@ func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
 	ftInfo.GeoshapesSzMB = internal.ToFloat(data["geoshapes_sz_mb"])
 	ftInfo.HashIndexingFailures = internal.ToInteger(data["hash_indexing_failures"])
 
-	if indexDef, ok := data["index_definition"].([]interface{}); ok {
+	if indexDef, ok := data["index_definition"].([]any); ok {
 		ftInfo.IndexDefinition = IndexDefinition{
 			KeyType:      internal.ToString(indexDef[1]),
 			Prefixes:     internal.ToStringSlice(indexDef[3]),
@@ -1349,7 +1349,7 @@ func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
 	}
 
 	ftInfo.IndexName = internal.ToString(data["index_name"])
-	ftInfo.IndexOptions = internal.ToStringSlice(data["index_options"].([]interface{}))
+	ftInfo.IndexOptions = internal.ToStringSlice(data["index_options"].([]any))
 	ftInfo.Indexing = internal.ToInteger(data["indexing"])
 	ftInfo.InvertedSzMB = internal.ToFloat(data["inverted_sz_mb"])
 	ftInfo.KeyTableSizeMB = internal.ToFloat(data["key_table_size_mb"])
@@ -1379,7 +1379,7 @@ type FTInfoCmd struct {
 	val FTInfoResult
 }
 
-func newFTInfoCmd(ctx context.Context, args ...interface{}) *FTInfoCmd {
+func newFTInfoCmd(ctx context.Context, args ...any) *FTInfoCmd {
 	return &FTInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1404,11 +1404,11 @@ func (cmd *FTInfoCmd) Val() FTInfoResult {
 	return cmd.val
 }
 
-func (cmd *FTInfoCmd) RawVal() interface{} {
+func (cmd *FTInfoCmd) RawVal() any {
 	return cmd.rawVal
 }
 
-func (cmd *FTInfoCmd) RawResult() (interface{}, error) {
+func (cmd *FTInfoCmd) RawResult() (any, error) {
 	return cmd.rawVal, cmd.err
 }
 func (cmd *FTInfoCmd) readReply(rd *proto.Reader) (err error) {
@@ -1417,7 +1417,7 @@ func (cmd *FTInfoCmd) readReply(rd *proto.Reader) (err error) {
 		return err
 	}
 
-	data := make(map[string]interface{}, n)
+	data := make(map[string]any, n)
 	for i := 0; i < n; i++ {
 		k, err := rd.ReadString()
 		if err != nil {
@@ -1461,7 +1461,7 @@ func (c cmdable) FTInfo(ctx context.Context, index string) *FTInfoCmd {
 // For more information, please refer to the Redis documentation:
 // [FT.SPELLCHECK]: (https://redis.io/commands/ft.spellcheck/)
 func (c cmdable) FTSpellCheck(ctx context.Context, index string, query string) *FTSpellCheckCmd {
-	args := []interface{}{"FT.SPELLCHECK", index, query}
+	args := []any{"FT.SPELLCHECK", index, query}
 	cmd := newFTSpellCheckCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -1473,7 +1473,7 @@ func (c cmdable) FTSpellCheck(ctx context.Context, index string, query string) *
 // For more information, please refer to the Redis documentation:
 // [FT.SPELLCHECK]: (https://redis.io/commands/ft.spellcheck/)
 func (c cmdable) FTSpellCheckWithArgs(ctx context.Context, index string, query string, options *FTSpellCheckOptions) *FTSpellCheckCmd {
-	args := []interface{}{"FT.SPELLCHECK", index, query}
+	args := []any{"FT.SPELLCHECK", index, query}
 	if options != nil {
 		if options.Distance > 0 {
 			args = append(args, "DISTANCE", options.Distance)
@@ -1498,7 +1498,7 @@ type FTSpellCheckCmd struct {
 	val []SpellCheckResult
 }
 
-func newFTSpellCheckCmd(ctx context.Context, args ...interface{}) *FTSpellCheckCmd {
+func newFTSpellCheckCmd(ctx context.Context, args ...any) *FTSpellCheckCmd {
 	return &FTSpellCheckCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1523,11 +1523,11 @@ func (cmd *FTSpellCheckCmd) Val() []SpellCheckResult {
 	return cmd.val
 }
 
-func (cmd *FTSpellCheckCmd) RawVal() interface{} {
+func (cmd *FTSpellCheckCmd) RawVal() any {
 	return cmd.rawVal
 }
 
-func (cmd *FTSpellCheckCmd) RawResult() (interface{}, error) {
+func (cmd *FTSpellCheckCmd) RawResult() (any, error) {
 	return cmd.rawVal, cmd.err
 }
 
@@ -1543,11 +1543,11 @@ func (cmd *FTSpellCheckCmd) readReply(rd *proto.Reader) (err error) {
 	return nil
 }
 
-func parseFTSpellCheck(data []interface{}) ([]SpellCheckResult, error) {
+func parseFTSpellCheck(data []any) ([]SpellCheckResult, error) {
 	results := make([]SpellCheckResult, 0, len(data))
 
 	for _, termData := range data {
-		termInfo, ok := termData.([]interface{})
+		termInfo, ok := termData.([]any)
 		if !ok || len(termInfo) != 3 {
 			return nil, fmt.Errorf("invalid term format")
 		}
@@ -1557,14 +1557,14 @@ func parseFTSpellCheck(data []interface{}) ([]SpellCheckResult, error) {
 			return nil, fmt.Errorf("invalid term format")
 		}
 
-		suggestionsData, ok := termInfo[2].([]interface{})
+		suggestionsData, ok := termInfo[2].([]any)
 		if !ok {
 			return nil, fmt.Errorf("invalid suggestions format")
 		}
 
 		suggestions := make([]SpellCheckSuggestion, 0, len(suggestionsData))
 		for _, suggestionData := range suggestionsData {
-			suggestionInfo, ok := suggestionData.([]interface{})
+			suggestionInfo, ok := suggestionData.([]any)
 			if !ok || len(suggestionInfo) != 2 {
 				return nil, fmt.Errorf("invalid suggestion format")
 			}
@@ -1598,7 +1598,7 @@ func parseFTSpellCheck(data []interface{}) ([]SpellCheckResult, error) {
 	return results, nil
 }
 
-func parseFTSearch(data []interface{}, noContent, withScores, withPayloads, withSortKeys bool) (FTSearchResult, error) {
+func parseFTSearch(data []any, noContent, withScores, withPayloads, withSortKeys bool) (FTSearchResult, error) {
 	if len(data) < 1 {
 		return FTSearchResult{}, fmt.Errorf("unexpected search result format")
 	}
@@ -1652,7 +1652,7 @@ func parseFTSearch(data []interface{}, noContent, withScores, withPayloads, with
 		}
 
 		if i < len(data) {
-			fields, ok := data[i].([]interface{})
+			fields, ok := data[i].([]any)
 			if !ok {
 				return FTSearchResult{}, fmt.Errorf("invalid document fields format")
 			}
@@ -1685,7 +1685,7 @@ type FTSearchCmd struct {
 	options *FTSearchOptions
 }
 
-func newFTSearchCmd(ctx context.Context, options *FTSearchOptions, args ...interface{}) *FTSearchCmd {
+func newFTSearchCmd(ctx context.Context, options *FTSearchOptions, args ...any) *FTSearchCmd {
 	return &FTSearchCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1711,11 +1711,11 @@ func (cmd *FTSearchCmd) Val() FTSearchResult {
 	return cmd.val
 }
 
-func (cmd *FTSearchCmd) RawVal() interface{} {
+func (cmd *FTSearchCmd) RawVal() any {
 	return cmd.rawVal
 }
 
-func (cmd *FTSearchCmd) RawResult() (interface{}, error) {
+func (cmd *FTSearchCmd) RawResult() (any, error) {
 	return cmd.rawVal, cmd.err
 }
 
@@ -1737,13 +1737,13 @@ func (cmd *FTSearchCmd) readReply(rd *proto.Reader) (err error) {
 //
 // [FT.SEARCH]: (https://redis.io/commands/ft.search/)
 func (c cmdable) FTSearch(ctx context.Context, index string, query string) *FTSearchCmd {
-	args := []interface{}{"FT.SEARCH", index, query}
+	args := []any{"FT.SEARCH", index, query}
 	cmd := newFTSearchCmd(ctx, &FTSearchOptions{}, args...)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
-type SearchQuery []interface{}
+type SearchQuery []any
 
 // FTSearchQuery - Executes a search query on an index with additional options.
 // The 'index' parameter specifies the index to search, the 'query' parameter specifies the search query,
@@ -1752,7 +1752,7 @@ type SearchQuery []interface{}
 //
 // [FT.SEARCH]: (https://redis.io/commands/ft.search/)
 func FTSearchQuery(query string, options *FTSearchOptions) SearchQuery {
-	queryArgs := []interface{}{query}
+	queryArgs := []any{query}
 	if options != nil {
 		if options.NoContent {
 			queryArgs = append(queryArgs, "NOCONTENT")
@@ -1792,7 +1792,7 @@ func FTSearchQuery(query string, options *FTSearchOptions) SearchQuery {
 		}
 		if options.Return != nil {
 			queryArgs = append(queryArgs, "RETURN")
-			queryArgsReturn := []interface{}{}
+			queryArgsReturn := []any{}
 			for _, ret := range options.Return {
 				queryArgsReturn = append(queryArgsReturn, ret.FieldName)
 				if ret.As != "" {
@@ -1869,7 +1869,7 @@ func FTSearchQuery(query string, options *FTSearchOptions) SearchQuery {
 //
 // [FT.SEARCH]: (https://redis.io/commands/ft.search/)
 func (c cmdable) FTSearchWithArgs(ctx context.Context, index string, query string, options *FTSearchOptions) *FTSearchCmd {
-	args := []interface{}{"FT.SEARCH", index, query}
+	args := []any{"FT.SEARCH", index, query}
 	if options != nil {
 		if options.NoContent {
 			args = append(args, "NOCONTENT")
@@ -1909,7 +1909,7 @@ func (c cmdable) FTSearchWithArgs(ctx context.Context, index string, query strin
 		}
 		if options.Return != nil {
 			args = append(args, "RETURN")
-			argsReturn := []interface{}{}
+			argsReturn := []any{}
 			for _, ret := range options.Return {
 				argsReturn = append(argsReturn, ret.FieldName)
 				if ret.As != "" {
@@ -1985,7 +1985,7 @@ func (c cmdable) FTSearchWithArgs(ctx context.Context, index string, query strin
 	return cmd
 }
 
-func NewFTSynDumpCmd(ctx context.Context, args ...interface{}) *FTSynDumpCmd {
+func NewFTSynDumpCmd(ctx context.Context, args ...any) *FTSynDumpCmd {
 	return &FTSynDumpCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -2010,11 +2010,11 @@ func (cmd *FTSynDumpCmd) Result() ([]FTSynDumpResult, error) {
 	return cmd.val, cmd.err
 }
 
-func (cmd *FTSynDumpCmd) RawVal() interface{} {
+func (cmd *FTSynDumpCmd) RawVal() any {
 	return cmd.rawVal
 }
 
-func (cmd *FTSynDumpCmd) RawResult() (interface{}, error) {
+func (cmd *FTSynDumpCmd) RawResult() (any, error) {
 	return cmd.rawVal, cmd.err
 }
 
@@ -2031,7 +2031,7 @@ func (cmd *FTSynDumpCmd) readReply(rd *proto.Reader) error {
 			return fmt.Errorf("invalid term format")
 		}
 
-		synonyms, ok := termSynonymPairs[i+1].([]interface{})
+		synonyms, ok := termSynonymPairs[i+1].([]any)
 		if !ok {
 			return fmt.Errorf("invalid synonyms format")
 		}
@@ -2069,8 +2069,8 @@ func (c cmdable) FTSynDump(ctx context.Context, index string) *FTSynDumpCmd {
 // The 'index' parameter specifies the index to update, the 'synGroupId' parameter specifies the synonym group id, and the 'terms' parameter specifies the additional terms.
 // For more information, please refer to the Redis documentation:
 // [FT.SYNUPDATE]: (https://redis.io/commands/ft.synupdate/)
-func (c cmdable) FTSynUpdate(ctx context.Context, index string, synGroupId interface{}, terms []interface{}) *StatusCmd {
-	args := []interface{}{"FT.SYNUPDATE", index, synGroupId}
+func (c cmdable) FTSynUpdate(ctx context.Context, index string, synGroupId any, terms []any) *StatusCmd {
+	args := []any{"FT.SYNUPDATE", index, synGroupId}
 	args = append(args, terms...)
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -2081,8 +2081,8 @@ func (c cmdable) FTSynUpdate(ctx context.Context, index string, synGroupId inter
 // The 'index' parameter specifies the index to update, the 'synGroupId' parameter specifies the synonym group id, the 'options' parameter specifies additional options for the update, and the 'terms' parameter specifies the additional terms.
 // For more information, please refer to the Redis documentation:
 // [FT.SYNUPDATE]: (https://redis.io/commands/ft.synupdate/)
-func (c cmdable) FTSynUpdateWithArgs(ctx context.Context, index string, synGroupId interface{}, options *FTSynUpdateOptions, terms []interface{}) *StatusCmd {
-	args := []interface{}{"FT.SYNUPDATE", index, synGroupId}
+func (c cmdable) FTSynUpdateWithArgs(ctx context.Context, index string, synGroupId any, options *FTSynUpdateOptions, terms []any) *StatusCmd {
+	args := []any{"FT.SYNUPDATE", index, synGroupId}
 	if options.SkipInitialScan {
 		args = append(args, "SKIPINITIALSCAN")
 	}

--- a/search_test.go
+++ b/search_test.go
@@ -69,7 +69,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should FTCreate and FTSearch stopwords", Label("search", "ftcreate", "ftsearch"), func() {
-		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{StopWords: []interface{}{"foo", "bar", "baz"}}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
+		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{StopWords: []any{"foo", "bar", "baz"}}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "txt")
@@ -108,7 +108,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		res4, err := client.FTSearchWithArgs(ctx, "txt", "foo", &redis.FTSearchOptions{GeoFilter: []redis.FTSearchGeoFilter{geoFilter2}, NoContent: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res4.Total).To(BeEquivalentTo(int64(2)))
-		docs := []interface{}{res4.Docs[0].ID, res4.Docs[1].ID}
+		docs := []any{res4.Docs[0].ID, res4.Docs[1].ID}
 		Expect(docs).To(ContainElement("doc1"))
 		Expect(docs).To(ContainElement("doc2"))
 
@@ -215,11 +215,11 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	It("should FTAlias", Label("search", "ftexplain"), func() {
 		text1 := &redis.FieldSchema{FieldName: "name", FieldType: redis.SearchFieldTypeText}
 		text2 := &redis.FieldSchema{FieldName: "name", FieldType: redis.SearchFieldTypeText}
-		val1, err := client.FTCreate(ctx, "testAlias", &redis.FTCreateOptions{Prefix: []interface{}{"index1:"}}, text1).Result()
+		val1, err := client.FTCreate(ctx, "testAlias", &redis.FTCreateOptions{Prefix: []any{"index1:"}}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val1).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "testAlias")
-		val2, err := client.FTCreate(ctx, "testAlias2", &redis.FTCreateOptions{Prefix: []interface{}{"index2:"}}, text2).Result()
+		val2, err := client.FTCreate(ctx, "testAlias2", &redis.FTCreateOptions{Prefix: []any{"index2:"}}, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val2).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "testAlias2")
@@ -272,7 +272,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
 
-		resAlter, err := client.FTAlter(ctx, "idx1", false, []interface{}{"body", redis.SearchFieldTypeText.String()}).Result()
+		resAlter, err := client.FTAlter(ctx, "idx1", false, []any{"body", redis.SearchFieldTypeText.String()}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resAlter).To(BeEquivalentTo("OK"))
 
@@ -385,7 +385,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		res2, err := client.FTSearch(ctx, "idx1", "Jon").Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res2.Total).To(BeEquivalentTo(int64(2)))
-		names := []interface{}{res2.Docs[0].Fields["name"], res2.Docs[1].Fields["name"]}
+		names := []any{res2.Docs[0].Fields["name"], res2.Docs[1].Fields["name"]}
 		Expect(names).To(ContainElement("Jon"))
 		Expect(names).To(ContainElement("John"))
 	})
@@ -486,7 +486,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		res, err = client.FTConfigGet(ctx, "MINPREFIX").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res).To(BeEquivalentTo(map[string]interface{}{"MINPREFIX": "1"}))
+		Expect(res).To(BeEquivalentTo(map[string]any{"MINPREFIX": "1"}))
 
 	})
 
@@ -514,77 +514,77 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			"random_num", 8)
 
 		reducer := redis.FTAggregateReducer{Reducer: redis.SearchCount}
-		options := &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		options := &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err := client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliascount"]).To(BeEquivalentTo("3"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchCountDistinct, Args: []interface{}{"@title"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchCountDistinct, Args: []any{"@title"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliascount_distincttitle"]).To(BeEquivalentTo("3"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchSum, Args: []interface{}{"@random_num"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchSum, Args: []any{"@random_num"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliassumrandom_num"]).To(BeEquivalentTo("21"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchMin, Args: []interface{}{"@random_num"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchMin, Args: []any{"@random_num"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliasminrandom_num"]).To(BeEquivalentTo("3"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchMax, Args: []interface{}{"@random_num"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchMax, Args: []any{"@random_num"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliasmaxrandom_num"]).To(BeEquivalentTo("10"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchAvg, Args: []interface{}{"@random_num"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchAvg, Args: []any{"@random_num"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliasavgrandom_num"]).To(BeEquivalentTo("7"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchStdDev, Args: []interface{}{"@random_num"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchStdDev, Args: []any{"@random_num"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliasstddevrandom_num"]).To(BeEquivalentTo("3.60555127546"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchQuantile, Args: []interface{}{"@random_num", 0.5}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchQuantile, Args: []any{"@random_num", 0.5}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliasquantilerandom_num,0.5"]).To(BeEquivalentTo("8"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchToList, Args: []interface{}{"@title"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchToList, Args: []any{"@title"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliastolisttitle"]).To(ContainElements("RediSearch", "RedisAI", "RedisJson"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchFirstValue, Args: []interface{}{"@title"}, As: "first"}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchFirstValue, Args: []any{"@title"}, As: "first"}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["first"]).To(Or(BeEquivalentTo("RediSearch"), BeEquivalentTo("RedisAI"), BeEquivalentTo("RedisJson")))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchRandomSample, Args: []interface{}{"@title", 2}, As: "random"}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchRandomSample, Args: []any{"@title", 2}, As: "random"}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
@@ -682,7 +682,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		SkipBeforeRedisVersion(7.4, "no addscores support")
 		title := &redis.FieldSchema{FieldName: "title", FieldType: redis.SearchFieldTypeText, Sortable: false}
 		description := &redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText, Sortable: false}
-		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnHash: true, Prefix: []interface{}{"product:"}}, title, description).Result()
+		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnHash: true, Prefix: []any{"product:"}}, title, description).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
@@ -755,7 +755,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		options := &redis.FTAggregateOptions{
 			Apply: []redis.FTAggregateApply{{Field: "floor(@CreatedDateTimeUTC /(60*60*24))", As: "TimestampAsDay"}},
 			GroupBy: []redis.FTAggregateGroupBy{{
-				Fields: []interface{}{"@TimestampAsDay"},
+				Fields: []any{"@TimestampAsDay"},
 				Reduce: []redis.FTAggregateReducer{reducer},
 			}},
 			SortBy: []redis.FTAggregateSortBy{{
@@ -902,7 +902,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	It("should FTCreate json", Label("search", "ftcreate"), func() {
 
 		text1 := &redis.FieldSchema{FieldName: "$.name", FieldType: redis.SearchFieldTypeText}
-		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []interface{}{"king:"}}, text1).Result()
+		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []any{"king:"}}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
@@ -1004,12 +1004,12 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
 
-		resSynUpdate, err := client.FTSynUpdateWithArgs(ctx, "idx1", "id1", &redis.FTSynUpdateOptions{SkipInitialScan: true}, []interface{}{"boy", "child", "offspring"}).Result()
+		resSynUpdate, err := client.FTSynUpdateWithArgs(ctx, "idx1", "id1", &redis.FTSynUpdateOptions{SkipInitialScan: true}, []any{"boy", "child", "offspring"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 		client.HSet(ctx, "doc1", "title", "he is a baby", "body", "this is a test")
 
-		resSynUpdate, err = client.FTSynUpdateWithArgs(ctx, "idx1", "id1", &redis.FTSynUpdateOptions{SkipInitialScan: true}, []interface{}{"baby"}).Result()
+		resSynUpdate, err = client.FTSynUpdateWithArgs(ctx, "idx1", "id1", &redis.FTSynUpdateOptions{SkipInitialScan: true}, []any{"baby"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 		client.HSet(ctx, "doc2", "title", "he is another baby", "body", "another test")
@@ -1030,15 +1030,15 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
 
-		resSynUpdate, err := client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"boy", "child", "offspring"}).Result()
+		resSynUpdate, err := client.FTSynUpdate(ctx, "idx1", "id1", []any{"boy", "child", "offspring"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 
-		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"baby", "child"}).Result()
+		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []any{"baby", "child"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 
-		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"tree", "wood"}).Result()
+		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []any{"tree", "wood"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 
@@ -1063,7 +1063,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		text1 := &redis.FieldSchema{FieldName: "$.name", FieldType: redis.SearchFieldTypeText, As: "name"}
 		num1 := &redis.FieldSchema{FieldName: "$.num", FieldType: redis.SearchFieldTypeNumeric, As: "num"}
-		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []interface{}{"king:"}}, text1, num1).Result()
+		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []any{"king:"}}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
@@ -1087,7 +1087,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	It("should FTCreate json with multipath", Label("search", "ftcreate"), func() {
 
 		tag1 := &redis.FieldSchema{FieldName: "$..name", FieldType: redis.SearchFieldTypeTag, As: "name"}
-		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []interface{}{"king:"}}, tag1).Result()
+		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []any{"king:"}}, tag1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
@@ -1147,7 +1147,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			Return:         []redis.FTSearchReturn{{FieldName: "__v_score"}},
 			SortBy:         []redis.FTSearchSortBy{{FieldName: "__v_score", Asc: true}},
 			DialectVersion: 2,
-			Params:         map[string]interface{}{"vec": "aaaaaaaa"},
+			Params:         map[string]any{"vec": "aaaaaaaa"},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 2 @v $vec]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1196,7 +1196,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			Return: []redis.FTSearchReturn{{FieldName: "__v_score"}},
 			SortBy: []redis.FTSearchSortBy{{FieldName: "__v_score", Asc: true}},
-			Params: map[string]interface{}{"vec": "aaaaaaaa"},
+			Params: map[string]any{"vec": "aaaaaaaa"},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 2 @v $vec]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1214,7 +1214,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc2", "name", "Bob")
 		client.HSet(ctx, "doc3", "name", "Carol")
 
-		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@name:($name1 | $name2 )", &redis.FTSearchOptions{Params: map[string]interface{}{"name1": "Alice", "name2": "Bob"}, DialectVersion: 2}).Result()
+		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@name:($name1 | $name2 )", &redis.FTSearchOptions{Params: map[string]any{"name1": "Alice", "name2": "Bob"}, DialectVersion: 2}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res1.Total).To(BeEquivalentTo(int64(2)))
 		Expect(res1.Docs[0].ID).To(BeEquivalentTo("doc1"))
@@ -1232,7 +1232,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc2", "numval", 102)
 		client.HSet(ctx, "doc3", "numval", 103)
 
-		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@numval:[$min $max]", &redis.FTSearchOptions{Params: map[string]interface{}{"min": 101, "max": 102}, DialectVersion: 2}).Result()
+		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@numval:[$min $max]", &redis.FTSearchOptions{Params: map[string]any{"min": 101, "max": 102}, DialectVersion: 2}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res1.Total).To(BeEquivalentTo(int64(2)))
 		Expect(res1.Docs[0].ID).To(BeEquivalentTo("doc1"))
@@ -1250,7 +1250,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc2", "g", "29.69350, 34.94737")
 		client.HSet(ctx, "doc3", "g", "29.68746, 34.94882")
 
-		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@g:[$lon $lat $radius $units]", &redis.FTSearchOptions{Params: map[string]interface{}{"lat": "34.95126", "lon": "29.69465", "radius": 1000, "units": "km"}, DialectVersion: 2}).Result()
+		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@g:[$lon $lat $radius $units]", &redis.FTSearchOptions{Params: map[string]any{"lat": "34.95126", "lon": "29.69465", "radius": 1000, "units": "km"}, DialectVersion: 2}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res1.Total).To(BeEquivalentTo(int64(3)))
 		Expect(res1.Docs[0].ID).To(BeEquivalentTo("doc1"))
@@ -1266,7 +1266,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		defDialect, err := client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "1"}))
+		Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "1"}))
 
 		res, err = client.FTConfigSet(ctx, "DEFAULT_DIALECT", "2").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1274,7 +1274,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		defDialect, err = client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "2"}))
+		Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "2"}))
 	})
 
 	It("should FTConfigSet and FTConfigGet dialect", Label("search", "ftconfigget", "ftconfigset", "NonRedisEnterprise"), func() {
@@ -1284,7 +1284,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		defDialect, err := client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "1"}))
+		Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "1"}))
 
 		res, err = client.FTConfigSet(ctx, "DEFAULT_DIALECT", "2").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1292,7 +1292,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		defDialect, err = client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "2"}))
+		Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "2"}))
 	})
 
 	It("should FTCreate WithSuffixtrie", Label("search", "ftcreate", "ftinfo"), func() {
@@ -1337,7 +1337,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	It("should test dialect 4", Label("search", "ftcreate", "ftsearch", "NonRedisEnterprise"), func() {
 		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{
-			Prefix: []interface{}{"resource:"},
+			Prefix: []any{"resource:"},
 		}, &redis.FieldSchema{
 			FieldName: "uuid",
 			FieldType: redis.SearchFieldTypeTag,
@@ -1354,13 +1354,13 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 
-		client.HSet(ctx, "resource:1", map[string]interface{}{
+		client.HSet(ctx, "resource:1", map[string]any{
 			"uuid":        "123e4567-e89b-12d3-a456-426614174000",
 			"tags":        "finance|crypto|$btc|blockchain",
 			"description": "Analysis of blockchain technologies & Bitcoin's potential.",
 			"rating":      5,
 		})
-		client.HSet(ctx, "resource:2", map[string]interface{}{
+		client.HSet(ctx, "resource:2", map[string]any{
 			"uuid":        "987e6543-e21c-12d3-a456-426614174999",
 			"tags":        "health|well-being|fitness|new-year's-resolutions",
 			"description": "Health trends for the new year, including fitness regimes.",
@@ -1370,7 +1370,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "@uuid:{$uuid}",
 			&redis.FTSearchOptions{
 				DialectVersion: 2,
-				Params:         map[string]interface{}{"uuid": "123e4567-e89b-12d3-a456-426614174000"},
+				Params:         map[string]any{"uuid": "123e4567-e89b-12d3-a456-426614174000"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Total).To(BeEquivalentTo(int64(1)))
@@ -1379,13 +1379,13 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		res, err = client.FTSearchWithArgs(ctx, "idx1", "@uuid:{$uuid}",
 			&redis.FTSearchOptions{
 				DialectVersion: 4,
-				Params:         map[string]interface{}{"uuid": "123e4567-e89b-12d3-a456-426614174000"},
+				Params:         map[string]any{"uuid": "123e4567-e89b-12d3-a456-426614174000"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Total).To(BeEquivalentTo(int64(1)))
 		Expect(res.Docs[0].ID).To(BeEquivalentTo("resource:1"))
 
-		client.HSet(ctx, "test:1", map[string]interface{}{
+		client.HSet(ctx, "test:1", map[string]any{
 			"uuid":  "3d3586fe-0416-4572-8ce",
 			"email": "adriano@acme.com.ie",
 			"num":   5,
@@ -1393,7 +1393,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		// Create the index
 		ftCreateOptions := &redis.FTCreateOptions{
-			Prefix: []interface{}{"test:"},
+			Prefix: []any{"test:"},
 		}
 		schema := []*redis.FieldSchema{
 			{
@@ -1417,7 +1417,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		ftSearchOptions := &redis.FTSearchOptions{
 			DialectVersion: 4,
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"uuid":  "3d3586fe-0416-4572-8ce",
 				"email": "adriano@acme.com.ie",
 			},
@@ -1433,7 +1433,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(res.Docs[0].ID).To(BeEquivalentTo("test:1"))
 		Expect(res.Docs[0].Fields["email"]).To(BeEquivalentTo("adriano@acme.com.ie"))
 
-		ftSearchOptions.Params = map[string]interface{}{"num": 5}
+		ftSearchOptions.Params = map[string]any{"num": 5}
 		res, err = client.FTSearchWithArgs(ctx, "idx_hash", "@num:[5]", ftSearchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Docs[0].ID).To(BeEquivalentTo("test:1"))
@@ -1452,7 +1452,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@geom:[WITHIN $poly]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"poly": "POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))"},
+				Params:         map[string]any{"poly": "POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res1.Total).To(BeEquivalentTo(int64(1)))
@@ -1461,7 +1461,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		res2, err := client.FTSearchWithArgs(ctx, "idx1", "@geom:[CONTAINS $poly]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"poly": "POLYGON((2 2, 2 50, 50 50, 50 2, 2 2))"},
+				Params:         map[string]any{"poly": "POLYGON((2 2, 2 50, 50 50, 50 2, 2 2))"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res2.Total).To(BeEquivalentTo(int64(2)))
@@ -1495,7 +1495,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		intersection, err := client.FTSearchWithArgs(ctx, "idx1", "@g:[intersects $shape]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"shape": "POLYGON((15 15, 75 15, 50 70, 20 40, 15 15))"},
+				Params:         map[string]any{"shape": "POLYGON((15 15, 75 15, 50 70, 20 40, 15 15))"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		_assert_geosearch_result(&intersection, []string{"doc_point2", "doc_polygon1"})
@@ -1503,7 +1503,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		disjunction, err := client.FTSearchWithArgs(ctx, "idx1", "@g:[disjoint $shape]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"shape": "POLYGON((15 15, 75 15, 50 70, 20 40, 15 15))"},
+				Params:         map[string]any{"shape": "POLYGON((15 15, 75 15, 50 70, 20 40, 15 15))"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		_assert_geosearch_result(&disjunction, []string{"doc_point1", "doc_polygon2"})
@@ -1525,7 +1525,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		containsA, err := client.FTSearchWithArgs(ctx, "idx2", "@g:[contains $shape]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"shape": "POINT(25 25)"},
+				Params:         map[string]any{"shape": "POINT(25 25)"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		_assert_geosearch_result(&containsA, []string{"doc_polygon1"})
@@ -1533,7 +1533,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		containsB, err := client.FTSearchWithArgs(ctx, "idx2", "@g:[contains $shape]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"shape": "POLYGON((24 24, 24 26, 25 25, 24 24))"},
+				Params:         map[string]any{"shape": "POLYGON((24 24, 24 26, 25 25, 24 24))"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		_assert_geosearch_result(&containsB, []string{"doc_polygon1"})
@@ -1541,7 +1541,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		within, err := client.FTSearchWithArgs(ctx, "idx2", "@g:[within $shape]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"shape": "POLYGON((15 15, 75 15, 50 70, 20 40, 15 15))"},
+				Params:         map[string]any{"shape": "POLYGON((15 15, 75 15, 50 70, 20 40, 15 15))"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		_assert_geosearch_result(&within, []string{"doc_point2", "doc_polygon1"})
@@ -1549,7 +1549,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 	It("should search missing fields", Label("search", "ftcreate", "ftsearch", "NonRedisEnterprise"), func() {
 		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
-		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{Prefix: []interface{}{"property:"}},
+		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{Prefix: []any{"property:"}},
 			&redis.FieldSchema{FieldName: "title", FieldType: redis.SearchFieldTypeText, Sortable: true},
 			&redis.FieldSchema{FieldName: "features", FieldType: redis.SearchFieldTypeTag, IndexMissing: true},
 			&redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText, IndexMissing: true}).Result()
@@ -1557,18 +1557,18 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
 
-		client.HSet(ctx, "property:1", map[string]interface{}{
+		client.HSet(ctx, "property:1", map[string]any{
 			"title":       "Luxury Villa in Malibu",
 			"features":    "pool,sea view,modern",
 			"description": "A stunning modern villa overlooking the Pacific Ocean.",
 		})
 
-		client.HSet(ctx, "property:2", map[string]interface{}{
+		client.HSet(ctx, "property:2", map[string]any{
 			"title":       "Downtown Flat",
 			"description": "Modern flat in central Paris with easy access to metro.",
 		})
 
-		client.HSet(ctx, "property:3", map[string]interface{}{
+		client.HSet(ctx, "property:3", map[string]any{
 			"title":    "Beachfront Bungalow",
 			"features": "beachfront,sun deck",
 		})
@@ -1594,7 +1594,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 	It("should search empty fields", Label("search", "ftcreate", "ftsearch", "NonRedisEnterprise"), func() {
 		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
-		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{Prefix: []interface{}{"property:"}},
+		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{Prefix: []any{"property:"}},
 			&redis.FieldSchema{FieldName: "title", FieldType: redis.SearchFieldTypeText, Sortable: true},
 			&redis.FieldSchema{FieldName: "features", FieldType: redis.SearchFieldTypeTag, IndexEmpty: true},
 			&redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText, IndexEmpty: true}).Result()
@@ -1602,19 +1602,19 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
 
-		client.HSet(ctx, "property:1", map[string]interface{}{
+		client.HSet(ctx, "property:1", map[string]any{
 			"title":       "Luxury Villa in Malibu",
 			"features":    "pool,sea view,modern",
 			"description": "A stunning modern villa overlooking the Pacific Ocean.",
 		})
 
-		client.HSet(ctx, "property:2", map[string]interface{}{
+		client.HSet(ctx, "property:2", map[string]any{
 			"title":       "Downtown Flat",
 			"features":    "",
 			"description": "Modern flat in central Paris with easy access to metro.",
 		})
 
-		client.HSet(ctx, "property:3", map[string]interface{}{
+		client.HSet(ctx, "property:3", map[string]any{
 			"title":       "Beachfront Bungalow",
 			"features":    "beachfront,sun deck",
 			"description": "",
@@ -1675,7 +1675,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			Return:         []redis.FTSearchReturn{{FieldName: "int8_vector"}},
 			SortBy:         []redis.FTSearchSortBy{{FieldName: "int8_vector", Asc: true}},
 			DialectVersion: 2,
-			Params:         map[string]interface{}{"vec": "\x01\x02"},
+			Params:         map[string]any{"vec": "\x01\x02"},
 		}
 
 		resInt8, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 1 @int8_vector $vec]", searchOptionsInt8).Result()
@@ -1687,7 +1687,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			Return:         []redis.FTSearchReturn{{FieldName: "uint8_vector"}},
 			SortBy:         []redis.FTSearchSortBy{{FieldName: "uint8_vector", Asc: true}},
 			DialectVersion: 2,
-			Params:         map[string]interface{}{"vec": "\x01\x02"},
+			Params:         map[string]any{"vec": "\x01\x02"},
 		}
 
 		resUint8, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 1 @uint8_vector $vec]", searchOptionsUint8).Result()
@@ -1704,7 +1704,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			DistanceMetric: "IP",
 		}
 		_, err := client.FTCreate(ctx, "idx_vec",
-			&redis.FTCreateOptions{OnHash: true, Prefix: []interface{}{"doc:"}},
+			&redis.FTCreateOptions{OnHash: true, Prefix: []any{"doc:"}},
 			&redis.FieldSchema{FieldName: "vector", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{FlatOptions: vecField}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		WaitForIndexing(client, "idx_vec")
@@ -1719,7 +1719,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc:3", "vector", encodeFloat32Vector(nanVec))
 		client.HSet(ctx, "doc:4", "vector", encodeFloat32Vector(negNanVec))
 
-		searchOptions := &redis.FTSearchOptions{WithScores: true, Params: map[string]interface{}{"vec": encodeFloat32Vector(bigPos)}}
+		searchOptions := &redis.FTSearchOptions{WithScores: true, Params: map[string]any{"vec": encodeFloat32Vector(bigPos)}}
 		res, err := client.FTSearchWithArgs(ctx, "idx_vec", "*=>[KNN 4 @vector $vec]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Total).To(BeEquivalentTo(4))
@@ -1825,10 +1825,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc1", "grp", "g1")
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchAvg, Args: []interface{}{"@n"}, As: "avg"},
+			{Reducer: redis.SearchAvg, Args: []any{"@n"}, As: "avg"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestAvg", "*", options).Result()
@@ -1854,7 +1854,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			{Reducer: redis.SearchCount, As: "cnt"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestCount", "*", options).Result()
@@ -1877,10 +1877,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc1", "grp", "g1")
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchSum, Args: []interface{}{"@n"}, As: "sum"},
+			{Reducer: redis.SearchSum, Args: []any{"@n"}, As: "sum"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestSum", "*", options).Result()
@@ -1966,10 +1966,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc1", "grp", "g1")
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchCountDistinct, Args: []interface{}{"@x"}, As: "distinct_count"},
+			{Reducer: redis.SearchCountDistinct, Args: []any{"@x"}, As: "distinct_count"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 
@@ -1993,10 +1993,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchCountDistinctish, Args: []interface{}{"@y"}, As: "distinctish_count"},
+			{Reducer: redis.SearchCountDistinctish, Args: []any{"@y"}, As: "distinctish_count"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestCountDistinctIsh", "*", options).Result()
@@ -2045,10 +2045,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchStdDev, Args: []interface{}{"@n"}, As: "stddev"},
+			{Reducer: redis.SearchStdDev, Args: []any{"@n"}, As: "stddev"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestStddev", "*", options).Result()
@@ -2072,10 +2072,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchQuantile, Args: []interface{}{"@n", 0.5}, As: "quantile"},
+			{Reducer: redis.SearchQuantile, Args: []any{"@n", 0.5}, As: "quantile"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestQuantile", "*", options).Result()
@@ -2098,10 +2098,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchFirstValue, Args: []interface{}{"@t"}, As: "first_val"},
+			{Reducer: redis.SearchFirstValue, Args: []any{"@t"}, As: "first_val"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestFirstValue", "*", options).Result()
@@ -2247,11 +2247,11 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchMin, Args: []interface{}{"@n"}, As: "minValue"},
-			{Reducer: redis.SearchMax, Args: []interface{}{"@n"}, As: "maxValue"},
+			{Reducer: redis.SearchMin, Args: []any{"@n"}, As: "minValue"},
+			{Reducer: redis.SearchMax, Args: []any{"@n"}, As: "maxValue"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestMinMax", "*", options).Result()
@@ -2295,11 +2295,11 @@ var _ = Describe("RediSearch FT.Config with Resp2 and Resp3", Label("search", "N
 
 		res2, err := clientResp2.FTConfigGet(ctx, "MINPREFIX").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res2).To(BeEquivalentTo(map[string]interface{}{"MINPREFIX": "1"}))
+		Expect(res2).To(BeEquivalentTo(map[string]any{"MINPREFIX": "1"}))
 
 		res3, err := clientResp3.FTConfigGet(ctx, "MINPREFIX").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res3).To(BeEquivalentTo(map[string]interface{}{"MINPREFIX": "1"}))
+		Expect(res3).To(BeEquivalentTo(map[string]any{"MINPREFIX": "1"}))
 	})
 
 	It("should FTConfigGet all resp2 and resp3", Label("search", "NonRedisEnterprise"), func() {
@@ -2341,14 +2341,14 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 
 		options := &redis.FTAggregateOptions{Apply: []redis.FTAggregateApply{{Field: "@CreatedDateTimeUTC * 10", As: "CreatedDateTimeUTC"}}}
 		res, err := client.FTAggregateWithArgs(ctx, "idx1", "*", options).RawResult()
-		results := res.(map[interface{}]interface{})["results"].([]interface{})
-		Expect(results[0].(map[interface{}]interface{})["extra_attributes"].(map[interface{}]interface{})["CreatedDateTimeUTC"]).
+		results := res.(map[any]any)["results"].([]any)
+		Expect(results[0].(map[any]any)["extra_attributes"].(map[any]any)["CreatedDateTimeUTC"]).
 			To(Or(BeEquivalentTo("6373878785249699840"), BeEquivalentTo("6373878758592700416")))
-		Expect(results[1].(map[interface{}]interface{})["extra_attributes"].(map[interface{}]interface{})["CreatedDateTimeUTC"]).
+		Expect(results[1].(map[any]any)["extra_attributes"].(map[any]any)["CreatedDateTimeUTC"]).
 			To(Or(BeEquivalentTo("6373878785249699840"), BeEquivalentTo("6373878758592700416")))
 
 		rawVal := client.FTAggregateWithArgs(ctx, "idx1", "*", options).RawVal()
-		rawValResults := rawVal.(map[interface{}]interface{})["results"].([]interface{})
+		rawValResults := rawVal.(map[any]any)["results"].([]any)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rawValResults[0]).To(Or(BeEquivalentTo(results[0]), BeEquivalentTo(results[1])))
 		Expect(rawValResults[1]).To(Or(BeEquivalentTo(results[0]), BeEquivalentTo(results[1])))
@@ -2372,13 +2372,13 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 
 		resInfo, err := client.FTInfo(ctx, "idx1").RawResult()
 		Expect(err).NotTo(HaveOccurred())
-		attributes := resInfo.(map[interface{}]interface{})["attributes"].([]interface{})
-		flags := attributes[0].(map[interface{}]interface{})["flags"].([]interface{})
+		attributes := resInfo.(map[any]any)["attributes"].([]any)
+		flags := attributes[0].(map[any]any)["flags"].([]any)
 		Expect(flags).To(ConsistOf("SORTABLE", "NOSTEM"))
 
 		valInfo := client.FTInfo(ctx, "idx1").RawVal()
-		attributes = valInfo.(map[interface{}]interface{})["attributes"].([]interface{})
-		flags = attributes[0].(map[interface{}]interface{})["flags"].([]interface{})
+		attributes = valInfo.(map[any]any)["attributes"].([]any)
+		flags = attributes[0].(map[any]any)["flags"].([]any)
 		Expect(flags).To(ConsistOf("SORTABLE", "NOSTEM"))
 
 		// Test with UnstableResp3 false
@@ -2405,8 +2405,8 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		valSpellCheck := client.FTSpellCheck(ctx, "idx1", "impornant").RawVal()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(valSpellCheck).To(BeEquivalentTo(resSpellCheck))
-		results := resSpellCheck.(map[interface{}]interface{})["results"].(map[interface{}]interface{})
-		Expect(results["impornant"].([]interface{})[0].(map[interface{}]interface{})["important"]).To(BeEquivalentTo(0.5))
+		results := resSpellCheck.(map[any]any)["results"].(map[any]any)
+		Expect(results["impornant"].([]any)[0].(map[any]any)["important"]).To(BeEquivalentTo(0.5))
 
 		// Test with UnstableResp3 false
 		Expect(func() {
@@ -2418,7 +2418,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 	})
 
 	It("should handle FTSearch with Unstable RESP3 Search Module and without stability", Label("search", "ftcreate", "ftsearch"), func() {
-		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{StopWords: []interface{}{"foo", "bar", "baz"}}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
+		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{StopWords: []any{"foo", "bar", "baz"}}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "txt")
@@ -2428,11 +2428,11 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val1 := client.FTSearchWithArgs(ctx, "txt", "foo bar", &redis.FTSearchOptions{NoContent: true}).RawVal()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val1).To(BeEquivalentTo(res1))
-		totalResults := res1.(map[interface{}]interface{})["total_results"]
+		totalResults := res1.(map[any]any)["total_results"]
 		Expect(totalResults).To(BeEquivalentTo(int64(0)))
 		res2, err := client.FTSearchWithArgs(ctx, "txt", "foo bar hello world", &redis.FTSearchOptions{NoContent: true}).RawResult()
 		Expect(err).NotTo(HaveOccurred())
-		totalResults2 := res2.(map[interface{}]interface{})["total_results"]
+		totalResults2 := res2.(map[any]any)["total_results"]
 		Expect(totalResults2).To(BeEquivalentTo(int64(1)))
 
 		// Test with UnstableResp3 false
@@ -2451,15 +2451,15 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
 
-		resSynUpdate, err := client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"boy", "child", "offspring"}).Result()
+		resSynUpdate, err := client.FTSynUpdate(ctx, "idx1", "id1", []any{"boy", "child", "offspring"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 
-		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"baby", "child"}).Result()
+		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []any{"baby", "child"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 
-		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"tree", "wood"}).Result()
+		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []any{"tree", "wood"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 
@@ -2467,7 +2467,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		valSynDump := client.FTSynDump(ctx, "idx1").RawVal()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(valSynDump).To(BeEquivalentTo(resSynDump))
-		Expect(resSynDump.(map[interface{}]interface{})["baby"]).To(BeEquivalentTo([]interface{}{"id1"}))
+		Expect(resSynDump.(map[any]any)["baby"]).To(BeEquivalentTo([]any{"id1"}))
 
 		// Test with UnstableResp3 false
 		Expect(func() {

--- a/set_commands.go
+++ b/set_commands.go
@@ -3,23 +3,23 @@ package redis
 import "context"
 
 type SetCmdable interface {
-	SAdd(ctx context.Context, key string, members ...interface{}) *IntCmd
+	SAdd(ctx context.Context, key string, members ...any) *IntCmd
 	SCard(ctx context.Context, key string) *IntCmd
 	SDiff(ctx context.Context, keys ...string) *StringSliceCmd
 	SDiffStore(ctx context.Context, destination string, keys ...string) *IntCmd
 	SInter(ctx context.Context, keys ...string) *StringSliceCmd
 	SInterCard(ctx context.Context, limit int64, keys ...string) *IntCmd
 	SInterStore(ctx context.Context, destination string, keys ...string) *IntCmd
-	SIsMember(ctx context.Context, key string, member interface{}) *BoolCmd
-	SMIsMember(ctx context.Context, key string, members ...interface{}) *BoolSliceCmd
+	SIsMember(ctx context.Context, key string, member any) *BoolCmd
+	SMIsMember(ctx context.Context, key string, members ...any) *BoolSliceCmd
 	SMembers(ctx context.Context, key string) *StringSliceCmd
 	SMembersMap(ctx context.Context, key string) *StringStructMapCmd
-	SMove(ctx context.Context, source, destination string, member interface{}) *BoolCmd
+	SMove(ctx context.Context, source, destination string, member any) *BoolCmd
 	SPop(ctx context.Context, key string) *StringCmd
 	SPopN(ctx context.Context, key string, count int64) *StringSliceCmd
 	SRandMember(ctx context.Context, key string) *StringCmd
 	SRandMemberN(ctx context.Context, key string, count int64) *StringSliceCmd
-	SRem(ctx context.Context, key string, members ...interface{}) *IntCmd
+	SRem(ctx context.Context, key string, members ...any) *IntCmd
 	SScan(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd
 	SUnion(ctx context.Context, keys ...string) *StringSliceCmd
 	SUnionStore(ctx context.Context, destination string, keys ...string) *IntCmd
@@ -27,8 +27,8 @@ type SetCmdable interface {
 
 //------------------------------------------------------------------------------
 
-func (c cmdable) SAdd(ctx context.Context, key string, members ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(members))
+func (c cmdable) SAdd(ctx context.Context, key string, members ...any) *IntCmd {
+	args := make([]any, 2, 2+len(members))
 	args[0] = "sadd"
 	args[1] = key
 	args = appendArgs(args, members)
@@ -44,7 +44,7 @@ func (c cmdable) SCard(ctx context.Context, key string) *IntCmd {
 }
 
 func (c cmdable) SDiff(ctx context.Context, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "sdiff"
 	for i, key := range keys {
 		args[1+i] = key
@@ -55,7 +55,7 @@ func (c cmdable) SDiff(ctx context.Context, keys ...string) *StringSliceCmd {
 }
 
 func (c cmdable) SDiffStore(ctx context.Context, destination string, keys ...string) *IntCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]any, 2+len(keys))
 	args[0] = "sdiffstore"
 	args[1] = destination
 	for i, key := range keys {
@@ -67,7 +67,7 @@ func (c cmdable) SDiffStore(ctx context.Context, destination string, keys ...str
 }
 
 func (c cmdable) SInter(ctx context.Context, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "sinter"
 	for i, key := range keys {
 		args[1+i] = key
@@ -79,7 +79,7 @@ func (c cmdable) SInter(ctx context.Context, keys ...string) *StringSliceCmd {
 
 func (c cmdable) SInterCard(ctx context.Context, limit int64, keys ...string) *IntCmd {
 	numKeys := len(keys)
-	args := make([]interface{}, 4+numKeys)
+	args := make([]any, 4+numKeys)
 	args[0] = "sintercard"
 	args[1] = numKeys
 	for i, key := range keys {
@@ -93,7 +93,7 @@ func (c cmdable) SInterCard(ctx context.Context, limit int64, keys ...string) *I
 }
 
 func (c cmdable) SInterStore(ctx context.Context, destination string, keys ...string) *IntCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]any, 2+len(keys))
 	args[0] = "sinterstore"
 	args[1] = destination
 	for i, key := range keys {
@@ -104,15 +104,15 @@ func (c cmdable) SInterStore(ctx context.Context, destination string, keys ...st
 	return cmd
 }
 
-func (c cmdable) SIsMember(ctx context.Context, key string, member interface{}) *BoolCmd {
+func (c cmdable) SIsMember(ctx context.Context, key string, member any) *BoolCmd {
 	cmd := NewBoolCmd(ctx, "sismember", key, member)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
 // SMIsMember Redis `SMISMEMBER key member [member ...]` command.
-func (c cmdable) SMIsMember(ctx context.Context, key string, members ...interface{}) *BoolSliceCmd {
-	args := make([]interface{}, 2, 2+len(members))
+func (c cmdable) SMIsMember(ctx context.Context, key string, members ...any) *BoolSliceCmd {
+	args := make([]any, 2, 2+len(members))
 	args[0] = "smismember"
 	args[1] = key
 	args = appendArgs(args, members)
@@ -135,7 +135,7 @@ func (c cmdable) SMembersMap(ctx context.Context, key string) *StringStructMapCm
 	return cmd
 }
 
-func (c cmdable) SMove(ctx context.Context, source, destination string, member interface{}) *BoolCmd {
+func (c cmdable) SMove(ctx context.Context, source, destination string, member any) *BoolCmd {
 	cmd := NewBoolCmd(ctx, "smove", source, destination, member)
 	_ = c(ctx, cmd)
 	return cmd
@@ -169,8 +169,8 @@ func (c cmdable) SRandMemberN(ctx context.Context, key string, count int64) *Str
 	return cmd
 }
 
-func (c cmdable) SRem(ctx context.Context, key string, members ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(members))
+func (c cmdable) SRem(ctx context.Context, key string, members ...any) *IntCmd {
+	args := make([]any, 2, 2+len(members))
 	args[0] = "srem"
 	args[1] = key
 	args = appendArgs(args, members)
@@ -180,7 +180,7 @@ func (c cmdable) SRem(ctx context.Context, key string, members ...interface{}) *
 }
 
 func (c cmdable) SUnion(ctx context.Context, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "sunion"
 	for i, key := range keys {
 		args[1+i] = key
@@ -191,7 +191,7 @@ func (c cmdable) SUnion(ctx context.Context, keys ...string) *StringSliceCmd {
 }
 
 func (c cmdable) SUnionStore(ctx context.Context, destination string, keys ...string) *IntCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]any, 2+len(keys))
 	args[0] = "sunionstore"
 	args[1] = destination
 	for i, key := range keys {
@@ -203,7 +203,7 @@ func (c cmdable) SUnionStore(ctx context.Context, destination string, keys ...st
 }
 
 func (c cmdable) SScan(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd {
-	args := []interface{}{"sscan", key, cursor}
+	args := []any{"sscan", key, cursor}
 	if match != "" {
 		args = append(args, "match", match)
 	}

--- a/sortedset_commands.go
+++ b/sortedset_commands.go
@@ -39,7 +39,7 @@ type SortedSetCmdable interface {
 	ZRangeStore(ctx context.Context, dst string, z ZRangeArgs) *IntCmd
 	ZRank(ctx context.Context, key, member string) *IntCmd
 	ZRankWithScore(ctx context.Context, key, member string) *RankWithScoreCmd
-	ZRem(ctx context.Context, key string, members ...interface{}) *IntCmd
+	ZRem(ctx context.Context, key string, members ...any) *IntCmd
 	ZRemRangeByRank(ctx context.Context, key string, start, stop int64) *IntCmd
 	ZRemRangeByScore(ctx context.Context, key, min, max string) *IntCmd
 	ZRemRangeByLex(ctx context.Context, key, min, max string) *IntCmd
@@ -64,7 +64,7 @@ type SortedSetCmdable interface {
 
 // BZPopMax Redis `BZPOPMAX key [key ...] timeout` command.
 func (c cmdable) BZPopMax(ctx context.Context, timeout time.Duration, keys ...string) *ZWithKeyCmd {
-	args := make([]interface{}, 1+len(keys)+1)
+	args := make([]any, 1+len(keys)+1)
 	args[0] = "bzpopmax"
 	for i, key := range keys {
 		args[1+i] = key
@@ -78,7 +78,7 @@ func (c cmdable) BZPopMax(ctx context.Context, timeout time.Duration, keys ...st
 
 // BZPopMin Redis `BZPOPMIN key [key ...] timeout` command.
 func (c cmdable) BZPopMin(ctx context.Context, timeout time.Duration, keys ...string) *ZWithKeyCmd {
-	args := make([]interface{}, 1+len(keys)+1)
+	args := make([]any, 1+len(keys)+1)
 	args[0] = "bzpopmin"
 	for i, key := range keys {
 		args[1+i] = key
@@ -96,7 +96,7 @@ func (c cmdable) BZPopMin(ctx context.Context, timeout time.Duration, keys ...st
 // A timeout of zero can be used to block indefinitely.
 // example: client.BZMPop(ctx, 0,"max", 1, "set")
 func (c cmdable) BZMPop(ctx context.Context, timeout time.Duration, order string, count int64, keys ...string) *ZSliceWithKeyCmd {
-	args := make([]interface{}, 3+len(keys), 6+len(keys))
+	args := make([]any, 3+len(keys), 6+len(keys))
 	args[0] = "bzmpop"
 	args[1] = formatSec(ctx, timeout)
 	args[2] = len(keys)
@@ -120,8 +120,8 @@ type ZAddArgs struct {
 	Members []Z
 }
 
-func (c cmdable) zAddArgs(key string, args ZAddArgs, incr bool) []interface{} {
-	a := make([]interface{}, 0, 6+2*len(args.Members))
+func (c cmdable) zAddArgs(key string, args ZAddArgs, incr bool) []any {
+	a := make([]any, 0, 6+2*len(args.Members))
 	a = append(a, "zadd", key)
 
 	// The GT, LT and NX options are mutually exclusive.
@@ -226,7 +226,7 @@ func (c cmdable) ZIncrBy(ctx context.Context, key string, increment float64, mem
 }
 
 func (c cmdable) ZInterStore(ctx context.Context, destination string, store *ZStore) *IntCmd {
-	args := make([]interface{}, 0, 3+store.len())
+	args := make([]any, 0, 3+store.len())
 	args = append(args, "zinterstore", destination, len(store.Keys))
 	args = store.appendArgs(args)
 	cmd := NewIntCmd(ctx, args...)
@@ -236,7 +236,7 @@ func (c cmdable) ZInterStore(ctx context.Context, destination string, store *ZSt
 }
 
 func (c cmdable) ZInter(ctx context.Context, store *ZStore) *StringSliceCmd {
-	args := make([]interface{}, 0, 2+store.len())
+	args := make([]any, 0, 2+store.len())
 	args = append(args, "zinter", len(store.Keys))
 	args = store.appendArgs(args)
 	cmd := NewStringSliceCmd(ctx, args...)
@@ -246,7 +246,7 @@ func (c cmdable) ZInter(ctx context.Context, store *ZStore) *StringSliceCmd {
 }
 
 func (c cmdable) ZInterWithScores(ctx context.Context, store *ZStore) *ZSliceCmd {
-	args := make([]interface{}, 0, 3+store.len())
+	args := make([]any, 0, 3+store.len())
 	args = append(args, "zinter", len(store.Keys))
 	args = store.appendArgs(args)
 	args = append(args, "withscores")
@@ -258,7 +258,7 @@ func (c cmdable) ZInterWithScores(ctx context.Context, store *ZStore) *ZSliceCmd
 
 func (c cmdable) ZInterCard(ctx context.Context, limit int64, keys ...string) *IntCmd {
 	numKeys := len(keys)
-	args := make([]interface{}, 4+numKeys)
+	args := make([]any, 4+numKeys)
 	args[0] = "zintercard"
 	args[1] = numKeys
 	for i, key := range keys {
@@ -275,7 +275,7 @@ func (c cmdable) ZInterCard(ctx context.Context, limit int64, keys ...string) *I
 // direction: "max" (highest score) or "min" (lowest score), count: > 0
 // example: client.ZMPop(ctx, "max", 5, "set1", "set2")
 func (c cmdable) ZMPop(ctx context.Context, order string, count int64, keys ...string) *ZSliceWithKeyCmd {
-	args := make([]interface{}, 2+len(keys), 5+len(keys))
+	args := make([]any, 2+len(keys), 5+len(keys))
 	args[0] = "zmpop"
 	args[1] = len(keys)
 	for i, key := range keys {
@@ -288,7 +288,7 @@ func (c cmdable) ZMPop(ctx context.Context, order string, count int64, keys ...s
 }
 
 func (c cmdable) ZMScore(ctx context.Context, key string, members ...string) *FloatSliceCmd {
-	args := make([]interface{}, 2+len(members))
+	args := make([]any, 2+len(members))
 	args[0] = "zmscore"
 	args[1] = key
 	for i, member := range members {
@@ -300,7 +300,7 @@ func (c cmdable) ZMScore(ctx context.Context, key string, members ...string) *Fl
 }
 
 func (c cmdable) ZPopMax(ctx context.Context, key string, count ...int64) *ZSliceCmd {
-	args := []interface{}{
+	args := []any{
 		"zpopmax",
 		key,
 	}
@@ -320,7 +320,7 @@ func (c cmdable) ZPopMax(ctx context.Context, key string, count ...int64) *ZSlic
 }
 
 func (c cmdable) ZPopMin(ctx context.Context, key string, count ...int64) *ZSliceCmd {
-	args := []interface{}{
+	args := []any{
 		"zpopmin",
 		key,
 	}
@@ -378,8 +378,8 @@ type ZRangeArgs struct {
 	//
 	// For normal cases (ByScore==false && ByLex==false), <Start> and <Stop> should be set to the index range (int).
 	// You can read the documentation for more information: https://redis.io/commands/zrange
-	Start interface{}
-	Stop  interface{}
+	Start any
+	Stop  any
 
 	// The ByScore and ByLex options are mutually exclusive.
 	ByScore bool
@@ -392,7 +392,7 @@ type ZRangeArgs struct {
 	Count  int64
 }
 
-func (z ZRangeArgs) appendArgs(args []interface{}) []interface{} {
+func (z ZRangeArgs) appendArgs(args []any) []any {
 	// For Rev+ByScore/ByLex, we need to adjust the position of <Start> and <Stop>.
 	if z.Rev && (z.ByScore || z.ByLex) {
 		args = append(args, z.Key, z.Stop, z.Start)
@@ -415,7 +415,7 @@ func (z ZRangeArgs) appendArgs(args []interface{}) []interface{} {
 }
 
 func (c cmdable) ZRangeArgs(ctx context.Context, z ZRangeArgs) *StringSliceCmd {
-	args := make([]interface{}, 0, 9)
+	args := make([]any, 0, 9)
 	args = append(args, "zrange")
 	args = z.appendArgs(args)
 	cmd := NewStringSliceCmd(ctx, args...)
@@ -424,7 +424,7 @@ func (c cmdable) ZRangeArgs(ctx context.Context, z ZRangeArgs) *StringSliceCmd {
 }
 
 func (c cmdable) ZRangeArgsWithScores(ctx context.Context, z ZRangeArgs) *ZSliceCmd {
-	args := make([]interface{}, 0, 10)
+	args := make([]any, 0, 10)
 	args = append(args, "zrange")
 	args = z.appendArgs(args)
 	args = append(args, "withscores")
@@ -455,7 +455,7 @@ type ZRangeBy struct {
 }
 
 func (c cmdable) zRangeBy(ctx context.Context, zcmd, key string, opt *ZRangeBy, withScores bool) *StringSliceCmd {
-	args := []interface{}{zcmd, key, opt.Min, opt.Max}
+	args := []any{zcmd, key, opt.Min, opt.Max}
 	if withScores {
 		args = append(args, "withscores")
 	}
@@ -481,7 +481,7 @@ func (c cmdable) ZRangeByLex(ctx context.Context, key string, opt *ZRangeBy) *St
 }
 
 func (c cmdable) ZRangeByScoreWithScores(ctx context.Context, key string, opt *ZRangeBy) *ZSliceCmd {
-	args := []interface{}{"zrangebyscore", key, opt.Min, opt.Max, "withscores"}
+	args := []any{"zrangebyscore", key, opt.Min, opt.Max, "withscores"}
 	if opt.Offset != 0 || opt.Count != 0 {
 		args = append(
 			args,
@@ -496,7 +496,7 @@ func (c cmdable) ZRangeByScoreWithScores(ctx context.Context, key string, opt *Z
 }
 
 func (c cmdable) ZRangeStore(ctx context.Context, dst string, z ZRangeArgs) *IntCmd {
-	args := make([]interface{}, 0, 10)
+	args := make([]any, 0, 10)
 	args = append(args, "zrangestore", dst)
 	args = z.appendArgs(args)
 	cmd := NewIntCmd(ctx, args...)
@@ -518,8 +518,8 @@ func (c cmdable) ZRankWithScore(ctx context.Context, key, member string) *RankWi
 	return cmd
 }
 
-func (c cmdable) ZRem(ctx context.Context, key string, members ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(members))
+func (c cmdable) ZRem(ctx context.Context, key string, members ...any) *IntCmd {
+	args := make([]any, 2, 2+len(members))
 	args[0] = "zrem"
 	args[1] = key
 	args = appendArgs(args, members)
@@ -567,7 +567,7 @@ func (c cmdable) ZRevRangeWithScores(ctx context.Context, key string, start, sto
 }
 
 func (c cmdable) zRevRangeBy(ctx context.Context, zcmd, key string, opt *ZRangeBy) *StringSliceCmd {
-	args := []interface{}{zcmd, key, opt.Max, opt.Min}
+	args := []any{zcmd, key, opt.Max, opt.Min}
 	if opt.Offset != 0 || opt.Count != 0 {
 		args = append(
 			args,
@@ -590,7 +590,7 @@ func (c cmdable) ZRevRangeByLex(ctx context.Context, key string, opt *ZRangeBy) 
 }
 
 func (c cmdable) ZRevRangeByScoreWithScores(ctx context.Context, key string, opt *ZRangeBy) *ZSliceCmd {
-	args := []interface{}{"zrevrangebyscore", key, opt.Max, opt.Min, "withscores"}
+	args := []any{"zrevrangebyscore", key, opt.Max, opt.Min, "withscores"}
 	if opt.Offset != 0 || opt.Count != 0 {
 		args = append(
 			args,
@@ -623,7 +623,7 @@ func (c cmdable) ZScore(ctx context.Context, key, member string) *FloatCmd {
 }
 
 func (c cmdable) ZUnion(ctx context.Context, store ZStore) *StringSliceCmd {
-	args := make([]interface{}, 0, 2+store.len())
+	args := make([]any, 0, 2+store.len())
 	args = append(args, "zunion", len(store.Keys))
 	args = store.appendArgs(args)
 	cmd := NewStringSliceCmd(ctx, args...)
@@ -633,7 +633,7 @@ func (c cmdable) ZUnion(ctx context.Context, store ZStore) *StringSliceCmd {
 }
 
 func (c cmdable) ZUnionWithScores(ctx context.Context, store ZStore) *ZSliceCmd {
-	args := make([]interface{}, 0, 3+store.len())
+	args := make([]any, 0, 3+store.len())
 	args = append(args, "zunion", len(store.Keys))
 	args = store.appendArgs(args)
 	args = append(args, "withscores")
@@ -644,7 +644,7 @@ func (c cmdable) ZUnionWithScores(ctx context.Context, store ZStore) *ZSliceCmd 
 }
 
 func (c cmdable) ZUnionStore(ctx context.Context, dest string, store *ZStore) *IntCmd {
-	args := make([]interface{}, 0, 3+store.len())
+	args := make([]any, 0, 3+store.len())
 	args = append(args, "zunionstore", dest, len(store.Keys))
 	args = store.appendArgs(args)
 	cmd := NewIntCmd(ctx, args...)
@@ -669,7 +669,7 @@ func (c cmdable) ZRandMemberWithScores(ctx context.Context, key string, count in
 
 // ZDiff redis-server version >= 6.2.0.
 func (c cmdable) ZDiff(ctx context.Context, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]any, 2+len(keys))
 	args[0] = "zdiff"
 	args[1] = len(keys)
 	for i, key := range keys {
@@ -684,7 +684,7 @@ func (c cmdable) ZDiff(ctx context.Context, keys ...string) *StringSliceCmd {
 
 // ZDiffWithScores redis-server version >= 6.2.0.
 func (c cmdable) ZDiffWithScores(ctx context.Context, keys ...string) *ZSliceCmd {
-	args := make([]interface{}, 3+len(keys))
+	args := make([]any, 3+len(keys))
 	args[0] = "zdiff"
 	args[1] = len(keys)
 	for i, key := range keys {
@@ -700,7 +700,7 @@ func (c cmdable) ZDiffWithScores(ctx context.Context, keys ...string) *ZSliceCmd
 
 // ZDiffStore redis-server version >=6.2.0.
 func (c cmdable) ZDiffStore(ctx context.Context, destination string, keys ...string) *IntCmd {
-	args := make([]interface{}, 0, 3+len(keys))
+	args := make([]any, 0, 3+len(keys))
 	args = append(args, "zdiffstore", destination, len(keys))
 	for _, key := range keys {
 		args = append(args, key)
@@ -711,7 +711,7 @@ func (c cmdable) ZDiffStore(ctx context.Context, destination string, keys ...str
 }
 
 func (c cmdable) ZScan(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd {
-	args := []interface{}{"zscan", key, cursor}
+	args := []any{"zscan", key, cursor}
 	if match != "" {
 		args = append(args, "match", match)
 	}
@@ -726,7 +726,7 @@ func (c cmdable) ZScan(ctx context.Context, key string, cursor uint64, match str
 // Z represents sorted set member.
 type Z struct {
 	Score  float64
-	Member interface{}
+	Member any
 }
 
 // ZWithKey represents sorted set member including the name of the key where it was popped.
@@ -754,7 +754,7 @@ func (z ZStore) len() (n int) {
 	return n
 }
 
-func (z ZStore) appendArgs(args []interface{}) []interface{} {
+func (z ZStore) appendArgs(args []any) []any {
 	for _, key := range z.Keys {
 		args = append(args, key)
 	}

--- a/stream_commands.go
+++ b/stream_commands.go
@@ -40,9 +40,9 @@ type StreamCmdable interface {
 }
 
 // XAddArgs accepts values in the following formats:
-//   - XAddArgs.Values = []interface{}{"key1", "value1", "key2", "value2"}
+//   - XAddArgs.Values = []any{"key1", "value1", "key2", "value2"}
 //   - XAddArgs.Values = []string("key1", "value1", "key2", "value2")
-//   - XAddArgs.Values = map[string]interface{}{"key1": "value1", "key2": "value2"}
+//   - XAddArgs.Values = map[string]any{"key1": "value1", "key2": "value2"}
 //
 // Note that map will not preserve the order of key-value pairs.
 // MaxLen/MaxLenApprox and MinID are in conflict, only one of them can be used.
@@ -55,11 +55,11 @@ type XAddArgs struct {
 	Approx bool
 	Limit  int64
 	ID     string
-	Values interface{}
+	Values any
 }
 
 func (c cmdable) XAdd(ctx context.Context, a *XAddArgs) *StringCmd {
-	args := make([]interface{}, 0, 11)
+	args := make([]any, 0, 11)
 	args = append(args, "xadd", a.Stream)
 	if a.NoMkStream {
 		args = append(args, "nomkstream")
@@ -94,7 +94,7 @@ func (c cmdable) XAdd(ctx context.Context, a *XAddArgs) *StringCmd {
 }
 
 func (c cmdable) XDel(ctx context.Context, stream string, ids ...string) *IntCmd {
-	args := []interface{}{"xdel", stream}
+	args := []any{"xdel", stream}
 	for _, id := range ids {
 		args = append(args, id)
 	}
@@ -141,7 +141,7 @@ type XReadArgs struct {
 }
 
 func (c cmdable) XRead(ctx context.Context, a *XReadArgs) *XStreamSliceCmd {
-	args := make([]interface{}, 0, 2*len(a.Streams)+6)
+	args := make([]any, 0, 2*len(a.Streams)+6)
 	args = append(args, "xread")
 
 	keyPos := int8(1)
@@ -234,7 +234,7 @@ type XReadGroupArgs struct {
 }
 
 func (c cmdable) XReadGroup(ctx context.Context, a *XReadGroupArgs) *XStreamSliceCmd {
-	args := make([]interface{}, 0, 10+len(a.Streams))
+	args := make([]any, 0, 10+len(a.Streams))
 	args = append(args, "xreadgroup", "group", a.Group, a.Consumer)
 
 	keyPos := int8(4)
@@ -266,7 +266,7 @@ func (c cmdable) XReadGroup(ctx context.Context, a *XReadGroupArgs) *XStreamSlic
 }
 
 func (c cmdable) XAck(ctx context.Context, stream, group string, ids ...string) *IntCmd {
-	args := []interface{}{"xack", stream, group}
+	args := []any{"xack", stream, group}
 	for _, id := range ids {
 		args = append(args, id)
 	}
@@ -292,7 +292,7 @@ type XPendingExtArgs struct {
 }
 
 func (c cmdable) XPendingExt(ctx context.Context, a *XPendingExtArgs) *XPendingExtCmd {
-	args := make([]interface{}, 0, 9)
+	args := make([]any, 0, 9)
 	args = append(args, "xpending", a.Stream, a.Group)
 	if a.Idle != 0 {
 		args = append(args, "idle", formatMs(ctx, a.Idle))
@@ -330,8 +330,8 @@ func (c cmdable) XAutoClaimJustID(ctx context.Context, a *XAutoClaimArgs) *XAuto
 	return cmd
 }
 
-func xAutoClaimArgs(ctx context.Context, a *XAutoClaimArgs) []interface{} {
-	args := make([]interface{}, 0, 8)
+func xAutoClaimArgs(ctx context.Context, a *XAutoClaimArgs) []any {
+	args := make([]any, 0, 8)
 	args = append(args, "xautoclaim", a.Stream, a.Group, a.Consumer, formatMs(ctx, a.MinIdle), a.Start)
 	if a.Count > 0 {
 		args = append(args, "count", a.Count)
@@ -362,8 +362,8 @@ func (c cmdable) XClaimJustID(ctx context.Context, a *XClaimArgs) *StringSliceCm
 	return cmd
 }
 
-func xClaimArgs(a *XClaimArgs) []interface{} {
-	args := make([]interface{}, 0, 5+len(a.Messages))
+func xClaimArgs(a *XClaimArgs) []any {
+	args := make([]any, 0, 5+len(a.Messages))
 	args = append(args,
 		"xclaim",
 		a.Stream,
@@ -384,9 +384,9 @@ func xClaimArgs(a *XClaimArgs) []interface{} {
 // The redis-server version is lower than 6.2, please set limit to 0.
 func (c cmdable) xTrim(
 	ctx context.Context, key, strategy string,
-	approx bool, threshold interface{}, limit int64,
+	approx bool, threshold any, limit int64,
 ) *IntCmd {
-	args := make([]interface{}, 0, 7)
+	args := make([]any, 0, 7)
 	args = append(args, "xtrim", key, strategy)
 	if approx {
 		args = append(args, "~")
@@ -439,7 +439,7 @@ func (c cmdable) XInfoStream(ctx context.Context, key string) *XInfoStreamCmd {
 // XInfoStreamFull XINFO STREAM FULL [COUNT count]
 // redis-server >= 6.0.
 func (c cmdable) XInfoStreamFull(ctx context.Context, key string, count int) *XInfoStreamFullCmd {
-	args := make([]interface{}, 0, 6)
+	args := make([]any, 0, 6)
 	args = append(args, "xinfo", "stream", key, "full")
 	if count > 0 {
 		args = append(args, "count", count)

--- a/timeseries_commands.go
+++ b/timeseries_commands.go
@@ -8,8 +8,8 @@ import (
 )
 
 type TimeseriesCmdable interface {
-	TSAdd(ctx context.Context, key string, timestamp interface{}, value float64) *IntCmd
-	TSAddWithArgs(ctx context.Context, key string, timestamp interface{}, value float64, options *TSOptions) *IntCmd
+	TSAdd(ctx context.Context, key string, timestamp any, value float64) *IntCmd
+	TSAddWithArgs(ctx context.Context, key string, timestamp any, value float64, options *TSOptions) *IntCmd
 	TSCreate(ctx context.Context, key string) *StatusCmd
 	TSCreateWithArgs(ctx context.Context, key string, options *TSOptions) *StatusCmd
 	TSAlter(ctx context.Context, key string, options *TSAlterOptions) *StatusCmd
@@ -25,7 +25,7 @@ type TimeseriesCmdable interface {
 	TSGetWithArgs(ctx context.Context, key string, options *TSGetOptions) *TSTimestampValueCmd
 	TSInfo(ctx context.Context, key string) *MapStringInterfaceCmd
 	TSInfoWithArgs(ctx context.Context, key string, options *TSInfoOptions) *MapStringInterfaceCmd
-	TSMAdd(ctx context.Context, ktvSlices [][]interface{}) *IntSliceCmd
+	TSMAdd(ctx context.Context, ktvSlices [][]any) *IntSliceCmd
 	TSQueryIndex(ctx context.Context, filterExpr []string) *StringSliceCmd
 	TSRevRange(ctx context.Context, key string, fromTimestamp int, toTimestamp int) *TSTimestampValueSliceCmd
 	TSRevRangeWithArgs(ctx context.Context, key string, fromTimestamp int, toTimestamp int, options *TSRevRangeOptions) *TSTimestampValueSliceCmd
@@ -138,10 +138,10 @@ type TSRangeOptions struct {
 	FilterByTS      []int
 	FilterByValue   []int
 	Count           int
-	Align           interface{}
+	Align           any
 	Aggregator      Aggregator
 	BucketDuration  int
-	BucketTimestamp interface{}
+	BucketTimestamp any
 	Empty           bool
 }
 
@@ -150,10 +150,10 @@ type TSRevRangeOptions struct {
 	FilterByTS      []int
 	FilterByValue   []int
 	Count           int
-	Align           interface{}
+	Align           any
 	Aggregator      Aggregator
 	BucketDuration  int
-	BucketTimestamp interface{}
+	BucketTimestamp any
 	Empty           bool
 }
 
@@ -162,15 +162,15 @@ type TSMRangeOptions struct {
 	FilterByTS      []int
 	FilterByValue   []int
 	WithLabels      bool
-	SelectedLabels  []interface{}
+	SelectedLabels  []any
 	Count           int
-	Align           interface{}
+	Align           any
 	Aggregator      Aggregator
 	BucketDuration  int
-	BucketTimestamp interface{}
+	BucketTimestamp any
 	Empty           bool
-	GroupByLabel    interface{}
-	Reducer         interface{}
+	GroupByLabel    any
+	Reducer         any
 }
 
 type TSMRevRangeOptions struct {
@@ -178,27 +178,27 @@ type TSMRevRangeOptions struct {
 	FilterByTS      []int
 	FilterByValue   []int
 	WithLabels      bool
-	SelectedLabels  []interface{}
+	SelectedLabels  []any
 	Count           int
-	Align           interface{}
+	Align           any
 	Aggregator      Aggregator
 	BucketDuration  int
-	BucketTimestamp interface{}
+	BucketTimestamp any
 	Empty           bool
-	GroupByLabel    interface{}
-	Reducer         interface{}
+	GroupByLabel    any
+	Reducer         any
 }
 
 type TSMGetOptions struct {
 	Latest         bool
 	WithLabels     bool
-	SelectedLabels []interface{}
+	SelectedLabels []any
 }
 
 // TSAdd - Adds one or more observations to a t-digest sketch.
 // For more information - https://redis.io/commands/ts.add/
-func (c cmdable) TSAdd(ctx context.Context, key string, timestamp interface{}, value float64) *IntCmd {
-	args := []interface{}{"TS.ADD", key, timestamp, value}
+func (c cmdable) TSAdd(ctx context.Context, key string, timestamp any, value float64) *IntCmd {
+	args := []any{"TS.ADD", key, timestamp, value}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -208,8 +208,8 @@ func (c cmdable) TSAdd(ctx context.Context, key string, timestamp interface{}, v
 // This function also allows for specifying additional options such as:
 // Retention, ChunkSize, Encoding, DuplicatePolicy and Labels.
 // For more information - https://redis.io/commands/ts.add/
-func (c cmdable) TSAddWithArgs(ctx context.Context, key string, timestamp interface{}, value float64, options *TSOptions) *IntCmd {
-	args := []interface{}{"TS.ADD", key, timestamp, value}
+func (c cmdable) TSAddWithArgs(ctx context.Context, key string, timestamp any, value float64, options *TSOptions) *IntCmd {
+	args := []any{"TS.ADD", key, timestamp, value}
 	if options != nil {
 		if options.Retention != 0 {
 			args = append(args, "RETENTION", options.Retention)
@@ -242,7 +242,7 @@ func (c cmdable) TSAddWithArgs(ctx context.Context, key string, timestamp interf
 // TSCreate - Creates a new time-series key.
 // For more information - https://redis.io/commands/ts.create/
 func (c cmdable) TSCreate(ctx context.Context, key string) *StatusCmd {
-	args := []interface{}{"TS.CREATE", key}
+	args := []any{"TS.CREATE", key}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -253,7 +253,7 @@ func (c cmdable) TSCreate(ctx context.Context, key string) *StatusCmd {
 // Retention, ChunkSize, Encoding, DuplicatePolicy and Labels.
 // For more information - https://redis.io/commands/ts.create/
 func (c cmdable) TSCreateWithArgs(ctx context.Context, key string, options *TSOptions) *StatusCmd {
-	args := []interface{}{"TS.CREATE", key}
+	args := []any{"TS.CREATE", key}
 	if options != nil {
 		if options.Retention != 0 {
 			args = append(args, "RETENTION", options.Retention)
@@ -288,7 +288,7 @@ func (c cmdable) TSCreateWithArgs(ctx context.Context, key string, options *TSOp
 // Retention, ChunkSize and DuplicatePolicy.
 // For more information - https://redis.io/commands/ts.alter/
 func (c cmdable) TSAlter(ctx context.Context, key string, options *TSAlterOptions) *StatusCmd {
-	args := []interface{}{"TS.ALTER", key}
+	args := []any{"TS.ALTER", key}
 	if options != nil {
 		if options.Retention != 0 {
 			args = append(args, "RETENTION", options.Retention)
@@ -317,7 +317,7 @@ func (c cmdable) TSAlter(ctx context.Context, key string, options *TSAlterOption
 // TSCreateRule - Creates a compaction rule from sourceKey to destKey.
 // For more information - https://redis.io/commands/ts.createrule/
 func (c cmdable) TSCreateRule(ctx context.Context, sourceKey string, destKey string, aggregator Aggregator, bucketDuration int) *StatusCmd {
-	args := []interface{}{"TS.CREATERULE", sourceKey, destKey, "AGGREGATION", aggregator.String(), bucketDuration}
+	args := []any{"TS.CREATERULE", sourceKey, destKey, "AGGREGATION", aggregator.String(), bucketDuration}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -328,7 +328,7 @@ func (c cmdable) TSCreateRule(ctx context.Context, sourceKey string, destKey str
 // alignTimestamp.
 // For more information - https://redis.io/commands/ts.createrule/
 func (c cmdable) TSCreateRuleWithArgs(ctx context.Context, sourceKey string, destKey string, aggregator Aggregator, bucketDuration int, options *TSCreateRuleOptions) *StatusCmd {
-	args := []interface{}{"TS.CREATERULE", sourceKey, destKey, "AGGREGATION", aggregator.String(), bucketDuration}
+	args := []any{"TS.CREATERULE", sourceKey, destKey, "AGGREGATION", aggregator.String(), bucketDuration}
 	if options != nil {
 		if options.alignTimestamp != 0 {
 			args = append(args, options.alignTimestamp)
@@ -342,7 +342,7 @@ func (c cmdable) TSCreateRuleWithArgs(ctx context.Context, sourceKey string, des
 // TSIncrBy - Increments the value of a time-series key by the specified timestamp.
 // For more information - https://redis.io/commands/ts.incrby/
 func (c cmdable) TSIncrBy(ctx context.Context, Key string, timestamp float64) *IntCmd {
-	args := []interface{}{"TS.INCRBY", Key, timestamp}
+	args := []any{"TS.INCRBY", Key, timestamp}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -353,7 +353,7 @@ func (c cmdable) TSIncrBy(ctx context.Context, Key string, timestamp float64) *I
 // Timestamp, Retention, ChunkSize, Uncompressed and Labels.
 // For more information - https://redis.io/commands/ts.incrby/
 func (c cmdable) TSIncrByWithArgs(ctx context.Context, key string, timestamp float64, options *TSIncrDecrOptions) *IntCmd {
-	args := []interface{}{"TS.INCRBY", key, timestamp}
+	args := []any{"TS.INCRBY", key, timestamp}
 	if options != nil {
 		if options.Timestamp != 0 {
 			args = append(args, "TIMESTAMP", options.Timestamp)
@@ -388,7 +388,7 @@ func (c cmdable) TSIncrByWithArgs(ctx context.Context, key string, timestamp flo
 // TSDecrBy - Decrements the value of a time-series key by the specified timestamp.
 // For more information - https://redis.io/commands/ts.decrby/
 func (c cmdable) TSDecrBy(ctx context.Context, Key string, timestamp float64) *IntCmd {
-	args := []interface{}{"TS.DECRBY", Key, timestamp}
+	args := []any{"TS.DECRBY", Key, timestamp}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -399,7 +399,7 @@ func (c cmdable) TSDecrBy(ctx context.Context, Key string, timestamp float64) *I
 // Timestamp, Retention, ChunkSize, Uncompressed and Labels.
 // For more information - https://redis.io/commands/ts.decrby/
 func (c cmdable) TSDecrByWithArgs(ctx context.Context, key string, timestamp float64, options *TSIncrDecrOptions) *IntCmd {
-	args := []interface{}{"TS.DECRBY", key, timestamp}
+	args := []any{"TS.DECRBY", key, timestamp}
 	if options != nil {
 		if options.Timestamp != 0 {
 			args = append(args, "TIMESTAMP", options.Timestamp)
@@ -434,7 +434,7 @@ func (c cmdable) TSDecrByWithArgs(ctx context.Context, key string, timestamp flo
 // TSDel - Deletes a range of samples from a time-series key.
 // For more information - https://redis.io/commands/ts.del/
 func (c cmdable) TSDel(ctx context.Context, Key string, fromTimestamp int, toTimestamp int) *IntCmd {
-	args := []interface{}{"TS.DEL", Key, fromTimestamp, toTimestamp}
+	args := []any{"TS.DEL", Key, fromTimestamp, toTimestamp}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -443,7 +443,7 @@ func (c cmdable) TSDel(ctx context.Context, Key string, fromTimestamp int, toTim
 // TSDeleteRule - Deletes a compaction rule from sourceKey to destKey.
 // For more information - https://redis.io/commands/ts.deleterule/
 func (c cmdable) TSDeleteRule(ctx context.Context, sourceKey string, destKey string) *StatusCmd {
-	args := []interface{}{"TS.DELETERULE", sourceKey, destKey}
+	args := []any{"TS.DELETERULE", sourceKey, destKey}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -454,7 +454,7 @@ func (c cmdable) TSDeleteRule(ctx context.Context, sourceKey string, destKey str
 // Latest.
 // For more information - https://redis.io/commands/ts.get/
 func (c cmdable) TSGetWithArgs(ctx context.Context, key string, options *TSGetOptions) *TSTimestampValueCmd {
-	args := []interface{}{"TS.GET", key}
+	args := []any{"TS.GET", key}
 	if options != nil {
 		if options.Latest {
 			args = append(args, "LATEST")
@@ -468,7 +468,7 @@ func (c cmdable) TSGetWithArgs(ctx context.Context, key string, options *TSGetOp
 // TSGet - Gets the last sample of a time-series key.
 // For more information - https://redis.io/commands/ts.get/
 func (c cmdable) TSGet(ctx context.Context, key string) *TSTimestampValueCmd {
-	args := []interface{}{"TS.GET", key}
+	args := []any{"TS.GET", key}
 	cmd := newTSTimestampValueCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -483,7 +483,7 @@ type TSTimestampValueCmd struct {
 	val TSTimestampValue
 }
 
-func newTSTimestampValueCmd(ctx context.Context, args ...interface{}) *TSTimestampValueCmd {
+func newTSTimestampValueCmd(ctx context.Context, args ...any) *TSTimestampValueCmd {
 	return &TSTimestampValueCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -536,7 +536,7 @@ func (cmd *TSTimestampValueCmd) readReply(rd *proto.Reader) (err error) {
 // TSInfo - Returns information about a time-series key.
 // For more information - https://redis.io/commands/ts.info/
 func (c cmdable) TSInfo(ctx context.Context, key string) *MapStringInterfaceCmd {
-	args := []interface{}{"TS.INFO", key}
+	args := []any{"TS.INFO", key}
 	cmd := NewMapStringInterfaceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -547,7 +547,7 @@ func (c cmdable) TSInfo(ctx context.Context, key string) *MapStringInterfaceCmd 
 // Debug.
 // For more information - https://redis.io/commands/ts.info/
 func (c cmdable) TSInfoWithArgs(ctx context.Context, key string, options *TSInfoOptions) *MapStringInterfaceCmd {
-	args := []interface{}{"TS.INFO", key}
+	args := []any{"TS.INFO", key}
 	if options != nil {
 		if options.Debug {
 			args = append(args, "DEBUG")
@@ -562,8 +562,8 @@ func (c cmdable) TSInfoWithArgs(ctx context.Context, key string, options *TSInfo
 // It accepts a slice of 'ktv' slices, each containing exactly three elements: key, timestamp, and value.
 // This struct must be provided for this command to work.
 // For more information - https://redis.io/commands/ts.madd/
-func (c cmdable) TSMAdd(ctx context.Context, ktvSlices [][]interface{}) *IntSliceCmd {
-	args := []interface{}{"TS.MADD"}
+func (c cmdable) TSMAdd(ctx context.Context, ktvSlices [][]any) *IntSliceCmd {
+	args := []any{"TS.MADD"}
 	for _, ktv := range ktvSlices {
 		args = append(args, ktv...)
 	}
@@ -575,7 +575,7 @@ func (c cmdable) TSMAdd(ctx context.Context, ktvSlices [][]interface{}) *IntSlic
 // TSQueryIndex - Returns all the keys matching the filter expression.
 // For more information - https://redis.io/commands/ts.queryindex/
 func (c cmdable) TSQueryIndex(ctx context.Context, filterExpr []string) *StringSliceCmd {
-	args := []interface{}{"TS.QUERYINDEX"}
+	args := []any{"TS.QUERYINDEX"}
 	for _, f := range filterExpr {
 		args = append(args, f)
 	}
@@ -587,7 +587,7 @@ func (c cmdable) TSQueryIndex(ctx context.Context, filterExpr []string) *StringS
 // TSRevRange - Returns a range of samples from a time-series key in reverse order.
 // For more information - https://redis.io/commands/ts.revrange/
 func (c cmdable) TSRevRange(ctx context.Context, key string, fromTimestamp int, toTimestamp int) *TSTimestampValueSliceCmd {
-	args := []interface{}{"TS.REVRANGE", key, fromTimestamp, toTimestamp}
+	args := []any{"TS.REVRANGE", key, fromTimestamp, toTimestamp}
 	cmd := newTSTimestampValueSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -599,7 +599,7 @@ func (c cmdable) TSRevRange(ctx context.Context, key string, fromTimestamp int, 
 // BucketDuration, BucketTimestamp and Empty.
 // For more information - https://redis.io/commands/ts.revrange/
 func (c cmdable) TSRevRangeWithArgs(ctx context.Context, key string, fromTimestamp int, toTimestamp int, options *TSRevRangeOptions) *TSTimestampValueSliceCmd {
-	args := []interface{}{"TS.REVRANGE", key, fromTimestamp, toTimestamp}
+	args := []any{"TS.REVRANGE", key, fromTimestamp, toTimestamp}
 	if options != nil {
 		if options.Latest {
 			args = append(args, "LATEST")
@@ -643,7 +643,7 @@ func (c cmdable) TSRevRangeWithArgs(ctx context.Context, key string, fromTimesta
 // TSRange - Returns a range of samples from a time-series key.
 // For more information - https://redis.io/commands/ts.range/
 func (c cmdable) TSRange(ctx context.Context, key string, fromTimestamp int, toTimestamp int) *TSTimestampValueSliceCmd {
-	args := []interface{}{"TS.RANGE", key, fromTimestamp, toTimestamp}
+	args := []any{"TS.RANGE", key, fromTimestamp, toTimestamp}
 	cmd := newTSTimestampValueSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -655,7 +655,7 @@ func (c cmdable) TSRange(ctx context.Context, key string, fromTimestamp int, toT
 // BucketDuration, BucketTimestamp and Empty.
 // For more information - https://redis.io/commands/ts.range/
 func (c cmdable) TSRangeWithArgs(ctx context.Context, key string, fromTimestamp int, toTimestamp int, options *TSRangeOptions) *TSTimestampValueSliceCmd {
-	args := []interface{}{"TS.RANGE", key, fromTimestamp, toTimestamp}
+	args := []any{"TS.RANGE", key, fromTimestamp, toTimestamp}
 	if options != nil {
 		if options.Latest {
 			args = append(args, "LATEST")
@@ -701,7 +701,7 @@ type TSTimestampValueSliceCmd struct {
 	val []TSTimestampValue
 }
 
-func newTSTimestampValueSliceCmd(ctx context.Context, args ...interface{}) *TSTimestampValueSliceCmd {
+func newTSTimestampValueSliceCmd(ctx context.Context, args ...any) *TSTimestampValueSliceCmd {
 	return &TSTimestampValueSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -755,7 +755,7 @@ func (cmd *TSTimestampValueSliceCmd) readReply(rd *proto.Reader) (err error) {
 // TSMRange - Returns a range of samples from multiple time-series keys.
 // For more information - https://redis.io/commands/ts.mrange/
 func (c cmdable) TSMRange(ctx context.Context, fromTimestamp int, toTimestamp int, filterExpr []string) *MapStringSliceInterfaceCmd {
-	args := []interface{}{"TS.MRANGE", fromTimestamp, toTimestamp, "FILTER"}
+	args := []any{"TS.MRANGE", fromTimestamp, toTimestamp, "FILTER"}
 	for _, f := range filterExpr {
 		args = append(args, f)
 	}
@@ -771,7 +771,7 @@ func (c cmdable) TSMRange(ctx context.Context, fromTimestamp int, toTimestamp in
 // Empty, GroupByLabel and Reducer.
 // For more information - https://redis.io/commands/ts.mrange/
 func (c cmdable) TSMRangeWithArgs(ctx context.Context, fromTimestamp int, toTimestamp int, filterExpr []string, options *TSMRangeOptions) *MapStringSliceInterfaceCmd {
-	args := []interface{}{"TS.MRANGE", fromTimestamp, toTimestamp}
+	args := []any{"TS.MRANGE", fromTimestamp, toTimestamp}
 	if options != nil {
 		if options.Latest {
 			args = append(args, "LATEST")
@@ -834,7 +834,7 @@ func (c cmdable) TSMRangeWithArgs(ctx context.Context, fromTimestamp int, toTime
 // TSMRevRange - Returns a range of samples from multiple time-series keys in reverse order.
 // For more information - https://redis.io/commands/ts.mrevrange/
 func (c cmdable) TSMRevRange(ctx context.Context, fromTimestamp int, toTimestamp int, filterExpr []string) *MapStringSliceInterfaceCmd {
-	args := []interface{}{"TS.MREVRANGE", fromTimestamp, toTimestamp, "FILTER"}
+	args := []any{"TS.MREVRANGE", fromTimestamp, toTimestamp, "FILTER"}
 	for _, f := range filterExpr {
 		args = append(args, f)
 	}
@@ -850,7 +850,7 @@ func (c cmdable) TSMRevRange(ctx context.Context, fromTimestamp int, toTimestamp
 // Empty, GroupByLabel and Reducer.
 // For more information - https://redis.io/commands/ts.mrevrange/
 func (c cmdable) TSMRevRangeWithArgs(ctx context.Context, fromTimestamp int, toTimestamp int, filterExpr []string, options *TSMRevRangeOptions) *MapStringSliceInterfaceCmd {
-	args := []interface{}{"TS.MREVRANGE", fromTimestamp, toTimestamp}
+	args := []any{"TS.MREVRANGE", fromTimestamp, toTimestamp}
 	if options != nil {
 		if options.Latest {
 			args = append(args, "LATEST")
@@ -913,7 +913,7 @@ func (c cmdable) TSMRevRangeWithArgs(ctx context.Context, fromTimestamp int, toT
 // TSMGet - Returns the last sample of multiple time-series keys.
 // For more information - https://redis.io/commands/ts.mget/
 func (c cmdable) TSMGet(ctx context.Context, filters []string) *MapStringSliceInterfaceCmd {
-	args := []interface{}{"TS.MGET", "FILTER"}
+	args := []any{"TS.MGET", "FILTER"}
 	for _, f := range filters {
 		args = append(args, f)
 	}
@@ -927,7 +927,7 @@ func (c cmdable) TSMGet(ctx context.Context, filters []string) *MapStringSliceIn
 // Latest, WithLabels and SelectedLabels.
 // For more information - https://redis.io/commands/ts.mget/
 func (c cmdable) TSMGetWithArgs(ctx context.Context, filters []string, options *TSMGetOptions) *MapStringSliceInterfaceCmd {
-	args := []interface{}{"TS.MGET"}
+	args := []any{"TS.MGET"}
 	if options != nil {
 		if options.Latest {
 			args = append(args, "LATEST")

--- a/timeseries_commands_test.go
+++ b/timeseries_commands_test.go
@@ -63,9 +63,9 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				resultInfo, err := client.TSInfo(ctx, "4").Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(resultInfo["labels"].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"Time", "Series"}))
+					Expect(resultInfo["labels"].([]any)[0]).To(BeEquivalentTo([]any{"Time", "Series"}))
 				} else {
-					Expect(resultInfo["labels"].(map[interface{}]interface{})["Time"]).To(BeEquivalentTo("Series"))
+					Expect(resultInfo["labels"].(map[any]any)["Time"]).To(BeEquivalentTo("Series"))
 				}
 				// Test chunk size
 				opt = &redis.TSOptions{ChunkSize: 128}
@@ -160,9 +160,9 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				resultInfo, err := client.TSInfo(ctx, "4").Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(resultInfo["labels"].([]interface{})).To(ContainElement([]interface{}{"Time", "Series"}))
+					Expect(resultInfo["labels"].([]any)).To(ContainElement([]any{"Time", "Series"}))
 				} else {
-					Expect(resultInfo["labels"].(map[interface{}]interface{})["Time"]).To(BeEquivalentTo("Series"))
+					Expect(resultInfo["labels"].(map[any]any)["Time"]).To(BeEquivalentTo("Series"))
 				}
 				// Test chunk size
 				opt = &redis.TSOptions{ChunkSize: 128}
@@ -254,9 +254,9 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				resultInfo, err = client.TSInfo(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(resultInfo["labels"]).To(BeEquivalentTo([]interface{}{}))
+					Expect(resultInfo["labels"]).To(BeEquivalentTo([]any{}))
 				} else {
-					Expect(resultInfo["labels"]).To(BeEquivalentTo(map[interface{}]interface{}{}))
+					Expect(resultInfo["labels"]).To(BeEquivalentTo(map[any]any{}))
 				}
 
 				opt = &redis.TSAlterOptions{Labels: map[string]string{"Time": "Series"}}
@@ -267,7 +267,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				resultInfo, err = client.TSInfo(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(resultInfo["labels"].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"Time", "Series"}))
+					Expect(resultInfo["labels"].([]any)[0]).To(BeEquivalentTo([]any{"Time", "Series"}))
 					Expect(resultInfo["retentionTime"]).To(BeEquivalentTo(10))
 					if RedisVersion >= 8 {
 						Expect(resultInfo["duplicatePolicy"]).To(BeEquivalentTo("block"))
@@ -276,7 +276,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 						Expect(resultInfo["duplicatePolicy"]).To(BeEquivalentTo(redis.Nil))
 					}
 				} else {
-					Expect(resultInfo["labels"].(map[interface{}]interface{})["Time"]).To(BeEquivalentTo("Series"))
+					Expect(resultInfo["labels"].(map[any]any)["Time"]).To(BeEquivalentTo("Series"))
 					Expect(resultInfo["retentionTime"]).To(BeEquivalentTo(10))
 					if RedisVersion >= 8 {
 						Expect(resultInfo["duplicatePolicy"]).To(BeEquivalentTo("block"))
@@ -355,9 +355,9 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				resultInfo, err := client.TSInfo(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(resultInfo["rules"]).To(BeEquivalentTo([]interface{}{}))
+					Expect(resultInfo["rules"]).To(BeEquivalentTo([]any{}))
 				} else {
-					Expect(resultInfo["rules"]).To(BeEquivalentTo(map[interface{}]interface{}{}))
+					Expect(resultInfo["rules"]).To(BeEquivalentTo(map[any]any{}))
 				}
 			})
 
@@ -527,9 +527,9 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				resultGet, err := client.TSCreate(ctx, "a").Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resultGet).To(BeEquivalentTo("OK"))
-				ktvSlices := make([][]interface{}, 3)
+				ktvSlices := make([][]any, 3)
 				for i := 0; i < 3; i++ {
-					ktvSlices[i] = make([]interface{}, 3)
+					ktvSlices[i] = make([]any, 3)
 					ktvSlices[i][0] = "a"
 					for j := 1; j < 3; j++ {
 						ktvSlices[i][j] = (i + j) * j
@@ -557,19 +557,19 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err := client.TSMGet(ctx, []string{"Test=This"}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1].([]interface{})[1]).To(BeEquivalentTo("15"))
-					Expect(result["b"][1].([]interface{})[1]).To(BeEquivalentTo("25"))
+					Expect(result["a"][1].([]any)[1]).To(BeEquivalentTo("15"))
+					Expect(result["b"][1].([]any)[1]).To(BeEquivalentTo("25"))
 				} else {
-					Expect(result["a"][1].([]interface{})[1]).To(BeEquivalentTo(15))
-					Expect(result["b"][1].([]interface{})[1]).To(BeEquivalentTo(25))
+					Expect(result["a"][1].([]any)[1]).To(BeEquivalentTo(15))
+					Expect(result["b"][1].([]any)[1]).To(BeEquivalentTo(25))
 				}
 				mgetOpt := &redis.TSMGetOptions{WithLabels: true}
 				result, err = client.TSMGetWithArgs(ctx, []string{"Test=This"}, mgetOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["b"][0]).To(ConsistOf([]interface{}{"Test", "This"}, []interface{}{"Taste", "That"}))
+					Expect(result["b"][0]).To(ConsistOf([]any{"Test", "This"}, []any{"Taste", "That"}))
 				} else {
-					Expect(result["b"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"Test": "This", "Taste": "That"}))
+					Expect(result["b"][0]).To(BeEquivalentTo(map[any]any{"Test": "This", "Taste": "That"}))
 				}
 
 				resultCreate, err = client.TSCreate(ctx, "c").Result()
@@ -593,17 +593,17 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMGet(ctx, []string{"is_compaction=true"}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(0), "4"}))
+					Expect(result["d"][1]).To(BeEquivalentTo([]any{int64(0), "4"}))
 				} else {
-					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(0), 4.0}))
+					Expect(result["d"][1]).To(BeEquivalentTo([]any{int64(0), 4.0}))
 				}
 				mgetOpt = &redis.TSMGetOptions{Latest: true}
 				result, err = client.TSMGetWithArgs(ctx, []string{"is_compaction=true"}, mgetOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(10), "8"}))
+					Expect(result["d"][1]).To(BeEquivalentTo([]any{int64(10), "8"}))
 				} else {
-					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(10), 8.0}))
+					Expect(result["d"][1]).To(BeEquivalentTo([]any{int64(10), 8.0}))
 				}
 			})
 
@@ -903,18 +903,18 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
 				if client.Options().Protocol == 2 {
-					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(100))
+					Expect(len(result["a"][1].([]any))).To(BeEquivalentTo(100))
 				} else {
-					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(100))
+					Expect(len(result["a"][2].([]any))).To(BeEquivalentTo(100))
 				}
 				// Test Count
 				mrangeOpt := &redis.TSMRangeOptions{Count: 10}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(10))
+					Expect(len(result["a"][1].([]any))).To(BeEquivalentTo(10))
 				} else {
-					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(10))
+					Expect(len(result["a"][2].([]any))).To(BeEquivalentTo(10))
 				}
 				// Test Aggregation and BucketDuration
 				for i := 0; i < 100; i++ {
@@ -926,34 +926,34 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
 				if client.Options().Protocol == 2 {
-					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(20))
+					Expect(len(result["a"][1].([]any))).To(BeEquivalentTo(20))
 				} else {
-					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(20))
+					Expect(len(result["a"][2].([]any))).To(BeEquivalentTo(20))
 				}
 				// Test WithLabels
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][0]).To(BeEquivalentTo([]interface{}{}))
+					Expect(result["a"][0]).To(BeEquivalentTo([]any{}))
 				} else {
-					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{}))
+					Expect(result["a"][0]).To(BeEquivalentTo(map[any]any{}))
 				}
 				mrangeOpt = &redis.TSMRangeOptions{WithLabels: true}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][0]).To(ConsistOf([]interface{}{[]interface{}{"Test", "This"}, []interface{}{"team", "ny"}}))
+					Expect(result["a"][0]).To(ConsistOf([]any{[]any{"Test", "This"}, []any{"team", "ny"}}))
 				} else {
-					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"Test": "This", "team": "ny"}))
+					Expect(result["a"][0]).To(BeEquivalentTo(map[any]any{"Test": "This", "team": "ny"}))
 				}
 				// Test SelectedLabels
-				mrangeOpt = &redis.TSMRangeOptions{SelectedLabels: []interface{}{"team"}}
+				mrangeOpt = &redis.TSMRangeOptions{SelectedLabels: []any{"team"}}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "ny"}))
-					Expect(result["b"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "sf"}))
+					Expect(result["a"][0].([]any)[0]).To(BeEquivalentTo([]any{"team", "ny"}))
+					Expect(result["b"][0].([]any)[0]).To(BeEquivalentTo([]any{"team", "sf"}))
 				} else {
-					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"team": "ny"}))
-					Expect(result["b"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"team": "sf"}))
+					Expect(result["a"][0]).To(BeEquivalentTo(map[any]any{"team": "ny"}))
+					Expect(result["b"][0]).To(BeEquivalentTo(map[any]any{"team": "sf"}))
 				}
 				// Test FilterBy
 				fts := make([]int, 0)
@@ -964,26 +964,26 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1].([]interface{})).To(BeEquivalentTo([]interface{}{[]interface{}{int64(15), "1"}, []interface{}{int64(16), "2"}}))
+					Expect(result["a"][1].([]any)).To(BeEquivalentTo([]any{[]any{int64(15), "1"}, []any{int64(16), "2"}}))
 				} else {
-					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(15), 1.0}, []interface{}{int64(16), 2.0}}))
+					Expect(result["a"][2]).To(BeEquivalentTo([]any{[]any{int64(15), 1.0}, []any{int64(16), 2.0}}))
 				}
 				// Test GroupBy
 				mrangeOpt = &redis.TSMRangeOptions{GroupByLabel: "Test", Reducer: "sum"}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "2"}, []interface{}{int64(2), "4"}, []interface{}{int64(3), "6"}}))
+					Expect(result["Test=This"][1]).To(BeEquivalentTo([]any{[]any{int64(0), "0"}, []any{int64(1), "2"}, []any{int64(2), "4"}, []any{int64(3), "6"}}))
 				} else {
-					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 0.0}, []interface{}{int64(1), 2.0}, []interface{}{int64(2), 4.0}, []interface{}{int64(3), 6.0}}))
+					Expect(result["Test=This"][3]).To(BeEquivalentTo([]any{[]any{int64(0), 0.0}, []any{int64(1), 2.0}, []any{int64(2), 4.0}, []any{int64(3), 6.0}}))
 				}
 				mrangeOpt = &redis.TSMRangeOptions{GroupByLabel: "Test", Reducer: "max"}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "1"}, []interface{}{int64(2), "2"}, []interface{}{int64(3), "3"}}))
+					Expect(result["Test=This"][1]).To(BeEquivalentTo([]any{[]any{int64(0), "0"}, []any{int64(1), "1"}, []any{int64(2), "2"}, []any{int64(3), "3"}}))
 				} else {
-					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 0.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(3), 3.0}}))
+					Expect(result["Test=This"][3]).To(BeEquivalentTo([]any{[]any{int64(0), 0.0}, []any{int64(1), 1.0}, []any{int64(2), 2.0}, []any{int64(3), 3.0}}))
 				}
 
 				mrangeOpt = &redis.TSMRangeOptions{GroupByLabel: "team", Reducer: "min"}
@@ -991,29 +991,29 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
 				if client.Options().Protocol == 2 {
-					Expect(result["team=ny"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "1"}, []interface{}{int64(2), "2"}, []interface{}{int64(3), "3"}}))
-					Expect(result["team=sf"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "1"}, []interface{}{int64(2), "2"}, []interface{}{int64(3), "3"}}))
+					Expect(result["team=ny"][1]).To(BeEquivalentTo([]any{[]any{int64(0), "0"}, []any{int64(1), "1"}, []any{int64(2), "2"}, []any{int64(3), "3"}}))
+					Expect(result["team=sf"][1]).To(BeEquivalentTo([]any{[]any{int64(0), "0"}, []any{int64(1), "1"}, []any{int64(2), "2"}, []any{int64(3), "3"}}))
 				} else {
-					Expect(result["team=ny"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 0.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(3), 3.0}}))
-					Expect(result["team=sf"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 0.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(3), 3.0}}))
+					Expect(result["team=ny"][3]).To(BeEquivalentTo([]any{[]any{int64(0), 0.0}, []any{int64(1), 1.0}, []any{int64(2), 2.0}, []any{int64(3), 3.0}}))
+					Expect(result["team=sf"][3]).To(BeEquivalentTo([]any{[]any{int64(0), 0.0}, []any{int64(1), 1.0}, []any{int64(2), 2.0}, []any{int64(3), 3.0}}))
 				}
 				// Test Align
 				mrangeOpt = &redis.TSMRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: "-"}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "10"}, []interface{}{int64(10), "1"}}))
+					Expect(result["a"][1]).To(BeEquivalentTo([]any{[]any{int64(0), "10"}, []any{int64(10), "1"}}))
 				} else {
-					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 10.0}, []interface{}{int64(10), 1.0}}))
+					Expect(result["a"][2]).To(BeEquivalentTo([]any{[]any{int64(0), 10.0}, []any{int64(10), 1.0}}))
 				}
 
 				mrangeOpt = &redis.TSMRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: 5}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "5"}, []interface{}{int64(5), "6"}}))
+					Expect(result["a"][1]).To(BeEquivalentTo([]any{[]any{int64(0), "5"}, []any{int64(5), "6"}}))
 				} else {
-					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 5.0}, []interface{}{int64(5), 6.0}}))
+					Expect(result["a"][2]).To(BeEquivalentTo([]any{[]any{int64(0), 5.0}, []any{int64(5), 6.0}}))
 				}
 			})
 
@@ -1062,11 +1062,11 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err := client.TSMRangeWithArgs(ctx, 0, 10, []string{"is_compaction=true"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["b"][1]).To(ConsistOf([]interface{}{int64(0), "4"}, []interface{}{int64(10), "8"}))
-					Expect(result["d"][1]).To(ConsistOf([]interface{}{int64(0), "4"}, []interface{}{int64(10), "8"}))
+					Expect(result["b"][1]).To(ConsistOf([]any{int64(0), "4"}, []any{int64(10), "8"}))
+					Expect(result["d"][1]).To(ConsistOf([]any{int64(0), "4"}, []any{int64(10), "8"}))
 				} else {
-					Expect(result["b"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 4.0}, []interface{}{int64(10), 8.0}}))
-					Expect(result["d"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 4.0}, []interface{}{int64(10), 8.0}}))
+					Expect(result["b"][2]).To(BeEquivalentTo([]any{[]any{int64(0), 4.0}, []any{int64(10), 8.0}}))
+					Expect(result["d"][2]).To(BeEquivalentTo([]any{[]any{int64(0), 4.0}, []any{int64(10), 8.0}}))
 				}
 			})
 			It("should TSMRevRange and TSMRevRangeWithArgs", Label("timeseries", "tsmrevrange", "tsmrevrangeWithArgs"), func() {
@@ -1089,18 +1089,18 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
 				if client.Options().Protocol == 2 {
-					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(100))
+					Expect(len(result["a"][1].([]any))).To(BeEquivalentTo(100))
 				} else {
-					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(100))
+					Expect(len(result["a"][2].([]any))).To(BeEquivalentTo(100))
 				}
 				// Test Count
 				mrangeOpt := &redis.TSMRevRangeOptions{Count: 10}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(10))
+					Expect(len(result["a"][1].([]any))).To(BeEquivalentTo(10))
 				} else {
-					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(10))
+					Expect(len(result["a"][2].([]any))).To(BeEquivalentTo(10))
 				}
 				// Test Aggregation and BucketDuration
 				for i := 0; i < 100; i++ {
@@ -1112,30 +1112,30 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
 				if client.Options().Protocol == 2 {
-					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(20))
-					Expect(result["a"][0]).To(BeEquivalentTo([]interface{}{}))
+					Expect(len(result["a"][1].([]any))).To(BeEquivalentTo(20))
+					Expect(result["a"][0]).To(BeEquivalentTo([]any{}))
 				} else {
-					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(20))
-					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{}))
+					Expect(len(result["a"][2].([]any))).To(BeEquivalentTo(20))
+					Expect(result["a"][0]).To(BeEquivalentTo(map[any]any{}))
 				}
 				mrangeOpt = &redis.TSMRevRangeOptions{WithLabels: true}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][0]).To(ConsistOf([]interface{}{[]interface{}{"Test", "This"}, []interface{}{"team", "ny"}}))
+					Expect(result["a"][0]).To(ConsistOf([]any{[]any{"Test", "This"}, []any{"team", "ny"}}))
 				} else {
-					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"Test": "This", "team": "ny"}))
+					Expect(result["a"][0]).To(BeEquivalentTo(map[any]any{"Test": "This", "team": "ny"}))
 				}
 				// Test SelectedLabels
-				mrangeOpt = &redis.TSMRevRangeOptions{SelectedLabels: []interface{}{"team"}}
+				mrangeOpt = &redis.TSMRevRangeOptions{SelectedLabels: []any{"team"}}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "ny"}))
-					Expect(result["b"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "sf"}))
+					Expect(result["a"][0].([]any)[0]).To(BeEquivalentTo([]any{"team", "ny"}))
+					Expect(result["b"][0].([]any)[0]).To(BeEquivalentTo([]any{"team", "sf"}))
 				} else {
-					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"team": "ny"}))
-					Expect(result["b"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"team": "sf"}))
+					Expect(result["a"][0]).To(BeEquivalentTo(map[any]any{"team": "ny"}))
+					Expect(result["b"][0]).To(BeEquivalentTo(map[any]any{"team": "sf"}))
 				}
 				// Test FilterBy
 				fts := make([]int, 0)
@@ -1146,54 +1146,54 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1].([]interface{})).To(ConsistOf([]interface{}{int64(16), "2"}, []interface{}{int64(15), "1"}))
+					Expect(result["a"][1].([]any)).To(ConsistOf([]any{int64(16), "2"}, []any{int64(15), "1"}))
 				} else {
-					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(16), 2.0}, []interface{}{int64(15), 1.0}}))
+					Expect(result["a"][2]).To(BeEquivalentTo([]any{[]any{int64(16), 2.0}, []any{int64(15), 1.0}}))
 				}
 				// Test GroupBy
 				mrangeOpt = &redis.TSMRevRangeOptions{GroupByLabel: "Test", Reducer: "sum"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "6"}, []interface{}{int64(2), "4"}, []interface{}{int64(1), "2"}, []interface{}{int64(0), "0"}}))
+					Expect(result["Test=This"][1]).To(BeEquivalentTo([]any{[]any{int64(3), "6"}, []any{int64(2), "4"}, []any{int64(1), "2"}, []any{int64(0), "0"}}))
 				} else {
-					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), 6.0}, []interface{}{int64(2), 4.0}, []interface{}{int64(1), 2.0}, []interface{}{int64(0), 0.0}}))
+					Expect(result["Test=This"][3]).To(BeEquivalentTo([]any{[]any{int64(3), 6.0}, []any{int64(2), 4.0}, []any{int64(1), 2.0}, []any{int64(0), 0.0}}))
 				}
 				mrangeOpt = &redis.TSMRevRangeOptions{GroupByLabel: "Test", Reducer: "max"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "3"}, []interface{}{int64(2), "2"}, []interface{}{int64(1), "1"}, []interface{}{int64(0), "0"}}))
+					Expect(result["Test=This"][1]).To(BeEquivalentTo([]any{[]any{int64(3), "3"}, []any{int64(2), "2"}, []any{int64(1), "1"}, []any{int64(0), "0"}}))
 				} else {
-					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), 3.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(0), 0.0}}))
+					Expect(result["Test=This"][3]).To(BeEquivalentTo([]any{[]any{int64(3), 3.0}, []any{int64(2), 2.0}, []any{int64(1), 1.0}, []any{int64(0), 0.0}}))
 				}
 				mrangeOpt = &redis.TSMRevRangeOptions{GroupByLabel: "team", Reducer: "min"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
 				if client.Options().Protocol == 2 {
-					Expect(result["team=ny"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "3"}, []interface{}{int64(2), "2"}, []interface{}{int64(1), "1"}, []interface{}{int64(0), "0"}}))
-					Expect(result["team=sf"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "3"}, []interface{}{int64(2), "2"}, []interface{}{int64(1), "1"}, []interface{}{int64(0), "0"}}))
+					Expect(result["team=ny"][1]).To(BeEquivalentTo([]any{[]any{int64(3), "3"}, []any{int64(2), "2"}, []any{int64(1), "1"}, []any{int64(0), "0"}}))
+					Expect(result["team=sf"][1]).To(BeEquivalentTo([]any{[]any{int64(3), "3"}, []any{int64(2), "2"}, []any{int64(1), "1"}, []any{int64(0), "0"}}))
 				} else {
-					Expect(result["team=ny"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), 3.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(0), 0.0}}))
-					Expect(result["team=sf"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), 3.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(0), 0.0}}))
+					Expect(result["team=ny"][3]).To(BeEquivalentTo([]any{[]any{int64(3), 3.0}, []any{int64(2), 2.0}, []any{int64(1), 1.0}, []any{int64(0), 0.0}}))
+					Expect(result["team=sf"][3]).To(BeEquivalentTo([]any{[]any{int64(3), 3.0}, []any{int64(2), 2.0}, []any{int64(1), 1.0}, []any{int64(0), 0.0}}))
 				}
 				// Test Align
 				mrangeOpt = &redis.TSMRevRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: "-"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), "1"}, []interface{}{int64(0), "10"}}))
+					Expect(result["a"][1]).To(BeEquivalentTo([]any{[]any{int64(10), "1"}, []any{int64(0), "10"}}))
 				} else {
-					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), 1.0}, []interface{}{int64(0), 10.0}}))
+					Expect(result["a"][2]).To(BeEquivalentTo([]any{[]any{int64(10), 1.0}, []any{int64(0), 10.0}}))
 				}
 				mrangeOpt = &redis.TSMRevRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: 1}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(1), "10"}, []interface{}{int64(0), "1"}}))
+					Expect(result["a"][1]).To(BeEquivalentTo([]any{[]any{int64(1), "10"}, []any{int64(0), "1"}}))
 				} else {
-					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(1), 10.0}, []interface{}{int64(0), 1.0}}))
+					Expect(result["a"][2]).To(BeEquivalentTo([]any{[]any{int64(1), 10.0}, []any{int64(0), 1.0}}))
 				}
 			})
 
@@ -1242,11 +1242,11 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err := client.TSMRevRangeWithArgs(ctx, 0, 10, []string{"is_compaction=true"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["b"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), "8"}, []interface{}{int64(0), "4"}}))
-					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), "8"}, []interface{}{int64(0), "4"}}))
+					Expect(result["b"][1]).To(BeEquivalentTo([]any{[]any{int64(10), "8"}, []any{int64(0), "4"}}))
+					Expect(result["d"][1]).To(BeEquivalentTo([]any{[]any{int64(10), "8"}, []any{int64(0), "4"}}))
 				} else {
-					Expect(result["b"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), 8.0}, []interface{}{int64(0), 4.0}}))
-					Expect(result["d"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), 8.0}, []interface{}{int64(0), 4.0}}))
+					Expect(result["b"][2]).To(BeEquivalentTo([]any{[]any{int64(10), 8.0}, []any{int64(0), 4.0}}))
+					Expect(result["d"][2]).To(BeEquivalentTo([]any{[]any{int64(10), 8.0}, []any{int64(0), 4.0}}))
 				}
 			})
 		})

--- a/tx.go
+++ b/tx.go
@@ -75,7 +75,7 @@ func (c *Tx) Close(ctx context.Context) error {
 // Watch marks the keys to be watched for conditional execution
 // of a transaction.
 func (c *Tx) Watch(ctx context.Context, keys ...string) *StatusCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "watch"
 	for i, key := range keys {
 		args[1+i] = key
@@ -87,7 +87,7 @@ func (c *Tx) Watch(ctx context.Context, keys ...string) *StatusCmd {
 
 // Unwatch flushes all the previously watched keys for a transaction.
 func (c *Tx) Unwatch(ctx context.Context, keys ...string) *StatusCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "unwatch"
 	for i, key := range keys {
 		args[1+i] = key

--- a/universal.go
+++ b/universal.go
@@ -241,7 +241,7 @@ type UniversalClient interface {
 	Cmdable
 	AddHook(Hook)
 	Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error
-	Do(ctx context.Context, args ...interface{}) *Cmd
+	Do(ctx context.Context, args ...any) *Cmd
 	Process(ctx context.Context, cmd Cmder) error
 	Subscribe(ctx context.Context, channels ...string) *PubSub
 	PSubscribe(ctx context.Context, channels ...string) *PubSub

--- a/universal_test.go
+++ b/universal_test.go
@@ -82,7 +82,7 @@ var _ = Describe("UniversalClient", func() {
 		role, err := roleCmd.Result()
 		Expect(err).NotTo(HaveOccurred())
 
-		roleSlice, ok := role.([]interface{})
+		roleSlice, ok := role.([]any)
 		Expect(ok).To(BeTrue())
 		Expect(roleSlice[0]).To(Equal("slave"))
 


### PR DESCRIPTION
Hello @ndyakov , Do you agree with replacing `interface{}` with `any` in non-constraint scenarios? If approved, we can migrate all `interface{}` occurrences.
(similar to the commit: https://github.com/golang/go/commit/2580d0e08d5e9f979b943758d3c49877fb2324cb#diff-eca48ce939b837cddc0194885eff25247d2ef2c481b63a667ee14fafcc0f7c7c).