### PR TITLE
Add tracing hooks for existing connections

### DIFF
--- a/extra/redisotel/tracing.go
+++ b/extra/redisotel/tracing.go
@@ -42,6 +42,7 @@ func InstrumentTracing(ctx context.Context, rdb redis.UniversalClient, opts ...T
 			opts = addServerAttributes(opts, opt.Addr)
 			connString := formatDBConnString(opt.Network, opt.Addr)
 			rdb.AddHook(newTracingHook(connString, opts...))
+			return nil
 		})
 		return nil
 	case *redis.Ring:
@@ -57,6 +58,7 @@ func InstrumentTracing(ctx context.Context, rdb redis.UniversalClient, opts ...T
 			opts = addServerAttributes(opts, opt.Addr)
 			connString := formatDBConnString(opt.Network, opt.Addr)
 			rdb.AddHook(newTracingHook(connString, opts...))
+			return nil
 		})
 		return nil
 	default:


### PR DESCRIPTION
Previously the redis/go-redis library would call newTracingHook with no connString as default tracing, but that was recently removed in 9.8.0 which has caused our clients to lose oteltracing if connections are created before tracing can be instrumented.