### PR TITLE
Support subscriptions against cluster slave nodes

### DIFF
--- a/osscluster.go
+++ b/osscluster.go
@@ -1821,14 +1821,33 @@ func (c *ClusterClient) pubSub() *PubSub {
 			}
 
 			var err error
+
 			if len(channels) > 0 {
 				slot := hashtag.Slot(channels[0])
-				node, err = c.slotMasterNode(ctx, slot)
+
+				// newConn in PubSub is only used for subscription connections, so it is safe to
+				// assume that a slave node can always be used when client options specify ReadOnly.
+				if c.opt.ReadOnly {
+					state, err := c.state.Get(ctx)
+					if err != nil {
+						return nil, err
+					}
+
+					node, err = c.slotReadOnlyNode(state, slot)
+					if err != nil {
+						return nil, err
+					}
+				} else {
+					node, err = c.slotMasterNode(ctx, slot)
+					if err != nil {
+						return nil, err
+					}
+				}
 			} else {
 				node, err = c.nodes.Random()
-			}
-			if err != nil {
-				return nil, err
+				if err != nil {
+					return nil, err
+				}
 			}
 
 			cn, err := node.Client.newConn(context.TODO())


### PR DESCRIPTION
Currently, `SUBSCRIBE` (and its sibling variant commands) establish connections only to masters, regardless of the `ReadOnly` option specified in client options.

This PR allows go-redis to respect the `ReadOnly` option for subscriptions in the pubsub client, by preferring slave nodes for new connections. Note that in both global and sharded pubsub modes, messages are replicated to slaves by Redis.

Note that `newConn` in the pubsub client is only used for creating connections for long-lived subscriptions, so it does not need to consider any per-command R/W-family properties as in the case for commands outside of the pubsub client.

I added a new unit test case for both global and sharded subscriptions with `ReadOnly` set to true, with an additional assertion on the value of `pubsub{shard}_channels` as returned by `INFO` to additionally verify that the subscription is served only by slave nodes.