### PR TITLE
feat(ring): add GetShardClients and GetShardClientForKey methods to Ring for shard access

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -848,7 +848,9 @@ func (c *Ring) Close() error {
 	return c.sharding.Close()
 }
 
-func (c *Ring) GetShards() []*Client {
+// GetShardClients returns a list of all shard clients in the ring.
+// This can be used to create dedicated connections (e.g., PubSub) for each shard.
+func (c *Ring) GetShardClients() []*Client {
 	shards := c.sharding.List()
 	clients := make([]*Client, 0, len(shards))
 	for _, shard := range shards {
@@ -859,7 +861,9 @@ func (c *Ring) GetShards() []*Client {
 	return clients
 }
 
-func (c *Ring) GetShardByKey(key string) (*Client, error) {
+// GetShardClientForKey returns the shard client that would handle the given key.
+// This can be used to determine which shard a particular key/channel would be routed to.
+func (c *Ring) GetShardClientForKey(key string) (*Client, error) {
 	shard, err := c.sharding.GetByKey(key)
 	if err != nil {
 		return nil, err

--- a/ring.go
+++ b/ring.go
@@ -847,3 +847,22 @@ func (c *Ring) Close() error {
 
 	return c.sharding.Close()
 }
+
+func (c *Ring) GetShards() []*Client {
+	shards := c.sharding.List()
+	clients := make([]*Client, 0, len(shards))
+	for _, shard := range shards {
+		if shard.IsUp() {
+			clients = append(clients, shard.Client)
+		}
+	}
+	return clients
+}
+
+func (c *Ring) GetShardByKey(key string) (*Client, error) {
+	shard, err := c.sharding.GetByKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return shard.Client, nil
+}


### PR DESCRIPTION
This PR adds two new methods to the `Ring` client that provide access to individual shard clients, addressing the need to create dedicated connections (e.g., PubSub) for each shard.

When using Redis Ring with PubSub connections, users need to create separate PubSub connections for each shard because PubSub connections enter a special mode and cannot be used for other Redis operations. Currently, there's no way to access the underlying shard clients directly, making it impossible to pre-create and reuse PubSub connections [related issue](https://github.com/redis/go-redis/issues/3341)

This PR introduces two new public methods to the `Ring` struct, users can pre-create and reuse PubSub connections per shard

1. `GetShards() []*Client`
- Returns a list of all currently active shard clients
- Only includes shards that are marked as "up" 
- Allows users to iterate over all available shards

2. `GetShardByKey(key string) (*Client, error)`
- Returns the shard client that would handle a specific key/channel
- Uses the same consistent hashing logic as the Ring's internal routing
- Enables users to determine which shard a particular key would be routed to

Checklist:
- [x] Code follows project style guidelines
- [x] Tests pass 
- [x] New functionality is documented  
- [x] Backward compatibility maintained
- [x] Uses existing patterns and conventions
- [x] Test coverage includes edge cases
- [x] No security vulnerabilities introduced


closes #3341
