### PR TITLE
Retract 9.15.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-# 9.15.0-beta.2 (2025-09-26)
+# 9.15.0-beta.3 (2025-09-26)
 
 ## Highlights
 This beta release includes a pre-production version of processing push notifications and hitless upgrades.

--- a/example/del-keys-without-ttl/go.mod
+++ b/example/del-keys-without-ttl/go.mod
@@ -5,7 +5,7 @@ go 1.18
 replace github.com/redis/go-redis/v9 => ../..
 
 require (
-	github.com/redis/go-redis/v9 v9.15.0-beta.2
+	github.com/redis/go-redis/v9 v9.15.0-beta.3
 	go.uber.org/zap v1.24.0
 )
 

--- a/example/hll/go.mod
+++ b/example/hll/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.15.0-beta.2
+require github.com/redis/go-redis/v9 v9.15.0-beta.3
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/hset-struct/go.mod
+++ b/example/hset-struct/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/redis/go-redis/v9 v9.15.0-beta.2
+	github.com/redis/go-redis/v9 v9.15.0-beta.3
 )
 
 require (

--- a/example/lua-scripting/go.mod
+++ b/example/lua-scripting/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.15.0-beta.2
+require github.com/redis/go-redis/v9 v9.15.0-beta.3
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/otel/go.mod
+++ b/example/otel/go.mod
@@ -11,8 +11,8 @@ replace github.com/redis/go-redis/extra/redisotel/v9 => ../../extra/redisotel
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../../extra/rediscmd
 
 require (
-	github.com/redis/go-redis/extra/redisotel/v9 v9.15.0-beta.2
-	github.com/redis/go-redis/v9 v9.15.0-beta.2
+	github.com/redis/go-redis/extra/redisotel/v9 v9.15.0-beta.3
+	github.com/redis/go-redis/v9 v9.15.0-beta.3
 	github.com/uptrace/uptrace-go v1.21.0
 	go.opentelemetry.io/otel v1.22.0
 )
@@ -25,7 +25,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0 // indirect
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.15.0-beta.2 // indirect
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.15.0-beta.3 // indirect
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.46.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.44.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0 // indirect

--- a/example/redis-bloom/go.mod
+++ b/example/redis-bloom/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.15.0-beta.2
+require github.com/redis/go-redis/v9 v9.15.0-beta.3
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/scan-struct/go.mod
+++ b/example/scan-struct/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/redis/go-redis/v9 v9.15.0-beta.2
+	github.com/redis/go-redis/v9 v9.15.0-beta.3
 )
 
 require (

--- a/extra/rediscensus/go.mod
+++ b/extra/rediscensus/go.mod
@@ -7,8 +7,8 @@ replace github.com/redis/go-redis/v9 => ../..
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../rediscmd
 
 require (
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.15.0-beta.2
-	github.com/redis/go-redis/v9 v9.15.0-beta.2
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.15.0-beta.3
+	github.com/redis/go-redis/v9 v9.15.0-beta.3
 	go.opencensus.io v0.24.0
 )
 

--- a/extra/rediscmd/go.mod
+++ b/extra/rediscmd/go.mod
@@ -7,7 +7,7 @@ replace github.com/redis/go-redis/v9 => ../..
 require (
 	github.com/bsm/ginkgo/v2 v2.12.0
 	github.com/bsm/gomega v1.27.10
-	github.com/redis/go-redis/v9 v9.15.0-beta.2
+	github.com/redis/go-redis/v9 v9.15.0-beta.3
 )
 
 require (

--- a/extra/redisotel/go.mod
+++ b/extra/redisotel/go.mod
@@ -7,8 +7,8 @@ replace github.com/redis/go-redis/v9 => ../..
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../rediscmd
 
 require (
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.15.0-beta.2
-	github.com/redis/go-redis/v9 v9.15.0-beta.2
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.15.0-beta.3
+	github.com/redis/go-redis/v9 v9.15.0-beta.3
 	go.opentelemetry.io/otel v1.22.0
 	go.opentelemetry.io/otel/metric v1.22.0
 	go.opentelemetry.io/otel/sdk v1.22.0

--- a/extra/redisprometheus/go.mod
+++ b/extra/redisprometheus/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redis/go-redis/v9 v9.15.0-beta.2
+	github.com/redis/go-redis/v9 v9.15.0-beta.3
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 retract (
+	v9.15.0 // This version was accidentally released. It is identical to 9.15.0-beta.2
 	v9.7.2 // This version was accidentally released. Please use version 9.7.3 instead.
 	v9.5.4 // This version was accidentally released. Please use version 9.6.0 instead.
 	v9.5.3 // This version was accidentally released. Please use version 9.6.0 instead.

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package redis
 
 // Version is the current release version.
 func Version() string {
-	return "9.15.0-beta.2"
+	return "9.15.0-beta.3"
 }


### PR DESCRIPTION
https://pkg.go.dev/ shows that v9.15.0 was released alongside v9.15.0-beta.2 with both versions being identical.
Retract v9.15.0 to avoid confusion