### PR TITLE
fix(otel): register wait metrics

### DIFF
--- a/extra/redisotel/metrics.go
+++ b/extra/redisotel/metrics.go
@@ -220,6 +220,8 @@ func reportPoolStats(rdb *redis.Client, conf *config) (metric.Registration, erro
 		idleMin,
 		connsMax,
 		usage,
+		waits,
+		waitsDuration,
 		timeouts,
 		hits,
 		misses,


### PR DESCRIPTION
Follow up to #3493

Apologies for missing this the first time. It registers the new metrics so we can send them.