### PR TITLE
chore(release): 9.12.0 / redis 8.2

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -25,7 +25,7 @@ runs:
         
         # Mapping of redis version to redis testing containers
         declare -A redis_version_mapping=(
-          ["8.2.x"]="8.2-rc2-pre"
+          ["8.2.x"]="8.2"
           ["8.0.x"]="8.0.2"
           ["7.4.x"]="rs-7.4.0-v5"
           ["7.2.x"]="rs-7.2.0-v17"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           
           # Mapping of redis version to redis testing containers
           declare -A redis_version_mapping=(
-            ["8.2.x"]="8.2-rc2-pre"
+            ["8.2.x"]="8.2"
             ["8.0.x"]="8.0.2"
             ["7.4.x"]="rs-7.4.0-v5"
           )

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,17 +1,16 @@
 # Release Notes
 
-# 9.12.0-beta.1 (2025-08-04)
+# 9.12.0 (2025-08-05)
 
 ## 🚀 Highlights
 
-- This is a beta release for Redis 8.2 support.
+- This release includes support for [Redis 8.2](https://redis.io/docs/latest/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.2-release-notes/).
 - Introduces an experimental Query Builders for `FTSearch`, `FTAggregate` and other search commands.
 - Adds support for `EPSILON` option in `FT.VSIM`.
-- Includes bug fixes and improvements related to search and community contributions for [redisotel](https://github.com/redis/go-redis/tree/master/extra/redisotel).
+- Includes bug fixes and improvements contributed by the community related to ring and [redisotel](https://github.com/redis/go-redis/tree/master/extra/redisotel).
 
 ## Changes
-
-- chore(github): Improve stale issue workflow ([#3458](https://github.com/redis/go-redis/pull/3458))
+- Improve stale issue workflow ([#3458](https://github.com/redis/go-redis/pull/3458))
 - chore(ci): Add 8.2 rc2 pre build for CI ([#3459](https://github.com/redis/go-redis/pull/3459))
 - Added new stream commands ([#3450](https://github.com/redis/go-redis/pull/3450))
 - feat: Add "skip_verify" to Sentinel ([#3428](https://github.com/redis/go-redis/pull/3428))
@@ -21,19 +20,25 @@
 
 ## 🚀 New Features
 
+- feat: recover addIdleConn may occur panic ([#2445](https://github.com/redis/go-redis/pull/2445))
+- feat(ring): specify custom health check func via HeartbeatFn option ([#2940](https://github.com/redis/go-redis/pull/2940))
 - Add Query Builder for RediSearch commands ([#3436](https://github.com/redis/go-redis/pull/3436))
-- Add configurable buffer sizes for Redis connections ([#3453](https://github.com/redis/go-redis/pull/3453))
+- add configurable buffer sizes for Redis connections ([#3453](https://github.com/redis/go-redis/pull/3453))
 - Add VAMANA vector type to RediSearch ([#3449](https://github.com/redis/go-redis/pull/3449))
 - VSIM add `EPSILON` option ([#3454](https://github.com/redis/go-redis/pull/3454))
 - Add closing support to otel metrics instrumentation ([#3444](https://github.com/redis/go-redis/pull/3444))
 
 ## 🐛 Bug Fixes
 
+- fix(redisotel): fix buggy append in reportPoolStats ([#3122](https://github.com/redis/go-redis/pull/3122))
 - fix(search): return results even if doc is empty ([#3457](https://github.com/redis/go-redis/pull/3457))
 - [ISSUE-3402]: Ring.Pipelined return dial timeout error ([#3403](https://github.com/redis/go-redis/pull/3403))
 
 ## 🧰 Maintenance
 
+- Merges stale issues jobs into one job with two steps ([#3463](https://github.com/redis/go-redis/pull/3463))
+- improve code readability ([#3446](https://github.com/redis/go-redis/pull/3446))
+- chore(release): 9.12.0-beta.1 ([#3460](https://github.com/redis/go-redis/pull/3460))
 - DOC-5472 time series doc examples ([#3443](https://github.com/redis/go-redis/pull/3443))
 - Add VAMANA compression algorithm tests ([#3461](https://github.com/redis/go-redis/pull/3461))
 - bumped redis 8.2 version used in the CI/CD ([#3451](https://github.com/redis/go-redis/pull/3451))
@@ -41,13 +46,12 @@
 ## Contributors
 We'd like to thank all the contributors who worked on this release!
 
-[@andy-stark-redis](https://github.com/andy-stark-redis), [@cxljs](https://github.com/cxljs), [@htemelski-redis](https://github.com/htemelski-redis), [@jouir](https://github.com/jouir), [@ndyakov](https://github.com/ndyakov), [@ofekshenawa](https://github.com/ofekshenawa), [@rokn](https://github.com/rokn) and [@smnvdev](https://github.com/smnvdev)
+[@andy-stark-redis](https://github.com/andy-stark-redis), [@cxljs](https://github.com/cxljs), [@elena-kolevska](https://github.com/elena-kolevska), [@htemelski-redis](https://github.com/htemelski-redis), [@jouir](https://github.com/jouir), [@monkey92t](https://github.com/monkey92t), [@ndyakov](https://github.com/ndyakov), [@ofekshenawa](https://github.com/ofekshenawa), [@rokn](https://github.com/rokn), [@smnvdev](https://github.com/smnvdev), [@strobil](https://github.com/strobil) and [@wzy9607](https://github.com/wzy9607)
 
 ## New Contributors
-* [@htemelski-redis](https://github.com/htemelski-redis) made their first contribution in https://github.com/redis/go-redis/pull/3409
-* [@smnvdev](https://github.com/smnvdev) made their first contribution in https://github.com/redis/go-redis/pull/3403
-* [@rokn](https://github.com/rokn) made their first contribution in https://github.com/redis/go-redis/pull/3444
-
+* [@htemelski-redis](https://github.com/htemelski-redis) made their first contribution in [#3409](https://github.com/redis/go-redis/pull/3409)
+* [@smnvdev](https://github.com/smnvdev) made their first contribution in [#3403](https://github.com/redis/go-redis/pull/3403)
+* [@rokn](https://github.com/rokn) made their first contribution in [#3444](https://github.com/redis/go-redis/pull/3444)
 
 # 9.11.0 (2025-06-24)
 

--- a/example/del-keys-without-ttl/go.mod
+++ b/example/del-keys-without-ttl/go.mod
@@ -5,7 +5,7 @@ go 1.18
 replace github.com/redis/go-redis/v9 => ../..
 
 require (
-	github.com/redis/go-redis/v9 v9.12.0-beta.1
+	github.com/redis/go-redis/v9 v9.12.0
 	go.uber.org/zap v1.24.0
 )
 

--- a/example/hll/go.mod
+++ b/example/hll/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.12.0-beta.1
+require github.com/redis/go-redis/v9 v9.12.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/hset-struct/go.mod
+++ b/example/hset-struct/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/redis/go-redis/v9 v9.12.0-beta.1
+	github.com/redis/go-redis/v9 v9.12.0
 )
 
 require (

--- a/example/lua-scripting/go.mod
+++ b/example/lua-scripting/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.12.0-beta.1
+require github.com/redis/go-redis/v9 v9.12.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/otel/go.mod
+++ b/example/otel/go.mod
@@ -11,8 +11,8 @@ replace github.com/redis/go-redis/extra/redisotel/v9 => ../../extra/redisotel
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../../extra/rediscmd
 
 require (
-	github.com/redis/go-redis/extra/redisotel/v9 v9.12.0-beta.1
-	github.com/redis/go-redis/v9 v9.12.0-beta.1
+	github.com/redis/go-redis/extra/redisotel/v9 v9.12.0
+	github.com/redis/go-redis/v9 v9.12.0
 	github.com/uptrace/uptrace-go v1.21.0
 	go.opentelemetry.io/otel v1.22.0
 )
@@ -25,7 +25,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 // indirect
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.12.0-beta.1 // indirect
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.12.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.46.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0 // indirect

--- a/example/redis-bloom/go.mod
+++ b/example/redis-bloom/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.12.0-beta.1
+require github.com/redis/go-redis/v9 v9.12.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/scan-struct/go.mod
+++ b/example/scan-struct/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/redis/go-redis/v9 v9.12.0-beta.1
+	github.com/redis/go-redis/v9 v9.12.0
 )
 
 require (

--- a/extra/rediscensus/go.mod
+++ b/extra/rediscensus/go.mod
@@ -7,8 +7,8 @@ replace github.com/redis/go-redis/v9 => ../..
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../rediscmd
 
 require (
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.12.0-beta.1
-	github.com/redis/go-redis/v9 v9.12.0-beta.1
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.12.0
+	github.com/redis/go-redis/v9 v9.12.0
 	go.opencensus.io v0.24.0
 )
 

--- a/extra/rediscmd/go.mod
+++ b/extra/rediscmd/go.mod
@@ -7,7 +7,7 @@ replace github.com/redis/go-redis/v9 => ../..
 require (
 	github.com/bsm/ginkgo/v2 v2.12.0
 	github.com/bsm/gomega v1.27.10
-	github.com/redis/go-redis/v9 v9.12.0-beta.1
+	github.com/redis/go-redis/v9 v9.12.0
 )
 
 require (

--- a/extra/redisotel/go.mod
+++ b/extra/redisotel/go.mod
@@ -7,8 +7,8 @@ replace github.com/redis/go-redis/v9 => ../..
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../rediscmd
 
 require (
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.12.0-beta.1
-	github.com/redis/go-redis/v9 v9.12.0-beta.1
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.12.0
+	github.com/redis/go-redis/v9 v9.12.0
 	go.opentelemetry.io/otel v1.22.0
 	go.opentelemetry.io/otel/metric v1.22.0
 	go.opentelemetry.io/otel/sdk v1.22.0

--- a/extra/redisprometheus/go.mod
+++ b/extra/redisprometheus/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redis/go-redis/v9 v9.12.0-beta.1
+	github.com/redis/go-redis/v9 v9.12.0
 )
 
 require (

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package redis
 
 // Version is the current release version.
 func Version() string {
-	return "9.12.0-beta.1"
+	return "9.12.0"
 }


### PR DESCRIPTION
- update the release notes
- update dependencies in extra package
- update version
- update ci image to use 8.2