### PR TITLE
Add tracing hooks for existing connections

### DIFF
--- a/extra/redisotel/tracing.go
+++ b/extra/redisotel/tracing.go
@@ -21,7 +21,7 @@ const (
 	instrumName = "github.com/redis/go-redis/extra/redisotel"
 )
 
-func InstrumentTracing(rdb redis.UniversalClient, opts ...TracingOption) error {
+func InstrumentTracing(ctx context.Context, rdb redis.UniversalClient, opts ...TracingOption) error {
 	switch rdb := rdb.(type) {
 	case *redis.Client:
 		opt := rdb.Options()
@@ -36,6 +36,14 @@ func InstrumentTracing(rdb redis.UniversalClient, opts ...TracingOption) error {
 			connString := formatDBConnString(opt.Network, opt.Addr)
 			rdb.AddHook(newTracingHook(connString, opts...))
 		})
+
+		rdb.ForEachShard(ctx, func(ctx context.Context, rdb *redis.Client) error {
+			opt := rdb.Options()
+			opts = addServerAttributes(opts, opt.Addr)
+			connString := formatDBConnString(opt.Network, opt.Addr)
+			rdb.AddHook(newTracingHook(connString, opts...))
+			return nil
+		})
 		return nil
 	case *redis.Ring:
 		rdb.OnNewNode(func(rdb *redis.Client) {
@@ -43,6 +51,14 @@ func InstrumentTracing(rdb redis.UniversalClient, opts ...TracingOption) error {
 			opts = addServerAttributes(opts, opt.Addr)
 			connString := formatDBConnString(opt.Network, opt.Addr)
 			rdb.AddHook(newTracingHook(connString, opts...))
+		})
+
+		rdb.ForEachShard(ctx, func(ctx context.Context, rdb *redis.Client) error {
+			opt := rdb.Options()
+			opts = addServerAttributes(opts, opt.Addr)
+			connString := formatDBConnString(opt.Network, opt.Addr)
+			rdb.AddHook(newTracingHook(connString, opts...))
+			return nil
 		})
 		return nil
 	default:


### PR DESCRIPTION
Previously `InstruementTracing` would call `newTracingHook` with no connString as a default tracing hook, but that was recently removed in v9.8.0 which has caused our clients to lose tracing if connections are created before tracing can be instrumented. In https://github.com/redis/go-redis/pull/3433, I've reverted the change to remove the default tracing hook, but a potential solution would be to use `ForEachShard` to create tracing hooks for any existing connections. This is a breaking change since it requires context, open to feedback if this PR should be moved forward instead of the revert.