### PR TITLE
test: refactor TestBasicCredentials using table-driven tests

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -179,36 +179,50 @@ func TestStreamingCredentialsProvider(t *testing.T) {
 }
 
 func TestBasicCredentials(t *testing.T) {
-	t.Run("basic auth", func(t *testing.T) {
-		creds := NewBasicCredentials("user1", "pass1")
-		username, password := creds.BasicAuth()
-		if username != "user1" {
-			t.Fatalf("expected username 'user1', got '%s'", username)
-		}
-		if password != "pass1" {
-			t.Fatalf("expected password 'pass1', got '%s'", password)
-		}
-	})
+	tests := []struct {
+		name         string
+		username     string
+		password     string
+		expectedUser string
+		expectedPass string
+		expectedRaw  string
+	}{
+		{
+			name:         "basic auth",
+			username:     "user1",
+			password:     "pass1",
+			expectedUser: "user1",
+			expectedPass: "pass1",
+			expectedRaw:  "user1:pass1",
+		},
+		{
+			name:         "empty username",
+			username:     "",
+			password:     "pass1",
+			expectedUser: "",
+			expectedPass: "pass1",
+			expectedRaw:  ":pass1",
+		},
+	}
 
-	t.Run("raw credentials", func(t *testing.T) {
-		creds := NewBasicCredentials("user1", "pass1")
-		raw := creds.RawCredentials()
-		expected := "user1:pass1"
-		if raw != expected {
-			t.Fatalf("expected raw credentials '%s', got '%s'", expected, raw)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creds := NewBasicCredentials(tt.username, tt.password)
 
-	t.Run("empty username", func(t *testing.T) {
-		creds := NewBasicCredentials("", "pass1")
-		username, password := creds.BasicAuth()
-		if username != "" {
-			t.Fatalf("expected empty username, got '%s'", username)
-		}
-		if password != "pass1" {
-			t.Fatalf("expected password 'pass1', got '%s'", password)
-		}
-	})
+			user, pass := creds.BasicAuth()
+			if user != tt.expectedUser {
+				t.Errorf("BasicAuth() username = %q; want %q", user, tt.expectedUser)
+			}
+			if pass != tt.expectedPass {
+				t.Errorf("BasicAuth() password = %q; want %q", pass, tt.expectedPass)
+			}
+
+			raw := creds.RawCredentials()
+			if raw != tt.expectedRaw {
+				t.Errorf("RawCredentials() = %q; want %q", raw, tt.expectedRaw)
+			}
+		})
+	}
 }
 
 func TestReAuthCredentialsListener(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR refactors the `TestBasicCredentials` function to use a table-driven testing approach. The goal is to improve test clarity, reduce duplication, and make it easier to extend with new cases in the future.

---

## Changes

* ✅ Refactored `TestBasicCredentials` to table-driven format
* ✅ Combined basic auth and raw credentials checks under unified inputs
* ✅ Preserved all existing logic including the empty username case
* ✅ Replaced `t.Fatalf` with `t.Errorf` to allow multiple assertion failures per test run

---

## Motivation

Table-driven tests are idiomatic in Go and make it easier to:

* Maintain and scale tests
* Add edge cases (e.g., empty password, special characters)
* Keep tests concise and DRY

---

## Notes

If desired, I'm happy to extend this further to include additional edge cases such as:

* Empty passwords
* Special characters
* Long strings
* Unicode characters
