### PR TITLE
Add the missing NewFloatSliceResult for testing

### DIFF
--- a/result.go
+++ b/result.go
@@ -82,6 +82,14 @@ func NewBoolSliceResult(val []bool, err error) *BoolSliceCmd {
 	return &cmd
 }
 
+// NewFloatSliceResult returns a FloatSliceCmd initialised with val and err for testing.
+func NewFloatSliceResult(val []float64, err error) *FloatSliceCmd {
+	var cmd FloatSliceCmd
+	cmd.val = val
+	cmd.SetErr(err)
+	return &cmd
+}
+
 // NewMapStringStringResult returns a MapStringStringCmd initialised with val and err for testing.
 func NewMapStringStringResult(val map[string]string, err error) *MapStringStringCmd {
 	var cmd MapStringStringCmd


### PR DESCRIPTION
When I was developing for another project, I ran into a situation in which I needed to test `ZMScore` in my unit tests.

However, I found out that there existed no helper method that returned a mocked `FloatSliceCmd` with a populated result.

After digging into the code, it looked to me like there existed `NewStringSliceResult`, `NewBoolSliceResult`,  but no `NewFloatSliceResult` method.

This PR simply adds that method so that it can be used for testing in other projects.