### PR TITLE
fix UniversalOptions miss ReadBufferSize and WriteBufferSize options

### DIFF
--- a/universal.go
+++ b/universal.go
@@ -61,6 +61,20 @@ type UniversalOptions struct {
 	WriteTimeout          time.Duration
 	ContextTimeoutEnabled bool
 
+	// ReadBufferSize is the size of the bufio.Reader buffer for each connection.
+	// Larger buffers can improve performance for commands that return large responses.
+	// Smaller buffers can improve memory usage for larger pools.
+	//
+	// default: 256KiB (262144 bytes)
+	ReadBufferSize int
+
+	// WriteBufferSize is the size of the bufio.Writer buffer for each connection.
+	// Larger buffers can improve performance for large pipelines and commands with many arguments.
+	// Smaller buffers can improve memory usage for larger pools.
+	//
+	// default: 256KiB (262144 bytes)
+	WriteBufferSize int
+
 	// PoolFIFO uses FIFO mode for each node connection pool GET/PUT (default LIFO).
 	PoolFIFO bool
 
@@ -143,6 +157,9 @@ func (o *UniversalOptions) Cluster() *ClusterOptions {
 		WriteTimeout:          o.WriteTimeout,
 		ContextTimeoutEnabled: o.ContextTimeoutEnabled,
 
+		ReadBufferSize:  o.ReadBufferSize,
+		WriteBufferSize: o.WriteBufferSize,
+
 		PoolFIFO: o.PoolFIFO,
 
 		PoolSize:        o.PoolSize,
@@ -200,6 +217,9 @@ func (o *UniversalOptions) Failover() *FailoverOptions {
 		WriteTimeout:          o.WriteTimeout,
 		ContextTimeoutEnabled: o.ContextTimeoutEnabled,
 
+		ReadBufferSize:  o.ReadBufferSize,
+		WriteBufferSize: o.WriteBufferSize,
+
 		PoolFIFO:        o.PoolFIFO,
 		PoolSize:        o.PoolSize,
 		PoolTimeout:     o.PoolTimeout,
@@ -249,6 +269,9 @@ func (o *UniversalOptions) Simple() *Options {
 		ReadTimeout:           o.ReadTimeout,
 		WriteTimeout:          o.WriteTimeout,
 		ContextTimeoutEnabled: o.ContextTimeoutEnabled,
+
+		ReadBufferSize:  o.ReadBufferSize,
+		WriteBufferSize: o.WriteBufferSize,
 
 		PoolFIFO:        o.PoolFIFO,
 		PoolSize:        o.PoolSize,


### PR DESCRIPTION
refs: https://github.com/redis/go-redis/issues/3465#issuecomment-3196217612