### PR TITLE
push/push_test: Use t.Fatal for pointer nil checks

### DIFF
--- a/push/push_test.go
+++ b/push/push_test.go
@@ -144,7 +144,7 @@ func TestRegistry(t *testing.T) {
 	t.Run("NewRegistry", func(t *testing.T) {
 		registry := NewRegistry()
 		if registry == nil {
-			t.Error("NewRegistry should not return nil")
+			t.Fatal("NewRegistry should not return nil")
 		}
 
 		if registry.handlers == nil {
@@ -407,7 +407,7 @@ func TestProcessor(t *testing.T) {
 	t.Run("NewProcessor", func(t *testing.T) {
 		processor := NewProcessor()
 		if processor == nil {
-			t.Error("NewProcessor should not return nil")
+			t.Fatal("NewProcessor should not return nil")
 		}
 
 		if processor.registry == nil {


### PR DESCRIPTION
Replaces t.Error with t.Fatal in NewRegistry and NewProcessor tests to immediately stop test execution when a nil value is encountered.