### PR TITLE
feat(proto): support scanning uuid.UUID in Scan()

### DIFF
--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"reflect"
 	"time"
-
+	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9/internal/util"
 )
 
@@ -22,6 +22,14 @@ func Scan(b []byte, v interface{}) error {
 		return nil
 	case *[]byte:
 		*v = b
+		return nil
+	case *uuid.UUID:
+		str := util.BytesToString(b)
+		u, err := uuid.Parse(str)
+		if err != nil {
+			return fmt.Errorf("redis: failed to parse uuid: %w", err)
+		}
+		*v = u
 		return nil
 	case *int:
 		var err error
@@ -120,6 +128,7 @@ func Scan(b []byte, v interface{}) error {
 	case *net.IP:
 		*v = b
 		return nil
+
 	default:
 		return fmt.Errorf(
 			"redis: can't unmarshal %T (consider implementing BinaryUnmarshaler)", v)

--- a/internal/proto/test_scanuuid.go
+++ b/internal/proto/test_scanuuid.go
@@ -1,0 +1,20 @@
+package proto
+
+import (
+	"github.com/google/uuid"
+	"testing"
+)
+
+func TestScanUUID(t *testing.T) {
+	u1 := uuid.New()
+	var u2 uuid.UUID
+
+	err := Scan([]byte(u1.String()), &u2)
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+
+	if u1 != u2 {
+		t.Errorf("UUID mismatch, got %v, want %v", u2, u1)
+	}
+}


### PR DESCRIPTION
### What this PR does

Adds support for scanning Redis string/bytes values into `uuid.UUID` via the `proto.Scan()` function.

### Why

Currently, scanning into `*uuid.UUID` fails even if the Redis string is a valid UUID. This PR enhances `proto.Scan()` to handle `*uuid.UUID` by parsing string/[]byte via `uuid.Parse`.

### How

- Extended the type switch in `proto.Scan` to detect `*uuid.UUID`
- Uses `util.BytesToString` to convert input to string
- Uses `uuid.Parse` to validate and assign
- Added unit test: `TestScanUUIDFromRedis`

### Related Issue

Fixes #3139 (or your own issue link)
