### PR TITLE
fix: Prioritize TextMarshaler for argument serialization (#3139)

### DIFF
--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -185,6 +185,8 @@ func (w *Writer) WriteArg(v interface{}) error {
 			return w.int(0)
 		}
 		return w.int(v.Nanoseconds())
+	case net.IP:
+		return w.bytes(v)
 	case encoding.TextMarshaler:
 		b, err := v.MarshalText()
 		if err != nil {
@@ -197,8 +199,6 @@ func (w *Writer) WriteArg(v interface{}) error {
 			return err
 		}
 		return w.bytes(b)
-	case net.IP:
-		return w.bytes(v)
 	default:
 		return fmt.Errorf(
 			"redis: can't marshal %T (implement encoding.BinaryMarshaler)", v)

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -185,6 +185,12 @@ func (w *Writer) WriteArg(v interface{}) error {
 			return w.int(0)
 		}
 		return w.int(v.Nanoseconds())
+	case encoding.TextMarshaler:
+		b, err := v.MarshalText()
+		if err != nil {
+			return err
+		}
+		return w.bytes(b)
 	case encoding.BinaryMarshaler:
 		b, err := v.MarshalBinary()
 		if err != nil {


### PR DESCRIPTION
Fixes: #3139 
* Ensures types implementing both TextMarshaler and BinaryMarshaler are marshaled as text.
* Also required reordering net.IP case to prevent string conversion due to added case.