### PR TITLE
improve code readability

### DIFF
--- a/osscluster.go
+++ b/osscluster.go
@@ -342,8 +342,7 @@ type clusterNode struct {
 	failing    uint32 // atomic
 	loaded     uint32 // atomic
 
-	// last time the latency measurement was performed for the node, stored in nanoseconds
-	// from epoch
+	// last time the latency measurement was performed for the node, stored in nanoseconds from epoch
 	lastLatencyMeasurement int64 // atomic
 }
 
@@ -480,13 +479,12 @@ type clusterNodes struct {
 	closed      bool
 	onNewNode   []func(rdb *Client)
 
-	_generation uint32 // atomic
+	generation uint32 // atomic
 }
 
 func newClusterNodes(opt *ClusterOptions) *clusterNodes {
 	return &clusterNodes{
-		opt: opt,
-
+		opt:   opt,
 		addrs: opt.Addrs,
 		nodes: make(map[string]*clusterNode),
 	}
@@ -546,12 +544,11 @@ func (c *clusterNodes) Addrs() ([]string, error) {
 }
 
 func (c *clusterNodes) NextGeneration() uint32 {
-	return atomic.AddUint32(&c._generation, 1)
+	return atomic.AddUint32(&c.generation, 1)
 }
 
 // GC removes unused nodes.
 func (c *clusterNodes) GC(generation uint32) {
-	//nolint:prealloc
 	var collected []*clusterNode
 
 	c.mu.Lock()
@@ -604,23 +601,20 @@ func (c *clusterNodes) GetOrCreate(addr string) (*clusterNode, error) {
 		fn(node.Client)
 	}
 
-	c.addrs = appendIfNotExists(c.addrs, addr)
+	c.addrs = appendIfNotExist(c.addrs, addr)
 	c.nodes[addr] = node
 
 	return node, nil
 }
 
 func (c *clusterNodes) get(addr string) (*clusterNode, error) {
-	var node *clusterNode
-	var err error
 	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if c.closed {
-		err = pool.ErrClosed
-	} else {
-		node = c.nodes[addr]
+		return nil, pool.ErrClosed
 	}
-	c.mu.RUnlock()
-	return node, err
+	return c.nodes[addr], nil
 }
 
 func (c *clusterNodes) All() ([]*clusterNode, error) {
@@ -651,8 +645,9 @@ func (c *clusterNodes) Random() (*clusterNode, error) {
 //------------------------------------------------------------------------------
 
 type clusterSlot struct {
-	start, end int
-	nodes      []*clusterNode
+	start int
+	end   int
+	nodes []*clusterNode
 }
 
 type clusterSlotSlice []*clusterSlot
@@ -712,9 +707,9 @@ func newClusterState(
 			nodes = append(nodes, node)
 
 			if i == 0 {
-				c.Masters = appendUniqueNode(c.Masters, node)
+				c.Masters = appendIfNotExist(c.Masters, node)
 			} else {
-				c.Slaves = appendUniqueNode(c.Slaves, node)
+				c.Slaves = appendIfNotExist(c.Slaves, node)
 			}
 		}
 
@@ -1273,7 +1268,7 @@ func (c *ClusterClient) loadState(ctx context.Context) (*clusterState, error) {
 			continue
 		}
 
-		return newClusterState(c.nodes, slots, node.Client.opt.Addr)
+		return newClusterState(c.nodes, slots, addr)
 	}
 
 	/*
@@ -1995,7 +1990,7 @@ func (c *ClusterClient) MasterForKey(ctx context.Context, key string) (*Client, 
 	if err != nil {
 		return nil, err
 	}
-	return node.Client, err
+	return node.Client, nil
 }
 
 func (c *ClusterClient) context(ctx context.Context) context.Context {
@@ -2005,26 +2000,13 @@ func (c *ClusterClient) context(ctx context.Context) context.Context {
 	return context.Background()
 }
 
-func appendUniqueNode(nodes []*clusterNode, node *clusterNode) []*clusterNode {
-	for _, n := range nodes {
-		if n == node {
-			return nodes
+func appendIfNotExist[T comparable](vals []T, newVal T) []T {
+	for _, v := range vals {
+		if v == newVal {
+			return vals
 		}
 	}
-	return append(nodes, node)
-}
-
-func appendIfNotExists(ss []string, es ...string) []string {
-loop:
-	for _, e := range es {
-		for _, s := range ss {
-			if s == e {
-				continue loop
-			}
-		}
-		ss = append(ss, e)
-	}
-	return ss
+	return append(vals, newVal)
 }
 
 //------------------------------------------------------------------------------

--- a/redis.go
+++ b/redis.go
@@ -383,7 +383,7 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 
 	// for redis-server versions that do not support the HELLO command,
 	// RESP2 will continue to be used.
-  if err = conn.Hello(ctx, c.opt.Protocol, username, password, c.opt.ClientName).Err(); err == nil {
+	if err = conn.Hello(ctx, c.opt.Protocol, username, password, c.opt.ClientName).Err(); err == nil {
 		// Authentication successful with HELLO command
 	} else if !isRedisError(err) {
 		// When the server responds with the RESP protocol and the result is not a normal

--- a/sentinel.go
+++ b/sentinel.go
@@ -657,10 +657,10 @@ type sentinelFailover struct {
 	onFailover func(ctx context.Context, addr string)
 	onUpdate   func(ctx context.Context)
 
-	mu          sync.RWMutex
-	_masterAddr string
-	sentinel    *SentinelClient
-	pubsub      *PubSub
+	mu         sync.RWMutex
+	masterAddr string
+	sentinel   *SentinelClient
+	pubsub     *PubSub
 }
 
 func (c *sentinelFailover) Close() error {
@@ -921,7 +921,7 @@ func parseReplicaAddrs(addrs []map[string]string, keepDisconnected bool) []strin
 
 func (c *sentinelFailover) trySwitchMaster(ctx context.Context, addr string) {
 	c.mu.RLock()
-	currentAddr := c._masterAddr //nolint:ifshort
+	currentAddr := c.masterAddr //nolint:ifshort
 	c.mu.RUnlock()
 
 	if addr == currentAddr {
@@ -931,10 +931,10 @@ func (c *sentinelFailover) trySwitchMaster(ctx context.Context, addr string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if addr == c._masterAddr {
+	if addr == c.masterAddr {
 		return
 	}
-	c._masterAddr = addr
+	c.masterAddr = addr
 
 	internal.Logger.Printf(ctx, "sentinel: new master=%q addr=%q",
 		c.opt.MasterName, addr)


### PR DESCRIPTION
- replace two similar functions `appendUniqueNode` and `appendIfNotExists` with a generic function.

- simplify the implementation of the `get` method in `clusterNodes`.

- keep the member name `_generation` of `clusterNodes` consistent with other types.

- rename a data member `_masterAddr` to `masterAddr`.
