### PR TITLE
Revert "fix(redisotel): fix the situation of reporting spans multiple times (#3168)"

### DIFF
--- a/extra/redisotel/tracing.go
+++ b/extra/redisotel/tracing.go
@@ -30,6 +30,8 @@ func InstrumentTracing(rdb redis.UniversalClient, opts ...TracingOption) error {
 		rdb.AddHook(newTracingHook(connString, opts...))
 		return nil
 	case *redis.ClusterClient:
+		rdb.AddHook(newTracingHook("", opts...))
+
 		rdb.OnNewNode(func(rdb *redis.Client) {
 			opt := rdb.Options()
 			opts = addServerAttributes(opts, opt.Addr)
@@ -38,6 +40,8 @@ func InstrumentTracing(rdb redis.UniversalClient, opts ...TracingOption) error {
 		})
 		return nil
 	case *redis.Ring:
+		rdb.AddHook(newTracingHook("", opts...))
+
 		rdb.OnNewNode(func(rdb *redis.Client) {
 			opt := rdb.Options()
 			opts = addServerAttributes(opts, opt.Addr)


### PR DESCRIPTION
This reverts commit 5314a571322c58b0b8218c1c418fdb7ad3f19c9e ([PR](https://github.com/redis/go-redis/pull/3168)) which removed the default tracing hook. We've observed that since v9.8.0 our clients no longer emit traces, I believe this is due to a race condition between nodes getting created and instrumenting tracing. Before v9.8.0 there would always be a default tracing hook, and in the latest version there would only be tracing hooks for new nodes which means any existing nodes would not have tracing.

I've proposed another change that adds tracing hooks for existing nodes, https://github.com/redis/go-redis/pull/3432. That requires a breaking change to include context in the params, so I think the revert would make sense in the short term.

cc @ndyakov and @flc1125 since you all were involved in the PR I'm proposing we revert.