### PR TITLE
Updates release drafter config to exclude dependabot

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -36,6 +36,8 @@ categories:
 change-template: '- $TITLE (#$NUMBER)'
 exclude-labels:
   - 'skip-changelog'
+exclude-contributors:
+  - 'dependabot'
 template: |
   # Changes
 


### PR DESCRIPTION
Exclude 'dependabot' from contributors in release drafter config.