### PR TITLE
fix(search): return results even if doc is empty

### DIFF
--- a/search_commands.go
+++ b/search_commands.go
@@ -474,6 +474,7 @@ type Document struct {
 	Payload *string
 	SortKey *string
 	Fields  map[string]string
+	Error   error
 }
 
 type AggregateQuery []interface{}
@@ -1654,7 +1655,13 @@ func parseFTSearch(data []interface{}, noContent, withScores, withPayloads, with
 		if i < len(data) {
 			fields, ok := data[i].([]interface{})
 			if !ok {
-				return FTSearchResult{}, fmt.Errorf("invalid document fields format")
+				if data[i] == proto.Nil || data[i] == nil {
+					doc.Error = proto.Nil
+					doc.Fields = map[string]string{}
+					fields = []interface{}{}
+				} else {
+					return FTSearchResult{}, fmt.Errorf("invalid document fields format")
+				}
 			}
 
 			for j := 0; j < len(fields); j += 2 {


### PR DESCRIPTION
"If a relevant key expires while a query is running, an attempt to load the key's value will return a null array. However, the key is still counted in the total number of results." - Redis Search return documentation