### PR TITLE
fix(pool): remove conn from idleConns if present

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -441,6 +441,16 @@ func (p *ConnPool) removeConnWithLock(cn *Conn) {
 }
 
 func (p *ConnPool) removeConn(cn *Conn) {
+	// check idleConns and remove it if present
+	for i, c := range p.idleConns {
+		if c == cn {
+			p.idleConns = append(p.idleConns[:i], p.idleConns[i+1:]...)
+			p.idleConnsLen--
+			break
+		}
+	}
+
+	// then check conns and remove it
 	for i, c := range p.conns {
 		if c == cn {
 			p.conns = append(p.conns[:i], p.conns[i+1:]...)
@@ -451,6 +461,7 @@ func (p *ConnPool) removeConn(cn *Conn) {
 			break
 		}
 	}
+
 	atomic.AddUint32(&p.stats.StaleConns, 1)
 }
 


### PR DESCRIPTION
If a connection is used in the StreamingCredentialsProvider it may need to be removed (when authentication fails) and at this point of time the connection may be in the idleConns slice. We have to remove it to prevent leaking unused/closed connection. This connection would have been marked as bad later and although the leak would have resolved itself, the proper approach would be to remove it early, so `checkMinIdle` can keep the correct number of idle connections. 

Fixes #3542