### PR TITLE
DOC-5743 BITOP examples

### DIFF
--- a/doctests/bitmap_tutorial_test.go
+++ b/doctests/bitmap_tutorial_test.go
@@ -164,28 +164,40 @@ func ExampleClient_bitops() {
 	// STEP_END
 
 	// STEP_START bitop_diff
-	rdb.BitOpDiff(ctx, "R", "A", "B", "C")
+	_, err := rdb.BitOpDiff(ctx, "R", "A", "B", "C").Result()
+	if err != nil {
+		panic(err)
+	}
 	br, _ = rdb.Get(ctx, "R").Bytes()
 	fmt.Printf("%08b\n", br[0])
 	// >>> 10000000
 	// STEP_END
 
 	// STEP_START bitop_diff1
-	rdb.BitOpDiff1(ctx, "R", "A", "B", "C")
+	_, err = rdb.BitOpDiff1(ctx, "R", "A", "B", "C").Result()
+	if err != nil {
+		panic(err)
+	}
 	br, _ = rdb.Get(ctx, "R").Bytes()
 	fmt.Printf("%08b\n", br[0])
 	// >>> 00100101
 	// STEP_END
 
 	// STEP_START bitop_andor
-	rdb.BitOpAndOr(ctx, "R", "A", "B", "C")
+	_, err = rdb.BitOpAndOr(ctx, "R", "A", "B", "C").Result()
+	if err != nil {
+		panic(err)
+	}
 	br, _ = rdb.Get(ctx, "R").Bytes()
 	fmt.Printf("%08b\n", br[0])
 	// >>> 01011000
 	// STEP_END
 
 	// STEP_START bitop_one
-	rdb.BitOpOne(ctx, "R", "A", "B", "C")
+	_, err = rdb.BitOpOne(ctx, "R", "A", "B", "C").Result()
+	if err != nil {
+		panic(err)
+	}
 	br, _ = rdb.Get(ctx, "R").Bytes()
 	fmt.Printf("%08b\n", br[0])
 	// >>> 10100101


### PR DESCRIPTION
[DOC-5743](https://redislabs.atlassian.net/browse/DOC-5743)

[`BITOP`](https://redis.io/docs/latest/commands/bitop/) examples, including the new operations added in Redis 8.2.

[DOC-5743]: https://redislabs.atlassian.net/browse/DOC-5743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ