### PR TITLE
feat(redisotel): add WithCallerEnabled option

### DIFF
--- a/extra/redisotel/config.go
+++ b/extra/redisotel/config.go
@@ -115,8 +115,8 @@ func WithDBStatement(on bool) TracingOption {
 	})
 }
 
-// WithCaller tells the tracing hook to log the calling function, file and line.
-func WithCaller(on bool) TracingOption {
+// WithCallerEnabled tells the tracing hook to log the calling function, file and line.
+func WithCallerEnabled(on bool) TracingOption {
 	return tracingOption(func(conf *config) {
 		conf.callerEnabled = on
 	})

--- a/extra/redisotel/config.go
+++ b/extra/redisotel/config.go
@@ -20,6 +20,7 @@ type config struct {
 	tracer trace.Tracer
 
 	dbStmtEnabled bool
+	callerEnabled bool
 
 	// Metrics options.
 
@@ -57,6 +58,7 @@ func newConfig(opts ...baseOption) *config {
 		tp:            otel.GetTracerProvider(),
 		mp:            otel.GetMeterProvider(),
 		dbStmtEnabled: true,
+		callerEnabled: true,
 	}
 
 	for _, opt := range opts {
@@ -110,6 +112,13 @@ func WithTracerProvider(provider trace.TracerProvider) TracingOption {
 func WithDBStatement(on bool) TracingOption {
 	return tracingOption(func(conf *config) {
 		conf.dbStmtEnabled = on
+	})
+}
+
+// WithCaller tells the tracing hook log the calling function, file and line.
+func WithCaller(on bool) TracingOption {
+	return tracingOption(func(conf *config) {
+		conf.callerEnabled = on
 	})
 }
 

--- a/extra/redisotel/config.go
+++ b/extra/redisotel/config.go
@@ -108,14 +108,14 @@ func WithTracerProvider(provider trace.TracerProvider) TracingOption {
 	})
 }
 
-// WithDBStatement tells the tracing hook not to log raw redis commands.
+// WithDBStatement tells the tracing hook to log raw redis commands.
 func WithDBStatement(on bool) TracingOption {
 	return tracingOption(func(conf *config) {
 		conf.dbStmtEnabled = on
 	})
 }
 
-// WithCaller tells the tracing hook log the calling function, file and line.
+// WithCaller tells the tracing hook to log the calling function, file and line.
 func WithCaller(on bool) TracingOption {
 	return tracingOption(func(conf *config) {
 		conf.callerEnabled = on

--- a/extra/redisotel/tracing.go
+++ b/extra/redisotel/tracing.go
@@ -101,14 +101,16 @@ func (th *tracingHook) DialHook(hook redis.DialHook) redis.DialHook {
 
 func (th *tracingHook) ProcessHook(hook redis.ProcessHook) redis.ProcessHook {
 	return func(ctx context.Context, cmd redis.Cmder) error {
-		fn, file, line := funcFileLine("github.com/redis/go-redis")
 
 		attrs := make([]attribute.KeyValue, 0, 8)
-		attrs = append(attrs,
-			semconv.CodeFunction(fn),
-			semconv.CodeFilepath(file),
-			semconv.CodeLineNumber(line),
-		)
+		if th.conf.callerEnabled {
+			fn, file, line := funcFileLine("github.com/redis/go-redis")
+			attrs = append(attrs,
+				semconv.CodeFunction(fn),
+				semconv.CodeFilepath(file),
+				semconv.CodeLineNumber(line),
+			)
+		}
 
 		if th.conf.dbStmtEnabled {
 			cmdString := rediscmd.CmdString(cmd)
@@ -133,15 +135,19 @@ func (th *tracingHook) ProcessPipelineHook(
 	hook redis.ProcessPipelineHook,
 ) redis.ProcessPipelineHook {
 	return func(ctx context.Context, cmds []redis.Cmder) error {
-		fn, file, line := funcFileLine("github.com/redis/go-redis")
-
 		attrs := make([]attribute.KeyValue, 0, 8)
 		attrs = append(attrs,
-			semconv.CodeFunction(fn),
-			semconv.CodeFilepath(file),
-			semconv.CodeLineNumber(line),
 			attribute.Int("db.redis.num_cmd", len(cmds)),
 		)
+
+		if th.conf.callerEnabled {
+			fn, file, line := funcFileLine("github.com/redis/go-redis")
+			attrs = append(attrs,
+				semconv.CodeFunction(fn),
+				semconv.CodeFilepath(file),
+				semconv.CodeLineNumber(line),
+			)
+		}
 
 		summary, cmdsString := rediscmd.CmdsString(cmds)
 		if th.conf.dbStmtEnabled {

--- a/extra/redisotel/tracing_test.go
+++ b/extra/redisotel/tracing_test.go
@@ -71,7 +71,7 @@ func TestWithoutCaller(t *testing.T) {
 	hook := newTracingHook(
 		"",
 		WithTracerProvider(provider),
-		WithCaller(false),
+		WithCallerEnabled(false),
 	)
 	ctx, span := provider.Tracer("redis-test").Start(context.TODO(), "redis-test")
 	cmd := redis.NewCmd(ctx, "ping")

--- a/extra/redisotel/tracing_test.go
+++ b/extra/redisotel/tracing_test.go
@@ -66,6 +66,35 @@ func TestWithDBStatement(t *testing.T) {
 	}
 }
 
+func TestWithoutCaller(t *testing.T) {
+	provider := sdktrace.NewTracerProvider()
+	hook := newTracingHook(
+		"",
+		WithTracerProvider(provider),
+		WithCaller(false),
+	)
+	ctx, span := provider.Tracer("redis-test").Start(context.TODO(), "redis-test")
+	cmd := redis.NewCmd(ctx, "ping")
+	defer span.End()
+
+	processHook := hook.ProcessHook(func(ctx context.Context, cmd redis.Cmder) error {
+		attrs := trace.SpanFromContext(ctx).(sdktrace.ReadOnlySpan).Attributes()
+		for _, attr := range attrs {
+			switch attr.Key {
+			case semconv.CodeFunctionKey,
+				semconv.CodeFilepathKey,
+				semconv.CodeLineNumberKey:
+				t.Fatalf("Attribute with %s statement should not exist", attr.Key)
+			}
+		}
+		return nil
+	})
+	err := processHook(ctx, cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestTracingHook_DialHook(t *testing.T) {
 	imsb := tracetest.NewInMemoryExporter()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(imsb))


### PR DESCRIPTION
Good day,

While profiling our application we noticed that more time then we expected was spend in `funcFileLine` called as part of the redisotel tracing. In our scenario we don't actually need the `code.function`, `code.filepath` and `code.lineno`  attributes for which `funcFileLine` is called, so I created this PR. 

This PR introduces a new option for redisotel tracing called `WithCallerEnabled` using it allows one to disable the collection of the `code.function`, `code.filepath` and `code.lineno` tracing attributes. When setting `WithCallerEnabled(false)` overall performance is increased as the "expensive" `runtime.Callers` and `runtime.(*Frames).Next` calls are no longer needed.

Thank you for reviewing this PR and please let me know what you think!
Have a great day!

![image](https://github.com/user-attachments/assets/cd8436c4-8d24-493c-b037-9dd220b255ff)