### PR TITLE
fix: SetErr on Cmd if the command cannot be queued correctly in multi/exec

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -630,6 +630,7 @@ func (c *baseClient) generalProcessPipeline(
 			return err
 		})
 		if lastErr == nil || !canRetry || !shouldRetry(lastErr, true) {
+			setCmdsErr(cmds, lastErr)
 			return lastErr
 		}
 	}

--- a/redis.go
+++ b/redis.go
@@ -703,9 +703,12 @@ func txPipelineReadQueued(rd *proto.Reader, statusCmd *StatusCmd, cmds []Cmder) 
 	}
 
 	// Parse +QUEUED.
-	for range cmds {
-		if err := statusCmd.readReply(rd); err != nil && !isRedisError(err) {
-			return err
+	for _, cmd := range cmds {
+		if err := statusCmd.readReply(rd); err != nil {
+			cmd.SetErr(err)
+			if !isRedisError(err) {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #2871 
Two separate issues:

- The first one reported by @AvyChanna was related to first error which was not supposed to be retried, especially if it is a client error before being able to get a connection, to not be assigned to the commands.

- The second one, reported by @tptodorov, was related to TxPipeline which was ignoring errors when queueing commands.

