### PR TITLE
Set the read/write buffer size of the sentinel client to 4KiB

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -201,8 +201,9 @@ func (opt *FailoverOptions) sentinelOptions(addr string) *Options {
 		MinRetryBackoff: opt.MinRetryBackoff,
 		MaxRetryBackoff: opt.MaxRetryBackoff,
 
-		ReadBufferSize:  opt.ReadBufferSize,
-		WriteBufferSize: opt.WriteBufferSize,
+		// The sentinel client uses a 4KiB read/write buffer size.
+		ReadBufferSize:  4096,
+		WriteBufferSize: 4096,
 
 		DialTimeout:           opt.DialTimeout,
 		ReadTimeout:           opt.ReadTimeout,


### PR DESCRIPTION
Set the read/write buffer size of the sentinel client to 4KiB since there's no need for the sentinel client to handle large data transfers or pipeline scenarios.