### PR TITLE
fix(test): fix a timing issue in pubsub test

### DIFF
--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -113,6 +113,9 @@ var _ = Describe("PubSub", func() {
 		pubsub := client.SSubscribe(ctx, "mychannel", "mychannel2")
 		defer pubsub.Close()
 
+		// Let Redis process the ssubscribe command.
+		time.Sleep(10 * time.Millisecond)
+
 		channels, err = client.PubSubShardChannels(ctx, "mychannel*").Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(channels).To(ConsistOf([]string{"mychannel", "mychannel2"}))


### PR DESCRIPTION
Recent github action have encountered sporadic errors, such as case #https://github.com/redis/go-redis/actions/runs/17021636203/job/48251478581?pr=3481 (This also occurred in PR #3496 , but I couldn't find the error logs after resubmitting).

The error log:
```
• [FAILED] [0.005 seconds]
PubSub [It] should sharded pub/sub channels
/home/runner/work/go-redis/go-redis/pubsub_test.go:108

  [FAILED] Expected
      <[]string | len:0, cap:0>: []
  to consist of
      <[]string | len:2, cap:2>: ["mychannel", "mychannel2"]
  the missing elements were
      <[]string | len:2, cap:2>: ["mychannel", "mychannel2"]
  In [It] at: /home/runner/work/go-redis/go-redis/pubsub_test.go:118 @ 08/17/25 13:35:51.76
```

The reason is that after sending the ssubscribe command, the pubsub shardchannels command was immediately called without waiting for Redis to process the ssubscribe command, resulting in unexpected results.
