### PR TITLE
fix: add missing error variable for non-unix build constraints

### DIFF
--- a/internal/pool/conn_check_dummy.go
+++ b/internal/pool/conn_check_dummy.go
@@ -2,7 +2,13 @@
 
 package pool
 
-import "net"
+import (
+	"errors"
+	"net"
+)
+
+// errUnexpectedRead is placeholder error variable for non-unix build constraints
+var errUnexpectedRead = errors.New("unexpected read from socket")
 
 func connCheck(conn net.Conn) error {
 	return nil

--- a/internal/pool/conn_check_dummy.go
+++ b/internal/pool/conn_check_dummy.go
@@ -10,11 +10,11 @@ import (
 // errUnexpectedRead is placeholder error variable for non-unix build constraints
 var errUnexpectedRead = errors.New("unexpected read from socket")
 
-func connCheck(conn net.Conn) error {
+func connCheck(_ net.Conn) error {
 	return nil
 }
 
 // since we can't check for data on the socket, we just assume there is some
-func maybeHasData(conn net.Conn) bool {
+func maybeHasData(_ net.Conn) bool {
 	return true
 }


### PR DESCRIPTION
Add missing `errUnexpectedRead` error variable to `conn_check_dummy.go` for non-unix build constraints.

---

The variable was used in common code, missing it caused build errors on non-unix systems.
https://github.com/redis/go-redis/blob/a44df882570340438949258c6c29710ac3e236b3/internal/pool/pool.go#L808-L810
