### PR TITLE
fix(ring): Pipelined returns error when shard is down

### DIFF
--- a/ring_test.go
+++ b/ring_test.go
@@ -867,3 +867,20 @@ var _ = Describe("Ring GetShardClients and GetShardClientForKey", func() {
 		Expect(len(shardMap)).To(BeNumerically("<=", 2)) // At most 2 shards (our setup)
 	})
 })
+
+var _ = Describe("unreachable ring shard", func() {
+	It("pipeline returns dial error", func() {
+		ring := redis.NewRing(&redis.RingOptions{
+			Addrs:              map[string]string{"shard1": "10.255.255.1:6379"},
+			DialTimeout:        100 * time.Millisecond,
+			HeartbeatFrequency: time.Hour,
+		})
+		defer ring.Close()
+
+		_, err := ring.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+			pipe.Ping(ctx)
+			return nil
+		})
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Closes
#3402

### Problem
When a shard in a Ringis unreachable due to a network issue or a low DialTimeout、
•.'Ring.Pipelined () would not return an error. Instead, it failed silently, giving the false impression that the pipelined commands were successfully executed. This behavior was inconsistent with 'Client.Pipelined () and could lead to undetected data loss.

### Solution
This change modifies the `generalProcessPipeline` function to correctly handle and propagate errors.
- It now captures the first error that occurs when attempting to get a shard client or execute the pipeline on a shard.
- A `sync.Mutex` is used to ensure thread-safe error reporting| from the concurrent shard operations.
- The captured error is returned to the caller of Pipelined () , ensuring that failures are no longer silent.
A new test case has also been added to verify that Pipelined () 、returns a `dial` error when a shard is unreachable, preventing future regressions.