### PR TITLE
all: Replace interface{} with any throughout codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ For example:
 		"idx:bicycle",
 		"@pickup_zone:[CONTAINS $bike]",
 		&redis.FTSearchOptions{
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"bike": "POINT(-0.1278 51.5074)",
 			},
 			DialectVersion: 3,

--- a/acl_commands.go
+++ b/acl_commands.go
@@ -3,7 +3,7 @@ package redis
 import "context"
 
 type ACLCmdable interface {
-	ACLDryRun(ctx context.Context, username string, command ...interface{}) *StringCmd
+	ACLDryRun(ctx context.Context, username string, command ...any) *StringCmd
 
 	ACLLog(ctx context.Context, count int64) *ACLLogCmd
 	ACLLogReset(ctx context.Context) *StatusCmd
@@ -20,8 +20,8 @@ type ACLCatArgs struct {
 	Category string
 }
 
-func (c cmdable) ACLDryRun(ctx context.Context, username string, command ...interface{}) *StringCmd {
-	args := make([]interface{}, 0, 3+len(command))
+func (c cmdable) ACLDryRun(ctx context.Context, username string, command ...any) *StringCmd {
+	args := make([]any, 0, 3+len(command))
 	args = append(args, "acl", "dryrun", username)
 	args = append(args, command...)
 	cmd := NewStringCmd(ctx, args...)
@@ -30,7 +30,7 @@ func (c cmdable) ACLDryRun(ctx context.Context, username string, command ...inte
 }
 
 func (c cmdable) ACLLog(ctx context.Context, count int64) *ACLLogCmd {
-	args := make([]interface{}, 0, 3)
+	args := make([]any, 0, 3)
 	args = append(args, "acl", "log")
 	if count > 0 {
 		args = append(args, count)
@@ -53,7 +53,7 @@ func (c cmdable) ACLDelUser(ctx context.Context, username string) *IntCmd {
 }
 
 func (c cmdable) ACLSetUser(ctx context.Context, username string, rules ...string) *StatusCmd {
-	args := make([]interface{}, 3+len(rules))
+	args := make([]any, 3+len(rules))
 	args[0] = "acl"
 	args[1] = "setuser"
 	args[2] = username

--- a/acl_commands_test.go
+++ b/acl_commands_test.go
@@ -430,7 +430,7 @@ var _ = Describe("ACL Categories", func() {
 			"tdigest":    "tdigest.rank",
 			"timeseries": "ts.range",
 		}
-		var cats []interface{}
+		var cats []any
 
 		for cat, subitem := range aclTestCase {
 			cats = append(cats, cat)

--- a/adapters.go
+++ b/adapters.go
@@ -93,7 +93,7 @@ type pushProcessorAdapter struct {
 }
 
 // RegisterHandler registers a handler for a specific push notification name.
-func (ppa *pushProcessorAdapter) RegisterHandler(pushNotificationName string, handler interface{}, protected bool) error {
+func (ppa *pushProcessorAdapter) RegisterHandler(pushNotificationName string, handler any, protected bool) error {
 	if pushHandler, ok := handler.(push.NotificationHandler); ok {
 		return ppa.processor.RegisterHandler(pushNotificationName, pushHandler, protected)
 	}
@@ -106,6 +106,6 @@ func (ppa *pushProcessorAdapter) UnregisterHandler(pushNotificationName string) 
 }
 
 // GetHandler returns the handler for a specific push notification name.
-func (ppa *pushProcessorAdapter) GetHandler(pushNotificationName string) interface{} {
+func (ppa *pushProcessorAdapter) GetHandler(pushNotificationName string) any {
 	return ppa.processor.GetHandler(pushNotificationName)
 }

--- a/bitmap_commands.go
+++ b/bitmap_commands.go
@@ -19,8 +19,8 @@ type BitMapCmdable interface {
 	BitOpNot(ctx context.Context, destKey string, key string) *IntCmd
 	BitPos(ctx context.Context, key string, bit int64, pos ...int64) *IntCmd
 	BitPosSpan(ctx context.Context, key string, bit int8, start, end int64, span string) *IntCmd
-	BitField(ctx context.Context, key string, values ...interface{}) *IntSliceCmd
-	BitFieldRO(ctx context.Context, key string, values ...interface{}) *IntSliceCmd
+	BitField(ctx context.Context, key string, values ...any) *IntSliceCmd
+	BitFieldRO(ctx context.Context, key string, values ...any) *IntSliceCmd
 }
 
 func (c cmdable) GetBit(ctx context.Context, key string, offset int64) *IntCmd {
@@ -70,7 +70,7 @@ func (c cmdable) BitCount(ctx context.Context, key string, bitCount *BitCount) *
 }
 
 func (c cmdable) bitOp(ctx context.Context, op, destKey string, keys ...string) *IntCmd {
-	args := make([]interface{}, 3+len(keys))
+	args := make([]any, 3+len(keys))
 	args[0] = "bitop"
 	args[1] = op
 	args[2] = destKey
@@ -129,7 +129,7 @@ func (c cmdable) BitOpOne(ctx context.Context, destKey string, keys ...string) *
 // BitPos is an API before Redis version 7.0, cmd: bitpos key bit start end
 // if you need the `byte | bit` parameter, please use `BitPosSpan`.
 func (c cmdable) BitPos(ctx context.Context, key string, bit int64, pos ...int64) *IntCmd {
-	args := make([]interface{}, 3+len(pos))
+	args := make([]any, 3+len(pos))
 	args[0] = "bitpos"
 	args[1] = key
 	args[2] = bit
@@ -163,9 +163,9 @@ func (c cmdable) BitPosSpan(ctx context.Context, key string, bit int8, start, en
 // BitField accepts multiple values:
 //   - BitField("set", "i1", "offset1", "value1","cmd2", "type2", "offset2", "value2")
 //   - BitField([]string{"cmd1", "type1", "offset1", "value1","cmd2", "type2", "offset2", "value2"})
-//   - BitField([]interface{}{"cmd1", "type1", "offset1", "value1","cmd2", "type2", "offset2", "value2"})
-func (c cmdable) BitField(ctx context.Context, key string, values ...interface{}) *IntSliceCmd {
-	args := make([]interface{}, 2, 2+len(values))
+//   - BitField([]any{"cmd1", "type1", "offset1", "value1","cmd2", "type2", "offset2", "value2"})
+func (c cmdable) BitField(ctx context.Context, key string, values ...any) *IntSliceCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "bitfield"
 	args[1] = key
 	args = appendArgs(args, values)
@@ -177,8 +177,8 @@ func (c cmdable) BitField(ctx context.Context, key string, values ...interface{}
 // BitFieldRO - Read-only variant of the BITFIELD command.
 // It is like the original BITFIELD but only accepts GET subcommand and can safely be used in read-only replicas.
 // - BitFieldRO(ctx, key, "<Encoding0>", "<Offset0>", "<Encoding1>","<Offset1>")
-func (c cmdable) BitFieldRO(ctx context.Context, key string, values ...interface{}) *IntSliceCmd {
-	args := make([]interface{}, 2, 2+len(values))
+func (c cmdable) BitFieldRO(ctx context.Context, key string, values ...any) *IntSliceCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "BITFIELD_RO"
 	args[1] = key
 	if len(values)%2 != 0 {

--- a/cluster_commands.go
+++ b/cluster_commands.go
@@ -127,7 +127,7 @@ func (c cmdable) ClusterCountKeysInSlot(ctx context.Context, slot int) *IntCmd {
 }
 
 func (c cmdable) ClusterDelSlots(ctx context.Context, slots ...int) *StatusCmd {
-	args := make([]interface{}, 2+len(slots))
+	args := make([]any, 2+len(slots))
 	args[0] = "cluster"
 	args[1] = "delslots"
 	for i, slot := range slots {
@@ -166,7 +166,7 @@ func (c cmdable) ClusterFailover(ctx context.Context) *StatusCmd {
 }
 
 func (c cmdable) ClusterAddSlots(ctx context.Context, slots ...int) *StatusCmd {
-	args := make([]interface{}, 2+len(slots))
+	args := make([]any, 2+len(slots))
 	args[0] = "cluster"
 	args[1] = "addslots"
 	for i, num := range slots {

--- a/command.go
+++ b/command.go
@@ -77,7 +77,7 @@ type Cmder interface {
 
 	// all args of the command.
 	// e.g. "set k v ex 10" -> "[set k v ex 10]".
-	Args() []interface{}
+	Args() []any
 
 	// format request and response string.
 	// e.g. "set k v ex 10" -> "set k v ex 10: OK", "get k" -> "get k: v".
@@ -157,7 +157,7 @@ func cmdFirstKeyPos(cmd Cmder) int {
 	return 1
 }
 
-func cmdString(cmd Cmder, val interface{}) string {
+func cmdString(cmd Cmder, val any) string {
 	b := make([]byte, 0, 64)
 
 	for i, arg := range cmd.Args() {
@@ -182,10 +182,10 @@ func cmdString(cmd Cmder, val interface{}) string {
 
 type baseCmd struct {
 	ctx          context.Context
-	args         []interface{}
+	args         []any
 	err          error
 	keyPos       int8
-	rawVal       interface{}
+	rawVal       any
 	_readTimeout *time.Duration
 }
 
@@ -214,7 +214,7 @@ func (cmd *baseCmd) FullName() string {
 	}
 }
 
-func (cmd *baseCmd) Args() []interface{} {
+func (cmd *baseCmd) Args() []any {
 	return cmd.args
 }
 
@@ -268,10 +268,10 @@ func (cmd *baseCmd) readRawReply(rd *proto.Reader) (err error) {
 type Cmd struct {
 	baseCmd
 
-	val interface{}
+	val any
 }
 
-func NewCmd(ctx context.Context, args ...interface{}) *Cmd {
+func NewCmd(ctx context.Context, args ...any) *Cmd {
 	return &Cmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -284,15 +284,15 @@ func (cmd *Cmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
-func (cmd *Cmd) SetVal(val interface{}) {
+func (cmd *Cmd) SetVal(val any) {
 	cmd.val = val
 }
 
-func (cmd *Cmd) Val() interface{} {
+func (cmd *Cmd) Val() any {
 	return cmd.val
 }
 
-func (cmd *Cmd) Result() (interface{}, error) {
+func (cmd *Cmd) Result() (any, error) {
 	return cmd.val, cmd.err
 }
 
@@ -303,7 +303,7 @@ func (cmd *Cmd) Text() (string, error) {
 	return toString(cmd.val)
 }
 
-func toString(val interface{}) (string, error) {
+func toString(val any) (string, error) {
 	switch val := val.(type) {
 	case string:
 		return val, nil
@@ -335,7 +335,7 @@ func (cmd *Cmd) Int64() (int64, error) {
 	return toInt64(cmd.val)
 }
 
-func toInt64(val interface{}) (int64, error) {
+func toInt64(val any) (int64, error) {
 	switch val := val.(type) {
 	case int64:
 		return val, nil
@@ -354,7 +354,7 @@ func (cmd *Cmd) Uint64() (uint64, error) {
 	return toUint64(cmd.val)
 }
 
-func toUint64(val interface{}) (uint64, error) {
+func toUint64(val any) (uint64, error) {
 	switch val := val.(type) {
 	case int64:
 		return uint64(val), nil
@@ -373,7 +373,7 @@ func (cmd *Cmd) Float32() (float32, error) {
 	return toFloat32(cmd.val)
 }
 
-func toFloat32(val interface{}) (float32, error) {
+func toFloat32(val any) (float32, error) {
 	switch val := val.(type) {
 	case int64:
 		return float32(val), nil
@@ -396,7 +396,7 @@ func (cmd *Cmd) Float64() (float64, error) {
 	return toFloat64(cmd.val)
 }
 
-func toFloat64(val interface{}) (float64, error) {
+func toFloat64(val any) (float64, error) {
 	switch val := val.(type) {
 	case int64:
 		return float64(val), nil
@@ -415,7 +415,7 @@ func (cmd *Cmd) Bool() (bool, error) {
 	return toBool(cmd.val)
 }
 
-func toBool(val interface{}) (bool, error) {
+func toBool(val any) (bool, error) {
 	switch val := val.(type) {
 	case bool:
 		return val, nil
@@ -429,12 +429,12 @@ func toBool(val interface{}) (bool, error) {
 	}
 }
 
-func (cmd *Cmd) Slice() ([]interface{}, error) {
+func (cmd *Cmd) Slice() ([]any, error) {
 	if cmd.err != nil {
 		return nil, cmd.err
 	}
 	switch val := cmd.val.(type) {
-	case []interface{}:
+	case []any:
 		return val, nil
 	default:
 		return nil, fmt.Errorf("redis: unexpected type=%T for Slice", val)
@@ -553,12 +553,12 @@ func (cmd *Cmd) readReply(rd *proto.Reader) (err error) {
 type SliceCmd struct {
 	baseCmd
 
-	val []interface{}
+	val []any
 }
 
 var _ Cmder = (*SliceCmd)(nil)
 
-func NewSliceCmd(ctx context.Context, args ...interface{}) *SliceCmd {
+func NewSliceCmd(ctx context.Context, args ...any) *SliceCmd {
 	return &SliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -567,15 +567,15 @@ func NewSliceCmd(ctx context.Context, args ...interface{}) *SliceCmd {
 	}
 }
 
-func (cmd *SliceCmd) SetVal(val []interface{}) {
+func (cmd *SliceCmd) SetVal(val []any) {
 	cmd.val = val
 }
 
-func (cmd *SliceCmd) Val() []interface{} {
+func (cmd *SliceCmd) Val() []any {
 	return cmd.val
 }
 
-func (cmd *SliceCmd) Result() ([]interface{}, error) {
+func (cmd *SliceCmd) Result() ([]any, error) {
 	return cmd.val, cmd.err
 }
 
@@ -585,14 +585,14 @@ func (cmd *SliceCmd) String() string {
 
 // Scan scans the results from the map into a destination struct. The map keys
 // are matched in the Redis struct fields by the `redis:"field"` tag.
-func (cmd *SliceCmd) Scan(dst interface{}) error {
+func (cmd *SliceCmd) Scan(dst any) error {
 	if cmd.err != nil {
 		return cmd.err
 	}
 
 	// Pass the list of keys and values.
 	// Skip the first two args for: HMGET key
-	var args []interface{}
+	var args []any
 	if cmd.args[0] == "hmget" {
 		args = cmd.args[2:]
 	} else {
@@ -618,7 +618,7 @@ type StatusCmd struct {
 
 var _ Cmder = (*StatusCmd)(nil)
 
-func NewStatusCmd(ctx context.Context, args ...interface{}) *StatusCmd {
+func NewStatusCmd(ctx context.Context, args ...any) *StatusCmd {
 	return &StatusCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -662,7 +662,7 @@ type IntCmd struct {
 
 var _ Cmder = (*IntCmd)(nil)
 
-func NewIntCmd(ctx context.Context, args ...interface{}) *IntCmd {
+func NewIntCmd(ctx context.Context, args ...any) *IntCmd {
 	return &IntCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -706,7 +706,7 @@ type IntSliceCmd struct {
 
 var _ Cmder = (*IntSliceCmd)(nil)
 
-func NewIntSliceCmd(ctx context.Context, args ...interface{}) *IntSliceCmd {
+func NewIntSliceCmd(ctx context.Context, args ...any) *IntSliceCmd {
 	return &IntSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -756,7 +756,7 @@ type DurationCmd struct {
 
 var _ Cmder = (*DurationCmd)(nil)
 
-func NewDurationCmd(ctx context.Context, precision time.Duration, args ...interface{}) *DurationCmd {
+func NewDurationCmd(ctx context.Context, precision time.Duration, args ...any) *DurationCmd {
 	return &DurationCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -808,7 +808,7 @@ type TimeCmd struct {
 
 var _ Cmder = (*TimeCmd)(nil)
 
-func NewTimeCmd(ctx context.Context, args ...interface{}) *TimeCmd {
+func NewTimeCmd(ctx context.Context, args ...any) *TimeCmd {
 	return &TimeCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -859,7 +859,7 @@ type BoolCmd struct {
 
 var _ Cmder = (*BoolCmd)(nil)
 
-func NewBoolCmd(ctx context.Context, args ...interface{}) *BoolCmd {
+func NewBoolCmd(ctx context.Context, args ...any) *BoolCmd {
 	return &BoolCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -906,7 +906,7 @@ type StringCmd struct {
 
 var _ Cmder = (*StringCmd)(nil)
 
-func NewStringCmd(ctx context.Context, args ...interface{}) *StringCmd {
+func NewStringCmd(ctx context.Context, args ...any) *StringCmd {
 	return &StringCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -984,7 +984,7 @@ func (cmd *StringCmd) Time() (time.Time, error) {
 	return time.Parse(time.RFC3339Nano, cmd.Val())
 }
 
-func (cmd *StringCmd) Scan(val interface{}) error {
+func (cmd *StringCmd) Scan(val any) error {
 	if cmd.err != nil {
 		return cmd.err
 	}
@@ -1010,7 +1010,7 @@ type FloatCmd struct {
 
 var _ Cmder = (*FloatCmd)(nil)
 
-func NewFloatCmd(ctx context.Context, args ...interface{}) *FloatCmd {
+func NewFloatCmd(ctx context.Context, args ...any) *FloatCmd {
 	return &FloatCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1050,7 +1050,7 @@ type FloatSliceCmd struct {
 
 var _ Cmder = (*FloatSliceCmd)(nil)
 
-func NewFloatSliceCmd(ctx context.Context, args ...interface{}) *FloatSliceCmd {
+func NewFloatSliceCmd(ctx context.Context, args ...any) *FloatSliceCmd {
 	return &FloatSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1105,7 +1105,7 @@ type StringSliceCmd struct {
 
 var _ Cmder = (*StringSliceCmd)(nil)
 
-func NewStringSliceCmd(ctx context.Context, args ...interface{}) *StringSliceCmd {
+func NewStringSliceCmd(ctx context.Context, args ...any) *StringSliceCmd {
 	return &StringSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1130,7 +1130,7 @@ func (cmd *StringSliceCmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
-func (cmd *StringSliceCmd) ScanSlice(container interface{}) error {
+func (cmd *StringSliceCmd) ScanSlice(container any) error {
 	return proto.ScanSlice(cmd.Val(), container)
 }
 
@@ -1168,7 +1168,7 @@ type KeyValueSliceCmd struct {
 
 var _ Cmder = (*KeyValueSliceCmd)(nil)
 
-func NewKeyValueSliceCmd(ctx context.Context, args ...interface{}) *KeyValueSliceCmd {
+func NewKeyValueSliceCmd(ctx context.Context, args ...any) *KeyValueSliceCmd {
 	return &KeyValueSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1257,7 +1257,7 @@ type BoolSliceCmd struct {
 
 var _ Cmder = (*BoolSliceCmd)(nil)
 
-func NewBoolSliceCmd(ctx context.Context, args ...interface{}) *BoolSliceCmd {
+func NewBoolSliceCmd(ctx context.Context, args ...any) *BoolSliceCmd {
 	return &BoolSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1306,7 +1306,7 @@ type MapStringStringCmd struct {
 
 var _ Cmder = (*MapStringStringCmd)(nil)
 
-func NewMapStringStringCmd(ctx context.Context, args ...interface{}) *MapStringStringCmd {
+func NewMapStringStringCmd(ctx context.Context, args ...any) *MapStringStringCmd {
 	return &MapStringStringCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1333,7 +1333,7 @@ func (cmd *MapStringStringCmd) String() string {
 
 // Scan scans the results from the map into a destination struct. The map keys
 // are matched in the Redis struct fields by the `redis:"field"` tag.
-func (cmd *MapStringStringCmd) Scan(dest interface{}) error {
+func (cmd *MapStringStringCmd) Scan(dest any) error {
 	if cmd.err != nil {
 		return cmd.err
 	}
@@ -1385,7 +1385,7 @@ type MapStringIntCmd struct {
 
 var _ Cmder = (*MapStringIntCmd)(nil)
 
-func NewMapStringIntCmd(ctx context.Context, args ...interface{}) *MapStringIntCmd {
+func NewMapStringIntCmd(ctx context.Context, args ...any) *MapStringIntCmd {
 	return &MapStringIntCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1435,10 +1435,10 @@ func (cmd *MapStringIntCmd) readReply(rd *proto.Reader) error {
 // ------------------------------------------------------------------------------
 type MapStringSliceInterfaceCmd struct {
 	baseCmd
-	val map[string][]interface{}
+	val map[string][]any
 }
 
-func NewMapStringSliceInterfaceCmd(ctx context.Context, args ...interface{}) *MapStringSliceInterfaceCmd {
+func NewMapStringSliceInterfaceCmd(ctx context.Context, args ...any) *MapStringSliceInterfaceCmd {
 	return &MapStringSliceInterfaceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1451,15 +1451,15 @@ func (cmd *MapStringSliceInterfaceCmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
-func (cmd *MapStringSliceInterfaceCmd) SetVal(val map[string][]interface{}) {
+func (cmd *MapStringSliceInterfaceCmd) SetVal(val map[string][]any) {
 	cmd.val = val
 }
 
-func (cmd *MapStringSliceInterfaceCmd) Result() (map[string][]interface{}, error) {
+func (cmd *MapStringSliceInterfaceCmd) Result() (map[string][]any, error) {
 	return cmd.val, cmd.err
 }
 
-func (cmd *MapStringSliceInterfaceCmd) Val() map[string][]interface{} {
+func (cmd *MapStringSliceInterfaceCmd) Val() map[string][]any {
 	return cmd.val
 }
 
@@ -1469,7 +1469,7 @@ func (cmd *MapStringSliceInterfaceCmd) readReply(rd *proto.Reader) (err error) {
 		return err
 	}
 
-	cmd.val = make(map[string][]interface{})
+	cmd.val = make(map[string][]any)
 
 	switch readType {
 	case proto.RespMap:
@@ -1486,7 +1486,7 @@ func (cmd *MapStringSliceInterfaceCmd) readReply(rd *proto.Reader) (err error) {
 			if err != nil {
 				return err
 			}
-			cmd.val[k] = make([]interface{}, nn)
+			cmd.val[k] = make([]any, nn)
 			for j := 0; j < nn; j++ {
 				value, err := rd.ReadReply()
 				if err != nil {
@@ -1513,7 +1513,7 @@ func (cmd *MapStringSliceInterfaceCmd) readReply(rd *proto.Reader) (err error) {
 			if err != nil {
 				return err
 			}
-			cmd.val[key] = make([]interface{}, 0, itemLen-1)
+			cmd.val[key] = make([]any, 0, itemLen-1)
 			for j := 1; j < itemLen; j++ {
 				// Read the inner array for timestamp-value pairs
 				data, err := rd.ReadReply()
@@ -1538,7 +1538,7 @@ type StringStructMapCmd struct {
 
 var _ Cmder = (*StringStructMapCmd)(nil)
 
-func NewStringStructMapCmd(ctx context.Context, args ...interface{}) *StringStructMapCmd {
+func NewStringStructMapCmd(ctx context.Context, args ...any) *StringStructMapCmd {
 	return &StringStructMapCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1584,7 +1584,7 @@ func (cmd *StringStructMapCmd) readReply(rd *proto.Reader) error {
 
 type XMessage struct {
 	ID     string
-	Values map[string]interface{}
+	Values map[string]any
 }
 
 type XMessageSliceCmd struct {
@@ -1595,7 +1595,7 @@ type XMessageSliceCmd struct {
 
 var _ Cmder = (*XMessageSliceCmd)(nil)
 
-func NewXMessageSliceCmd(ctx context.Context, args ...interface{}) *XMessageSliceCmd {
+func NewXMessageSliceCmd(ctx context.Context, args ...any) *XMessageSliceCmd {
 	return &XMessageSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1663,13 +1663,13 @@ func readXMessage(rd *proto.Reader) (XMessage, error) {
 	}, nil
 }
 
-func stringInterfaceMapParser(rd *proto.Reader) (map[string]interface{}, error) {
+func stringInterfaceMapParser(rd *proto.Reader) (map[string]any, error) {
 	n, err := rd.ReadMapLen()
 	if err != nil {
 		return nil, err
 	}
 
-	m := make(map[string]interface{}, n)
+	m := make(map[string]any, n)
 	for i := 0; i < n; i++ {
 		key, err := rd.ReadString()
 		if err != nil {
@@ -1701,7 +1701,7 @@ type XStreamSliceCmd struct {
 
 var _ Cmder = (*XStreamSliceCmd)(nil)
 
-func NewXStreamSliceCmd(ctx context.Context, args ...interface{}) *XStreamSliceCmd {
+func NewXStreamSliceCmd(ctx context.Context, args ...any) *XStreamSliceCmd {
 	return &XStreamSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1774,7 +1774,7 @@ type XPendingCmd struct {
 
 var _ Cmder = (*XPendingCmd)(nil)
 
-func NewXPendingCmd(ctx context.Context, args ...interface{}) *XPendingCmd {
+func NewXPendingCmd(ctx context.Context, args ...any) *XPendingCmd {
 	return &XPendingCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1857,7 +1857,7 @@ type XPendingExtCmd struct {
 
 var _ Cmder = (*XPendingExtCmd)(nil)
 
-func NewXPendingExtCmd(ctx context.Context, args ...interface{}) *XPendingExtCmd {
+func NewXPendingExtCmd(ctx context.Context, args ...any) *XPendingExtCmd {
 	return &XPendingExtCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1927,7 +1927,7 @@ type XAutoClaimCmd struct {
 
 var _ Cmder = (*XAutoClaimCmd)(nil)
 
-func NewXAutoClaimCmd(ctx context.Context, args ...interface{}) *XAutoClaimCmd {
+func NewXAutoClaimCmd(ctx context.Context, args ...any) *XAutoClaimCmd {
 	return &XAutoClaimCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1997,7 +1997,7 @@ type XAutoClaimJustIDCmd struct {
 
 var _ Cmder = (*XAutoClaimJustIDCmd)(nil)
 
-func NewXAutoClaimJustIDCmd(ctx context.Context, args ...interface{}) *XAutoClaimJustIDCmd {
+func NewXAutoClaimJustIDCmd(ctx context.Context, args ...any) *XAutoClaimJustIDCmd {
 	return &XAutoClaimJustIDCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -2084,7 +2084,7 @@ func NewXInfoConsumersCmd(ctx context.Context, stream string, group string) *XIn
 	return &XInfoConsumersCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
-			args: []interface{}{"xinfo", "consumers", stream, group},
+			args: []any{"xinfo", "consumers", stream, group},
 		},
 	}
 }
@@ -2174,7 +2174,7 @@ func NewXInfoGroupsCmd(ctx context.Context, stream string) *XInfoGroupsCmd {
 	return &XInfoGroupsCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
-			args: []interface{}{"xinfo", "groups", stream},
+			args: []any{"xinfo", "groups", stream},
 		},
 	}
 }
@@ -2289,7 +2289,7 @@ func NewXInfoStreamCmd(ctx context.Context, stream string) *XInfoStreamCmd {
 	return &XInfoStreamCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
-			args: []interface{}{"xinfo", "stream", stream},
+			args: []any{"xinfo", "stream", stream},
 		},
 	}
 }
@@ -2432,7 +2432,7 @@ type XInfoStreamConsumerPending struct {
 
 var _ Cmder = (*XInfoStreamFullCmd)(nil)
 
-func NewXInfoStreamFullCmd(ctx context.Context, args ...interface{}) *XInfoStreamFullCmd {
+func NewXInfoStreamFullCmd(ctx context.Context, args ...any) *XInfoStreamFullCmd {
 	return &XInfoStreamFullCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -2731,7 +2731,7 @@ type ZSliceCmd struct {
 
 var _ Cmder = (*ZSliceCmd)(nil)
 
-func NewZSliceCmd(ctx context.Context, args ...interface{}) *ZSliceCmd {
+func NewZSliceCmd(ctx context.Context, args ...any) *ZSliceCmd {
 	return &ZSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -2809,7 +2809,7 @@ type ZWithKeyCmd struct {
 
 var _ Cmder = (*ZWithKeyCmd)(nil)
 
-func NewZWithKeyCmd(ctx context.Context, args ...interface{}) *ZWithKeyCmd {
+func NewZWithKeyCmd(ctx context.Context, args ...any) *ZWithKeyCmd {
 	return &ZWithKeyCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -2866,7 +2866,7 @@ type ScanCmd struct {
 
 var _ Cmder = (*ScanCmd)(nil)
 
-func NewScanCmd(ctx context.Context, process cmdable, args ...interface{}) *ScanCmd {
+func NewScanCmd(ctx context.Context, process cmdable, args ...any) *ScanCmd {
 	return &ScanCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -2947,7 +2947,7 @@ type ClusterSlotsCmd struct {
 
 var _ Cmder = (*ClusterSlotsCmd)(nil)
 
-func NewClusterSlotsCmd(ctx context.Context, args ...interface{}) *ClusterSlotsCmd {
+func NewClusterSlotsCmd(ctx context.Context, args ...any) *ClusterSlotsCmd {
 	return &ClusterSlotsCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3100,7 +3100,7 @@ type GeoLocationCmd struct {
 
 var _ Cmder = (*GeoLocationCmd)(nil)
 
-func NewGeoLocationCmd(ctx context.Context, q *GeoRadiusQuery, args ...interface{}) *GeoLocationCmd {
+func NewGeoLocationCmd(ctx context.Context, q *GeoRadiusQuery, args ...any) *GeoLocationCmd {
 	return &GeoLocationCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3110,7 +3110,7 @@ func NewGeoLocationCmd(ctx context.Context, q *GeoRadiusQuery, args ...interface
 	}
 }
 
-func geoLocationArgs(q *GeoRadiusQuery, args ...interface{}) []interface{} {
+func geoLocationArgs(q *GeoRadiusQuery, args ...any) []any {
 	args = append(args, q.Radius)
 	if q.Unit != "" {
 		args = append(args, q.Unit)
@@ -3256,7 +3256,7 @@ type GeoSearchStoreQuery struct {
 	StoreDist bool
 }
 
-func geoSearchLocationArgs(q *GeoSearchLocationQuery, args []interface{}) []interface{} {
+func geoSearchLocationArgs(q *GeoSearchLocationQuery, args []any) []any {
 	args = geoSearchArgs(&q.GeoSearchQuery, args)
 
 	if q.WithCoord {
@@ -3272,7 +3272,7 @@ func geoSearchLocationArgs(q *GeoSearchLocationQuery, args []interface{}) []inte
 	return args
 }
 
-func geoSearchArgs(q *GeoSearchQuery, args []interface{}) []interface{} {
+func geoSearchArgs(q *GeoSearchQuery, args []any) []any {
 	if q.Member != "" {
 		args = append(args, "frommember", q.Member)
 	} else {
@@ -3315,7 +3315,7 @@ type GeoSearchLocationCmd struct {
 var _ Cmder = (*GeoSearchLocationCmd)(nil)
 
 func NewGeoSearchLocationCmd(
-	ctx context.Context, opt *GeoSearchLocationQuery, args ...interface{},
+	ctx context.Context, opt *GeoSearchLocationQuery, args ...any,
 ) *GeoSearchLocationCmd {
 	return &GeoSearchLocationCmd{
 		baseCmd: baseCmd{
@@ -3407,7 +3407,7 @@ type GeoPosCmd struct {
 
 var _ Cmder = (*GeoPosCmd)(nil)
 
-func NewGeoPosCmd(ctx context.Context, args ...interface{}) *GeoPosCmd {
+func NewGeoPosCmd(ctx context.Context, args ...any) *GeoPosCmd {
 	return &GeoPosCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3488,7 +3488,7 @@ type CommandsInfoCmd struct {
 
 var _ Cmder = (*CommandsInfoCmd)(nil)
 
-func NewCommandsInfoCmd(ctx context.Context, args ...interface{}) *CommandsInfoCmd {
+func NewCommandsInfoCmd(ctx context.Context, args ...any) *CommandsInfoCmd {
 	return &CommandsInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3677,7 +3677,7 @@ type SlowLogCmd struct {
 
 var _ Cmder = (*SlowLogCmd)(nil)
 
-func NewSlowLogCmd(ctx context.Context, args ...interface{}) *SlowLogCmd {
+func NewSlowLogCmd(ctx context.Context, args ...any) *SlowLogCmd {
 	return &SlowLogCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3771,12 +3771,12 @@ func (cmd *SlowLogCmd) readReply(rd *proto.Reader) error {
 type MapStringInterfaceCmd struct {
 	baseCmd
 
-	val map[string]interface{}
+	val map[string]any
 }
 
 var _ Cmder = (*MapStringInterfaceCmd)(nil)
 
-func NewMapStringInterfaceCmd(ctx context.Context, args ...interface{}) *MapStringInterfaceCmd {
+func NewMapStringInterfaceCmd(ctx context.Context, args ...any) *MapStringInterfaceCmd {
 	return &MapStringInterfaceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3785,15 +3785,15 @@ func NewMapStringInterfaceCmd(ctx context.Context, args ...interface{}) *MapStri
 	}
 }
 
-func (cmd *MapStringInterfaceCmd) SetVal(val map[string]interface{}) {
+func (cmd *MapStringInterfaceCmd) SetVal(val map[string]any) {
 	cmd.val = val
 }
 
-func (cmd *MapStringInterfaceCmd) Val() map[string]interface{} {
+func (cmd *MapStringInterfaceCmd) Val() map[string]any {
 	return cmd.val
 }
 
-func (cmd *MapStringInterfaceCmd) Result() (map[string]interface{}, error) {
+func (cmd *MapStringInterfaceCmd) Result() (map[string]any, error) {
 	return cmd.val, cmd.err
 }
 
@@ -3807,7 +3807,7 @@ func (cmd *MapStringInterfaceCmd) readReply(rd *proto.Reader) error {
 		return err
 	}
 
-	cmd.val = make(map[string]interface{}, n)
+	cmd.val = make(map[string]any, n)
 	for i := 0; i < n; i++ {
 		k, err := rd.ReadString()
 		if err != nil {
@@ -3840,7 +3840,7 @@ type MapStringStringSliceCmd struct {
 
 var _ Cmder = (*MapStringStringSliceCmd)(nil)
 
-func NewMapStringStringSliceCmd(ctx context.Context, args ...interface{}) *MapStringStringSliceCmd {
+func NewMapStringStringSliceCmd(ctx context.Context, args ...any) *MapStringStringSliceCmd {
 	return &MapStringStringSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3896,13 +3896,13 @@ func (cmd *MapStringStringSliceCmd) readReply(rd *proto.Reader) error {
 
 // -----------------------------------------------------------------------
 
-// MapMapStringInterfaceCmd represents a command that returns a map of strings to interface{}.
+// MapMapStringInterfaceCmd represents a command that returns a map of strings to any.
 type MapMapStringInterfaceCmd struct {
 	baseCmd
-	val map[string]interface{}
+	val map[string]any
 }
 
-func NewMapMapStringInterfaceCmd(ctx context.Context, args ...interface{}) *MapMapStringInterfaceCmd {
+func NewMapMapStringInterfaceCmd(ctx context.Context, args ...any) *MapMapStringInterfaceCmd {
 	return &MapMapStringInterfaceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3915,15 +3915,15 @@ func (cmd *MapMapStringInterfaceCmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
-func (cmd *MapMapStringInterfaceCmd) SetVal(val map[string]interface{}) {
+func (cmd *MapMapStringInterfaceCmd) SetVal(val map[string]any) {
 	cmd.val = val
 }
 
-func (cmd *MapMapStringInterfaceCmd) Result() (map[string]interface{}, error) {
+func (cmd *MapMapStringInterfaceCmd) Result() (map[string]any, error) {
 	return cmd.val, cmd.err
 }
 
-func (cmd *MapMapStringInterfaceCmd) Val() map[string]interface{} {
+func (cmd *MapMapStringInterfaceCmd) Val() map[string]any {
 	return cmd.val
 }
 
@@ -3933,10 +3933,10 @@ func (cmd *MapMapStringInterfaceCmd) readReply(rd *proto.Reader) (err error) {
 	if err != nil {
 		return err
 	}
-	resultMap := map[string]interface{}{}
+	resultMap := map[string]any{}
 
 	switch midResponse := data.(type) {
-	case map[interface{}]interface{}: // resp3 will return map
+	case map[any]any: // resp3 will return map
 		for k, v := range midResponse {
 			stringKey, ok := k.(string)
 			if !ok {
@@ -3944,10 +3944,10 @@ func (cmd *MapMapStringInterfaceCmd) readReply(rd *proto.Reader) (err error) {
 			}
 			resultMap[stringKey] = v
 		}
-	case []interface{}: // resp2 will return array of arrays
+	case []any: // resp2 will return array of arrays
 		n := len(midResponse)
 		for i := 0; i < n; i++ {
-			finalArr, ok := midResponse[i].([]interface{}) // final array that we need to transform to map
+			finalArr, ok := midResponse[i].([]any) // final array that we need to transform to map
 			if !ok {
 				return fmt.Errorf("redis: unexpected response %#v", data)
 			}
@@ -3977,12 +3977,12 @@ func (cmd *MapMapStringInterfaceCmd) readReply(rd *proto.Reader) (err error) {
 type MapStringInterfaceSliceCmd struct {
 	baseCmd
 
-	val []map[string]interface{}
+	val []map[string]any
 }
 
 var _ Cmder = (*MapStringInterfaceSliceCmd)(nil)
 
-func NewMapStringInterfaceSliceCmd(ctx context.Context, args ...interface{}) *MapStringInterfaceSliceCmd {
+func NewMapStringInterfaceSliceCmd(ctx context.Context, args ...any) *MapStringInterfaceSliceCmd {
 	return &MapStringInterfaceSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -3991,15 +3991,15 @@ func NewMapStringInterfaceSliceCmd(ctx context.Context, args ...interface{}) *Ma
 	}
 }
 
-func (cmd *MapStringInterfaceSliceCmd) SetVal(val []map[string]interface{}) {
+func (cmd *MapStringInterfaceSliceCmd) SetVal(val []map[string]any) {
 	cmd.val = val
 }
 
-func (cmd *MapStringInterfaceSliceCmd) Val() []map[string]interface{} {
+func (cmd *MapStringInterfaceSliceCmd) Val() []map[string]any {
 	return cmd.val
 }
 
-func (cmd *MapStringInterfaceSliceCmd) Result() ([]map[string]interface{}, error) {
+func (cmd *MapStringInterfaceSliceCmd) Result() ([]map[string]any, error) {
 	return cmd.val, cmd.err
 }
 
@@ -4013,13 +4013,13 @@ func (cmd *MapStringInterfaceSliceCmd) readReply(rd *proto.Reader) error {
 		return err
 	}
 
-	cmd.val = make([]map[string]interface{}, n)
+	cmd.val = make([]map[string]any, n)
 	for i := 0; i < n; i++ {
 		nn, err := rd.ReadMapLen()
 		if err != nil {
 			return err
 		}
-		cmd.val[i] = make(map[string]interface{}, nn)
+		cmd.val[i] = make(map[string]any, nn)
 		for f := 0; f < nn; f++ {
 			k, err := rd.ReadString()
 			if err != nil {
@@ -4048,7 +4048,7 @@ type KeyValuesCmd struct {
 
 var _ Cmder = (*KeyValuesCmd)(nil)
 
-func NewKeyValuesCmd(ctx context.Context, args ...interface{}) *KeyValuesCmd {
+func NewKeyValuesCmd(ctx context.Context, args ...any) *KeyValuesCmd {
 	return &KeyValuesCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -4110,7 +4110,7 @@ type ZSliceWithKeyCmd struct {
 
 var _ Cmder = (*ZSliceWithKeyCmd)(nil)
 
-func NewZSliceWithKeyCmd(ctx context.Context, args ...interface{}) *ZSliceWithKeyCmd {
+func NewZSliceWithKeyCmd(ctx context.Context, args ...any) *ZSliceWithKeyCmd {
 	return &ZSliceWithKeyCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -4203,7 +4203,7 @@ type FunctionListCmd struct {
 
 var _ Cmder = (*FunctionListCmd)(nil)
 
-func NewFunctionListCmd(ctx context.Context, args ...interface{}) *FunctionListCmd {
+func NewFunctionListCmd(ctx context.Context, args ...any) *FunctionListCmd {
 	return &FunctionListCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -4384,7 +4384,7 @@ type FunctionStatsCmd struct {
 
 var _ Cmder = (*FunctionStatsCmd)(nil)
 
-func NewFunctionStatsCmd(ctx context.Context, args ...interface{}) *FunctionStatsCmd {
+func NewFunctionStatsCmd(ctx context.Context, args ...any) *FunctionStatsCmd {
 	return &FunctionStatsCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -4602,7 +4602,7 @@ type LCSCmd struct {
 }
 
 func NewLCSCmd(ctx context.Context, q *LCSQuery) *LCSCmd {
-	args := make([]interface{}, 3, 7)
+	args := make([]any, 3, 7)
 	args[0] = "lcs"
 	args[1] = q.Key1
 	args[2] = q.Key2
@@ -4750,7 +4750,7 @@ type KeyFlagsCmd struct {
 
 var _ Cmder = (*KeyFlagsCmd)(nil)
 
-func NewKeyFlagsCmd(ctx context.Context, args ...interface{}) *KeyFlagsCmd {
+func NewKeyFlagsCmd(ctx context.Context, args ...any) *KeyFlagsCmd {
 	return &KeyFlagsCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -4832,7 +4832,7 @@ type ClusterLinksCmd struct {
 
 var _ Cmder = (*ClusterLinksCmd)(nil)
 
-func NewClusterLinksCmd(ctx context.Context, args ...interface{}) *ClusterLinksCmd {
+func NewClusterLinksCmd(ctx context.Context, args ...any) *ClusterLinksCmd {
 	return &ClusterLinksCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -4934,7 +4934,7 @@ type ClusterShardsCmd struct {
 
 var _ Cmder = (*ClusterShardsCmd)(nil)
 
-func NewClusterShardsCmd(ctx context.Context, args ...interface{}) *ClusterShardsCmd {
+func NewClusterShardsCmd(ctx context.Context, args ...any) *ClusterShardsCmd {
 	return &ClusterShardsCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -5067,7 +5067,7 @@ type RankWithScoreCmd struct {
 
 var _ Cmder = (*RankWithScoreCmd)(nil)
 
-func NewRankWithScoreCmd(ctx context.Context, args ...interface{}) *RankWithScoreCmd {
+func NewRankWithScoreCmd(ctx context.Context, args ...any) *RankWithScoreCmd {
 	return &RankWithScoreCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -5218,7 +5218,7 @@ type ClientInfoCmd struct {
 
 var _ Cmder = (*ClientInfoCmd)(nil)
 
-func NewClientInfoCmd(ctx context.Context, args ...interface{}) *ClientInfoCmd {
+func NewClientInfoCmd(ctx context.Context, args ...any) *ClientInfoCmd {
 	return &ClientInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -5422,7 +5422,7 @@ type ACLLogCmd struct {
 
 var _ Cmder = (*ACLLogCmd)(nil)
 
-func NewACLLogCmd(ctx context.Context, args ...interface{}) *ACLLogCmd {
+func NewACLLogCmd(ctx context.Context, args ...any) *ACLLogCmd {
 	return &ACLLogCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -5533,7 +5533,7 @@ type InfoCmd struct {
 
 var _ Cmder = (*InfoCmd)(nil)
 
-func NewInfoCmd(ctx context.Context, args ...interface{}) *InfoCmd {
+func NewInfoCmd(ctx context.Context, args ...any) *InfoCmd {
 	return &InfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -5622,7 +5622,7 @@ func newMonitorCmd(ctx context.Context, ch chan string) *MonitorCmd {
 	return &MonitorCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
-			args: []interface{}{"monitor"},
+			args: []any{"monitor"},
 		},
 		ch:     ch,
 		status: monitorStatusIdle,

--- a/commands.go
+++ b/commands.go
@@ -50,7 +50,7 @@ func formatSec(ctx context.Context, dur time.Duration) int64 {
 	return int64(dur / time.Second)
 }
 
-func appendArgs(dst, src []interface{}) []interface{} {
+func appendArgs(dst, src []any) []any {
 	if len(src) == 1 {
 		return appendArg(dst, src[0])
 	}
@@ -59,17 +59,17 @@ func appendArgs(dst, src []interface{}) []interface{} {
 	return dst
 }
 
-func appendArg(dst []interface{}, arg interface{}) []interface{} {
+func appendArg(dst []any, arg any) []any {
 	switch arg := arg.(type) {
 	case []string:
 		for _, s := range arg {
 			dst = append(dst, s)
 		}
 		return dst
-	case []interface{}:
+	case []any:
 		dst = append(dst, arg...)
 		return dst
-	case map[string]interface{}:
+	case map[string]any:
 		for k, v := range arg {
 			dst = append(dst, k, v)
 		}
@@ -103,7 +103,7 @@ func appendArg(dst []interface{}, arg interface{}) []interface{} {
 }
 
 // appendStructField appends the field and value held by the structure v to dst, and returns the appended dst.
-func appendStructField(dst []interface{}, v reflect.Value) []interface{} {
+func appendStructField(dst []any, v reflect.Value) []any {
 	typ := v.Type()
 	for i := 0; i < typ.NumField(); i++ {
 		tag := typ.Field(i).Tag.Get("redis")
@@ -174,10 +174,10 @@ type Cmdable interface {
 
 	Command(ctx context.Context) *CommandsInfoCmd
 	CommandList(ctx context.Context, filter *FilterBy) *StringSliceCmd
-	CommandGetKeys(ctx context.Context, commands ...interface{}) *StringSliceCmd
-	CommandGetKeysAndFlags(ctx context.Context, commands ...interface{}) *KeyFlagsCmd
+	CommandGetKeys(ctx context.Context, commands ...any) *StringSliceCmd
+	CommandGetKeysAndFlags(ctx context.Context, commands ...any) *KeyFlagsCmd
 	ClientGetName(ctx context.Context) *StringCmd
-	Echo(ctx context.Context, message interface{}) *StringCmd
+	Echo(ctx context.Context, message any) *StringCmd
 	Ping(ctx context.Context) *StatusCmd
 	Quit(ctx context.Context) *StatusCmd
 	Unlink(ctx context.Context, keys ...string) *IntCmd
@@ -345,7 +345,7 @@ func (info LibraryInfo) Validate() error {
 func (c statefulCmdable) Hello(ctx context.Context,
 	ver int, username, password, clientName string,
 ) *MapStringInterfaceCmd {
-	args := make([]interface{}, 0, 7)
+	args := make([]any, 0, 7)
 	args = append(args, "hello", ver)
 	if password != "" {
 		if username != "" {
@@ -378,7 +378,7 @@ type FilterBy struct {
 }
 
 func (c cmdable) CommandList(ctx context.Context, filter *FilterBy) *StringSliceCmd {
-	args := make([]interface{}, 0, 5)
+	args := make([]any, 0, 5)
 	args = append(args, "command", "list")
 	if filter != nil {
 		if filter.Module != "" {
@@ -394,8 +394,8 @@ func (c cmdable) CommandList(ctx context.Context, filter *FilterBy) *StringSlice
 	return cmd
 }
 
-func (c cmdable) CommandGetKeys(ctx context.Context, commands ...interface{}) *StringSliceCmd {
-	args := make([]interface{}, 2+len(commands))
+func (c cmdable) CommandGetKeys(ctx context.Context, commands ...any) *StringSliceCmd {
+	args := make([]any, 2+len(commands))
 	args[0] = "command"
 	args[1] = "getkeys"
 	copy(args[2:], commands)
@@ -404,8 +404,8 @@ func (c cmdable) CommandGetKeys(ctx context.Context, commands ...interface{}) *S
 	return cmd
 }
 
-func (c cmdable) CommandGetKeysAndFlags(ctx context.Context, commands ...interface{}) *KeyFlagsCmd {
-	args := make([]interface{}, 2+len(commands))
+func (c cmdable) CommandGetKeysAndFlags(ctx context.Context, commands ...any) *KeyFlagsCmd {
+	args := make([]any, 2+len(commands))
 	args[0] = "command"
 	args[1] = "getkeysandflags"
 	copy(args[2:], commands)
@@ -421,7 +421,7 @@ func (c cmdable) ClientGetName(ctx context.Context) *StringCmd {
 	return cmd
 }
 
-func (c cmdable) Echo(ctx context.Context, message interface{}) *StringCmd {
+func (c cmdable) Echo(ctx context.Context, message any) *StringCmd {
 	cmd := NewStringCmd(ctx, "echo", message)
 	_ = c(ctx, cmd)
 	return cmd
@@ -433,7 +433,7 @@ func (c cmdable) Ping(ctx context.Context) *StatusCmd {
 	return cmd
 }
 
-func (c cmdable) Do(ctx context.Context, args ...interface{}) *Cmd {
+func (c cmdable) Do(ctx context.Context, args ...any) *Cmd {
 	cmd := NewCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -467,7 +467,7 @@ func (c cmdable) ClientKill(ctx context.Context, ipPort string) *StatusCmd {
 //
 //	CLIENT KILL <option> [value] ... <option> [value]
 func (c cmdable) ClientKillByFilter(ctx context.Context, keys ...string) *IntCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]any, 2+len(keys))
 	args[0] = "client"
 	args[1] = "kill"
 	for i, key := range keys {
@@ -523,7 +523,7 @@ func (c cmdable) ClientInfo(ctx context.Context) *ClientInfoCmd {
 // ClientMaintNotifications enables or disables maintenance notifications for maintenance upgrades.
 // When enabled, the client will receive push notifications about Redis maintenance events.
 func (c cmdable) ClientMaintNotifications(ctx context.Context, enabled bool, endpointType string) *StatusCmd {
-	args := []interface{}{"client", "maint_notifications"}
+	args := []any{"client", "maint_notifications"}
 	if enabled {
 		if endpointType == "" {
 			endpointType = "none"
@@ -594,7 +594,7 @@ func (c cmdable) FlushDBAsync(ctx context.Context) *StatusCmd {
 }
 
 func (c cmdable) Info(ctx context.Context, sections ...string) *StringCmd {
-	args := make([]interface{}, 1+len(sections))
+	args := make([]any, 1+len(sections))
 	args[0] = "info"
 	for i, section := range sections {
 		args[i+1] = section
@@ -605,7 +605,7 @@ func (c cmdable) Info(ctx context.Context, sections ...string) *StringCmd {
 }
 
 func (c cmdable) InfoMap(ctx context.Context, sections ...string) *InfoCmd {
-	args := make([]interface{}, 1+len(sections))
+	args := make([]any, 1+len(sections))
 	args[0] = "info"
 	for i, section := range sections {
 		args[i+1] = section
@@ -628,11 +628,11 @@ func (c cmdable) Save(ctx context.Context) *StatusCmd {
 }
 
 func (c cmdable) shutdown(ctx context.Context, modifier string) *StatusCmd {
-	var args []interface{}
+	var args []any
 	if modifier == "" {
-		args = []interface{}{"shutdown"}
+		args = []any{"shutdown"}
 	} else {
-		args = []interface{}{"shutdown", modifier}
+		args = []any{"shutdown", modifier}
 	}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -690,7 +690,7 @@ func (c cmdable) DebugObject(ctx context.Context, key string) *StringCmd {
 }
 
 func (c cmdable) MemoryUsage(ctx context.Context, key string, samples ...int) *IntCmd {
-	args := []interface{}{"memory", "usage", key}
+	args := []any{"memory", "usage", key}
 	if len(samples) > 0 {
 		if len(samples) != 1 {
 			panic("MemoryUsage expects single sample count")
@@ -709,12 +709,12 @@ func (c cmdable) MemoryUsage(ctx context.Context, key string, samples ...int) *I
 // `MODULE LOADEX path [CONFIG name value [CONFIG name value ...]] [ARGS args [args ...]]`
 type ModuleLoadexConfig struct {
 	Path string
-	Conf map[string]interface{}
-	Args []interface{}
+	Conf map[string]any
+	Args []any
 }
 
-func (c *ModuleLoadexConfig) toArgs() []interface{} {
-	args := make([]interface{}, 3, 3+len(c.Conf)*3+len(c.Args)*2)
+func (c *ModuleLoadexConfig) toArgs() []any {
+	args := make([]any, 3, 3+len(c.Conf)*3+len(c.Args)*2)
 	args[0] = "MODULE"
 	args[1] = "LOADEX"
 	args[2] = c.Path

--- a/commands_test.go
+++ b/commands_test.go
@@ -409,7 +409,7 @@ var _ = Describe("Commands", func() {
 
 			defDialect, err := client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "3"}))
+			Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "3"}))
 
 			resGet, err := client.ConfigGet(ctx, "search-default-dialect").Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -422,7 +422,7 @@ var _ = Describe("Commands", func() {
 
 			defDialect, err = client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "2"}))
+			Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "2"}))
 
 			// set to 1
 			res, err = client.ConfigSet(ctx, "search-default-dialect", "1").Result()
@@ -431,7 +431,7 @@ var _ = Describe("Commands", func() {
 
 			defDialect, err = client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "1"}))
+			Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "1"}))
 
 			resGet, err = client.ConfigGet(ctx, "search-default-dialect").Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -1190,7 +1190,7 @@ var _ = Describe("Commands", func() {
 					Get: []string{"object_*"},
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(els).To(Equal([]interface{}{nil, "value2", nil}))
+				Expect(els).To(Equal([]any{nil, "value2", nil}))
 			}
 		})
 
@@ -1819,29 +1819,29 @@ var _ = Describe("Commands", func() {
 
 			mGet := client.MGet(ctx, "key1", "key2", "_")
 			Expect(mGet.Err()).NotTo(HaveOccurred())
-			Expect(mGet.Val()).To(Equal([]interface{}{"hello1", "hello2", nil}))
+			Expect(mGet.Val()).To(Equal([]any{"hello1", "hello2", nil}))
 
 			// MSet struct
 			type set struct {
-				Set1 string                 `redis:"set1"`
-				Set2 int16                  `redis:"set2"`
-				Set3 time.Duration          `redis:"set3"`
-				Set4 interface{}            `redis:"set4"`
-				Set5 map[string]interface{} `redis:"-"`
+				Set1 string         `redis:"set1"`
+				Set2 int16          `redis:"set2"`
+				Set3 time.Duration  `redis:"set3"`
+				Set4 any            `redis:"set4"`
+				Set5 map[string]any `redis:"-"`
 			}
 			mSet = client.MSet(ctx, &set{
 				Set1: "val1",
 				Set2: 1024,
 				Set3: 2 * time.Millisecond,
 				Set4: nil,
-				Set5: map[string]interface{}{"k1": 1},
+				Set5: map[string]any{"k1": 1},
 			})
 			Expect(mSet.Err()).NotTo(HaveOccurred())
 			Expect(mSet.Val()).To(Equal("OK"))
 
 			mGet = client.MGet(ctx, "set1", "set2", "set3", "set4")
 			Expect(mGet.Err()).NotTo(HaveOccurred())
-			Expect(mGet.Val()).To(Equal([]interface{}{
+			Expect(mGet.Val()).To(Equal([]any{
 				"val1",
 				"1024",
 				strconv.Itoa(int(2 * time.Millisecond.Nanoseconds())),
@@ -1886,18 +1886,18 @@ var _ = Describe("Commands", func() {
 			// set struct
 			// MSet struct
 			type set struct {
-				Set1 string                 `redis:"set1"`
-				Set2 int16                  `redis:"set2"`
-				Set3 time.Duration          `redis:"set3"`
-				Set4 interface{}            `redis:"set4"`
-				Set5 map[string]interface{} `redis:"-"`
+				Set1 string         `redis:"set1"`
+				Set2 int16          `redis:"set2"`
+				Set3 time.Duration  `redis:"set3"`
+				Set4 any            `redis:"set4"`
+				Set5 map[string]any `redis:"-"`
 			}
 			mSetNX = client.MSetNX(ctx, &set{
 				Set1: "val1",
 				Set2: 1024,
 				Set3: 2 * time.Millisecond,
 				Set4: nil,
-				Set5: map[string]interface{}{"k1": 1},
+				Set5: map[string]any{"k1": 1},
 			})
 			Expect(mSetNX.Err()).NotTo(HaveOccurred())
 			Expect(mSetNX.Val()).To(Equal(true))
@@ -2368,10 +2368,10 @@ var _ = Describe("Commands", func() {
 		It("should fail module loadex", Label("NonRedisEnterprise"), func() {
 			dryRun := client.ModuleLoadex(ctx, &redis.ModuleLoadexConfig{
 				Path: "/path/to/non-existent-library.so",
-				Conf: map[string]interface{}{
+				Conf: map[string]any{
 					"param1": "value1",
 				},
-				Args: []interface{}{
+				Args: []any{
 					"arg1",
 				},
 			})
@@ -2382,10 +2382,10 @@ var _ = Describe("Commands", func() {
 		It("converts the module loadex configuration to a slice of arguments correctly", func() {
 			conf := &redis.ModuleLoadexConfig{
 				Path: "/path/to/your/module.so",
-				Conf: map[string]interface{}{
+				Conf: map[string]any{
 					"param1": "value1",
 				},
-				Args: []interface{}{
+				Args: []any{
 					"arg1",
 					"arg2",
 					3,
@@ -2395,7 +2395,7 @@ var _ = Describe("Commands", func() {
 			args := conf.ToArgs()
 
 			// Test if the arguments are in the correct order
-			expectedArgs := []interface{}{
+			expectedArgs := []any{
 				"MODULE",
 				"LOADEX",
 				"/path/to/your/module.so",
@@ -2647,11 +2647,11 @@ var _ = Describe("Commands", func() {
 
 			vals, err := client.HMGet(ctx, "hash", "key1", "key2", "_").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vals).To(Equal([]interface{}{"hello1", "hello2", nil}))
+			Expect(vals).To(Equal([]any{"hello1", "hello2", nil}))
 		})
 
 		It("should HSet", func() {
-			ok, err := client.HSet(ctx, "hash", map[string]interface{}{
+			ok, err := client.HSet(ctx, "hash", map[string]any{
 				"key1": "hello1",
 				"key2": "hello2",
 			}).Result()
@@ -2683,12 +2683,12 @@ var _ = Describe("Commands", func() {
 			// set struct
 			// MSet struct
 			type set struct {
-				Set1 string                 `redis:"set1"`
-				Set2 int16                  `redis:"set2"`
-				Set3 time.Duration          `redis:"set3"`
-				Set4 interface{}            `redis:"set4"`
-				Set5 map[string]interface{} `redis:"-"`
-				Set6 string                 `redis:"set6,omitempty"`
+				Set1 string         `redis:"set1"`
+				Set2 int16          `redis:"set2"`
+				Set3 time.Duration  `redis:"set3"`
+				Set4 any            `redis:"set4"`
+				Set5 map[string]any `redis:"-"`
+				Set6 string         `redis:"set6,omitempty"`
 			}
 
 			hSet = client.HSet(ctx, "hash", &set{
@@ -2696,14 +2696,14 @@ var _ = Describe("Commands", func() {
 				Set2: 1024,
 				Set3: 2 * time.Millisecond,
 				Set4: nil,
-				Set5: map[string]interface{}{"k1": 1},
+				Set5: map[string]any{"k1": 1},
 			})
 			Expect(hSet.Err()).NotTo(HaveOccurred())
 			Expect(hSet.Val()).To(Equal(int64(4)))
 
 			hMGet := client.HMGet(ctx, "hash", "set1", "set2", "set3", "set4", "set5", "set6")
 			Expect(hMGet.Err()).NotTo(HaveOccurred())
-			Expect(hMGet.Val()).To(Equal([]interface{}{
+			Expect(hMGet.Val()).To(Equal([]any{
 				"val1",
 				"1024",
 				strconv.Itoa(int(2 * time.Millisecond.Nanoseconds())),
@@ -2721,7 +2721,7 @@ var _ = Describe("Commands", func() {
 
 			hMGet = client.HMGet(ctx, "hash2", "set1", "set6")
 			Expect(hMGet.Err()).NotTo(HaveOccurred())
-			Expect(hMGet.Val()).To(Equal([]interface{}{
+			Expect(hMGet.Val()).To(Equal([]any{
 				"val2",
 				"val",
 			}))
@@ -3162,7 +3162,7 @@ var _ = Describe("Commands", func() {
 
 			values, err := client.HMGet(ctx, "myhash", "f1", "f2").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(values).To(Equal([]interface{}{"val1", "val2"}))
+			Expect(values).To(Equal([]any{"val1", "val2"}))
 		})
 	})
 
@@ -6193,16 +6193,16 @@ var _ = Describe("Commands", func() {
 			id, err := client.XAdd(ctx, &redis.XAddArgs{
 				Stream: "stream",
 				ID:     "1-0",
-				Values: map[string]interface{}{"uno": "un"},
+				Values: map[string]any{"uno": "un"},
 			}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(id).To(Equal("1-0"))
 
-			// Values supports []interface{}.
+			// Values supports []any.
 			id, err = client.XAdd(ctx, &redis.XAddArgs{
 				Stream: "stream",
 				ID:     "2-0",
-				Values: []interface{}{"dos", "deux"},
+				Values: []any{"dos", "deux"},
 			}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(id).To(Equal("2-0"))
@@ -6272,17 +6272,17 @@ var _ = Describe("Commands", func() {
 		It("should XAdd", func() {
 			id, err := client.XAdd(ctx, &redis.XAddArgs{
 				Stream: "stream",
-				Values: map[string]interface{}{"quatro": "quatre"},
+				Values: map[string]any{"quatro": "quatre"},
 			}).Result()
 			Expect(err).NotTo(HaveOccurred())
 
 			vals, err := client.XRange(ctx, "stream", "-", "+").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vals).To(Equal([]redis.XMessage{
-				{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
-				{ID: id, Values: map[string]interface{}{"quatro": "quatre"}},
+				{ID: "1-0", Values: map[string]any{"uno": "un"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
+				{ID: id, Values: map[string]any{"quatro": "quatre"}},
 			}))
 		})
 
@@ -6290,14 +6290,14 @@ var _ = Describe("Commands", func() {
 			id, err := client.XAdd(ctx, &redis.XAddArgs{
 				Stream: "stream",
 				MaxLen: 1,
-				Values: map[string]interface{}{"quatro": "quatre"},
+				Values: map[string]any{"quatro": "quatre"},
 			}).Result()
 			Expect(err).NotTo(HaveOccurred())
 
 			vals, err := client.XRange(ctx, "stream", "-", "+").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vals).To(Equal([]redis.XMessage{
-				{ID: id, Values: map[string]interface{}{"quatro": "quatre"}},
+				{ID: id, Values: map[string]any{"quatro": "quatre"}},
 			}))
 		})
 
@@ -6306,7 +6306,7 @@ var _ = Describe("Commands", func() {
 				Stream: "stream",
 				MinID:  "5-0",
 				ID:     "4-0",
-				Values: map[string]interface{}{"quatro": "quatre"},
+				Values: map[string]any{"quatro": "quatre"},
 			}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(id).To(Equal("4-0"))
@@ -6363,23 +6363,23 @@ var _ = Describe("Commands", func() {
 			msgs, err := client.XRange(ctx, "stream", "-", "+").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+				{ID: "1-0", Values: map[string]any{"uno": "un"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 			}))
 
 			msgs, err = client.XRange(ctx, "stream", "2", "+").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 			}))
 
 			msgs, err = client.XRange(ctx, "stream", "-", "2").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+				{ID: "1-0", Values: map[string]any{"uno": "un"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 			}))
 		})
 
@@ -6387,20 +6387,20 @@ var _ = Describe("Commands", func() {
 			msgs, err := client.XRangeN(ctx, "stream", "-", "+", 2).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+				{ID: "1-0", Values: map[string]any{"uno": "un"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 			}))
 
 			msgs, err = client.XRangeN(ctx, "stream", "2", "+", 1).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 			}))
 
 			msgs, err = client.XRangeN(ctx, "stream", "-", "2", 1).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
+				{ID: "1-0", Values: map[string]any{"uno": "un"}},
 			}))
 		})
 
@@ -6408,16 +6408,16 @@ var _ = Describe("Commands", func() {
 			msgs, err := client.XRevRange(ctx, "stream", "+", "-").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-				{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+				{ID: "1-0", Values: map[string]any{"uno": "un"}},
 			}))
 
 			msgs, err = client.XRevRange(ctx, "stream", "+", "2").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 			}))
 		})
 
@@ -6425,14 +6425,14 @@ var _ = Describe("Commands", func() {
 			msgs, err := client.XRevRangeN(ctx, "stream", "+", "-", 2).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
-				{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
+				{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 			}))
 
 			msgs, err = client.XRevRangeN(ctx, "stream", "+", "2", 1).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(msgs).To(Equal([]redis.XMessage{
-				{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+				{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 			}))
 		})
 
@@ -6443,9 +6443,9 @@ var _ = Describe("Commands", func() {
 				{
 					Stream: "stream",
 					Messages: []redis.XMessage{
-						{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-						{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-						{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+						{ID: "1-0", Values: map[string]any{"uno": "un"}},
+						{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+						{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 					},
 				},
 			}))
@@ -6465,8 +6465,8 @@ var _ = Describe("Commands", func() {
 				{
 					Stream: "stream",
 					Messages: []redis.XMessage{
-						{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-						{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+						{ID: "1-0", Values: map[string]any{"uno": "un"}},
+						{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 					},
 				},
 			}))
@@ -6491,7 +6491,7 @@ var _ = Describe("Commands", func() {
 				{
 					Stream: "stream",
 					Messages: []redis.XMessage{
-						{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+						{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 					},
 				},
 			}))
@@ -6508,13 +6508,13 @@ var _ = Describe("Commands", func() {
 				{
 					Stream: "stream",
 					Messages: []redis.XMessage{
-						{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+						{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 					},
 				},
 				{
 					Stream: "stream",
 					Messages: []redis.XMessage{
-						{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+						{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 					},
 				},
 			}))
@@ -6530,7 +6530,7 @@ var _ = Describe("Commands", func() {
 				id, err := client.XAdd(ctx, &redis.XAddArgs{
 					Stream: "empty",
 					ID:     "4-0",
-					Values: map[string]interface{}{"quatro": "quatre"},
+					Values: map[string]any{"quatro": "quatre"},
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(id).To(Equal("4-0"))
@@ -6548,7 +6548,7 @@ var _ = Describe("Commands", func() {
 				{
 					Stream: "empty",
 					Messages: []redis.XMessage{
-						{ID: "4-0", Values: map[string]interface{}{"quatro": "quatre"}},
+						{ID: "4-0", Values: map[string]any{"quatro": "quatre"}},
 					},
 				},
 			}))
@@ -6569,9 +6569,9 @@ var _ = Describe("Commands", func() {
 					{
 						Stream: "stream",
 						Messages: []redis.XMessage{
-							{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-							{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-							{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+							{ID: "1-0", Values: map[string]any{"uno": "un"}},
+							{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+							{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 						},
 					},
 				}))
@@ -6598,9 +6598,9 @@ var _ = Describe("Commands", func() {
 					{
 						Stream: "stream",
 						Messages: []redis.XMessage{
-							{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
+							{ID: "1-0", Values: map[string]any{"uno": "un"}},
 							{ID: "2-0", Values: nil},
-							{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+							{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 						},
 					},
 				}))
@@ -6679,10 +6679,10 @@ var _ = Describe("Commands", func() {
 				Expect(start).To(Equal("3-0"))
 				Expect(msgs).To(Equal([]redis.XMessage{{
 					ID:     "1-0",
-					Values: map[string]interface{}{"uno": "un"},
+					Values: map[string]any{"uno": "un"},
 				}, {
 					ID:     "2-0",
-					Values: map[string]interface{}{"dos": "deux"},
+					Values: map[string]any{"dos": "deux"},
 				}}))
 
 				xca.Start = start
@@ -6691,7 +6691,7 @@ var _ = Describe("Commands", func() {
 				Expect(start).To(Equal("0-0"))
 				Expect(msgs).To(Equal([]redis.XMessage{{
 					ID:     "3-0",
-					Values: map[string]interface{}{"tres": "troix"},
+					Values: map[string]any{"tres": "troix"},
 				}}))
 
 				ids, start, err := client.XAutoClaimJustID(ctx, xca).Result()
@@ -6710,13 +6710,13 @@ var _ = Describe("Commands", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(msgs).To(Equal([]redis.XMessage{{
 					ID:     "1-0",
-					Values: map[string]interface{}{"uno": "un"},
+					Values: map[string]any{"uno": "un"},
 				}, {
 					ID:     "2-0",
-					Values: map[string]interface{}{"dos": "deux"},
+					Values: map[string]any{"dos": "deux"},
 				}, {
 					ID:     "3-0",
-					Values: map[string]interface{}{"tres": "troix"},
+					Values: map[string]any{"tres": "troix"},
 				}}))
 
 				ids, err := client.XClaimJustID(ctx, &redis.XClaimArgs{
@@ -6752,8 +6752,8 @@ var _ = Describe("Commands", func() {
 					{
 						Stream: "stream",
 						Messages: []redis.XMessage{
-							{ID: "1-0", Values: map[string]interface{}{"uno": "un"}},
-							{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
+							{ID: "1-0", Values: map[string]any{"uno": "un"}},
+							{ID: "2-0", Values: map[string]any{"dos": "deux"}},
 						},
 					},
 				}))
@@ -6768,7 +6768,7 @@ var _ = Describe("Commands", func() {
 					{
 						Stream: "stream",
 						Messages: []redis.XMessage{
-							{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+							{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 						},
 					},
 				}))
@@ -6786,8 +6786,8 @@ var _ = Describe("Commands", func() {
 					{
 						Stream: "stream",
 						Messages: []redis.XMessage{
-							{ID: "2-0", Values: map[string]interface{}{"dos": "deux"}},
-							{ID: "3-0", Values: map[string]interface{}{"tres": "troix"}},
+							{ID: "2-0", Values: map[string]any{"dos": "deux"}},
+							{ID: "3-0", Values: map[string]any{"tres": "troix"}},
 						},
 					},
 				}))
@@ -6818,11 +6818,11 @@ var _ = Describe("Commands", func() {
 					EntriesAdded:      3,
 					FirstEntry: redis.XMessage{
 						ID:     "1-0",
-						Values: map[string]interface{}{"uno": "un"},
+						Values: map[string]any{"uno": "un"},
 					},
 					LastEntry: redis.XMessage{
 						ID:     "3-0",
-						Values: map[string]interface{}{"tres": "troix"},
+						Values: map[string]any{"tres": "troix"},
 					},
 					RecordedFirstEntryID: "1-0",
 				}))
@@ -7416,9 +7416,9 @@ var _ = Describe("Commands", func() {
 
 	Describe("marshaling/unmarshaling", func() {
 		type convTest struct {
-			value  interface{}
+			value  any
 			wanted string
-			dest   interface{}
+			dest   any
 		}
 
 		convTests := []convTest{
@@ -7491,7 +7491,7 @@ var _ = Describe("Commands", func() {
 				"hello",
 			).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vals).To(Equal([]interface{}{"key", "hello"}))
+			Expect(vals).To(Equal([]any{"key", "hello"}))
 		})
 
 		It("returns all values after an error", func() {
@@ -7501,7 +7501,7 @@ var _ = Describe("Commands", func() {
 				nil,
 			).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vals).To(Equal([]interface{}{int64(12), proto.RedisError("error"), "abc"}))
+			Expect(vals).To(Equal([]any{int64(12), proto.RedisError("error"), "abc"}))
 		})
 
 		It("returns empty values when args are nil", func() {
@@ -7525,7 +7525,7 @@ var _ = Describe("Commands", func() {
 				"hello",
 			).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vals).To(Equal([]interface{}{"key", "hello"}))
+			Expect(vals).To(Equal([]any{"key", "hello"}))
 		})
 
 		It("returns all values after an error", func() {
@@ -7535,7 +7535,7 @@ var _ = Describe("Commands", func() {
 				nil,
 			).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(vals).To(Equal([]interface{}{int64(12), proto.RedisError("error"), "abc"}))
+			Expect(vals).To(Equal([]any{int64(12), proto.RedisError("error"), "abc"}))
 		})
 
 		It("returns empty values when args are nil", func() {
@@ -7925,7 +7925,7 @@ func (n *numberStruct) ScanRedis(str string) error {
 	return json.Unmarshal([]byte(str), n)
 }
 
-func deref(viface interface{}) interface{} {
+func deref(viface any) any {
 	v := reflect.ValueOf(viface)
 	for v.Kind() == reflect.Ptr {
 		v = v.Elem()

--- a/doctests/geo_index_test.go
+++ b/doctests/geo_index_test.go
@@ -34,7 +34,7 @@ func ExampleClient_geoindex() {
 		"productidx",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"product:"},
+			Prefix: []any{"product:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.location",
@@ -51,7 +51,7 @@ func ExampleClient_geoindex() {
 	// STEP_END
 
 	// STEP_START add_geo_json
-	prd46885 := map[string]interface{}{
+	prd46885 := map[string]any{
 		"description": "Navy Blue Slippers",
 		"price":       45.99,
 		"city":        "Denver",
@@ -66,7 +66,7 @@ func ExampleClient_geoindex() {
 
 	fmt.Println(gjResult1) // >>> OK
 
-	prd46886 := map[string]interface{}{
+	prd46886 := map[string]any{
 		"description": "Bright Green Socks",
 		"price":       25.50,
 		"city":        "Fort Collins",
@@ -99,7 +99,7 @@ func ExampleClient_geoindex() {
 	geomCreateResult, err := rdb.FTCreate(ctx, "geomidx",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"shape:"},
+			Prefix: []any{"shape:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.name",
@@ -122,7 +122,7 @@ func ExampleClient_geoindex() {
 	// STEP_END
 
 	// STEP_START add_gshape_json
-	shape1 := map[string]interface{}{
+	shape1 := map[string]any{
 		"name": "Green Square",
 		"geom": "POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))",
 	}
@@ -135,7 +135,7 @@ func ExampleClient_geoindex() {
 
 	fmt.Println(gmjResult1) // >>> OK
 
-	shape2 := map[string]interface{}{
+	shape2 := map[string]any{
 		"name": "Red Rectangle",
 		"geom": "POLYGON ((2 2.5, 2 3.5, 3.5 3.5, 3.5 2.5, 2 2.5))",
 	}
@@ -148,7 +148,7 @@ func ExampleClient_geoindex() {
 
 	fmt.Println(gmjResult2) // >>> OK
 
-	shape3 := map[string]interface{}{
+	shape3 := map[string]any{
 		"name": "Blue Triangle",
 		"geom": "POLYGON ((3.5 1, 3.75 2, 4 1, 3.5 1))",
 	}
@@ -161,7 +161,7 @@ func ExampleClient_geoindex() {
 
 	fmt.Println(gmjResult3) // >>> OK
 
-	shape4 := map[string]interface{}{
+	shape4 := map[string]any{
 		"name": "Purple Point",
 		"geom": "POINT (2 2)",
 	}
@@ -179,7 +179,7 @@ func ExampleClient_geoindex() {
 	geomQueryResult, err := rdb.FTSearchWithArgs(ctx, "geomidx",
 		"(-@name:(Green Square) @geom:[WITHIN $qshape])",
 		&redis.FTSearchOptions{
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"qshape": "POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))",
 			},
 			DialectVersion: 4,

--- a/doctests/home_json_example_test.go
+++ b/doctests/home_json_example_test.go
@@ -33,21 +33,21 @@ func ExampleClient_search_json() {
 	// REMOVE_END
 
 	// STEP_START create_data
-	user1 := map[string]interface{}{
+	user1 := map[string]any{
 		"name":  "Paul John",
 		"email": "paul.john@example.com",
 		"age":   42,
 		"city":  "London",
 	}
 
-	user2 := map[string]interface{}{
+	user2 := map[string]any{
 		"name":  "Eden Zamir",
 		"email": "eden.zamir@example.com",
 		"age":   29,
 		"city":  "Tel Aviv",
 	}
 
-	user3 := map[string]interface{}{
+	user3 := map[string]any{
 		"name":  "Paul Zamir",
 		"email": "paul.zamir@example.com",
 		"age":   35,
@@ -62,7 +62,7 @@ func ExampleClient_search_json() {
 		// Options:
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"user:"},
+			Prefix: []any{"user:"},
 		},
 		// Index schema fields:
 		&redis.FieldSchema{
@@ -182,7 +182,7 @@ func ExampleClient_search_json() {
 	aggOptions := redis.FTAggregateOptions{
 		GroupBy: []redis.FTAggregateGroupBy{
 			{
-				Fields: []interface{}{"@city"},
+				Fields: []any{"@city"},
 				Reduce: []redis.FTAggregateReducer{
 					{
 						Reducer: redis.SearchCount,
@@ -250,7 +250,7 @@ func ExampleClient_search_hash() {
 		// Options:
 		&redis.FTCreateOptions{
 			OnHash: true,
-			Prefix: []interface{}{"huser:"},
+			Prefix: []any{"huser:"},
 		},
 		// Index schema fields:
 		&redis.FieldSchema{
@@ -272,21 +272,21 @@ func ExampleClient_search_hash() {
 	}
 	// STEP_END
 
-	user1 := map[string]interface{}{
+	user1 := map[string]any{
 		"name":  "Paul John",
 		"email": "paul.john@example.com",
 		"age":   42,
 		"city":  "London",
 	}
 
-	user2 := map[string]interface{}{
+	user2 := map[string]any{
 		"name":  "Eden Zamir",
 		"email": "eden.zamir@example.com",
 		"age":   29,
 		"city":  "Tel Aviv",
 	}
 
-	user3 := map[string]interface{}{
+	user3 := map[string]any{
 		"name":  "Paul Zamir",
 		"email": "paul.zamir@example.com",
 		"age":   35,

--- a/doctests/json_tutorial_test.go
+++ b/doctests/json_tutorial_test.go
@@ -187,9 +187,9 @@ func ExampleClient_arr() {
 
 	// STEP_START arr
 	res11, err := rdb.JSONSet(ctx, "newbike", "$",
-		[]interface{}{
+		[]any{
 			"Deimos",
-			map[string]interface{}{"crashes": 0},
+			map[string]any{"crashes": 0},
 			nil,
 		},
 	).Result()
@@ -255,7 +255,7 @@ func ExampleClient_arr2() {
 	// REMOVE_END
 
 	// STEP_START arr2
-	res16, err := rdb.JSONSet(ctx, "riders", "$", []interface{}{}).Result()
+	res16, err := rdb.JSONSet(ctx, "riders", "$", []any{}).Result()
 
 	if err != nil {
 		panic(err)
@@ -361,7 +361,7 @@ func ExampleClient_obj() {
 
 	// STEP_START obj
 	res25, err := rdb.JSONSet(ctx, "bike:1", "$",
-		map[string]interface{}{
+		map[string]any{
 			"model": "Deimos",
 			"brand": "Ergonom",
 			"price": 4972,
@@ -397,10 +397,10 @@ func ExampleClient_obj() {
 	// [[brand model price]]
 }
 
-var inventory_json = map[string]interface{}{
-	"inventory": map[string]interface{}{
-		"mountain_bikes": []interface{}{
-			map[string]interface{}{
+var inventory_json = map[string]any{
+	"inventory": map[string]any{
+		"mountain_bikes": []any{
+			map[string]any{
 				"id":    "bike:1",
 				"model": "Phoebe",
 				"description": "This is a mid-travel trail slayer that is a fantastic " +
@@ -409,10 +409,10 @@ var inventory_json = map[string]interface{}{
 					"mudguards and a rack too.  This is the bike for the rider who wants " +
 					"trail manners with low fuss ownership.",
 				"price":  1920,
-				"specs":  map[string]interface{}{"material": "carbon", "weight": 13.1},
-				"colors": []interface{}{"black", "silver"},
+				"specs":  map[string]any{"material": "carbon", "weight": 13.1},
+				"colors": []any{"black", "silver"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":    "bike:2",
 				"model": "Quaoar",
 				"description": "Redesigned for the 2020 model year, this bike " +
@@ -422,10 +422,10 @@ var inventory_json = map[string]interface{}{
 					"and tear. All in all it's an impressive package for the price, " +
 					"making it very competitive.",
 				"price":  2072,
-				"specs":  map[string]interface{}{"material": "aluminium", "weight": 7.9},
-				"colors": []interface{}{"black", "white"},
+				"specs":  map[string]any{"material": "aluminium", "weight": 7.9},
+				"colors": []any{"black", "white"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":    "bike:3",
 				"model": "Weywot",
 				"description": "This bike gives kids aged six years and older " +
@@ -435,11 +435,11 @@ var inventory_json = map[string]interface{}{
 					"ability. If you're after a budget option, this is one of the best " +
 					"bikes you could get.",
 				"price": 3264,
-				"specs": map[string]interface{}{"material": "alloy", "weight": 13.8},
+				"specs": map[string]any{"material": "alloy", "weight": 13.8},
 			},
 		},
-		"commuter_bikes": []interface{}{
-			map[string]interface{}{
+		"commuter_bikes": []any{
+			map[string]any{
 				"id":    "bike:4",
 				"model": "Salacia",
 				"description": "This bike is a great option for anyone who just " +
@@ -448,10 +448,10 @@ var inventory_json = map[string]interface{}{
 					"bank and delivers craved performance.  It\u2019s for the rider " +
 					"who wants both efficiency and capability.",
 				"price":  1475,
-				"specs":  map[string]interface{}{"material": "aluminium", "weight": 16.6},
-				"colors": []interface{}{"black", "silver"},
+				"specs":  map[string]any{"material": "aluminium", "weight": 16.6},
+				"colors": []any{"black", "silver"},
 			},
-			map[string]interface{}{
+			map[string]any{
 				"id":    "bike:5",
 				"model": "Mimas",
 				"description": "A real joy to ride, this bike got very high " +
@@ -463,7 +463,7 @@ var inventory_json = map[string]interface{}{
 					"conveniently placed thumb throttle. Put it all together and you " +
 					"get a bike that helps redefine what can be done for this price.",
 				"price": 3941,
-				"specs": map[string]interface{}{"material": "alloy", "weight": 11.6},
+				"specs": map[string]any{"material": "alloy", "weight": 11.6},
 			},
 		},
 	},
@@ -483,10 +483,10 @@ func ExampleClient_setbikes() {
 	// REMOVE_END
 
 	// STEP_START set_bikes
-	var inventory_json = map[string]interface{}{
-		"inventory": map[string]interface{}{
-			"mountain_bikes": []interface{}{
-				map[string]interface{}{
+	var inventory_json = map[string]any{
+		"inventory": map[string]any{
+			"mountain_bikes": []any{
+				map[string]any{
 					"id":    "bike:1",
 					"model": "Phoebe",
 					"description": "This is a mid-travel trail slayer that is a fantastic " +
@@ -495,10 +495,10 @@ func ExampleClient_setbikes() {
 						"mudguards and a rack too.  This is the bike for the rider who wants " +
 						"trail manners with low fuss ownership.",
 					"price":  1920,
-					"specs":  map[string]interface{}{"material": "carbon", "weight": 13.1},
-					"colors": []interface{}{"black", "silver"},
+					"specs":  map[string]any{"material": "carbon", "weight": 13.1},
+					"colors": []any{"black", "silver"},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "bike:2",
 					"model": "Quaoar",
 					"description": "Redesigned for the 2020 model year, this bike " +
@@ -508,10 +508,10 @@ func ExampleClient_setbikes() {
 						"and tear. All in all it's an impressive package for the price, " +
 						"making it very competitive.",
 					"price":  2072,
-					"specs":  map[string]interface{}{"material": "aluminium", "weight": 7.9},
-					"colors": []interface{}{"black", "white"},
+					"specs":  map[string]any{"material": "aluminium", "weight": 7.9},
+					"colors": []any{"black", "white"},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "bike:3",
 					"model": "Weywot",
 					"description": "This bike gives kids aged six years and older " +
@@ -521,11 +521,11 @@ func ExampleClient_setbikes() {
 						"ability. If you're after a budget option, this is one of the best " +
 						"bikes you could get.",
 					"price": 3264,
-					"specs": map[string]interface{}{"material": "alloy", "weight": 13.8},
+					"specs": map[string]any{"material": "alloy", "weight": 13.8},
 				},
 			},
-			"commuter_bikes": []interface{}{
-				map[string]interface{}{
+			"commuter_bikes": []any{
+				map[string]any{
 					"id":    "bike:4",
 					"model": "Salacia",
 					"description": "This bike is a great option for anyone who just " +
@@ -534,10 +534,10 @@ func ExampleClient_setbikes() {
 						"bank and delivers craved performance.  It\u2019s for the rider " +
 						"who wants both efficiency and capability.",
 					"price":  1475,
-					"specs":  map[string]interface{}{"material": "aluminium", "weight": 16.6},
-					"colors": []interface{}{"black", "silver"},
+					"specs":  map[string]any{"material": "aluminium", "weight": 16.6},
+					"colors": []any{"black", "silver"},
 				},
-				map[string]interface{}{
+				map[string]any{
 					"id":    "bike:5",
 					"model": "Mimas",
 					"description": "A real joy to ride, this bike got very high " +
@@ -549,7 +549,7 @@ func ExampleClient_setbikes() {
 						"conveniently placed thumb throttle. Put it all together and you " +
 						"get a bike that helps redefine what can be done for this price.",
 					"price": 3941,
-					"specs": map[string]interface{}{"material": "alloy", "weight": 11.6},
+					"specs": map[string]any{"material": "alloy", "weight": 11.6},
 				},
 			},
 		},

--- a/doctests/query_agg_test.go
+++ b/doctests/query_agg_test.go
@@ -30,7 +30,7 @@ func ExampleClient_query_agg() {
 	_, err := rdb.FTCreate(ctx, "idx:bicycle",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"bicycle:"},
+			Prefix: []any{"bicycle:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.brand",
@@ -63,7 +63,7 @@ func ExampleClient_query_agg() {
 		panic(err)
 	}
 
-	exampleJsons := []map[string]interface{}{
+	exampleJsons := []map[string]any{
 		{
 			"pickup_zone": "POLYGON((-74.0610 40.7578, -73.9510 40.7578, -73.9510 40.6678, " +
 				"-74.0610 40.6678, -74.0610 40.7578))",
@@ -282,11 +282,11 @@ func ExampleClient_query_agg() {
 			},
 			GroupBy: []redis.FTAggregateGroupBy{
 				{
-					Fields: []interface{}{"@condition"},
+					Fields: []any{"@condition"},
 					Reduce: []redis.FTAggregateReducer{
 						{
 							Reducer: redis.SearchSum,
-							Args:    []interface{}{"@price_category"},
+							Args:    []any{"@price_category"},
 							As:      "num_affordable",
 						},
 					},
@@ -331,7 +331,7 @@ func ExampleClient_query_agg() {
 			},
 			GroupBy: []redis.FTAggregateGroupBy{
 				{
-					Fields: []interface{}{"@type"},
+					Fields: []any{"@type"},
 					Reduce: []redis.FTAggregateReducer{
 						{
 							Reducer: redis.SearchCount,
@@ -368,11 +368,11 @@ func ExampleClient_query_agg() {
 			},
 			GroupBy: []redis.FTAggregateGroupBy{
 				{
-					Fields: []interface{}{"@condition"},
+					Fields: []any{"@condition"},
 					Reduce: []redis.FTAggregateReducer{
 						{
 							Reducer: redis.SearchToList,
-							Args:    []interface{}{"__key"},
+							Args:    []any{"__key"},
 							As:      "bicycles",
 						},
 					},
@@ -393,7 +393,7 @@ func ExampleClient_query_agg() {
 	})
 
 	for _, row := range res4.Rows {
-		rowBikes := row.Fields["bicycles"].([]interface{})
+		rowBikes := row.Fields["bicycles"].([]any)
 		bikes := make([]string, len(rowBikes))
 
 		for i, rowBike := range rowBikes {

--- a/doctests/query_em_test.go
+++ b/doctests/query_em_test.go
@@ -32,7 +32,7 @@ func ExampleClient_query_em() {
 	_, err := rdb.FTCreate(ctx, "idx:bicycle",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"bicycle:"},
+			Prefix: []any{"bicycle:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.brand",
@@ -65,7 +65,7 @@ func ExampleClient_query_em() {
 		panic(err)
 	}
 
-	exampleJsons := []map[string]interface{}{
+	exampleJsons := []map[string]any{
 		{
 			"pickup_zone": "POLYGON((-74.0610 40.7578, -73.9510 40.7578, -73.9510 40.6678, " +
 				"-74.0610 40.6678, -74.0610 40.7578))",
@@ -298,7 +298,7 @@ func ExampleClient_query_em() {
 		"idx:email",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"key:"},
+			Prefix: []any{"key:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.email",
@@ -314,7 +314,7 @@ func ExampleClient_query_em() {
 	fmt.Println(res4) // >>> OK
 
 	res5, err := rdb.JSONSet(ctx, "key:1", "$",
-		map[string]interface{}{
+		map[string]any{
 			"email": "test@redis.com",
 		},
 	).Result()

--- a/doctests/query_ft_test.go
+++ b/doctests/query_ft_test.go
@@ -30,7 +30,7 @@ func ExampleClient_query_ft() {
 	_, err := rdb.FTCreate(ctx, "idx:bicycle",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"bicycle:"},
+			Prefix: []any{"bicycle:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.brand",
@@ -63,7 +63,7 @@ func ExampleClient_query_ft() {
 		panic(err)
 	}
 
-	exampleJsons := []map[string]interface{}{
+	exampleJsons := []map[string]any{
 		{
 			"pickup_zone": "POLYGON((-74.0610 40.7578, -73.9510 40.7578, -73.9510 40.6678, " +
 				"-74.0610 40.6678, -74.0610 40.7578))",

--- a/doctests/query_geo_test.go
+++ b/doctests/query_geo_test.go
@@ -29,7 +29,7 @@ func ExampleClient_query_geo() {
 	_, err := rdb.FTCreate(ctx, "idx:bicycle",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"bicycle:"},
+			Prefix: []any{"bicycle:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.brand",
@@ -73,7 +73,7 @@ func ExampleClient_query_geo() {
 		panic(err)
 	}
 
-	exampleJsons := []map[string]interface{}{
+	exampleJsons := []map[string]any{
 		{
 			"pickup_zone": "POLYGON((-74.0610 40.7578, -73.9510 40.7578, -73.9510 40.6678, " +
 				"-74.0610 40.6678, -74.0610 40.7578))",
@@ -237,7 +237,7 @@ func ExampleClient_query_geo() {
 	res1, err := rdb.FTSearchWithArgs(ctx,
 		"idx:bicycle", "@store_location:[$lon $lat $radius $units]",
 		&redis.FTSearchOptions{
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"lon":    -0.1778,
 				"lat":    51.5524,
 				"radius": 20,
@@ -264,7 +264,7 @@ func ExampleClient_query_geo() {
 		"idx:bicycle",
 		"@pickup_zone:[CONTAINS $bike]",
 		&redis.FTSearchOptions{
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"bike": "POINT(-0.1278 51.5074)",
 			},
 			DialectVersion: 3,
@@ -288,7 +288,7 @@ func ExampleClient_query_geo() {
 		"idx:bicycle",
 		"@pickup_zone:[WITHIN $europe]",
 		&redis.FTSearchOptions{
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"europe": "POLYGON((-25 35, 40 35, 40 70, -25 70, -25 35))",
 			},
 			DialectVersion: 3,

--- a/doctests/query_range_test.go
+++ b/doctests/query_range_test.go
@@ -28,7 +28,7 @@ func ExampleClient_query_range() {
 	_, err := rdb.FTCreate(ctx, "idx:bicycle",
 		&redis.FTCreateOptions{
 			OnJSON: true,
-			Prefix: []interface{}{"bicycle:"},
+			Prefix: []any{"bicycle:"},
 		},
 		&redis.FieldSchema{
 			FieldName: "$.brand",
@@ -61,7 +61,7 @@ func ExampleClient_query_range() {
 		panic(err)
 	}
 
-	exampleJsons := []map[string]interface{}{
+	exampleJsons := []map[string]any{
 		{
 			"pickup_zone": "POLYGON((-74.0610 40.7578, -73.9510 40.7578, -73.9510 40.6678, " +
 				"-74.0610 40.6678, -74.0610 40.7578))",

--- a/doctests/search_quickstart_test.go
+++ b/doctests/search_quickstart_test.go
@@ -11,8 +11,8 @@ import (
 
 // HIDE_END
 
-var bicycles = []interface{}{
-	map[string]interface{}{
+var bicycles = []any{
+	map[string]any{
 		"brand": "Velorim",
 		"model": "Jigger",
 		"price": 270,
@@ -24,7 +24,7 @@ var bicycles = []interface{}{
 			"raring to go.",
 		"condition": "new",
 	},
-	map[string]interface{}{
+	map[string]any{
 		"brand": "Bicyk",
 		"model": "Hillcraft",
 		"price": 1200,
@@ -35,7 +35,7 @@ var bicycles = []interface{}{
 			" they need!",
 		"condition": "used",
 	},
-	map[string]interface{}{
+	map[string]any{
 		"brand": "Nord",
 		"model": "Chook air 5",
 		"price": 815,
@@ -47,7 +47,7 @@ var bicycles = []interface{}{
 			" safety on the trails.",
 		"condition": "used",
 	},
-	map[string]interface{}{
+	map[string]any{
 		"brand": "Eva",
 		"model": "Eva 291",
 		"price": 3400,
@@ -62,7 +62,7 @@ var bicycles = []interface{}{
 			"aluminum frame and fast-rolling 29-inch wheels. Yippee!",
 		"condition": "used",
 	},
-	map[string]interface{}{
+	map[string]any{
 		"brand": "Noka Bikes",
 		"model": "Kahuna",
 		"price": 3200,
@@ -75,7 +75,7 @@ var bicycles = []interface{}{
 			"colourway.",
 		"condition": "used",
 	},
-	map[string]interface{}{
+	map[string]any{
 		"brand": "Breakout",
 		"model": "XBN 2.1 Alloy",
 		"price": 810,
@@ -86,7 +86,7 @@ var bicycles = []interface{}{
 			" break the bank and delivers craved performance.",
 		"condition": "new",
 	},
-	map[string]interface{}{
+	map[string]any{
 		"brand": "ScramBikes",
 		"model": "WattBike",
 		"price": 2300,
@@ -99,7 +99,7 @@ var bicycles = []interface{}{
 			" and normal bike modes.",
 		"condition": "new",
 	},
-	map[string]interface{}{
+	map[string]any{
 		"brand": "Peaknetic",
 		"model": "Secto",
 		"price": 430,
@@ -120,7 +120,7 @@ var bicycles = []interface{}{
 			" flashlight, bell, or phone holder.",
 		"condition": "new",
 	},
-	map[string]interface{}{
+	map[string]any{
 		"brand": "nHill",
 		"model": "Summit",
 		"price": 1200,
@@ -136,7 +136,7 @@ var bicycles = []interface{}{
 			" for money.",
 		"condition": "new",
 	},
-	map[string]interface{}{
+	map[string]any{
 		"model": "ThrillCycle",
 		"brand": "BikeShind",
 		"price": 815,
@@ -188,7 +188,7 @@ func ExampleClient_search_qs() {
 
 	_, err := rdb.FTCreate(ctx, "idx:bicycle",
 		&redis.FTCreateOptions{
-			Prefix: []interface{}{"bicycle:"},
+			Prefix: []any{"bicycle:"},
 			OnJSON: true,
 		},
 		schema...,

--- a/doctests/stream_tutorial_test.go
+++ b/doctests/stream_tutorial_test.go
@@ -12,7 +12,7 @@ import (
 // HIDE_END
 
 // REMOVE_START
-func UNUSED(v ...interface{}) {}
+func UNUSED(v ...any) {}
 
 // REMOVE_END
 
@@ -34,7 +34,7 @@ func ExampleClient_xadd() {
 	// STEP_START xadd
 	res1, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Castilla",
 			"speed":       30.2,
 			"position":    1,
@@ -50,7 +50,7 @@ func ExampleClient_xadd() {
 
 	res2, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Norem",
 			"speed":       28.8,
 			"position":    3,
@@ -66,7 +66,7 @@ func ExampleClient_xadd() {
 
 	res3, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Prickett",
 			"speed":       29.7,
 			"position":    2,
@@ -114,7 +114,7 @@ func ExampleClient_racefrance1() {
 
 	_, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Castilla",
 			"speed":       30.2,
 			"position":    1,
@@ -129,7 +129,7 @@ func ExampleClient_racefrance1() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Norem",
 			"speed":       28.8,
 			"position":    3,
@@ -144,7 +144,7 @@ func ExampleClient_racefrance1() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Prickett",
 			"speed":       29.7,
 			"position":    2,
@@ -186,7 +186,7 @@ func ExampleClient_racefrance1() {
 	// STEP_START xadd_2
 	res6, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Castilla",
 			"speed":       29.9,
 			"position":    1,
@@ -239,7 +239,7 @@ func ExampleClient_raceusa() {
 	// STEP_START xadd_id
 	res8, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:usa",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"racer": "Castilla",
 		},
 		ID: "0-1",
@@ -253,7 +253,7 @@ func ExampleClient_raceusa() {
 
 	res9, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:usa",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"racer": "Norem",
 		},
 		ID: "0-2",
@@ -268,7 +268,7 @@ func ExampleClient_raceusa() {
 
 	// STEP_START xadd_bad_id
 	res10, err := rdb.XAdd(ctx, &redis.XAddArgs{
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"racer": "Prickett",
 		},
 		ID: "0-1",
@@ -283,7 +283,7 @@ func ExampleClient_raceusa() {
 	// STEP_START xadd_7
 	res11, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:usa",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"racer": "Prickett",
 		},
 		ID: "0-*",
@@ -323,7 +323,7 @@ func ExampleClient_racefrance2() {
 
 	_, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Castilla",
 			"speed":       30.2,
 			"position":    1,
@@ -338,7 +338,7 @@ func ExampleClient_racefrance2() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Norem",
 			"speed":       28.8,
 			"position":    3,
@@ -353,7 +353,7 @@ func ExampleClient_racefrance2() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Prickett",
 			"speed":       29.7,
 			"position":    2,
@@ -368,7 +368,7 @@ func ExampleClient_racefrance2() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Castilla",
 			"speed":       29.9,
 			"position":    1,
@@ -493,7 +493,7 @@ func ExampleClient_xgroupcreate() {
 
 	_, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:france",
-		Values: map[string]interface{}{
+		Values: map[string]any{
 			"rider":       "Castilla",
 			"speed":       30.2,
 			"position":    1,
@@ -577,7 +577,7 @@ func ExampleClient_xgroupread() {
 	// STEP_START xgroup_read
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Castilla"},
+		Values: map[string]any{"rider": "Castilla"},
 	}).Result()
 	// >>> 1692632639151-0
 
@@ -587,7 +587,7 @@ func ExampleClient_xgroupread() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Royce"},
+		Values: map[string]any{"rider": "Royce"},
 	}).Result()
 	// >>> 1692632647899-0
 
@@ -597,7 +597,7 @@ func ExampleClient_xgroupread() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Sam-Bodden"},
+		Values: map[string]any{"rider": "Sam-Bodden"},
 	}).Result()
 	// >>> 1692632662819-0
 
@@ -607,7 +607,7 @@ func ExampleClient_xgroupread() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Prickett"},
+		Values: map[string]any{"rider": "Prickett"},
 	}).Result()
 	// >>> 1692632670501-0
 
@@ -617,7 +617,7 @@ func ExampleClient_xgroupread() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Norem"},
+		Values: map[string]any{"rider": "Norem"},
 	}).Result()
 	// >>> 1692632678249-0
 
@@ -684,7 +684,7 @@ func ExampleClient_raceitaly() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Castilla"},
+		Values: map[string]any{"rider": "Castilla"},
 		ID:     "1692632639151-0",
 	}).Result()
 
@@ -694,7 +694,7 @@ func ExampleClient_raceitaly() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Royce"},
+		Values: map[string]any{"rider": "Royce"},
 		ID:     "1692632647899-0",
 	}).Result()
 
@@ -704,7 +704,7 @@ func ExampleClient_raceitaly() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Sam-Bodden"},
+		Values: map[string]any{"rider": "Sam-Bodden"},
 		ID:     "1692632662819-0",
 	}).Result()
 
@@ -714,7 +714,7 @@ func ExampleClient_raceitaly() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Prickett"},
+		Values: map[string]any{"rider": "Prickett"},
 		ID:     "1692632670501-0",
 	}).Result()
 
@@ -724,7 +724,7 @@ func ExampleClient_raceitaly() {
 
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
-		Values: map[string]interface{}{"rider": "Norem"},
+		Values: map[string]any{"rider": "Norem"},
 		ID:     "1692632678249-0",
 	}).Result()
 
@@ -926,7 +926,7 @@ func ExampleClient_raceitaly() {
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
 		MaxLen: 2,
-		Values: map[string]interface{}{"rider": "Jones"},
+		Values: map[string]any{"rider": "Jones"},
 	},
 	).Result()
 
@@ -937,7 +937,7 @@ func ExampleClient_raceitaly() {
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
 		MaxLen: 2,
-		Values: map[string]interface{}{"rider": "Wood"},
+		Values: map[string]any{"rider": "Wood"},
 	},
 	).Result()
 
@@ -948,7 +948,7 @@ func ExampleClient_raceitaly() {
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
 		MaxLen: 2,
-		Values: map[string]interface{}{"rider": "Henshaw"},
+		Values: map[string]any{"rider": "Henshaw"},
 	},
 	).Result()
 
@@ -1035,7 +1035,7 @@ func ExampleClient_xdel() {
 	_, err := rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
 		MaxLen: 2,
-		Values: map[string]interface{}{"rider": "Wood"},
+		Values: map[string]any{"rider": "Wood"},
 		ID:     "1692633198206-0",
 	},
 	).Result()
@@ -1047,7 +1047,7 @@ func ExampleClient_xdel() {
 	_, err = rdb.XAdd(ctx, &redis.XAddArgs{
 		Stream: "race:italy",
 		MaxLen: 2,
-		Values: map[string]interface{}{"rider": "Henshaw"},
+		Values: map[string]any{"rider": "Henshaw"},
 		ID:     "1692633208557-0",
 	},
 	).Result()

--- a/doctests/timeseries_tut_test.go
+++ b/doctests/timeseries_tut_test.go
@@ -133,7 +133,7 @@ func ExampleClient_timeseries_add() {
 	// REMOVE_END
 
 	// STEP_START madd
-	res1, err := rdb.TSMAdd(ctx, [][]interface{}{
+	res1, err := rdb.TSMAdd(ctx, [][]any{
 		{"thermometer:1", 1, 9.2},
 		{"thermometer:1", 2, 9.9},
 		{"thermometer:2", 2, 10.3},
@@ -186,7 +186,7 @@ func ExampleClient_timeseries_range() {
 
 	fmt.Println(res1) // >>> OK
 
-	res2, err := rdb.TSMAdd(ctx, [][]interface{}{
+	res2, err := rdb.TSMAdd(ctx, [][]any{
 		{"rg:1", 0, 18},
 		{"rg:1", 1, 14},
 		{"rg:1", 2, 22},
@@ -356,7 +356,7 @@ func ExampleClient_timeseries_query_multi() {
 
 	fmt.Println(res22) // >>> OK
 
-	res23, err := rdb.TSMAdd(ctx, [][]interface{}{
+	res23, err := rdb.TSMAdd(ctx, [][]any{
 		{"rg:2", 0, 1.8},
 		{"rg:3", 0, 0.9},
 		{"rg:4", 0, 25},
@@ -367,7 +367,7 @@ func ExampleClient_timeseries_query_multi() {
 
 	fmt.Println(res23) // >>> [0 0 0]
 
-	res24, err := rdb.TSMAdd(ctx, [][]interface{}{
+	res24, err := rdb.TSMAdd(ctx, [][]any{
 		{"rg:2", 1, 2.1},
 		{"rg:3", 1, 0.77},
 		{"rg:4", 1, 18},
@@ -378,7 +378,7 @@ func ExampleClient_timeseries_query_multi() {
 
 	fmt.Println(res24) // >>> [1 1 1]
 
-	res25, err := rdb.TSMAdd(ctx, [][]interface{}{
+	res25, err := rdb.TSMAdd(ctx, [][]any{
 		{"rg:2", 2, 2.3},
 		{"rg:3", 2, 1.1},
 		{"rg:4", 2, 21},
@@ -389,7 +389,7 @@ func ExampleClient_timeseries_query_multi() {
 
 	fmt.Println(res25) // >>> [2 2 2]
 
-	res26, err := rdb.TSMAdd(ctx, [][]interface{}{
+	res26, err := rdb.TSMAdd(ctx, [][]any{
 		{"rg:2", 3, 1.9},
 		{"rg:3", 3, 0.81},
 		{"rg:4", 3, 19},
@@ -400,7 +400,7 @@ func ExampleClient_timeseries_query_multi() {
 
 	fmt.Println(res26) // >>> [3 3 3]
 
-	res27, err := rdb.TSMAdd(ctx, [][]interface{}{
+	res27, err := rdb.TSMAdd(ctx, [][]any{
 		{"rg:2", 4, 1.78},
 		{"rg:3", 4, 0.74},
 		{"rg:4", 4, 23},
@@ -421,7 +421,7 @@ func ExampleClient_timeseries_query_multi() {
 	sort.Strings(res28Keys)
 
 	for _, k := range res28Keys {
-		labels := res28[k][0].(map[interface{}]interface{})
+		labels := res28[k][0].(map[any]any)
 
 		labelKeys := make([]string, 0, len(labels))
 
@@ -450,7 +450,7 @@ func ExampleClient_timeseries_query_multi() {
 		ctx,
 		[]string{"location=us"},
 		&redis.TSMGetOptions{
-			SelectedLabels: []interface{}{"unit"},
+			SelectedLabels: []any{"unit"},
 		},
 	).Result()
 	if err != nil {
@@ -461,7 +461,7 @@ func ExampleClient_timeseries_query_multi() {
 	sort.Strings(res29Keys)
 
 	for _, k := range res29Keys {
-		labels := res29[k][0].(map[interface{}]interface{})
+		labels := res29[k][0].(map[any]any)
 
 		labelKeys := make([]string, 0, len(labels))
 
@@ -509,7 +509,7 @@ func ExampleClient_timeseries_query_multi() {
 	sort.Strings(res30Keys)
 
 	for _, k := range res30Keys {
-		labels := res30[k][0].(map[interface{}]interface{})
+		labels := res30[k][0].(map[any]any)
 		labelKeys := make([]string, 0, len(labels))
 
 		for lk := range labels {
@@ -543,7 +543,7 @@ func ExampleClient_timeseries_query_multi() {
 		3,
 		[]string{"unit=(cm,mm)"},
 		&redis.TSMRevRangeOptions{
-			SelectedLabels: []interface{}{"location"},
+			SelectedLabels: []any{"location"},
 		},
 	).Result()
 	if err != nil {
@@ -554,7 +554,7 @@ func ExampleClient_timeseries_query_multi() {
 	sort.Strings(res31Keys)
 
 	for _, k := range res31Keys {
-		labels := res31[k][0].(map[interface{}]interface{})
+		labels := res31[k][0].(map[any]any)
 		labelKeys := make([]string, 0, len(labels))
 
 		for lk := range labels {
@@ -639,7 +639,7 @@ func ExampleClient_timeseries_aggregation() {
 		panic(err)
 	}
 
-	_, err = rdb.TSMAdd(ctx, [][]interface{}{
+	_, err = rdb.TSMAdd(ctx, [][]any{
 		{"rg:2", 0, 1.8},
 		{"rg:2", 1, 2.1},
 		{"rg:2", 2, 2.3},
@@ -695,7 +695,7 @@ func ExampleClient_timeseries_agg_bucket() {
 
 	fmt.Println(res1) // >>> OK
 
-	res2, err := rdb.TSMAdd(ctx, [][]interface{}{
+	res2, err := rdb.TSMAdd(ctx, [][]any{
 		{"sensor3", 10, 1000},
 		{"sensor3", 20, 2000},
 		{"sensor3", 30, 3000},
@@ -805,7 +805,7 @@ func ExampleClient_timeseries_aggmulti() {
 
 	fmt.Println(res40) // >>> OK
 
-	res41, err := rdb.TSMAdd(ctx, [][]interface{}{
+	res41, err := rdb.TSMAdd(ctx, [][]any{
 		{"wind:1", 1, 12},
 		{"wind:2", 1, 18},
 		{"wind:3", 1, 5},
@@ -817,7 +817,7 @@ func ExampleClient_timeseries_aggmulti() {
 
 	fmt.Println(res41) // >>> [1 1 1 1]
 
-	res42, err := rdb.TSMAdd(ctx, [][]interface{}{
+	res42, err := rdb.TSMAdd(ctx, [][]any{
 		{"wind:1", 2, 14},
 		{"wind:2", 2, 21},
 		{"wind:3", 2, 4},
@@ -829,7 +829,7 @@ func ExampleClient_timeseries_aggmulti() {
 
 	fmt.Println(res42) // >>> [2 2 2 2]
 
-	res43, err := rdb.TSMAdd(ctx, [][]interface{}{
+	res43, err := rdb.TSMAdd(ctx, [][]any{
 		{"wind:1", 3, 10},
 		{"wind:2", 3, 24},
 		{"wind:3", 3, 8},
@@ -861,7 +861,7 @@ func ExampleClient_timeseries_aggmulti() {
 	sort.Strings(res44Keys)
 
 	for _, k := range res44Keys {
-		labels := res44[k][0].(map[interface{}]interface{})
+		labels := res44[k][0].(map[any]any)
 		labelKeys := make([]string, 0, len(labels))
 
 		for lk := range labels {
@@ -909,7 +909,7 @@ func ExampleClient_timeseries_aggmulti() {
 	sort.Strings(res45Keys)
 
 	for _, k := range res45Keys {
-		labels := res45[k][0].(map[interface{}]interface{})
+		labels := res45[k][0].(map[any]any)
 		labelKeys := make([]string, 0, len(labels))
 
 		for lk := range labels {
@@ -1019,7 +1019,7 @@ func ExampleClient_timeseries_compaction() {
 	// STEP_END
 
 	// STEP_START comp_add
-	res50, err := rdb.TSMAdd(ctx, [][]interface{}{
+	res50, err := rdb.TSMAdd(ctx, [][]any{
 		{"hyg:1", 0, 75},
 		{"hyg:1", 1, 77},
 		{"hyg:1", 2, 78},
@@ -1083,7 +1083,7 @@ func ExampleClient_timeseries_delete() {
 	rdb.Del(ctx, "thermometer:1")
 	// Setup initial data
 	rdb.TSCreate(ctx, "thermometer:1")
-	rdb.TSMAdd(ctx, [][]interface{}{
+	rdb.TSMAdd(ctx, [][]any{
 		{"thermometer:1", 1, 9.2},
 		{"thermometer:1", 2, 9.9},
 	})

--- a/doctests/vec_set_test.go
+++ b/doctests/vec_set_test.go
@@ -147,7 +147,7 @@ func ExampleClient_vectorset() {
 	// STEP_END
 
 	// STEP_START attr
-	attrs := map[string]interface{}{
+	attrs := map[string]any{
 		"name":        "Point A",
 		"description": "First point added",
 	}
@@ -256,7 +256,7 @@ func ExampleClient_vectorset() {
 	// STEP_START vsim_filter
 	// Set attributes for filtering
 	res24, err := rdb.VSetAttr(ctx, "points", "pt:A",
-		map[string]interface{}{
+		map[string]any{
 			"size":  "large",
 			"price": 18.99,
 		},
@@ -269,7 +269,7 @@ func ExampleClient_vectorset() {
 	fmt.Println(res24) // >>> true
 
 	res25, err := rdb.VSetAttr(ctx, "points", "pt:B",
-		map[string]interface{}{
+		map[string]any{
 			"size":  "large",
 			"price": 35.99,
 		},
@@ -282,7 +282,7 @@ func ExampleClient_vectorset() {
 	fmt.Println(res25) // >>> true
 
 	res26, err := rdb.VSetAttr(ctx, "points", "pt:C",
-		map[string]interface{}{
+		map[string]any{
 			"size":  "large",
 			"price": 25.99,
 		},
@@ -295,7 +295,7 @@ func ExampleClient_vectorset() {
 	fmt.Println(res26) // >>> true
 
 	res27, err := rdb.VSetAttr(ctx, "points", "pt:D",
-		map[string]interface{}{
+		map[string]any{
 			"size":  "small",
 			"price": 21.00,
 		},
@@ -308,7 +308,7 @@ func ExampleClient_vectorset() {
 	fmt.Println(res27) // >>> true
 
 	res28, err := rdb.VSetAttr(ctx, "points", "pt:E",
-		map[string]interface{}{
+		map[string]any{
 			"size":  "small",
 			"price": 17.75,
 		},

--- a/export_test.go
+++ b/export_test.go
@@ -99,7 +99,7 @@ func (c *Ring) ShardByName(name string) *ringShard {
 	return shard
 }
 
-func (c *ModuleLoadexConfig) ToArgs() []interface{} {
+func (c *ModuleLoadexConfig) ToArgs() []any {
 	return c.toArgs()
 }
 

--- a/extra/rediscmd/rediscmd.go
+++ b/extra/rediscmd/rediscmd.go
@@ -61,7 +61,7 @@ func AppendCmd(b []byte, cmd redis.Cmder) []byte {
 	return b
 }
 
-func appendArg(b []byte, v interface{}) []byte {
+func appendArg(b []byte, v any) []byte {
 	switch v := v.(type) {
 	case nil:
 		return append(b, "<nil>"...)

--- a/extra/redisotel/tracing_test.go
+++ b/extra/redisotel/tracing_test.go
@@ -661,7 +661,7 @@ func TestTracingHook_ProcessPipelineHook_LongCommands(t *testing.T) {
 	}
 }
 
-func assertEqual(t *testing.T, expected, actual interface{}) {
+func assertEqual(t *testing.T, expected, actual any) {
 	t.Helper()
 	if expected != actual {
 		t.Fatalf("expected %v, got %v", expected, actual)

--- a/generic_commands.go
+++ b/generic_commands.go
@@ -49,7 +49,7 @@ type GenericCmdable interface {
 }
 
 func (c cmdable) Del(ctx context.Context, keys ...string) *IntCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "del"
 	for i, key := range keys {
 		args[1+i] = key
@@ -60,7 +60,7 @@ func (c cmdable) Del(ctx context.Context, keys ...string) *IntCmd {
 }
 
 func (c cmdable) Unlink(ctx context.Context, keys ...string) *IntCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "unlink"
 	for i, key := range keys {
 		args[1+i] = key
@@ -77,7 +77,7 @@ func (c cmdable) Dump(ctx context.Context, key string) *StringCmd {
 }
 
 func (c cmdable) Exists(ctx context.Context, keys ...string) *IntCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "exists"
 	for i, key := range keys {
 		args[1+i] = key
@@ -110,7 +110,7 @@ func (c cmdable) ExpireLT(ctx context.Context, key string, expiration time.Durat
 func (c cmdable) expire(
 	ctx context.Context, key string, expiration time.Duration, mode string,
 ) *BoolCmd {
-	args := make([]interface{}, 3, 4)
+	args := make([]any, 3, 4)
 	args[0] = "expire"
 	args[1] = key
 	args[2] = formatSec(ctx, expiration)
@@ -272,8 +272,8 @@ type Sort struct {
 	Alpha         bool
 }
 
-func (sort *Sort) args(command, key string) []interface{} {
-	args := []interface{}{command, key}
+func (sort *Sort) args(command, key string) []any {
+	args := []any{command, key}
 
 	if sort.By != "" {
 		args = append(args, "by", sort.By)
@@ -322,7 +322,7 @@ func (c cmdable) SortInterfaces(ctx context.Context, key string, sort *Sort) *Sl
 }
 
 func (c cmdable) Touch(ctx context.Context, keys ...string) *IntCmd {
-	args := make([]interface{}, len(keys)+1)
+	args := make([]any, len(keys)+1)
 	args[0] = "touch"
 	for i, key := range keys {
 		args[i+1] = key
@@ -345,7 +345,7 @@ func (c cmdable) Type(ctx context.Context, key string) *StatusCmd {
 }
 
 func (c cmdable) Copy(ctx context.Context, sourceKey, destKey string, db int, replace bool) *IntCmd {
-	args := []interface{}{"copy", sourceKey, destKey, "DB", db}
+	args := []any{"copy", sourceKey, destKey, "DB", db}
 	if replace {
 		args = append(args, "REPLACE")
 	}
@@ -357,7 +357,7 @@ func (c cmdable) Copy(ctx context.Context, sourceKey, destKey string, db int, re
 //------------------------------------------------------------------------------
 
 func (c cmdable) Scan(ctx context.Context, cursor uint64, match string, count int64) *ScanCmd {
-	args := []interface{}{"scan", cursor}
+	args := []any{"scan", cursor}
 	if match != "" {
 		args = append(args, "match", match)
 	}
@@ -373,7 +373,7 @@ func (c cmdable) Scan(ctx context.Context, cursor uint64, match string, count in
 }
 
 func (c cmdable) ScanType(ctx context.Context, cursor uint64, match string, count int64, keyType string) *ScanCmd {
-	args := []interface{}{"scan", cursor}
+	args := []any{"scan", cursor}
 	if match != "" {
 		args = append(args, "match", match)
 	}

--- a/geo_commands.go
+++ b/geo_commands.go
@@ -20,7 +20,7 @@ type GeoCmdable interface {
 }
 
 func (c cmdable) GeoAdd(ctx context.Context, key string, geoLocation ...*GeoLocation) *IntCmd {
-	args := make([]interface{}, 2+3*len(geoLocation))
+	args := make([]any, 2+3*len(geoLocation))
 	args[0] = "geoadd"
 	args[1] = key
 	for i, eachLoc := range geoLocation {
@@ -88,7 +88,7 @@ func (c cmdable) GeoRadiusByMemberStore(
 }
 
 func (c cmdable) GeoSearch(ctx context.Context, key string, q *GeoSearchQuery) *StringSliceCmd {
-	args := make([]interface{}, 0, 13)
+	args := make([]any, 0, 13)
 	args = append(args, "geosearch", key)
 	args = geoSearchArgs(q, args)
 	cmd := NewStringSliceCmd(ctx, args...)
@@ -99,7 +99,7 @@ func (c cmdable) GeoSearch(ctx context.Context, key string, q *GeoSearchQuery) *
 func (c cmdable) GeoSearchLocation(
 	ctx context.Context, key string, q *GeoSearchLocationQuery,
 ) *GeoSearchLocationCmd {
-	args := make([]interface{}, 0, 16)
+	args := make([]any, 0, 16)
 	args = append(args, "geosearch", key)
 	args = geoSearchLocationArgs(q, args)
 	cmd := NewGeoSearchLocationCmd(ctx, q, args...)
@@ -108,7 +108,7 @@ func (c cmdable) GeoSearchLocation(
 }
 
 func (c cmdable) GeoSearchStore(ctx context.Context, key, store string, q *GeoSearchStoreQuery) *IntCmd {
-	args := make([]interface{}, 0, 15)
+	args := make([]any, 0, 15)
 	args = append(args, "geosearchstore", store, key)
 	args = geoSearchArgs(&q.GeoSearchQuery, args)
 	if q.StoreDist {
@@ -131,7 +131,7 @@ func (c cmdable) GeoDist(
 }
 
 func (c cmdable) GeoHash(ctx context.Context, key string, members ...string) *StringSliceCmd {
-	args := make([]interface{}, 2+len(members))
+	args := make([]any, 2+len(members))
 	args[0] = "geohash"
 	args[1] = key
 	for i, member := range members {
@@ -143,7 +143,7 @@ func (c cmdable) GeoHash(ctx context.Context, key string, members ...string) *St
 }
 
 func (c cmdable) GeoPos(ctx context.Context, key string, members ...string) *GeoPosCmd {
-	args := make([]interface{}, 2+len(members))
+	args := make([]any, 2+len(members))
 	args[0] = "geopos"
 	args[1] = key
 	for i, member := range members {

--- a/hyperloglog_commands.go
+++ b/hyperloglog_commands.go
@@ -3,13 +3,13 @@ package redis
 import "context"
 
 type HyperLogLogCmdable interface {
-	PFAdd(ctx context.Context, key string, els ...interface{}) *IntCmd
+	PFAdd(ctx context.Context, key string, els ...any) *IntCmd
 	PFCount(ctx context.Context, keys ...string) *IntCmd
 	PFMerge(ctx context.Context, dest string, keys ...string) *StatusCmd
 }
 
-func (c cmdable) PFAdd(ctx context.Context, key string, els ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(els))
+func (c cmdable) PFAdd(ctx context.Context, key string, els ...any) *IntCmd {
+	args := make([]any, 2, 2+len(els))
 	args[0] = "pfadd"
 	args[1] = key
 	args = appendArgs(args, els)
@@ -19,7 +19,7 @@ func (c cmdable) PFAdd(ctx context.Context, key string, els ...interface{}) *Int
 }
 
 func (c cmdable) PFCount(ctx context.Context, keys ...string) *IntCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "pfcount"
 	for i, key := range keys {
 		args[1+i] = key
@@ -30,7 +30,7 @@ func (c cmdable) PFCount(ctx context.Context, keys ...string) *IntCmd {
 }
 
 func (c cmdable) PFMerge(ctx context.Context, dest string, keys ...string) *StatusCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]any, 2+len(keys))
 	args[0] = "pfmerge"
 	args[1] = dest
 	for i, key := range keys {

--- a/internal/arg.go
+++ b/internal/arg.go
@@ -8,7 +8,7 @@ import (
 	"github.com/redis/go-redis/v9/internal/util"
 )
 
-func AppendArg(b []byte, v interface{}) []byte {
+func AppendArg(b []byte, v any) []byte {
 	switch v := v.(type) {
 	case nil:
 		return append(b, "<nil>"...)

--- a/internal/customvet/checks/setval/setval.go
+++ b/internal/customvet/checks/setval/setval.go
@@ -12,7 +12,7 @@ var Analyzer = &analysis.Analyzer{
 	Name: "setval",
 	Doc:  "find Cmder types that are missing a SetVal method",
 
-	Run: func(pass *analysis.Pass) (interface{}, error) {
+	Run: func(pass *analysis.Pass) (any, error) {
 		cmderTypes := make(map[string]token.Pos)
 		typesWithSetValMethod := make(map[string]bool)
 

--- a/internal/hscan/hscan.go
+++ b/internal/hscan/hscan.go
@@ -52,7 +52,7 @@ var (
 	globalStructMap = newStructMap()
 )
 
-func Struct(dst interface{}) (StructValue, error) {
+func Struct(dst any) (StructValue, error) {
 	v := reflect.ValueOf(dst)
 
 	// The destination to scan into should be a struct pointer.
@@ -73,7 +73,7 @@ func Struct(dst interface{}) (StructValue, error) {
 
 // Scan scans the results from a key-value Redis map result set to a destination struct.
 // The Redis keys are matched to the struct's field with the `redis` tag.
-func Scan(dst interface{}, keys []interface{}, vals []interface{}) error {
+func Scan(dst any, keys []any, vals []any) error {
 	if len(keys) != len(vals) {
 		return errors.New("args should have the same number of keys and vals")
 	}

--- a/internal/hscan/hscan_test.go
+++ b/internal/hscan/hscan_test.go
@@ -48,7 +48,7 @@ type TimeData struct {
 	Time *TimeRFC3339Nano `redis:"login"`
 }
 
-type i []interface{}
+type i []any
 
 func TestGinkgoSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -66,7 +66,7 @@ var _ = Describe("Scan", func() {
 		Expect(Scan(&d, i{"key"}, i{"1", "2"})).To(HaveOccurred())
 		Expect(Scan(nil, i{"key", "1"}, i{})).To(HaveOccurred())
 
-		var m map[string]interface{}
+		var m map[string]any
 		Expect(Scan(&m, i{"key"}, i{"1"})).To(HaveOccurred())
 		Expect(Scan(data{}, i{"key"}, i{"1"})).To(HaveOccurred())
 		Expect(Scan(data{}, i{"key", "string"}, i{nil, nil})).To(HaveOccurred())

--- a/internal/interfaces/interfaces.go
+++ b/internal/interfaces/interfaces.go
@@ -11,9 +11,9 @@ import (
 // NotificationProcessor is (most probably) a push.NotificationProcessor
 // forward declaration to avoid circular imports
 type NotificationProcessor interface {
-	RegisterHandler(pushNotificationName string, handler interface{}, protected bool) error
+	RegisterHandler(pushNotificationName string, handler any, protected bool) error
 	UnregisterHandler(pushNotificationName string) error
-	GetHandler(pushNotificationName string) interface{}
+	GetHandler(pushNotificationName string) any
 }
 
 // ClientInterface defines the interface that clients must implement for maintnotifications upgrades.

--- a/internal/log.go
+++ b/internal/log.go
@@ -11,14 +11,14 @@ import (
 // Add more standardized approach with log levels and configurability
 
 type Logging interface {
-	Printf(ctx context.Context, format string, v ...interface{})
+	Printf(ctx context.Context, format string, v ...any)
 }
 
 type DefaultLogger struct {
 	log *log.Logger
 }
 
-func (l *DefaultLogger) Printf(ctx context.Context, format string, v ...interface{}) {
+func (l *DefaultLogger) Printf(ctx context.Context, format string, v ...any) {
 	_ = l.log.Output(2, fmt.Sprintf(format, v...))
 }
 

--- a/internal/maintnotifications/logs/log_messages.go
+++ b/internal/maintnotifications/logs/log_messages.go
@@ -9,7 +9,7 @@ import (
 )
 
 // appendJSONIfDebug appends JSON data to a message only if the global log level is Debug
-func appendJSONIfDebug(message string, data map[string]interface{}) string {
+func appendJSONIfDebug(message string, data map[string]any) string {
 	if internal.LogLevel.DebugOrAbove() {
 		jsonData, _ := json.Marshal(data)
 		return fmt.Sprintf("%s %s", message, string(jsonData))
@@ -130,7 +130,7 @@ const (
 
 func HandoffStarted(connID uint64, newEndpoint string) string {
 	message := fmt.Sprintf("conn[%d] %s to %s", connID, HandoffStartedMessage, newEndpoint)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":   connID,
 		"endpoint": newEndpoint,
 	})
@@ -138,7 +138,7 @@ func HandoffStarted(connID uint64, newEndpoint string) string {
 
 func HandoffFailed(connID uint64, newEndpoint string, attempt int, maxAttempts int, err error) string {
 	message := fmt.Sprintf("conn[%d] %s to %s (attempt %d/%d): %v", connID, HandoffFailedMessage, newEndpoint, attempt, maxAttempts, err)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":      connID,
 		"endpoint":    newEndpoint,
 		"attempt":     attempt,
@@ -149,16 +149,16 @@ func HandoffFailed(connID uint64, newEndpoint string, attempt int, maxAttempts i
 
 func HandoffSucceeded(connID uint64, newEndpoint string) string {
 	message := fmt.Sprintf("conn[%d] %s to %s", connID, HandoffSuccessMessage, newEndpoint)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":   connID,
 		"endpoint": newEndpoint,
 	})
 }
 
 // Timeout-related log functions
-func RelaxedTimeoutDueToNotification(connID uint64, notificationType string, timeout interface{}) string {
+func RelaxedTimeoutDueToNotification(connID uint64, notificationType string, timeout any) string {
 	message := fmt.Sprintf("conn[%d] %s %s (%v)", connID, RelaxedTimeoutDueToNotificationMessage, notificationType, timeout)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":           connID,
 		"notificationType": notificationType,
 		"timeout":          fmt.Sprintf("%v", timeout),
@@ -167,14 +167,14 @@ func RelaxedTimeoutDueToNotification(connID uint64, notificationType string, tim
 
 func UnrelaxedTimeout(connID uint64) string {
 	message := fmt.Sprintf("conn[%d] %s", connID, UnrelaxedTimeoutMessage)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID": connID,
 	})
 }
 
 func UnrelaxedTimeoutAfterDeadline(connID uint64) string {
 	message := fmt.Sprintf("conn[%d] %s", connID, UnrelaxedTimeoutAfterDeadlineMessage)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID": connID,
 	})
 }
@@ -182,7 +182,7 @@ func UnrelaxedTimeoutAfterDeadline(connID uint64) string {
 // Handoff queue and marking functions
 func HandoffQueueFull(queueLen, queueCap int) string {
 	message := fmt.Sprintf("%s (%d/%d), cannot queue new handoff requests - consider increasing HandoffQueueSize or MaxWorkers in configuration", HandoffQueueFullMessage, queueLen, queueCap)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"queueLen": queueLen,
 		"queueCap": queueCap,
 	})
@@ -190,7 +190,7 @@ func HandoffQueueFull(queueLen, queueCap int) string {
 
 func FailedToQueueHandoff(connID uint64, err error) string {
 	message := fmt.Sprintf("conn[%d] %s: %v", connID, FailedToQueueHandoffMessage, err)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID": connID,
 		"error":  err.Error(),
 	})
@@ -198,7 +198,7 @@ func FailedToQueueHandoff(connID uint64, err error) string {
 
 func FailedToMarkForHandoff(connID uint64, err error) string {
 	message := fmt.Sprintf("conn[%d] %s: %v", connID, FailedToMarkForHandoffMessage, err)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID": connID,
 		"error":  err.Error(),
 	})
@@ -206,7 +206,7 @@ func FailedToMarkForHandoff(connID uint64, err error) string {
 
 func FailedToDialNewEndpoint(connID uint64, endpoint string, err error) string {
 	message := fmt.Sprintf("conn[%d] %s %s: %v", connID, FailedToDialNewEndpointMessage, endpoint, err)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":   connID,
 		"endpoint": endpoint,
 		"error":    err.Error(),
@@ -215,7 +215,7 @@ func FailedToDialNewEndpoint(connID uint64, endpoint string, err error) string {
 
 func ReachedMaxHandoffRetries(connID uint64, endpoint string, maxRetries int) string {
 	message := fmt.Sprintf("conn[%d] %s to %s (max retries: %d)", connID, ReachedMaxHandoffRetriesMessage, endpoint, maxRetries)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":     connID,
 		"endpoint":   endpoint,
 		"maxRetries": maxRetries,
@@ -223,9 +223,9 @@ func ReachedMaxHandoffRetries(connID uint64, endpoint string, maxRetries int) st
 }
 
 // Notification processing functions
-func ProcessingNotification(connID uint64, seqID int64, notificationType string, notification interface{}) string {
+func ProcessingNotification(connID uint64, seqID int64, notificationType string, notification any) string {
 	message := fmt.Sprintf("conn[%d] seqID[%d] %s %s: %v", connID, seqID, ProcessingNotificationMessage, notificationType, notification)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":           connID,
 		"seqID":            seqID,
 		"notificationType": notificationType,
@@ -233,9 +233,9 @@ func ProcessingNotification(connID uint64, seqID int64, notificationType string,
 	})
 }
 
-func ProcessingNotificationFailed(connID uint64, notificationType string, err error, notification interface{}) string {
+func ProcessingNotificationFailed(connID uint64, notificationType string, err error, notification any) string {
 	message := fmt.Sprintf("conn[%d] %s %s: %v - %v", connID, ProcessingNotificationFailedMessage, notificationType, err, notification)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":           connID,
 		"notificationType": notificationType,
 		"error":            err.Error(),
@@ -245,7 +245,7 @@ func ProcessingNotificationFailed(connID uint64, notificationType string, err er
 
 func ProcessingNotificationSucceeded(connID uint64, notificationType string) string {
 	message := fmt.Sprintf("conn[%d] %s %s", connID, ProcessingNotificationSucceededMessage, notificationType)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":           connID,
 		"notificationType": notificationType,
 	})
@@ -254,7 +254,7 @@ func ProcessingNotificationSucceeded(connID uint64, notificationType string) str
 // Moving operation tracking functions
 func DuplicateMovingOperation(connID uint64, endpoint string, seqID int64) string {
 	message := fmt.Sprintf("conn[%d] %s for %s seqID[%d]", connID, DuplicateMovingOperationMessage, endpoint, seqID)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":   connID,
 		"endpoint": endpoint,
 		"seqID":    seqID,
@@ -263,7 +263,7 @@ func DuplicateMovingOperation(connID uint64, endpoint string, seqID int64) strin
 
 func TrackingMovingOperation(connID uint64, endpoint string, seqID int64) string {
 	message := fmt.Sprintf("conn[%d] %s for %s seqID[%d]", connID, TrackingMovingOperationMessage, endpoint, seqID)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":   connID,
 		"endpoint": endpoint,
 		"seqID":    seqID,
@@ -272,7 +272,7 @@ func TrackingMovingOperation(connID uint64, endpoint string, seqID int64) string
 
 func UntrackingMovingOperation(connID uint64, seqID int64) string {
 	message := fmt.Sprintf("conn[%d] %s seqID[%d]", connID, UntrackingMovingOperationMessage, seqID)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID": connID,
 		"seqID":  seqID,
 	})
@@ -280,7 +280,7 @@ func UntrackingMovingOperation(connID uint64, seqID int64) string {
 
 func OperationNotTracked(connID uint64, seqID int64) string {
 	message := fmt.Sprintf("conn[%d] %s seqID[%d]", connID, OperationNotTrackedMessage, seqID)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID": connID,
 		"seqID":  seqID,
 	})
@@ -289,7 +289,7 @@ func OperationNotTracked(connID uint64, seqID int64) string {
 // Connection pool functions
 func RemovingConnectionFromPool(connID uint64, reason error) string {
 	message := fmt.Sprintf("conn[%d] %s due to: %v", connID, RemovingConnectionFromPoolMessage, reason)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID": connID,
 		"reason": reason.Error(),
 	})
@@ -297,7 +297,7 @@ func RemovingConnectionFromPool(connID uint64, reason error) string {
 
 func NoPoolProvidedCannotRemove(connID uint64, reason error) string {
 	message := fmt.Sprintf("conn[%d] %s due to: %v", connID, NoPoolProvidedMessageCannotRemoveMessage, reason)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID": connID,
 		"reason": reason.Error(),
 	})
@@ -306,7 +306,7 @@ func NoPoolProvidedCannotRemove(connID uint64, reason error) string {
 // Circuit breaker functions
 func CircuitBreakerOpen(connID uint64, endpoint string) string {
 	message := fmt.Sprintf("conn[%d] %s for %s", connID, CircuitBreakerOpenMessage, endpoint)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":   connID,
 		"endpoint": endpoint,
 	})
@@ -315,7 +315,7 @@ func CircuitBreakerOpen(connID uint64, endpoint string) string {
 // Additional handoff functions for specific cases
 func ConnectionNotMarkedForHandoff(connID uint64) string {
 	message := fmt.Sprintf("conn[%d] %s", connID, ConnectionNotMarkedForHandoffMessage)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID": connID,
 	})
 }
@@ -326,7 +326,7 @@ func ConnectionNotMarkedForHandoffError(connID uint64) string {
 
 func HandoffRetryAttempt(connID uint64, retries int, newEndpoint string, oldEndpoint string) string {
 	message := fmt.Sprintf("conn[%d] Retry %d: %s to %s(was %s)", connID, retries, HandoffRetryAttemptMessage, newEndpoint, oldEndpoint)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":      connID,
 		"retries":     retries,
 		"newEndpoint": newEndpoint,
@@ -336,66 +336,66 @@ func HandoffRetryAttempt(connID uint64, retries int, newEndpoint string, oldEndp
 
 func CannotQueueHandoffForRetry(err error) string {
 	message := fmt.Sprintf("%s: %v", CannotQueueHandoffForRetryMessage, err)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"error": err.Error(),
 	})
 }
 
 // Validation and error functions
-func InvalidNotificationFormat(notification interface{}) string {
+func InvalidNotificationFormat(notification any) string {
 	message := fmt.Sprintf("%s: %v", InvalidNotificationFormatMessage, notification)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"notification": fmt.Sprintf("%v", notification),
 	})
 }
 
-func InvalidNotificationTypeFormat(notificationType interface{}) string {
+func InvalidNotificationTypeFormat(notificationType any) string {
 	message := fmt.Sprintf("%s: %v", InvalidNotificationTypeFormatMessage, notificationType)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"notificationType": fmt.Sprintf("%v", notificationType),
 	})
 }
 
 // InvalidNotification creates a log message for invalid notifications of any type
-func InvalidNotification(notificationType string, notification interface{}) string {
+func InvalidNotification(notificationType string, notification any) string {
 	message := fmt.Sprintf("invalid %s notification: %v", notificationType, notification)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"notificationType": notificationType,
 		"notification":     fmt.Sprintf("%v", notification),
 	})
 }
 
-func InvalidSeqIDInMovingNotification(seqID interface{}) string {
+func InvalidSeqIDInMovingNotification(seqID any) string {
 	message := fmt.Sprintf("%s: %v", InvalidSeqIDInMovingNotificationMessage, seqID)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"seqID": fmt.Sprintf("%v", seqID),
 	})
 }
 
-func InvalidTimeSInMovingNotification(timeS interface{}) string {
+func InvalidTimeSInMovingNotification(timeS any) string {
 	message := fmt.Sprintf("%s: %v", InvalidTimeSInMovingNotificationMessage, timeS)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"timeS": fmt.Sprintf("%v", timeS),
 	})
 }
 
-func InvalidNewEndpointInMovingNotification(newEndpoint interface{}) string {
+func InvalidNewEndpointInMovingNotification(newEndpoint any) string {
 	message := fmt.Sprintf("%s: %v", InvalidNewEndpointInMovingNotificationMessage, newEndpoint)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"newEndpoint": fmt.Sprintf("%v", newEndpoint),
 	})
 }
 
 func NoConnectionInHandlerContext(notificationType string) string {
 	message := fmt.Sprintf("%s for %s notification", NoConnectionInHandlerContextMessage, notificationType)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"notificationType": notificationType,
 	})
 }
 
-func InvalidConnectionTypeInHandlerContext(notificationType string, conn interface{}, handlerCtx interface{}) string {
+func InvalidConnectionTypeInHandlerContext(notificationType string, conn any, handlerCtx any) string {
 	message := fmt.Sprintf("%s for %s notification - %T %#v", InvalidConnectionTypeInHandlerContextMessage, notificationType, conn, handlerCtx)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"notificationType": notificationType,
 		"connType":         fmt.Sprintf("%T", conn),
 	})
@@ -403,127 +403,127 @@ func InvalidConnectionTypeInHandlerContext(notificationType string, conn interfa
 
 func SchedulingHandoffToCurrentEndpoint(connID uint64, seconds float64) string {
 	message := fmt.Sprintf("conn[%d] %s in %v seconds", connID, SchedulingHandoffToCurrentEndpointMessage, seconds)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":  connID,
 		"seconds": seconds,
 	})
 }
 
 func ManagerNotInitialized() string {
-	return appendJSONIfDebug(ManagerNotInitializedMessage, map[string]interface{}{})
+	return appendJSONIfDebug(ManagerNotInitializedMessage, map[string]any{})
 }
 
 func FailedToRegisterHandler(notificationType string, err error) string {
 	message := fmt.Sprintf("%s for %s: %v", FailedToRegisterHandlerMessage, notificationType, err)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"notificationType": notificationType,
 		"error":            err.Error(),
 	})
 }
 
 func ShutdownError() string {
-	return appendJSONIfDebug(ShutdownErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(ShutdownErrorMessage, map[string]any{})
 }
 
 // Configuration validation error functions
 func InvalidRelaxedTimeoutError() string {
-	return appendJSONIfDebug(InvalidRelaxedTimeoutErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(InvalidRelaxedTimeoutErrorMessage, map[string]any{})
 }
 
 func InvalidHandoffTimeoutError() string {
-	return appendJSONIfDebug(InvalidHandoffTimeoutErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(InvalidHandoffTimeoutErrorMessage, map[string]any{})
 }
 
 func InvalidHandoffWorkersError() string {
-	return appendJSONIfDebug(InvalidHandoffWorkersErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(InvalidHandoffWorkersErrorMessage, map[string]any{})
 }
 
 func InvalidHandoffQueueSizeError() string {
-	return appendJSONIfDebug(InvalidHandoffQueueSizeErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(InvalidHandoffQueueSizeErrorMessage, map[string]any{})
 }
 
 func InvalidPostHandoffRelaxedDurationError() string {
-	return appendJSONIfDebug(InvalidPostHandoffRelaxedDurationErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(InvalidPostHandoffRelaxedDurationErrorMessage, map[string]any{})
 }
 
 func InvalidEndpointTypeError() string {
-	return appendJSONIfDebug(InvalidEndpointTypeErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(InvalidEndpointTypeErrorMessage, map[string]any{})
 }
 
 func InvalidMaintNotificationsError() string {
-	return appendJSONIfDebug(InvalidMaintNotificationsErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(InvalidMaintNotificationsErrorMessage, map[string]any{})
 }
 
 func InvalidHandoffRetriesError() string {
-	return appendJSONIfDebug(InvalidHandoffRetriesErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(InvalidHandoffRetriesErrorMessage, map[string]any{})
 }
 
 func InvalidClientError() string {
-	return appendJSONIfDebug(InvalidClientErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(InvalidClientErrorMessage, map[string]any{})
 }
 
 func InvalidNotificationError() string {
-	return appendJSONIfDebug(InvalidNotificationErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(InvalidNotificationErrorMessage, map[string]any{})
 }
 
 func MaxHandoffRetriesReachedError() string {
-	return appendJSONIfDebug(MaxHandoffRetriesReachedErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(MaxHandoffRetriesReachedErrorMessage, map[string]any{})
 }
 
 func HandoffQueueFullError() string {
-	return appendJSONIfDebug(HandoffQueueFullErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(HandoffQueueFullErrorMessage, map[string]any{})
 }
 
 func InvalidCircuitBreakerFailureThresholdError() string {
-	return appendJSONIfDebug(InvalidCircuitBreakerFailureThresholdErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(InvalidCircuitBreakerFailureThresholdErrorMessage, map[string]any{})
 }
 
 func InvalidCircuitBreakerResetTimeoutError() string {
-	return appendJSONIfDebug(InvalidCircuitBreakerResetTimeoutErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(InvalidCircuitBreakerResetTimeoutErrorMessage, map[string]any{})
 }
 
 func InvalidCircuitBreakerMaxRequestsError() string {
-	return appendJSONIfDebug(InvalidCircuitBreakerMaxRequestsErrorMessage, map[string]interface{}{})
+	return appendJSONIfDebug(InvalidCircuitBreakerMaxRequestsErrorMessage, map[string]any{})
 }
 
 // Configuration and debug functions
 func DebugLoggingEnabled() string {
-	return appendJSONIfDebug(DebugLoggingEnabledMessage, map[string]interface{}{})
+	return appendJSONIfDebug(DebugLoggingEnabledMessage, map[string]any{})
 }
 
-func ConfigDebug(config interface{}) string {
+func ConfigDebug(config any) string {
 	message := fmt.Sprintf("%s: %+v", ConfigDebugMessage, config)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"config": fmt.Sprintf("%+v", config),
 	})
 }
 
 // Handoff worker functions
 func WorkerExitingDueToShutdown() string {
-	return appendJSONIfDebug(WorkerExitingDueToShutdownMessage, map[string]interface{}{})
+	return appendJSONIfDebug(WorkerExitingDueToShutdownMessage, map[string]any{})
 }
 
 func WorkerExitingDueToShutdownWhileProcessing() string {
-	return appendJSONIfDebug(WorkerExitingDueToShutdownWhileProcessingMessage, map[string]interface{}{})
+	return appendJSONIfDebug(WorkerExitingDueToShutdownWhileProcessingMessage, map[string]any{})
 }
 
-func WorkerPanicRecovered(panicValue interface{}) string {
+func WorkerPanicRecovered(panicValue any) string {
 	message := fmt.Sprintf("%s: %v", WorkerPanicRecoveredMessage, panicValue)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"panic": fmt.Sprintf("%v", panicValue),
 	})
 }
 
-func WorkerExitingDueToInactivityTimeout(timeout interface{}) string {
+func WorkerExitingDueToInactivityTimeout(timeout any) string {
 	message := fmt.Sprintf("%s (%v)", WorkerExitingDueToInactivityTimeoutMessage, timeout)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"timeout": fmt.Sprintf("%v", timeout),
 	})
 }
 
-func ApplyingRelaxedTimeoutDueToPostHandoff(connID uint64, timeout interface{}, until string) string {
+func ApplyingRelaxedTimeoutDueToPostHandoff(connID uint64, timeout any, until string) string {
 	message := fmt.Sprintf("conn[%d] %s (%v) until %s", connID, ApplyingRelaxedTimeoutDueToPostHandoffMessage, timeout, until)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID":  connID,
 		"timeout": fmt.Sprintf("%v", timeout),
 		"until":   until,
@@ -533,7 +533,7 @@ func ApplyingRelaxedTimeoutDueToPostHandoff(connID uint64, timeout interface{}, 
 // Example hooks functions
 func MetricsHookProcessingNotification(notificationType string, connID uint64) string {
 	message := fmt.Sprintf("%s %s notification on conn[%d]", MetricsHookProcessingNotificationMessage, notificationType, connID)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"notificationType": notificationType,
 		"connID":           connID,
 	})
@@ -541,7 +541,7 @@ func MetricsHookProcessingNotification(notificationType string, connID uint64) s
 
 func MetricsHookRecordedError(notificationType string, connID uint64, err error) string {
 	message := fmt.Sprintf("%s for %s notification on conn[%d]: %v", MetricsHookRecordedErrorMessage, notificationType, connID, err)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"notificationType": notificationType,
 		"connID":           connID,
 		"error":            err.Error(),
@@ -551,7 +551,7 @@ func MetricsHookRecordedError(notificationType string, connID uint64, err error)
 // Pool hook functions
 func MarkedForHandoff(connID uint64) string {
 	message := fmt.Sprintf("conn[%d] %s", connID, MarkedForHandoffMessage)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"connID": connID,
 	})
 }
@@ -559,14 +559,14 @@ func MarkedForHandoff(connID uint64) string {
 // Circuit breaker additional functions
 func CircuitBreakerTransitioningToHalfOpen(endpoint string) string {
 	message := fmt.Sprintf("%s for %s", CircuitBreakerTransitioningToHalfOpenMessage, endpoint)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"endpoint": endpoint,
 	})
 }
 
 func CircuitBreakerOpened(endpoint string, failures int64) string {
 	message := fmt.Sprintf("%s for endpoint %s after %d failures", CircuitBreakerOpenedMessage, endpoint, failures)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"endpoint": endpoint,
 		"failures": failures,
 	})
@@ -574,14 +574,14 @@ func CircuitBreakerOpened(endpoint string, failures int64) string {
 
 func CircuitBreakerReopened(endpoint string) string {
 	message := fmt.Sprintf("%s for endpoint %s due to failure in half-open state", CircuitBreakerReopenedMessage, endpoint)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"endpoint": endpoint,
 	})
 }
 
 func CircuitBreakerClosed(endpoint string, successes int64) string {
 	message := fmt.Sprintf("%s for endpoint %s after %d successful requests", CircuitBreakerClosedMessage, endpoint, successes)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"endpoint":  endpoint,
 		"successes": successes,
 	})
@@ -589,7 +589,7 @@ func CircuitBreakerClosed(endpoint string, successes int64) string {
 
 func CircuitBreakerCleanup(removed int, total int) string {
 	message := fmt.Sprintf("%s removed %d/%d entries", CircuitBreakerCleanupMessage, removed, total)
-	return appendJSONIfDebug(message, map[string]interface{}{
+	return appendJSONIfDebug(message, map[string]any{
 		"removed": removed,
 		"total":   total,
 	})
@@ -598,9 +598,9 @@ func CircuitBreakerCleanup(removed int, total int) string {
 // ExtractDataFromLogMessage extracts structured data from maintnotifications log messages
 // Returns a map containing the parsed key-value pairs from the structured data section
 // Example: "conn[123] handoff started to localhost:6379 {"connID":123,"endpoint":"localhost:6379"}"
-// Returns: map[string]interface{}{"connID": 123, "endpoint": "localhost:6379"}
-func ExtractDataFromLogMessage(logMessage string) map[string]interface{} {
-	result := make(map[string]interface{})
+// Returns: map[string]any{"connID": 123, "endpoint": "localhost:6379"}
+func ExtractDataFromLogMessage(logMessage string) map[string]any {
+	result := make(map[string]any)
 
 	// Find the JSON data section at the end of the message
 	re := regexp.MustCompile(`(\{.*\})$`)
@@ -615,7 +615,7 @@ func ExtractDataFromLogMessage(logMessage string) map[string]interface{} {
 	}
 
 	// Parse the JSON directly
-	var jsonResult map[string]interface{}
+	var jsonResult map[string]any
 	if err := json.Unmarshal([]byte(jsonStr), &jsonResult); err == nil {
 		return jsonResult
 	}

--- a/internal/pool/buffer_size_test.go
+++ b/internal/pool/buffer_size_test.go
@@ -129,9 +129,9 @@ var _ = Describe("Buffer Size Configuration", func() {
 // cause runtime panics or incorrect memory access due to invalid pointer dereferencing.
 func getWriterBufSizeUnsafe(cn *pool.Conn) int {
 	cnPtr := (*struct {
-		id            uint64      // First field in pool.Conn
-		usedAt        int64       // Second field (atomic)
-		netConnAtomic interface{} // atomic.Value (interface{} has same size)
+		id            uint64 // First field in pool.Conn
+		usedAt        int64  // Second field (atomic)
+		netConnAtomic any    // atomic.Value (any has same size)
 		rd            *proto.Reader
 		bw            *bufio.Writer
 		wr            *proto.Writer
@@ -147,7 +147,7 @@ func getWriterBufSizeUnsafe(cn *pool.Conn) int {
 		err error
 		buf []byte
 		n   int
-		wr  interface{}
+		wr  any
 	})(unsafe.Pointer(cnPtr.bw))
 
 	return len(bwPtr.buf)
@@ -155,9 +155,9 @@ func getWriterBufSizeUnsafe(cn *pool.Conn) int {
 
 func getReaderBufSizeUnsafe(cn *pool.Conn) int {
 	cnPtr := (*struct {
-		id            uint64      // First field in pool.Conn
-		usedAt        int64       // Second field (atomic)
-		netConnAtomic interface{} // atomic.Value (interface{} has same size)
+		id            uint64 // First field in pool.Conn
+		usedAt        int64  // Second field (atomic)
+		netConnAtomic any    // atomic.Value (any has same size)
 		rd            *proto.Reader
 		bw            *bufio.Writer
 		wr            *proto.Writer
@@ -180,7 +180,7 @@ func getReaderBufSizeUnsafe(cn *pool.Conn) int {
 	// bufio.Reader internal structure
 	bufReaderPtr := (*struct {
 		buf          []byte
-		rd           interface{}
+		rd           any
 		r, w         int
 		err          error
 		lastByte     int

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -46,7 +46,7 @@ var (
 )
 
 var timers = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		t := time.NewTimer(time.Hour)
 		t.Stop()
 		return t

--- a/internal/pool/pubsub.go
+++ b/internal/pool/pubsub.go
@@ -62,7 +62,7 @@ func (p *PubSubPool) UntrackConn(cn *Conn) {
 
 func (p *PubSubPool) Close() error {
 	p.closed.Store(true)
-	p.activeConns.Range(func(key, value interface{}) bool {
+	p.activeConns.Range(func(key, value any) bool {
 		cn := value.(*Conn)
 		_ = cn.Close()
 		return true

--- a/internal/proto/peek_push_notification_test.go
+++ b/internal/proto/peek_push_notification_test.go
@@ -572,7 +572,7 @@ func TestPeekPushNotificationNameBehavior(t *testing.T) {
 		}
 
 		// Verify we got the complete notification
-		if replySlice, ok := reply.([]interface{}); ok {
+		if replySlice, ok := reply.([]any); ok {
 			if len(replySlice) != 2 {
 				t.Errorf("Expected 2 elements, got %d", len(replySlice))
 			}

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -246,7 +246,7 @@ func (r *Reader) readLine() ([]byte, error) {
 	return b[:len(b)-2], nil
 }
 
-func (r *Reader) ReadReply() (interface{}, error) {
+func (r *Reader) ReadReply() (any, error) {
 	line, err := r.ReadLine()
 	if err != nil {
 		return nil, err
@@ -334,13 +334,13 @@ func (r *Reader) readVerb(line []byte) (string, error) {
 	return s[4:], nil
 }
 
-func (r *Reader) readSlice(line []byte) ([]interface{}, error) {
+func (r *Reader) readSlice(line []byte) ([]any, error) {
 	n, err := replyLen(line)
 	if err != nil {
 		return nil, err
 	}
 
-	val := make([]interface{}, n)
+	val := make([]any, n)
 	for i := 0; i < len(val); i++ {
 		v, err := r.ReadReply()
 		if err != nil {
@@ -359,12 +359,12 @@ func (r *Reader) readSlice(line []byte) ([]interface{}, error) {
 	return val, nil
 }
 
-func (r *Reader) readMap(line []byte) (map[interface{}]interface{}, error) {
+func (r *Reader) readMap(line []byte) (map[any]any, error) {
 	n, err := replyLen(line)
 	if err != nil {
 		return nil, err
 	}
-	m := make(map[interface{}]interface{}, n)
+	m := make(map[any]any, n)
 	for i := 0; i < n; i++ {
 		k, err := r.ReadReply()
 		if err != nil {
@@ -497,7 +497,7 @@ func (r *Reader) ReadBool() (bool, error) {
 	return s == "OK" || s == "1" || s == "true", nil
 }
 
-func (r *Reader) ReadSlice() ([]interface{}, error) {
+func (r *Reader) ReadSlice() ([]any, error) {
 	line, err := r.ReadLine()
 	if err != nil {
 		return nil, err

--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -13,7 +13,7 @@ import (
 // Scan parses bytes `b` to `v` with appropriate type.
 //
 //nolint:gocyclo
-func Scan(b []byte, v interface{}) error {
+func Scan(b []byte, v any) error {
 	switch v := v.(type) {
 	case nil:
 		return fmt.Errorf("redis: Scan(nil)")
@@ -126,7 +126,7 @@ func Scan(b []byte, v interface{}) error {
 	}
 }
 
-func ScanSlice(data []string, slice interface{}) error {
+func ScanSlice(data []string, slice any) error {
 	v := reflect.ValueOf(slice)
 	if !v.IsValid() {
 		return fmt.Errorf("redis: ScanSlice(nil)")

--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -34,7 +34,7 @@ func NewWriter(wr writer) *Writer {
 	}
 }
 
-func (w *Writer) WriteArgs(args []interface{}) error {
+func (w *Writer) WriteArgs(args []any) error {
 	if err := w.WriteByte(RespArray); err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func (w *Writer) writeLen(n int) error {
 	return err
 }
 
-func (w *Writer) WriteArg(v interface{}) error {
+func (w *Writer) WriteArg(v any) error {
 	switch v := v.(type) {
 	case nil:
 		return w.string("")

--- a/internal/proto/writer_test.go
+++ b/internal/proto/writer_test.go
@@ -33,7 +33,7 @@ var _ = Describe("WriteBuffer", func() {
 	})
 
 	It("should write args", func() {
-		err := wr.WriteArgs([]interface{}{
+		err := wr.WriteArgs([]any{
 			"string",
 			12,
 			34.56,
@@ -55,14 +55,14 @@ var _ = Describe("WriteBuffer", func() {
 
 	It("should append time", func() {
 		tm := time.Date(2019, 1, 1, 9, 45, 10, 222125, time.UTC)
-		err := wr.WriteArgs([]interface{}{tm})
+		err := wr.WriteArgs([]any{tm})
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(buf.Len()).To(Equal(41))
 	})
 
 	It("should append marshalable args", func() {
-		err := wr.WriteArgs([]interface{}{&MyType{}})
+		err := wr.WriteArgs([]any{&MyType{}})
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(buf.Len()).To(Equal(15))
@@ -70,7 +70,7 @@ var _ = Describe("WriteBuffer", func() {
 
 	It("should append net.IP", func() {
 		ip := net.ParseIP("192.168.1.1")
-		err := wr.WriteArgs([]interface{}{ip})
+		err := wr.WriteArgs([]any{ip})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(buf.String()).To(Equal(fmt.Sprintf("*1\r\n$16\r\n%s\r\n", bytes.NewBuffer(ip))))
 	})
@@ -92,7 +92,7 @@ func (discard) WriteByte(c byte) error {
 
 func BenchmarkWriteBuffer_Append(b *testing.B) {
 	buf := proto.NewWriter(discard{})
-	args := []interface{}{"hello", "world", "foo", "bar"}
+	args := []any{"hello", "world", "foo", "bar"}
 
 	for i := 0; i < b.N; i++ {
 		err := buf.WriteArgs(args)

--- a/internal/util.go
+++ b/internal/util.go
@@ -68,7 +68,7 @@ func GetAddr(addr string) string {
 	return net.JoinHostPort(addr[:ind], addr[ind+1:])
 }
 
-func ToInteger(val interface{}) int {
+func ToInteger(val any) int {
 	switch v := val.(type) {
 	case int:
 		return v
@@ -82,7 +82,7 @@ func ToInteger(val interface{}) int {
 	}
 }
 
-func ToFloat(val interface{}) float64 {
+func ToFloat(val any) float64 {
 	switch v := val.(type) {
 	case float64:
 		return v
@@ -94,15 +94,15 @@ func ToFloat(val interface{}) float64 {
 	}
 }
 
-func ToString(val interface{}) string {
+func ToString(val any) string {
 	if str, ok := val.(string); ok {
 		return str
 	}
 	return ""
 }
 
-func ToStringSlice(val interface{}) []string {
-	if arr, ok := val.([]interface{}); ok {
+func ToStringSlice(val any) []string {
+	if arr, ok := val.([]any); ok {
 		result := make([]string, len(arr))
 		for i, v := range arr {
 			result[i] = ToString(v)

--- a/json.go
+++ b/json.go
@@ -12,10 +12,10 @@ import (
 // -------------------------------------------
 
 type JSONCmdable interface {
-	JSONArrAppend(ctx context.Context, key, path string, values ...interface{}) *IntSliceCmd
-	JSONArrIndex(ctx context.Context, key, path string, value ...interface{}) *IntSliceCmd
-	JSONArrIndexWithArgs(ctx context.Context, key, path string, options *JSONArrIndexArgs, value ...interface{}) *IntSliceCmd
-	JSONArrInsert(ctx context.Context, key, path string, index int64, values ...interface{}) *IntSliceCmd
+	JSONArrAppend(ctx context.Context, key, path string, values ...any) *IntSliceCmd
+	JSONArrIndex(ctx context.Context, key, path string, value ...any) *IntSliceCmd
+	JSONArrIndexWithArgs(ctx context.Context, key, path string, options *JSONArrIndexArgs, value ...any) *IntSliceCmd
+	JSONArrInsert(ctx context.Context, key, path string, index int64, values ...any) *IntSliceCmd
 	JSONArrLen(ctx context.Context, key, path string) *IntSliceCmd
 	JSONArrPop(ctx context.Context, key, path string, index int) *StringSliceCmd
 	JSONArrTrim(ctx context.Context, key, path string) *IntSliceCmd
@@ -28,13 +28,13 @@ type JSONCmdable interface {
 	JSONGetWithArgs(ctx context.Context, key string, options *JSONGetArgs, paths ...string) *JSONCmd
 	JSONMerge(ctx context.Context, key, path string, value string) *StatusCmd
 	JSONMSetArgs(ctx context.Context, docs []JSONSetArgs) *StatusCmd
-	JSONMSet(ctx context.Context, params ...interface{}) *StatusCmd
+	JSONMSet(ctx context.Context, params ...any) *StatusCmd
 	JSONMGet(ctx context.Context, path string, keys ...string) *JSONSliceCmd
 	JSONNumIncrBy(ctx context.Context, key, path string, value float64) *JSONCmd
 	JSONObjKeys(ctx context.Context, key, path string) *SliceCmd
 	JSONObjLen(ctx context.Context, key, path string) *IntPointerSliceCmd
-	JSONSet(ctx context.Context, key, path string, value interface{}) *StatusCmd
-	JSONSetMode(ctx context.Context, key, path string, value interface{}, mode string) *StatusCmd
+	JSONSet(ctx context.Context, key, path string, value any) *StatusCmd
+	JSONSetMode(ctx context.Context, key, path string, value any, mode string) *StatusCmd
 	JSONStrAppend(ctx context.Context, key, path, value string) *IntPointerSliceCmd
 	JSONStrLen(ctx context.Context, key, path string) *IntPointerSliceCmd
 	JSONToggle(ctx context.Context, key, path string) *IntPointerSliceCmd
@@ -44,7 +44,7 @@ type JSONCmdable interface {
 type JSONSetArgs struct {
 	Key   string
 	Path  string
-	Value interface{}
+	Value any
 }
 
 type JSONArrIndexArgs struct {
@@ -60,12 +60,12 @@ type JSONArrTrimArgs struct {
 type JSONCmd struct {
 	baseCmd
 	val      string
-	expanded interface{}
+	expanded any
 }
 
 var _ Cmder = (*JSONCmd)(nil)
 
-func newJSONCmd(ctx context.Context, args ...interface{}) *JSONCmd {
+func newJSONCmd(ctx context.Context, args ...any) *JSONCmd {
 	return &JSONCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -102,7 +102,7 @@ func (cmd *JSONCmd) Result() (string, error) {
 }
 
 // Expanded returns the result of the JSON.GET command as unmarshalled JSON.
-func (cmd *JSONCmd) Expanded() (interface{}, error) {
+func (cmd *JSONCmd) Expanded() (any, error) {
 	if len(cmd.val) != 0 && cmd.expanded == nil {
 		err := json.Unmarshal([]byte(cmd.val), &cmd.expanded)
 		if err != nil {
@@ -142,7 +142,7 @@ func (cmd *JSONCmd) readReply(rd *proto.Reader) error {
 			return nil
 		}
 
-		expanded := make([]interface{}, size)
+		expanded := make([]any, size)
 
 		for i := 0; i < size; i++ {
 			if expanded[i], err = rd.ReadReply(); err != nil {
@@ -169,10 +169,10 @@ func (cmd *JSONCmd) readReply(rd *proto.Reader) error {
 
 type JSONSliceCmd struct {
 	baseCmd
-	val []interface{}
+	val []any
 }
 
-func NewJSONSliceCmd(ctx context.Context, args ...interface{}) *JSONSliceCmd {
+func NewJSONSliceCmd(ctx context.Context, args ...any) *JSONSliceCmd {
 	return &JSONSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -185,15 +185,15 @@ func (cmd *JSONSliceCmd) String() string {
 	return cmdString(cmd, cmd.val)
 }
 
-func (cmd *JSONSliceCmd) SetVal(val []interface{}) {
+func (cmd *JSONSliceCmd) SetVal(val []any) {
 	cmd.val = val
 }
 
-func (cmd *JSONSliceCmd) Val() []interface{} {
+func (cmd *JSONSliceCmd) Val() []any {
 	return cmd.val
 }
 
-func (cmd *JSONSliceCmd) Result() ([]interface{}, error) {
+func (cmd *JSONSliceCmd) Result() ([]any, error) {
 	return cmd.val, cmd.err
 }
 
@@ -210,7 +210,7 @@ func (cmd *JSONSliceCmd) readReply(rd *proto.Reader) error {
 		if err != nil {
 			return nil
 		} else {
-			cmd.val = response.([]interface{})
+			cmd.val = response.([]any)
 		}
 
 	} else {
@@ -218,7 +218,7 @@ func (cmd *JSONSliceCmd) readReply(rd *proto.Reader) error {
 		if err != nil {
 			return err
 		}
-		cmd.val = make([]interface{}, n)
+		cmd.val = make([]any, n)
 		for i := 0; i < len(cmd.val); i++ {
 			switch s, err := rd.ReadString(); {
 			case err == Nil:
@@ -246,7 +246,7 @@ type IntPointerSliceCmd struct {
 }
 
 // NewIntPointerSliceCmd initialises an IntPointerSliceCmd
-func NewIntPointerSliceCmd(ctx context.Context, args ...interface{}) *IntPointerSliceCmd {
+func NewIntPointerSliceCmd(ctx context.Context, args ...any) *IntPointerSliceCmd {
 	return &IntPointerSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -294,8 +294,8 @@ func (cmd *IntPointerSliceCmd) readReply(rd *proto.Reader) error {
 
 // JSONArrAppend adds the provided JSON values to the end of the array at the given path.
 // For more information, see https://redis.io/commands/json.arrappend
-func (c cmdable) JSONArrAppend(ctx context.Context, key, path string, values ...interface{}) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRAPPEND", key, path}
+func (c cmdable) JSONArrAppend(ctx context.Context, key, path string, values ...any) *IntSliceCmd {
+	args := []any{"JSON.ARRAPPEND", key, path}
 	args = append(args, values...)
 	cmd := NewIntSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -304,8 +304,8 @@ func (c cmdable) JSONArrAppend(ctx context.Context, key, path string, values ...
 
 // JSONArrIndex searches for the first occurrence of the provided JSON value in the array at the given path.
 // For more information, see https://redis.io/commands/json.arrindex
-func (c cmdable) JSONArrIndex(ctx context.Context, key, path string, value ...interface{}) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRINDEX", key, path}
+func (c cmdable) JSONArrIndex(ctx context.Context, key, path string, value ...any) *IntSliceCmd {
+	args := []any{"JSON.ARRINDEX", key, path}
 	args = append(args, value...)
 	cmd := NewIntSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -315,8 +315,8 @@ func (c cmdable) JSONArrIndex(ctx context.Context, key, path string, value ...in
 // JSONArrIndexWithArgs searches for the first occurrence of a JSON value in an array while allowing the start and
 // stop options to be provided.
 // For more information, see https://redis.io/commands/json.arrindex
-func (c cmdable) JSONArrIndexWithArgs(ctx context.Context, key, path string, options *JSONArrIndexArgs, value ...interface{}) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRINDEX", key, path}
+func (c cmdable) JSONArrIndexWithArgs(ctx context.Context, key, path string, options *JSONArrIndexArgs, value ...any) *IntSliceCmd {
+	args := []any{"JSON.ARRINDEX", key, path}
 	args = append(args, value...)
 
 	if options != nil {
@@ -332,8 +332,8 @@ func (c cmdable) JSONArrIndexWithArgs(ctx context.Context, key, path string, opt
 
 // JSONArrInsert inserts the JSON values into the array at the specified path before the index (shifts to the right).
 // For more information, see https://redis.io/commands/json.arrinsert
-func (c cmdable) JSONArrInsert(ctx context.Context, key, path string, index int64, values ...interface{}) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRINSERT", key, path, index}
+func (c cmdable) JSONArrInsert(ctx context.Context, key, path string, index int64, values ...any) *IntSliceCmd {
+	args := []any{"JSON.ARRINSERT", key, path, index}
 	args = append(args, values...)
 	cmd := NewIntSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -343,7 +343,7 @@ func (c cmdable) JSONArrInsert(ctx context.Context, key, path string, index int6
 // JSONArrLen reports the length of the JSON array at the specified path in the given key.
 // For more information, see https://redis.io/commands/json.arrlen
 func (c cmdable) JSONArrLen(ctx context.Context, key, path string) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRLEN", key, path}
+	args := []any{"JSON.ARRLEN", key, path}
 	cmd := NewIntSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -352,7 +352,7 @@ func (c cmdable) JSONArrLen(ctx context.Context, key, path string) *IntSliceCmd 
 // JSONArrPop removes and returns an element from the specified index in the array.
 // For more information, see https://redis.io/commands/json.arrpop
 func (c cmdable) JSONArrPop(ctx context.Context, key, path string, index int) *StringSliceCmd {
-	args := []interface{}{"JSON.ARRPOP", key, path, index}
+	args := []any{"JSON.ARRPOP", key, path, index}
 	cmd := NewStringSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -361,7 +361,7 @@ func (c cmdable) JSONArrPop(ctx context.Context, key, path string, index int) *S
 // JSONArrTrim trims an array to contain only the specified inclusive range of elements.
 // For more information, see https://redis.io/commands/json.arrtrim
 func (c cmdable) JSONArrTrim(ctx context.Context, key, path string) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRTRIM", key, path}
+	args := []any{"JSON.ARRTRIM", key, path}
 	cmd := NewIntSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -370,7 +370,7 @@ func (c cmdable) JSONArrTrim(ctx context.Context, key, path string) *IntSliceCmd
 // JSONArrTrimWithArgs trims an array to contain only the specified inclusive range of elements.
 // For more information, see https://redis.io/commands/json.arrtrim
 func (c cmdable) JSONArrTrimWithArgs(ctx context.Context, key, path string, options *JSONArrTrimArgs) *IntSliceCmd {
-	args := []interface{}{"JSON.ARRTRIM", key, path}
+	args := []any{"JSON.ARRTRIM", key, path}
 
 	if options != nil {
 		args = append(args, options.Start)
@@ -387,7 +387,7 @@ func (c cmdable) JSONArrTrimWithArgs(ctx context.Context, key, path string, opti
 // JSONClear clears container values (arrays/objects) and sets numeric values to 0.
 // For more information, see https://redis.io/commands/json.clear
 func (c cmdable) JSONClear(ctx context.Context, key, path string) *IntCmd {
-	args := []interface{}{"JSON.CLEAR", key, path}
+	args := []any{"JSON.CLEAR", key, path}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -402,7 +402,7 @@ func (c cmdable) JSONDebugMemory(ctx context.Context, key, path string) *IntCmd 
 // JSONDel deletes a value.
 // For more information, see https://redis.io/commands/json.del
 func (c cmdable) JSONDel(ctx context.Context, key, path string) *IntCmd {
-	args := []interface{}{"JSON.DEL", key, path}
+	args := []any{"JSON.DEL", key, path}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -411,7 +411,7 @@ func (c cmdable) JSONDel(ctx context.Context, key, path string) *IntCmd {
 // JSONForget deletes a value.
 // For more information, see https://redis.io/commands/json.forget
 func (c cmdable) JSONForget(ctx context.Context, key, path string) *IntCmd {
-	args := []interface{}{"JSON.FORGET", key, path}
+	args := []any{"JSON.FORGET", key, path}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -422,7 +422,7 @@ func (c cmdable) JSONForget(ctx context.Context, key, path string) *IntCmd {
 // internal strings unprocessed by default (see Val())
 // For more information - https://redis.io/commands/json.get/
 func (c cmdable) JSONGet(ctx context.Context, key string, paths ...string) *JSONCmd {
-	args := make([]interface{}, len(paths)+2)
+	args := make([]any, len(paths)+2)
 	args[0] = "JSON.GET"
 	args[1] = key
 	for n, path := range paths {
@@ -444,7 +444,7 @@ type JSONGetArgs struct {
 // Indention, NewLine and Space
 // For more information - https://redis.io/commands/json.get/
 func (c cmdable) JSONGetWithArgs(ctx context.Context, key string, options *JSONGetArgs, paths ...string) *JSONCmd {
-	args := []interface{}{"JSON.GET", key}
+	args := []any{"JSON.GET", key}
 	if options != nil {
 		if options.Indent != "" {
 			args = append(args, "INDENT", options.Indent)
@@ -467,7 +467,7 @@ func (c cmdable) JSONGetWithArgs(ctx context.Context, key string, options *JSONG
 // JSONMerge merges a given JSON value into matching paths.
 // For more information, see https://redis.io/commands/json.merge
 func (c cmdable) JSONMerge(ctx context.Context, key, path string, value string) *StatusCmd {
-	args := []interface{}{"JSON.MERGE", key, path, value}
+	args := []any{"JSON.MERGE", key, path, value}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -478,7 +478,7 @@ func (c cmdable) JSONMerge(ctx context.Context, key, path string, value string) 
 // to follow the pattern of having the last argument be variable.
 // For more information, see https://redis.io/commands/json.mget
 func (c cmdable) JSONMGet(ctx context.Context, path string, keys ...string) *JSONSliceCmd {
-	args := make([]interface{}, len(keys)+1)
+	args := make([]any, len(keys)+1)
 	args[0] = "JSON.MGET"
 	for n, key := range keys {
 		args[n+1] = key
@@ -492,7 +492,7 @@ func (c cmdable) JSONMGet(ctx context.Context, path string, keys ...string) *JSO
 // JSONMSetArgs sets or updates one or more JSON values according to the specified key-path-value triplets.
 // For more information, see https://redis.io/commands/json.mset
 func (c cmdable) JSONMSetArgs(ctx context.Context, docs []JSONSetArgs) *StatusCmd {
-	args := []interface{}{"JSON.MSET"}
+	args := []any{"JSON.MSET"}
 	for _, doc := range docs {
 		args = append(args, doc.Key, doc.Path, doc.Value)
 	}
@@ -501,8 +501,8 @@ func (c cmdable) JSONMSetArgs(ctx context.Context, docs []JSONSetArgs) *StatusCm
 	return cmd
 }
 
-func (c cmdable) JSONMSet(ctx context.Context, params ...interface{}) *StatusCmd {
-	args := []interface{}{"JSON.MSET"}
+func (c cmdable) JSONMSet(ctx context.Context, params ...any) *StatusCmd {
+	args := []any{"JSON.MSET"}
 	args = append(args, params...)
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -512,7 +512,7 @@ func (c cmdable) JSONMSet(ctx context.Context, params ...interface{}) *StatusCmd
 // JSONNumIncrBy increments the number value stored at the specified path by the provided number.
 // For more information, see https://redis.io/docs/latest/commands/json.numincrby/
 func (c cmdable) JSONNumIncrBy(ctx context.Context, key, path string, value float64) *JSONCmd {
-	args := []interface{}{"JSON.NUMINCRBY", key, path, value}
+	args := []any{"JSON.NUMINCRBY", key, path, value}
 	cmd := newJSONCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -521,7 +521,7 @@ func (c cmdable) JSONNumIncrBy(ctx context.Context, key, path string, value floa
 // JSONObjKeys returns the keys in the object that's referenced by the specified path.
 // For more information, see https://redis.io/commands/json.objkeys
 func (c cmdable) JSONObjKeys(ctx context.Context, key, path string) *SliceCmd {
-	args := []interface{}{"JSON.OBJKEYS", key, path}
+	args := []any{"JSON.OBJKEYS", key, path}
 	cmd := NewSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -530,7 +530,7 @@ func (c cmdable) JSONObjKeys(ctx context.Context, key, path string) *SliceCmd {
 // JSONObjLen reports the number of keys in the JSON object at the specified path in the given key.
 // For more information, see https://redis.io/commands/json.objlen
 func (c cmdable) JSONObjLen(ctx context.Context, key, path string) *IntPointerSliceCmd {
-	args := []interface{}{"JSON.OBJLEN", key, path}
+	args := []any{"JSON.OBJLEN", key, path}
 	cmd := NewIntPointerSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -540,7 +540,7 @@ func (c cmdable) JSONObjLen(ctx context.Context, key, path string) *IntPointerSl
 // can be marshaled to JSON (using encoding/JSON) unless the argument is a string or a []byte when we assume that
 // it can be passed directly as JSON.
 // For more information, see https://redis.io/commands/json.set
-func (c cmdable) JSONSet(ctx context.Context, key, path string, value interface{}) *StatusCmd {
+func (c cmdable) JSONSet(ctx context.Context, key, path string, value any) *StatusCmd {
 	return c.JSONSetMode(ctx, key, path, value, "")
 }
 
@@ -548,7 +548,7 @@ func (c cmdable) JSONSet(ctx context.Context, key, path string, value interface{
 // (the mode value must be "XX" or "NX"). The value must be something that can be marshaled to JSON (using encoding/JSON) unless
 // the argument is a string or []byte when we assume that it can be passed directly as JSON.
 // For more information, see https://redis.io/commands/json.set
-func (c cmdable) JSONSetMode(ctx context.Context, key, path string, value interface{}, mode string) *StatusCmd {
+func (c cmdable) JSONSetMode(ctx context.Context, key, path string, value any, mode string) *StatusCmd {
 	var bytes []byte
 	var err error
 	switch v := value.(type) {
@@ -559,7 +559,7 @@ func (c cmdable) JSONSetMode(ctx context.Context, key, path string, value interf
 	default:
 		bytes, err = json.Marshal(v)
 	}
-	args := []interface{}{"JSON.SET", key, path, util.BytesToString(bytes)}
+	args := []any{"JSON.SET", key, path, util.BytesToString(bytes)}
 	if mode != "" {
 		switch strings.ToUpper(mode) {
 		case "XX", "NX":
@@ -581,7 +581,7 @@ func (c cmdable) JSONSetMode(ctx context.Context, key, path string, value interf
 // JSONStrAppend appends the JSON-string values to the string at the specified path.
 // For more information, see https://redis.io/commands/json.strappend
 func (c cmdable) JSONStrAppend(ctx context.Context, key, path, value string) *IntPointerSliceCmd {
-	args := []interface{}{"JSON.STRAPPEND", key, path, value}
+	args := []any{"JSON.STRAPPEND", key, path, value}
 	cmd := NewIntPointerSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -590,7 +590,7 @@ func (c cmdable) JSONStrAppend(ctx context.Context, key, path, value string) *In
 // JSONStrLen reports the length of the JSON String at the specified path in the given key.
 // For more information, see https://redis.io/commands/json.strlen
 func (c cmdable) JSONStrLen(ctx context.Context, key, path string) *IntPointerSliceCmd {
-	args := []interface{}{"JSON.STRLEN", key, path}
+	args := []any{"JSON.STRLEN", key, path}
 	cmd := NewIntPointerSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -599,7 +599,7 @@ func (c cmdable) JSONStrLen(ctx context.Context, key, path string) *IntPointerSl
 // JSONToggle toggles a Boolean value stored at the specified path.
 // For more information, see https://redis.io/commands/json.toggle
 func (c cmdable) JSONToggle(ctx context.Context, key, path string) *IntPointerSliceCmd {
-	args := []interface{}{"JSON.TOGGLE", key, path}
+	args := []any{"JSON.TOGGLE", key, path}
 	cmd := NewIntPointerSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -608,7 +608,7 @@ func (c cmdable) JSONToggle(ctx context.Context, key, path string) *IntPointerSl
 // JSONType reports the type of JSON value at the specified path.
 // For more information, see https://redis.io/commands/json.type
 func (c cmdable) JSONType(ctx context.Context, key, path string) *JSONSliceCmd {
-	args := []interface{}{"JSON.TYPE", key, path}
+	args := []any{"JSON.TYPE", key, path}
 	cmd := NewJSONSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd

--- a/json_test.go
+++ b/json_test.go
@@ -301,11 +301,11 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 
 				res, err := client.JSONMGet(ctx, "$", "mset1").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(res).To(Equal([]interface{}{`[{"a":1}]`}))
+				Expect(res).To(Equal([]any{`[{"a":1}]`}))
 
 				res, err = client.JSONMGet(ctx, "$", "mset1", "mset2").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(res).To(Equal([]interface{}{`[{"a":1}]`, "[2]"}))
+				Expect(res).To(Equal([]any{`[{"a":1}]`, "[2]"}))
 
 				_, err = client.JSONMSet(ctx, "mset1", "$.a", 2, "mset3", "$", `[1]`).Result()
 				Expect(err).NotTo(HaveOccurred())
@@ -337,15 +337,15 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 
 				iRes, err := client.JSONMGet(ctx, "$..a", "doc1").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(iRes).To(Equal([]interface{}{`[1,3,""]`}))
+				Expect(iRes).To(Equal([]any{`[1,3,""]`}))
 
 				iRes, err = client.JSONMGet(ctx, "$..a", "doc1", "doc2").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(iRes).To(Equal([]interface{}{`[1,3,""]`, `[4,6,[""]]`}))
+				Expect(iRes).To(Equal([]any{`[1,3,""]`, `[4,6,[""]]`}))
 
 				iRes, err = client.JSONMGet(ctx, "$..a", "non_existing_doc", "non_existing_doc1").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(iRes).To(Equal([]interface{}{nil, nil}))
+				Expect(iRes).To(Equal([]any{nil, nil}))
 			})
 		})
 
@@ -566,7 +566,7 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 				cmd2 := client.JSONObjKeys(ctx, "objkeys1", "$..*")
 				Expect(cmd2.Err()).NotTo(HaveOccurred())
 				Expect(cmd2.Val()).To(HaveLen(7))
-				Expect(cmd2.Val()).To(Equal([]interface{}{nil, []interface{}{"a"}, nil, nil, nil, nil, nil}))
+				Expect(cmd2.Val()).To(Equal([]any{nil, []any{"a"}, nil, nil, nil, nil, nil}))
 			})
 
 			It("should JSONObjKeys with $", Label("json.objkeys", "json"), func() {
@@ -581,15 +581,15 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 
 				cmd2, err := client.JSONObjKeys(ctx, "objkeys1", "$.nested1.a").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cmd2).To(Equal([]interface{}{[]interface{}{"foo", "bar"}}))
+				Expect(cmd2).To(Equal([]any{[]any{"foo", "bar"}}))
 
 				cmd2, err = client.JSONObjKeys(ctx, "objkeys1", ".*.a").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cmd2).To(Equal([]interface{}{"foo", "bar"}))
+				Expect(cmd2).To(Equal([]any{"foo", "bar"}))
 
 				cmd2, err = client.JSONObjKeys(ctx, "objkeys1", ".nested2.a").Result()
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cmd2).To(Equal([]interface{}{"baz"}))
+				Expect(cmd2).To(Equal([]any{"baz"}))
 
 				_, err = client.JSONObjKeys(ctx, "non_existing_doc", "..a").Result()
 				Expect(err).To(HaveOccurred())
@@ -674,7 +674,7 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 				Expect(cmd2.Err()).NotTo(HaveOccurred())
 				Expect(cmd2.Val()).To(HaveLen(1))
 				// RESP2 v RESP3
-				Expect(cmd2.Val()[0]).To(Or(Equal([]interface{}{"boolean"}), Equal("boolean")))
+				Expect(cmd2.Val()[0]).To(Or(Equal([]any{"boolean"}), Equal("boolean")))
 			})
 		})
 
@@ -762,27 +762,27 @@ var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
 				})
 
 				It("should perform complex JSON and RediSearch operations", func() {
-					jsonDoc := map[string]interface{}{
-						"person": map[string]interface{}{
+					jsonDoc := map[string]any{
+						"person": map[string]any{
 							"name":   "Alice",
 							"age":    30,
 							"status": true,
-							"address": map[string]interface{}{
+							"address": map[string]any{
 								"city":     "Wonderland",
 								"postcode": "12345",
 							},
-							"contacts": []map[string]interface{}{
+							"contacts": []map[string]any{
 								{"type": "email", "value": "alice@example.com"},
 								{"type": "phone", "value": "+123456789"},
 								{"type": "fax", "value": "+987654321"},
 							},
-							"friends": []map[string]interface{}{
+							"friends": []map[string]any{
 								{"name": "Bob", "age": 35, "status": true},
 								{"name": "Charlie", "age": 28, "status": false},
 							},
 						},
-						"settings": map[string]interface{}{
-							"notifications": map[string]interface{}{
+						"settings": map[string]any{
+							"notifications": map[string]any{
 								"email":  true,
 								"sms":    false,
 								"alerts": []string{"low battery", "door open"},
@@ -821,7 +821,7 @@ var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
 					arrTrimCmd := client.JSONArrTrimWithArgs(ctx, "person:1", "$.person.friends", &redis.JSONArrTrimArgs{Start: start, Stop: &stop})
 					Expect(arrTrimCmd.Err()).NotTo(HaveOccurred(), "JSON.ARRTRIM failed")
 
-					mergeData := map[string]interface{}{
+					mergeData := map[string]any{
 						"status":    false,
 						"nickname":  "WonderAlice",
 						"lastLogin": time.Now().Format(time.RFC3339),
@@ -832,7 +832,7 @@ var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
 					typeCmd := client.JSONType(ctx, "person:1", "$.person.nickname")
 					nicknameType, err := typeCmd.Result()
 					Expect(err).NotTo(HaveOccurred(), "JSON.TYPE failed")
-					Expect(nicknameType[0]).To(Equal([]interface{}{"string"}), "JSON.TYPE mismatch for nickname")
+					Expect(nicknameType[0]).To(Equal([]any{"string"}), "JSON.TYPE mismatch for nickname")
 
 					createIndexCmd := client.Do(ctx, "FT.CREATE", "person_idx", "ON", "JSON",
 						"PREFIX", "1", "person:", "SCHEMA",
@@ -867,7 +867,7 @@ var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
 })
 
 // Helper function to marshal data into JSON for comparisons
-func jsonMustMarshal(v interface{}) string {
+func jsonMustMarshal(v any) string {
 	bytes, err := json.Marshal(v)
 	Expect(err).NotTo(HaveOccurred())
 	return string(bytes)

--- a/list_commands.go
+++ b/list_commands.go
@@ -12,32 +12,32 @@ type ListCmdable interface {
 	BRPop(ctx context.Context, timeout time.Duration, keys ...string) *StringSliceCmd
 	BRPopLPush(ctx context.Context, source, destination string, timeout time.Duration) *StringCmd
 	LIndex(ctx context.Context, key string, index int64) *StringCmd
-	LInsert(ctx context.Context, key, op string, pivot, value interface{}) *IntCmd
-	LInsertBefore(ctx context.Context, key string, pivot, value interface{}) *IntCmd
-	LInsertAfter(ctx context.Context, key string, pivot, value interface{}) *IntCmd
+	LInsert(ctx context.Context, key, op string, pivot, value any) *IntCmd
+	LInsertBefore(ctx context.Context, key string, pivot, value any) *IntCmd
+	LInsertAfter(ctx context.Context, key string, pivot, value any) *IntCmd
 	LLen(ctx context.Context, key string) *IntCmd
 	LMPop(ctx context.Context, direction string, count int64, keys ...string) *KeyValuesCmd
 	LPop(ctx context.Context, key string) *StringCmd
 	LPopCount(ctx context.Context, key string, count int) *StringSliceCmd
 	LPos(ctx context.Context, key string, value string, args LPosArgs) *IntCmd
 	LPosCount(ctx context.Context, key string, value string, count int64, args LPosArgs) *IntSliceCmd
-	LPush(ctx context.Context, key string, values ...interface{}) *IntCmd
-	LPushX(ctx context.Context, key string, values ...interface{}) *IntCmd
+	LPush(ctx context.Context, key string, values ...any) *IntCmd
+	LPushX(ctx context.Context, key string, values ...any) *IntCmd
 	LRange(ctx context.Context, key string, start, stop int64) *StringSliceCmd
-	LRem(ctx context.Context, key string, count int64, value interface{}) *IntCmd
-	LSet(ctx context.Context, key string, index int64, value interface{}) *StatusCmd
+	LRem(ctx context.Context, key string, count int64, value any) *IntCmd
+	LSet(ctx context.Context, key string, index int64, value any) *StatusCmd
 	LTrim(ctx context.Context, key string, start, stop int64) *StatusCmd
 	RPop(ctx context.Context, key string) *StringCmd
 	RPopCount(ctx context.Context, key string, count int) *StringSliceCmd
 	RPopLPush(ctx context.Context, source, destination string) *StringCmd
-	RPush(ctx context.Context, key string, values ...interface{}) *IntCmd
-	RPushX(ctx context.Context, key string, values ...interface{}) *IntCmd
+	RPush(ctx context.Context, key string, values ...any) *IntCmd
+	RPushX(ctx context.Context, key string, values ...any) *IntCmd
 	LMove(ctx context.Context, source, destination, srcpos, destpos string) *StringCmd
 	BLMove(ctx context.Context, source, destination, srcpos, destpos string, timeout time.Duration) *StringCmd
 }
 
 func (c cmdable) BLPop(ctx context.Context, timeout time.Duration, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 1+len(keys)+1)
+	args := make([]any, 1+len(keys)+1)
 	args[0] = "blpop"
 	for i, key := range keys {
 		args[1+i] = key
@@ -50,7 +50,7 @@ func (c cmdable) BLPop(ctx context.Context, timeout time.Duration, keys ...strin
 }
 
 func (c cmdable) BLMPop(ctx context.Context, timeout time.Duration, direction string, count int64, keys ...string) *KeyValuesCmd {
-	args := make([]interface{}, 3+len(keys), 6+len(keys))
+	args := make([]any, 3+len(keys), 6+len(keys))
 	args[0] = "blmpop"
 	args[1] = formatSec(ctx, timeout)
 	args[2] = len(keys)
@@ -65,7 +65,7 @@ func (c cmdable) BLMPop(ctx context.Context, timeout time.Duration, direction st
 }
 
 func (c cmdable) BRPop(ctx context.Context, timeout time.Duration, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 1+len(keys)+1)
+	args := make([]any, 1+len(keys)+1)
 	args[0] = "brpop"
 	for i, key := range keys {
 		args[1+i] = key
@@ -100,7 +100,7 @@ func (c cmdable) LIndex(ctx context.Context, key string, index int64) *StringCmd
 // direction: left or right, count: > 0
 // example: client.LMPop(ctx, "left", 3, "key1", "key2")
 func (c cmdable) LMPop(ctx context.Context, direction string, count int64, keys ...string) *KeyValuesCmd {
-	args := make([]interface{}, 2+len(keys), 5+len(keys))
+	args := make([]any, 2+len(keys), 5+len(keys))
 	args[0] = "lmpop"
 	args[1] = len(keys)
 	for i, key := range keys {
@@ -112,19 +112,19 @@ func (c cmdable) LMPop(ctx context.Context, direction string, count int64, keys 
 	return cmd
 }
 
-func (c cmdable) LInsert(ctx context.Context, key, op string, pivot, value interface{}) *IntCmd {
+func (c cmdable) LInsert(ctx context.Context, key, op string, pivot, value any) *IntCmd {
 	cmd := NewIntCmd(ctx, "linsert", key, op, pivot, value)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
-func (c cmdable) LInsertBefore(ctx context.Context, key string, pivot, value interface{}) *IntCmd {
+func (c cmdable) LInsertBefore(ctx context.Context, key string, pivot, value any) *IntCmd {
 	cmd := NewIntCmd(ctx, "linsert", key, "before", pivot, value)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
-func (c cmdable) LInsertAfter(ctx context.Context, key string, pivot, value interface{}) *IntCmd {
+func (c cmdable) LInsertAfter(ctx context.Context, key string, pivot, value any) *IntCmd {
 	cmd := NewIntCmd(ctx, "linsert", key, "after", pivot, value)
 	_ = c(ctx, cmd)
 	return cmd
@@ -153,7 +153,7 @@ type LPosArgs struct {
 }
 
 func (c cmdable) LPos(ctx context.Context, key string, value string, a LPosArgs) *IntCmd {
-	args := []interface{}{"lpos", key, value}
+	args := []any{"lpos", key, value}
 	if a.Rank != 0 {
 		args = append(args, "rank", a.Rank)
 	}
@@ -167,7 +167,7 @@ func (c cmdable) LPos(ctx context.Context, key string, value string, a LPosArgs)
 }
 
 func (c cmdable) LPosCount(ctx context.Context, key string, value string, count int64, a LPosArgs) *IntSliceCmd {
-	args := []interface{}{"lpos", key, value, "count", count}
+	args := []any{"lpos", key, value, "count", count}
 	if a.Rank != 0 {
 		args = append(args, "rank", a.Rank)
 	}
@@ -179,8 +179,8 @@ func (c cmdable) LPosCount(ctx context.Context, key string, value string, count 
 	return cmd
 }
 
-func (c cmdable) LPush(ctx context.Context, key string, values ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(values))
+func (c cmdable) LPush(ctx context.Context, key string, values ...any) *IntCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "lpush"
 	args[1] = key
 	args = appendArgs(args, values)
@@ -189,8 +189,8 @@ func (c cmdable) LPush(ctx context.Context, key string, values ...interface{}) *
 	return cmd
 }
 
-func (c cmdable) LPushX(ctx context.Context, key string, values ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(values))
+func (c cmdable) LPushX(ctx context.Context, key string, values ...any) *IntCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "lpushx"
 	args[1] = key
 	args = appendArgs(args, values)
@@ -211,13 +211,13 @@ func (c cmdable) LRange(ctx context.Context, key string, start, stop int64) *Str
 	return cmd
 }
 
-func (c cmdable) LRem(ctx context.Context, key string, count int64, value interface{}) *IntCmd {
+func (c cmdable) LRem(ctx context.Context, key string, count int64, value any) *IntCmd {
 	cmd := NewIntCmd(ctx, "lrem", key, count, value)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
-func (c cmdable) LSet(ctx context.Context, key string, index int64, value interface{}) *StatusCmd {
+func (c cmdable) LSet(ctx context.Context, key string, index int64, value any) *StatusCmd {
 	cmd := NewStatusCmd(ctx, "lset", key, index, value)
 	_ = c(ctx, cmd)
 	return cmd
@@ -253,8 +253,8 @@ func (c cmdable) RPopLPush(ctx context.Context, source, destination string) *Str
 	return cmd
 }
 
-func (c cmdable) RPush(ctx context.Context, key string, values ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(values))
+func (c cmdable) RPush(ctx context.Context, key string, values ...any) *IntCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "rpush"
 	args[1] = key
 	args = appendArgs(args, values)
@@ -263,8 +263,8 @@ func (c cmdable) RPush(ctx context.Context, key string, values ...interface{}) *
 	return cmd
 }
 
-func (c cmdable) RPushX(ctx context.Context, key string, values ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(values))
+func (c cmdable) RPushX(ctx context.Context, key string, values ...any) *IntCmd {
+	args := make([]any, 2, 2+len(values))
 	args[0] = "rpushx"
 	args[1] = key
 	args = appendArgs(args, values)

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -23,7 +23,7 @@ const (
 // Used to disable logging and thus speed up the library.
 type VoidLogger struct{}
 
-func (v *VoidLogger) Printf(_ context.Context, _ string, _ ...interface{}) {
+func (v *VoidLogger) Printf(_ context.Context, _ string, _ ...any) {
 	// do nothing
 }
 
@@ -69,7 +69,7 @@ type filterLogger struct {
 	substr    []string
 }
 
-func (l *filterLogger) Printf(ctx context.Context, format string, v ...interface{}) {
+func (l *filterLogger) Printf(ctx context.Context, format string, v ...any) {
 	msg := fmt.Sprintf(format, v...)
 	found := false
 	for _, substr := range l.substr {

--- a/maintnotifications/circuit_breaker.go
+++ b/maintnotifications/circuit_breaker.go
@@ -268,7 +268,7 @@ func (cbm *CircuitBreakerManager) GetCircuitBreaker(endpoint string) *CircuitBre
 // GetAllStats returns statistics for all circuit breakers
 func (cbm *CircuitBreakerManager) GetAllStats() []CircuitBreakerStats {
 	var stats []CircuitBreakerStats
-	cbm.breakers.Range(func(key, value interface{}) bool {
+	cbm.breakers.Range(func(key, value any) bool {
 		entry := value.(*CircuitBreakerEntry)
 		stats = append(stats, entry.breaker.GetStats())
 		return true
@@ -305,7 +305,7 @@ func (cbm *CircuitBreakerManager) cleanup() {
 	var toDelete []string
 	count := 0
 
-	cbm.breakers.Range(func(key, value interface{}) bool {
+	cbm.breakers.Range(func(key, value any) bool {
 		endpoint := key.(string)
 		entry := value.(*CircuitBreakerEntry)
 
@@ -339,7 +339,7 @@ func (cbm *CircuitBreakerManager) Shutdown() {
 
 // Reset resets all circuit breakers (useful for testing)
 func (cbm *CircuitBreakerManager) Reset() {
-	cbm.breakers.Range(func(key, value interface{}) bool {
+	cbm.breakers.Range(func(key, value any) bool {
 		entry := value.(*CircuitBreakerEntry)
 		breaker := entry.breaker
 		breaker.state.Store(int32(CircuitBreakerClosed))

--- a/maintnotifications/e2e/DATABASE_MANAGEMENT.md
+++ b/maintnotifications/e2e/DATABASE_MANAGEMENT.md
@@ -196,7 +196,7 @@ resp, err := faultInjector.CreateDatabase(ctx, 0, dbConfig)
 ### Example 3: Create Database Using a Map
 
 ```go
-dbConfigMap := map[string]interface{}{
+dbConfigMap := map[string]any{
     "name":            "map-db",
     "port":            12002,
     "memory_size":     268435456,
@@ -307,7 +307,7 @@ Creates a new database using a structured `DatabaseConfig` object.
 func (c *FaultInjectorClient) CreateDatabaseFromMap(
     ctx context.Context,
     clusterIndex int,
-    databaseConfig map[string]interface{},
+    databaseConfig map[string]any,
 ) (*ActionResponse, error)
 ```
 

--- a/maintnotifications/e2e/config_parser_test.go
+++ b/maintnotifications/e2e/config_parser_test.go
@@ -32,7 +32,7 @@ type DatabaseEndpoint struct {
 
 // EnvDatabaseConfig represents the configuration for a single database
 type EnvDatabaseConfig struct {
-	BdbID                interface{}        `json:"bdb_id,omitempty"`
+	BdbID                any                `json:"bdb_id,omitempty"`
 	Username             string             `json:"username,omitempty"`
 	Password             string             `json:"password,omitempty"`
 	TLS                  bool               `json:"tls"`
@@ -696,7 +696,7 @@ func (m *TestDatabaseManager) CreateDatabase(ctx context.Context, dbConfig Datab
 	if status.Output != nil {
 		if id, ok := status.Output["bdb_id"].(float64); ok {
 			bdbID = int(id)
-		} else if resultMap, ok := status.Output["result"].(map[string]interface{}); ok {
+		} else if resultMap, ok := status.Output["result"].(map[string]any); ok {
 			if id, ok := resultMap["bdb_id"].(float64); ok {
 				bdbID = int(id)
 			}
@@ -763,7 +763,7 @@ func (m *TestDatabaseManager) CreateDatabaseAndGetConfig(ctx context.Context, db
 	}
 
 	// Extract endpoints
-	if endpoints, ok := status.Output["endpoints"].([]interface{}); ok {
+	if endpoints, ok := status.Output["endpoints"].([]any); ok {
 		envConfig.Endpoints = make([]string, 0, len(endpoints))
 		for _, ep := range endpoints {
 			if epStr, ok := ep.(string); ok {
@@ -773,14 +773,14 @@ func (m *TestDatabaseManager) CreateDatabaseAndGetConfig(ctx context.Context, db
 	}
 
 	// Extract raw_endpoints
-	if rawEndpoints, ok := status.Output["raw_endpoints"].([]interface{}); ok {
+	if rawEndpoints, ok := status.Output["raw_endpoints"].([]any); ok {
 		envConfig.RawEndpoints = make([]DatabaseEndpoint, 0, len(rawEndpoints))
 		for _, rawEp := range rawEndpoints {
-			if rawEpMap, ok := rawEp.(map[string]interface{}); ok {
+			if rawEpMap, ok := rawEp.(map[string]any); ok {
 				var dbEndpoint DatabaseEndpoint
 
 				// Extract addr
-				if addr, ok := rawEpMap["addr"].([]interface{}); ok {
+				if addr, ok := rawEpMap["addr"].([]any); ok {
 					dbEndpoint.Addr = make([]string, 0, len(addr))
 					for _, a := range addr {
 						if aStr, ok := a.(string); ok {
@@ -831,7 +831,6 @@ func (m *TestDatabaseManager) DeleteDatabase(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to trigger database deletion: %w", err)
 	}
-
 
 	// Wait for deletion to complete
 	status, err := m.faultInjector.WaitForAction(ctx, resp.ActionID,

--- a/maintnotifications/e2e/fault_injector_test.go
+++ b/maintnotifications/e2e/fault_injector_test.go
@@ -64,8 +64,8 @@ const (
 
 // ActionRequest represents a request to trigger an action
 type ActionRequest struct {
-	Type       ActionType             `json:"type"`
-	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	Type       ActionType     `json:"type"`
+	Parameters map[string]any `json:"parameters,omitempty"`
 }
 
 // ActionResponse represents the response from triggering an action
@@ -77,20 +77,20 @@ type ActionResponse struct {
 
 // ActionStatusResponse represents the status of an action
 type ActionStatusResponse struct {
-	ActionID  string                 `json:"action_id"`
-	Status    ActionStatus           `json:"status"`
-	Error     interface{}            `json:"error,omitempty"`
-	Output    map[string]interface{} `json:"output,omitempty"`
-	Progress  float64                `json:"progress,omitempty"`
-	StartTime time.Time              `json:"start_time,omitempty"`
-	EndTime   time.Time              `json:"end_time,omitempty"`
+	ActionID  string         `json:"action_id"`
+	Status    ActionStatus   `json:"status"`
+	Error     any            `json:"error,omitempty"`
+	Output    map[string]any `json:"output,omitempty"`
+	Progress  float64        `json:"progress,omitempty"`
+	StartTime time.Time      `json:"start_time,omitempty"`
+	EndTime   time.Time      `json:"end_time,omitempty"`
 }
 
 // SequenceAction represents an action in a sequence
 type SequenceAction struct {
-	Type       ActionType             `json:"type"`
-	Parameters map[string]interface{} `json:"params,omitempty"`
-	Delay      time.Duration          `json:"delay,omitempty"`
+	Type       ActionType     `json:"type"`
+	Parameters map[string]any `json:"params,omitempty"`
+	Delay      time.Duration  `json:"delay,omitempty"`
 }
 
 // FaultInjectorClient provides programmatic control over test infrastructure
@@ -132,7 +132,7 @@ func (c *FaultInjectorClient) TriggerAction(ctx context.Context, action ActionRe
 func (c *FaultInjectorClient) TriggerSequence(ctx context.Context, bdbID int, actions []SequenceAction) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionSequence,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"bdb_id":  bdbID,
 			"actions": actions,
 		},
@@ -187,7 +187,7 @@ func (c *FaultInjectorClient) WaitForAction(ctx context.Context, actionID string
 func (c *FaultInjectorClient) TriggerClusterFailover(ctx context.Context, nodeID string, force bool) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionClusterFailover,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"node_id": nodeID,
 			"force":   force,
 		},
@@ -198,7 +198,7 @@ func (c *FaultInjectorClient) TriggerClusterFailover(ctx context.Context, nodeID
 func (c *FaultInjectorClient) TriggerClusterReshard(ctx context.Context, slots []int, sourceNode, targetNode string) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionClusterReshard,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"slots":       slots,
 			"source_node": sourceNode,
 			"target_node": targetNode,
@@ -210,7 +210,7 @@ func (c *FaultInjectorClient) TriggerClusterReshard(ctx context.Context, slots [
 func (c *FaultInjectorClient) TriggerSlotMigration(ctx context.Context, startSlot, endSlot int, sourceNode, targetNode string) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionSlotMigration,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"start_slot":  startSlot,
 			"end_slot":    endSlot,
 			"source_node": sourceNode,
@@ -225,7 +225,7 @@ func (c *FaultInjectorClient) TriggerSlotMigration(ctx context.Context, startSlo
 func (c *FaultInjectorClient) RestartNode(ctx context.Context, nodeID string, graceful bool) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionNodeRestart,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"node_id":  nodeID,
 			"graceful": graceful,
 		},
@@ -236,7 +236,7 @@ func (c *FaultInjectorClient) RestartNode(ctx context.Context, nodeID string, gr
 func (c *FaultInjectorClient) StopNode(ctx context.Context, nodeID string, graceful bool) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionNodeStop,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"node_id":  nodeID,
 			"graceful": graceful,
 		},
@@ -247,7 +247,7 @@ func (c *FaultInjectorClient) StopNode(ctx context.Context, nodeID string, grace
 func (c *FaultInjectorClient) StartNode(ctx context.Context, nodeID string) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionNodeStart,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"node_id": nodeID,
 		},
 	})
@@ -257,7 +257,7 @@ func (c *FaultInjectorClient) StartNode(ctx context.Context, nodeID string) (*Ac
 func (c *FaultInjectorClient) KillNode(ctx context.Context, nodeID string) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionNodeKill,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"node_id": nodeID,
 		},
 	})
@@ -269,7 +269,7 @@ func (c *FaultInjectorClient) KillNode(ctx context.Context, nodeID string) (*Act
 func (c *FaultInjectorClient) SimulateNetworkPartition(ctx context.Context, nodes []string, duration time.Duration) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionNetworkPartition,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"nodes":    nodes,
 			"duration": duration.String(),
 		},
@@ -280,7 +280,7 @@ func (c *FaultInjectorClient) SimulateNetworkPartition(ctx context.Context, node
 func (c *FaultInjectorClient) SimulateNetworkLatency(ctx context.Context, nodes []string, latency time.Duration, jitter time.Duration) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionNetworkLatency,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"nodes":   nodes,
 			"latency": latency.String(),
 			"jitter":  jitter.String(),
@@ -292,7 +292,7 @@ func (c *FaultInjectorClient) SimulateNetworkLatency(ctx context.Context, nodes 
 func (c *FaultInjectorClient) SimulatePacketLoss(ctx context.Context, nodes []string, lossPercent float64) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionNetworkPacketLoss,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"nodes":        nodes,
 			"loss_percent": lossPercent,
 		},
@@ -303,7 +303,7 @@ func (c *FaultInjectorClient) SimulatePacketLoss(ctx context.Context, nodes []st
 func (c *FaultInjectorClient) LimitBandwidth(ctx context.Context, nodes []string, bandwidth string) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionNetworkBandwidth,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"nodes":     nodes,
 			"bandwidth": bandwidth,
 		},
@@ -314,7 +314,7 @@ func (c *FaultInjectorClient) LimitBandwidth(ctx context.Context, nodes []string
 func (c *FaultInjectorClient) RestoreNetwork(ctx context.Context, nodes []string) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionNetworkRestore,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"nodes": nodes,
 		},
 	})
@@ -326,7 +326,7 @@ func (c *FaultInjectorClient) RestoreNetwork(ctx context.Context, nodes []string
 func (c *FaultInjectorClient) ChangeConfig(ctx context.Context, nodeID string, config map[string]string) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionConfigChange,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"node_id": nodeID,
 			"config":  config,
 		},
@@ -337,7 +337,7 @@ func (c *FaultInjectorClient) ChangeConfig(ctx context.Context, nodeID string, c
 func (c *FaultInjectorClient) EnableMaintenanceMode(ctx context.Context, nodeID string) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionMaintenanceMode,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"node_id": nodeID,
 			"enabled": true,
 		},
@@ -348,7 +348,7 @@ func (c *FaultInjectorClient) EnableMaintenanceMode(ctx context.Context, nodeID 
 func (c *FaultInjectorClient) DisableMaintenanceMode(ctx context.Context, nodeID string) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionMaintenanceMode,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"node_id": nodeID,
 			"enabled": false,
 		},
@@ -393,7 +393,7 @@ type ShardKeyRegexPattern struct {
 func (c *FaultInjectorClient) DeleteDatabase(ctx context.Context, clusterIndex int, bdbID int) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionDeleteDatabase,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"cluster_index": clusterIndex,
 			"bdb_id":        bdbID,
 		},
@@ -407,7 +407,7 @@ func (c *FaultInjectorClient) DeleteDatabase(ctx context.Context, clusterIndex i
 func (c *FaultInjectorClient) CreateDatabase(ctx context.Context, clusterIndex int, databaseConfig DatabaseConfig) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionCreateDatabase,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"cluster_index":   clusterIndex,
 			"database_config": databaseConfig,
 		},
@@ -419,10 +419,10 @@ func (c *FaultInjectorClient) CreateDatabase(ctx context.Context, clusterIndex i
 // Parameters:
 //   - clusterIndex: The index of the cluster
 //   - databaseConfig: The database configuration as a map
-func (c *FaultInjectorClient) CreateDatabaseFromMap(ctx context.Context, clusterIndex int, databaseConfig map[string]interface{}) (*ActionResponse, error) {
+func (c *FaultInjectorClient) CreateDatabaseFromMap(ctx context.Context, clusterIndex int, databaseConfig map[string]any) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionCreateDatabase,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"cluster_index":   clusterIndex,
 			"database_config": databaseConfig,
 		},
@@ -435,7 +435,7 @@ func (c *FaultInjectorClient) CreateDatabaseFromMap(ctx context.Context, cluster
 func (c *FaultInjectorClient) ExecuteSequence(ctx context.Context, actions []SequenceAction) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionSequence,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"actions": actions,
 		},
 	})
@@ -445,7 +445,7 @@ func (c *FaultInjectorClient) ExecuteSequence(ctx context.Context, actions []Seq
 func (c *FaultInjectorClient) ExecuteCommand(ctx context.Context, nodeID, command string) (*ActionResponse, error) {
 	return c.TriggerAction(ctx, ActionRequest{
 		Type: ActionExecuteCommand,
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"node_id": nodeID,
 			"command": command,
 		},
@@ -462,7 +462,7 @@ func (c *FaultInjectorClient) SimulateClusterUpgrade(ctx context.Context, nodes 
 	for i, nodeID := range nodes {
 		actions = append(actions, SequenceAction{
 			Type: ActionNodeRestart,
-			Parameters: map[string]interface{}{
+			Parameters: map[string]any{
 				"node_id":  nodeID,
 				"graceful": true,
 			},
@@ -478,7 +478,7 @@ func (c *FaultInjectorClient) SimulateNetworkIssues(ctx context.Context, nodes [
 	actions := []SequenceAction{
 		{
 			Type: ActionNetworkLatency,
-			Parameters: map[string]interface{}{
+			Parameters: map[string]any{
 				"nodes":   nodes,
 				"latency": "100ms",
 				"jitter":  "20ms",
@@ -486,7 +486,7 @@ func (c *FaultInjectorClient) SimulateNetworkIssues(ctx context.Context, nodes [
 		},
 		{
 			Type: ActionNetworkPacketLoss,
-			Parameters: map[string]interface{}{
+			Parameters: map[string]any{
 				"nodes":        nodes,
 				"loss_percent": 2.0,
 			},
@@ -494,7 +494,7 @@ func (c *FaultInjectorClient) SimulateNetworkIssues(ctx context.Context, nodes [
 		},
 		{
 			Type: ActionNetworkRestore,
-			Parameters: map[string]interface{}{
+			Parameters: map[string]any{
 				"nodes": nodes,
 			},
 			Delay: 60 * time.Second,
@@ -528,7 +528,7 @@ func WithMaxWaitTime(maxWait time.Duration) WaitOption {
 }
 
 // Internal HTTP request method
-func (c *FaultInjectorClient) request(ctx context.Context, method, path string, body interface{}, result interface{}) error {
+func (c *FaultInjectorClient) request(ctx context.Context, method, path string, body any, result any) error {
 	url := c.baseURL + path
 
 	var reqBody io.Reader
@@ -570,14 +570,14 @@ func (c *FaultInjectorClient) request(ctx context.Context, method, path string, 
 			// sometimes the output of the action status is map, sometimes it is json.
 			// since we don't have a proper response structure we are going to handle it here
 			if result, ok := result.(*ActionStatusResponse); ok {
-				mapResult := map[string]interface{}{}
+				mapResult := map[string]any{}
 				err = json.Unmarshal(respBody, &mapResult)
 				if err != nil {
 					fmt.Println("Failed to unmarshal response:", string(respBody))
 					panic(err)
 				}
 				result.Error = mapResult["error"]
-				result.Output = map[string]interface{}{"result": mapResult["output"]}
+				result.Output = map[string]any{"result": mapResult["output"]}
 				if status, ok := mapResult["status"].(string); ok {
 					result.Status = ActionStatus(status)
 				}

--- a/maintnotifications/e2e/logcollector_test.go
+++ b/maintnotifications/e2e/logcollector_test.go
@@ -99,7 +99,7 @@ type MatchFunc struct {
 	done      func()
 }
 
-func (tlc *TestLogCollector) Printf(_ context.Context, format string, v ...interface{}) {
+func (tlc *TestLogCollector) Printf(_ context.Context, format string, v ...any) {
 	tlc.mu.Lock()
 	defer tlc.mu.Unlock()
 	lstr := fmt.Sprintf(format, v...)

--- a/maintnotifications/e2e/scenario_endpoint_types_test.go
+++ b/maintnotifications/e2e/scenario_endpoint_types_test.go
@@ -85,16 +85,16 @@ func TestEndpointTypesPushNotifications(t *testing.T) {
 			dump = true
 			// redefine p and e for each test to get
 			// proper test name in logs and proper test failures
-			var p = func(format string, args ...interface{}) {
+			var p = func(format string, args ...any) {
 				printLog("ENDPOINT-TYPES", false, format, args...)
 			}
 
-			var e = func(format string, args ...interface{}) {
+			var e = func(format string, args ...any) {
 				errorsDetected = true
 				printLog("ENDPOINT-TYPES", true, format, args...)
 			}
 
-			var ef = func(format string, args ...interface{}) {
+			var ef = func(format string, args ...any) {
 				printLog("ENDPOINT-TYPES", true, format, args...)
 				t.FailNow()
 			}
@@ -155,7 +155,7 @@ func TestEndpointTypesPushNotifications(t *testing.T) {
 			p("Testing failover with %s endpoint type on database [bdb_id:%s]...", endpointTest.name, endpointConfig.BdbID)
 			failoverResp, err := faultInjector.TriggerAction(ctx, ActionRequest{
 				Type: "failover",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"bdb_id": endpointConfig.BdbID,
 				},
 			})
@@ -204,7 +204,7 @@ func TestEndpointTypesPushNotifications(t *testing.T) {
 			p("Testing migration with %s endpoint type...", endpointTest.name)
 			migrateResp, err := faultInjector.TriggerAction(ctx, ActionRequest{
 				Type: "migrate",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"bdb_id": endpointConfig.BdbID,
 				},
 			})
@@ -247,7 +247,7 @@ func TestEndpointTypesPushNotifications(t *testing.T) {
 			// Complete migration with bind action
 			bindResp, err := faultInjector.TriggerAction(ctx, ActionRequest{
 				Type: "bind",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"bdb_id": endpointConfig.BdbID,
 				},
 			})

--- a/maintnotifications/e2e/scenario_push_notifications_test.go
+++ b/maintnotifications/e2e/scenario_push_notifications_test.go
@@ -40,16 +40,16 @@ func TestPushNotifications(t *testing.T) {
 	var status *ActionStatusResponse
 	var errorsDetected = false
 
-	var p = func(format string, args ...interface{}) {
+	var p = func(format string, args ...any) {
 		printLog("PUSH-NOTIFICATIONS", false, format, args...)
 	}
 
-	var e = func(format string, args ...interface{}) {
+	var e = func(format string, args ...any) {
 		errorsDetected = true
 		printLog("PUSH-NOTIFICATIONS", true, format, args...)
 	}
 
-	var ef = func(format string, args ...interface{}) {
+	var ef = func(format string, args ...any) {
 		printLog("PUSH-NOTIFICATIONS", true, format, args...)
 		t.FailNow()
 	}
@@ -127,7 +127,7 @@ func TestPushNotifications(t *testing.T) {
 	p("Triggering failover action to generate push notifications...")
 	failoverResp, err := faultInjector.TriggerAction(ctx, ActionRequest{
 		Type: "failover",
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"bdb_id": endpointConfig.BdbID,
 		},
 	})
@@ -178,7 +178,7 @@ func TestPushNotifications(t *testing.T) {
 	p("Triggering migrate action to generate push notifications...")
 	migrateResp, err := faultInjector.TriggerAction(ctx, ActionRequest{
 		Type: "migrate",
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"bdb_id": endpointConfig.BdbID,
 		},
 	})
@@ -238,7 +238,7 @@ func TestPushNotifications(t *testing.T) {
 
 	bindResp, err := faultInjector.TriggerAction(ctx, ActionRequest{
 		Type: "bind",
-		Parameters: map[string]interface{}{
+		Parameters: map[string]any{
 			"bdb_id": endpointConfig.BdbID,
 		},
 	})

--- a/maintnotifications/e2e/scenario_stress_test.go
+++ b/maintnotifications/e2e/scenario_stress_test.go
@@ -33,16 +33,16 @@ func TestStressPushNotifications(t *testing.T) {
 	var dump = true
 	var errorsDetected = false
 
-	var p = func(format string, args ...interface{}) {
+	var p = func(format string, args ...any) {
 		printLog("STRESS", false, format, args...)
 	}
 
-	var e = func(format string, args ...interface{}) {
+	var e = func(format string, args ...any) {
 		errorsDetected = true
 		printLog("STRESS", true, format, args...)
 	}
 
-	var ef = func(format string, args ...interface{}) {
+	var ef = func(format string, args ...any) {
 		printLog("STRESS", true, format, args...)
 		t.FailNow()
 	}
@@ -174,14 +174,14 @@ func TestStressPushNotifications(t *testing.T) {
 			case "failover":
 				resp, err = faultInjector.TriggerAction(ctx, ActionRequest{
 					Type: "failover",
-					Parameters: map[string]interface{}{
+					Parameters: map[string]any{
 						"bdb_id": endpointConfig.BdbID,
 					},
 				})
 			case "migrate":
 				resp, err = faultInjector.TriggerAction(ctx, ActionRequest{
 					Type: "migrate",
-					Parameters: map[string]interface{}{
+					Parameters: map[string]any{
 						"bdb_id": endpointConfig.BdbID,
 					},
 				})

--- a/maintnotifications/e2e/scenario_template.go.example
+++ b/maintnotifications/e2e/scenario_template.go.example
@@ -109,14 +109,14 @@ func TestScenarioTemplate(t *testing.T) {
 	// sequence := []SequenceAction{
 	//     {
 	//         Type: ActionNetworkLatency,
-	//         Parameters: map[string]interface{}{
+	//         Parameters: map[string]any{
 	//             "nodes":   []string{"localhost:7001"},
 	//             "latency": "50ms",
 	//         },
 	//     },
 	//     {
 	//         Type: ActionClusterFailover,
-	//         Parameters: map[string]interface{}{
+	//         Parameters: map[string]any{
 	//             "node_id": "node-1",
 	//             "force":   false,
 	//         },

--- a/maintnotifications/e2e/scenario_timeout_configs_test.go
+++ b/maintnotifications/e2e/scenario_timeout_configs_test.go
@@ -25,11 +25,11 @@ func TestTimeoutConfigurationsPushNotifications(t *testing.T) {
 	var dump = true
 
 	var errorsDetected = false
-	var p = func(format string, args ...interface{}) {
+	var p = func(format string, args ...any) {
 		printLog("TIMEOUT-CONFIGS", false, format, args...)
 	}
 
-	var e = func(format string, args ...interface{}) {
+	var e = func(format string, args ...any) {
 		errorsDetected = true
 		printLog("TIMEOUT-CONFIGS", true, format, args...)
 	}
@@ -99,7 +99,7 @@ func TestTimeoutConfigurationsPushNotifications(t *testing.T) {
 			}()
 
 			errorsDetected = false
-			var ef = func(format string, args ...interface{}) {
+			var ef = func(format string, args ...any) {
 				printLog("TIMEOUT-CONFIGS", true, format, args...)
 				t.FailNow()
 			}
@@ -171,7 +171,7 @@ func TestTimeoutConfigurationsPushNotifications(t *testing.T) {
 			p("Testing failover with %s timeout configuration...", timeoutTest.name)
 			failoverResp, err := faultInjector.TriggerAction(ctx, ActionRequest{
 				Type: "failover",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"bdb_id": endpointConfig.BdbID,
 				},
 			})
@@ -219,7 +219,7 @@ func TestTimeoutConfigurationsPushNotifications(t *testing.T) {
 			p("Testing migration with %s timeout configuration...", timeoutTest.name)
 			migrateResp, err := faultInjector.TriggerAction(ctx, ActionRequest{
 				Type: "migrate",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"bdb_id": endpointConfig.BdbID,
 				},
 			})
@@ -251,7 +251,7 @@ func TestTimeoutConfigurationsPushNotifications(t *testing.T) {
 			// do a bind action
 			bindResp, err := faultInjector.TriggerAction(ctx, ActionRequest{
 				Type: "bind",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"bdb_id": endpointConfig.BdbID,
 				},
 			})

--- a/maintnotifications/e2e/scenario_tls_configs_test.go
+++ b/maintnotifications/e2e/scenario_tls_configs_test.go
@@ -25,11 +25,11 @@ func ТestTLSConfigurationsPushNotifications(t *testing.T) {
 
 	var dump = true
 	var errorsDetected = false
-	var p = func(format string, args ...interface{}) {
+	var p = func(format string, args ...any) {
 		printLog("TLS-CONFIGS", false, format, args...)
 	}
 
-	var e = func(format string, args ...interface{}) {
+	var e = func(format string, args ...any) {
 		errorsDetected = true
 		printLog("TLS-CONFIGS", true, format, args...)
 	}
@@ -95,7 +95,7 @@ func ТestTLSConfigurationsPushNotifications(t *testing.T) {
 			}()
 
 			errorsDetected = false
-			var ef = func(format string, args ...interface{}) {
+			var ef = func(format string, args ...any) {
 				printLog("TLS-CONFIGS", true, format, args...)
 				t.FailNow()
 			}
@@ -173,7 +173,7 @@ func ТestTLSConfigurationsPushNotifications(t *testing.T) {
 			p("Testing migration with %s TLS configuration...", tlsTest.name)
 			migrateResp, err := faultInjector.TriggerAction(ctx, ActionRequest{
 				Type: "migrate",
-				Parameters: map[string]interface{}{
+				Parameters: map[string]any{
 					"bdb_id": endpointConfig.BdbID,
 				},
 			})

--- a/maintnotifications/e2e/utils_test.go
+++ b/maintnotifications/e2e/utils_test.go
@@ -50,7 +50,7 @@ func min(a, b int) int {
 	return b
 }
 
-func printLog(group string, isError bool, format string, args ...interface{}) {
+func printLog(group string, isError bool, format string, args ...any) {
 	_, filename, line, _ := runtime.Caller(2)
 	filename = filepath.Base(filename)
 	finalFormat := "%s:%d [%s][%s] " + format + "\n"
@@ -58,7 +58,7 @@ func printLog(group string, isError bool, format string, args ...interface{}) {
 		finalFormat = "%s:%d [%s][%s][ERROR] " + format + "\n"
 	}
 	ts := time.Now().Format("15:04:05.000")
-	args = append([]interface{}{filename, line, ts, group}, args...)
+	args = append([]any{filename, line, ts, group}, args...)
 	fmt.Printf(finalFormat, args...)
 }
 

--- a/maintnotifications/example_hooks.go
+++ b/maintnotifications/example_hooks.go
@@ -38,7 +38,7 @@ func NewMetricsHook() *MetricsHook {
 }
 
 // PreHook records the start time for processing metrics.
-func (mh *MetricsHook) PreHook(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []interface{}) ([]interface{}, bool) {
+func (mh *MetricsHook) PreHook(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []any) ([]any, bool) {
 	mh.NotificationCounts[notificationType]++
 
 	// Log connection information if available
@@ -54,7 +54,7 @@ func (mh *MetricsHook) PreHook(ctx context.Context, notificationCtx push.Notific
 }
 
 // PostHook records processing completion and any errors.
-func (mh *MetricsHook) PostHook(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []interface{}, result error) {
+func (mh *MetricsHook) PostHook(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []any, result error) {
 	// Calculate processing duration
 	if startTime, ok := ctx.Value(startTimeKey).(time.Time); ok {
 		duration := time.Since(startTime)
@@ -73,8 +73,8 @@ func (mh *MetricsHook) PostHook(ctx context.Context, notificationCtx push.Notifi
 }
 
 // GetMetrics returns a summary of collected metrics.
-func (mh *MetricsHook) GetMetrics() map[string]interface{} {
-	return map[string]interface{}{
+func (mh *MetricsHook) GetMetrics() map[string]any {
+	return map[string]any{
 		"notification_counts": mh.NotificationCounts,
 		"processing_times":    mh.ProcessingTimes,
 		"error_counts":        mh.ErrorCounts,

--- a/maintnotifications/hooks.go
+++ b/maintnotifications/hooks.go
@@ -16,7 +16,7 @@ type LoggingHook struct {
 }
 
 // PreHook logs the notification before processing and allows modification.
-func (lh *LoggingHook) PreHook(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []interface{}) ([]interface{}, bool) {
+func (lh *LoggingHook) PreHook(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []any) ([]any, bool) {
 	if lh.LogLevel >= 2 { // Info level
 		// Log the notification type and content
 		connID := uint64(0)
@@ -41,7 +41,7 @@ func (lh *LoggingHook) PreHook(ctx context.Context, notificationCtx push.Notific
 }
 
 // PostHook logs the result after processing.
-func (lh *LoggingHook) PostHook(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []interface{}, result error) {
+func (lh *LoggingHook) PostHook(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []any, result error) {
 	connID := uint64(0)
 	if conn, ok := notificationCtx.Conn.(*pool.Conn); ok {
 		connID = conn.GetID()

--- a/maintnotifications/manager.go
+++ b/maintnotifications/manager.go
@@ -38,8 +38,8 @@ var maintenanceNotificationTypes = []string{
 // PreHook can modify the notification and return false to skip processing
 // PostHook is called after successful processing
 type NotificationHook interface {
-	PreHook(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []interface{}) ([]interface{}, bool)
-	PostHook(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []interface{}, result error)
+	PreHook(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []any) ([]any, bool)
+	PostHook(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []any, result error)
 }
 
 // MovingOperationKey provides a unique key for tracking MOVING operations
@@ -194,7 +194,7 @@ func (hm *Manager) GetActiveMovingOperations() map[MovingOperationKey]*MovingOpe
 	result := make(map[MovingOperationKey]*MovingOperation)
 
 	// Iterate over sync.Map to build result
-	hm.activeMovingOps.Range(func(key, value interface{}) bool {
+	hm.activeMovingOps.Range(func(key, value any) bool {
 		k := key.(MovingOperationKey)
 		op := value.(*MovingOperation)
 
@@ -249,7 +249,7 @@ func (hm *Manager) Close() error {
 	}
 
 	// Clear all active operations
-	hm.activeMovingOps.Range(func(key, value interface{}) bool {
+	hm.activeMovingOps.Range(func(key, value any) bool {
 		hm.activeMovingOps.Delete(key)
 		return true
 	})
@@ -269,7 +269,7 @@ func (hm *Manager) GetState() State {
 }
 
 // processPreHooks calls all pre-hooks and returns the modified notification and whether to continue processing.
-func (hm *Manager) processPreHooks(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []interface{}) ([]interface{}, bool) {
+func (hm *Manager) processPreHooks(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []any) ([]any, bool) {
 	hm.hooksMu.RLock()
 	defer hm.hooksMu.RUnlock()
 
@@ -287,7 +287,7 @@ func (hm *Manager) processPreHooks(ctx context.Context, notificationCtx push.Not
 }
 
 // processPostHooks calls all post-hooks with the processing result.
-func (hm *Manager) processPostHooks(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []interface{}, result error) {
+func (hm *Manager) processPostHooks(ctx context.Context, notificationCtx push.NotificationHandlerContext, notificationType string, notification []any, result error) {
 	hm.hooksMu.RLock()
 	defer hm.hooksMu.RUnlock()
 

--- a/maintnotifications/manager_test.go
+++ b/maintnotifications/manager_test.go
@@ -25,7 +25,7 @@ func (mc *MockClient) GetPushProcessor() interfaces.NotificationProcessor {
 // MockPushProcessor implements interfaces.NotificationProcessor for testing
 type MockPushProcessor struct{}
 
-func (mpp *MockPushProcessor) RegisterHandler(notificationType string, handler interface{}, protected bool) error {
+func (mpp *MockPushProcessor) RegisterHandler(notificationType string, handler any, protected bool) error {
 	return nil
 }
 
@@ -33,7 +33,7 @@ func (mpp *MockPushProcessor) UnregisterHandler(pushNotificationName string) err
 	return nil
 }
 
-func (mpp *MockPushProcessor) GetHandler(pushNotificationName string) interface{} {
+func (mpp *MockPushProcessor) GetHandler(pushNotificationName string) any {
 	return nil
 }
 

--- a/maintnotifications/push_notification_handler.go
+++ b/maintnotifications/push_notification_handler.go
@@ -19,7 +19,7 @@ type NotificationHandler struct {
 }
 
 // HandlePushNotification processes push notifications with hook support.
-func (snh *NotificationHandler) HandlePushNotification(ctx context.Context, handlerCtx push.NotificationHandlerContext, notification []interface{}) error {
+func (snh *NotificationHandler) HandlePushNotification(ctx context.Context, handlerCtx push.NotificationHandlerContext, notification []any) error {
 	if len(notification) == 0 {
 		internal.Logger.Printf(ctx, logs.InvalidNotificationFormat(notification))
 		return ErrInvalidNotification
@@ -62,7 +62,7 @@ func (snh *NotificationHandler) HandlePushNotification(ctx context.Context, hand
 
 // handleMoving processes MOVING notifications.
 // ["MOVING", seqNum, timeS, endpoint] - per-connection handoff
-func (snh *NotificationHandler) handleMoving(ctx context.Context, handlerCtx push.NotificationHandlerContext, notification []interface{}) error {
+func (snh *NotificationHandler) handleMoving(ctx context.Context, handlerCtx push.NotificationHandlerContext, notification []any) error {
 	if len(notification) < 3 {
 		internal.Logger.Printf(ctx, logs.InvalidNotification("MOVING", notification))
 		return ErrInvalidNotification
@@ -167,7 +167,7 @@ func (snh *NotificationHandler) markConnForHandoff(conn *pool.Conn, newEndpoint 
 }
 
 // handleMigrating processes MIGRATING notifications.
-func (snh *NotificationHandler) handleMigrating(ctx context.Context, handlerCtx push.NotificationHandlerContext, notification []interface{}) error {
+func (snh *NotificationHandler) handleMigrating(ctx context.Context, handlerCtx push.NotificationHandlerContext, notification []any) error {
 	// MIGRATING notifications indicate that a connection is about to be migrated
 	// Apply relaxed timeouts to the specific connection that received this notification
 	if len(notification) < 2 {
@@ -195,7 +195,7 @@ func (snh *NotificationHandler) handleMigrating(ctx context.Context, handlerCtx 
 }
 
 // handleMigrated processes MIGRATED notifications.
-func (snh *NotificationHandler) handleMigrated(ctx context.Context, handlerCtx push.NotificationHandlerContext, notification []interface{}) error {
+func (snh *NotificationHandler) handleMigrated(ctx context.Context, handlerCtx push.NotificationHandlerContext, notification []any) error {
 	// MIGRATED notifications indicate that a connection migration has completed
 	// Restore normal timeouts for the specific connection that received this notification
 	if len(notification) < 2 {
@@ -224,7 +224,7 @@ func (snh *NotificationHandler) handleMigrated(ctx context.Context, handlerCtx p
 }
 
 // handleFailingOver processes FAILING_OVER notifications.
-func (snh *NotificationHandler) handleFailingOver(ctx context.Context, handlerCtx push.NotificationHandlerContext, notification []interface{}) error {
+func (snh *NotificationHandler) handleFailingOver(ctx context.Context, handlerCtx push.NotificationHandlerContext, notification []any) error {
 	// FAILING_OVER notifications indicate that a connection is about to failover
 	// Apply relaxed timeouts to the specific connection that received this notification
 	if len(notification) < 2 {
@@ -253,7 +253,7 @@ func (snh *NotificationHandler) handleFailingOver(ctx context.Context, handlerCt
 }
 
 // handleFailedOver processes FAILED_OVER notifications.
-func (snh *NotificationHandler) handleFailedOver(ctx context.Context, handlerCtx push.NotificationHandlerContext, notification []interface{}) error {
+func (snh *NotificationHandler) handleFailedOver(ctx context.Context, handlerCtx push.NotificationHandlerContext, notification []any) error {
 	// FAILED_OVER notifications indicate that a connection failover has completed
 	// Restore normal timeouts for the specific connection that received this notification
 	if len(notification) < 2 {

--- a/osscluster_commands.go
+++ b/osscluster_commands.go
@@ -69,7 +69,7 @@ func (c *ClusterClient) ScriptFlush(ctx context.Context) *StatusCmd {
 }
 
 func (c *ClusterClient) ScriptExists(ctx context.Context, hashes ...string) *BoolSliceCmd {
-	args := make([]interface{}, 2+len(hashes))
+	args := make([]any, 2+len(hashes))
 	args[0] = "script"
 	args[1] = "exists"
 	for i, hash := range hashes {

--- a/pipeline.go
+++ b/pipeline.go
@@ -28,7 +28,7 @@ type Pipeliner interface {
 
 	// Do is an API for executing any command.
 	// If a certain Redis command is not yet supported, you can use Do to execute it.
-	Do(ctx context.Context, args ...interface{}) *Cmd
+	Do(ctx context.Context, args ...any) *Cmd
 
 	// Process queues the cmd for later execution.
 	Process(ctx context.Context, cmd Cmder) error
@@ -70,7 +70,7 @@ func (c *Pipeline) Len() int {
 }
 
 // Do queues the custom command for later execution.
-func (c *Pipeline) Do(ctx context.Context, args ...interface{}) *Cmd {
+func (c *Pipeline) Do(ctx context.Context, args ...any) *Cmd {
 	cmd := NewCmd(ctx, args...)
 	if len(args) == 0 {
 		cmd.SetErr(errors.New("redis: please enter the command to be executed"))

--- a/probabilistic.go
+++ b/probabilistic.go
@@ -8,9 +8,9 @@ import (
 )
 
 type ProbabilisticCmdable interface {
-	BFAdd(ctx context.Context, key string, element interface{}) *BoolCmd
+	BFAdd(ctx context.Context, key string, element any) *BoolCmd
 	BFCard(ctx context.Context, key string) *IntCmd
-	BFExists(ctx context.Context, key string, element interface{}) *BoolCmd
+	BFExists(ctx context.Context, key string, element any) *BoolCmd
 	BFInfo(ctx context.Context, key string) *BFInfoCmd
 	BFInfoArg(ctx context.Context, key, option string) *BFInfoCmd
 	BFInfoCapacity(ctx context.Context, key string) *BFInfoCmd
@@ -18,48 +18,48 @@ type ProbabilisticCmdable interface {
 	BFInfoFilters(ctx context.Context, key string) *BFInfoCmd
 	BFInfoItems(ctx context.Context, key string) *BFInfoCmd
 	BFInfoExpansion(ctx context.Context, key string) *BFInfoCmd
-	BFInsert(ctx context.Context, key string, options *BFInsertOptions, elements ...interface{}) *BoolSliceCmd
-	BFMAdd(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd
-	BFMExists(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd
+	BFInsert(ctx context.Context, key string, options *BFInsertOptions, elements ...any) *BoolSliceCmd
+	BFMAdd(ctx context.Context, key string, elements ...any) *BoolSliceCmd
+	BFMExists(ctx context.Context, key string, elements ...any) *BoolSliceCmd
 	BFReserve(ctx context.Context, key string, errorRate float64, capacity int64) *StatusCmd
 	BFReserveExpansion(ctx context.Context, key string, errorRate float64, capacity, expansion int64) *StatusCmd
 	BFReserveNonScaling(ctx context.Context, key string, errorRate float64, capacity int64) *StatusCmd
 	BFReserveWithArgs(ctx context.Context, key string, options *BFReserveOptions) *StatusCmd
 	BFScanDump(ctx context.Context, key string, iterator int64) *ScanDumpCmd
-	BFLoadChunk(ctx context.Context, key string, iterator int64, data interface{}) *StatusCmd
+	BFLoadChunk(ctx context.Context, key string, iterator int64, data any) *StatusCmd
 
-	CFAdd(ctx context.Context, key string, element interface{}) *BoolCmd
-	CFAddNX(ctx context.Context, key string, element interface{}) *BoolCmd
-	CFCount(ctx context.Context, key string, element interface{}) *IntCmd
-	CFDel(ctx context.Context, key string, element interface{}) *BoolCmd
-	CFExists(ctx context.Context, key string, element interface{}) *BoolCmd
+	CFAdd(ctx context.Context, key string, element any) *BoolCmd
+	CFAddNX(ctx context.Context, key string, element any) *BoolCmd
+	CFCount(ctx context.Context, key string, element any) *IntCmd
+	CFDel(ctx context.Context, key string, element any) *BoolCmd
+	CFExists(ctx context.Context, key string, element any) *BoolCmd
 	CFInfo(ctx context.Context, key string) *CFInfoCmd
-	CFInsert(ctx context.Context, key string, options *CFInsertOptions, elements ...interface{}) *BoolSliceCmd
-	CFInsertNX(ctx context.Context, key string, options *CFInsertOptions, elements ...interface{}) *IntSliceCmd
-	CFMExists(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd
+	CFInsert(ctx context.Context, key string, options *CFInsertOptions, elements ...any) *BoolSliceCmd
+	CFInsertNX(ctx context.Context, key string, options *CFInsertOptions, elements ...any) *IntSliceCmd
+	CFMExists(ctx context.Context, key string, elements ...any) *BoolSliceCmd
 	CFReserve(ctx context.Context, key string, capacity int64) *StatusCmd
 	CFReserveWithArgs(ctx context.Context, key string, options *CFReserveOptions) *StatusCmd
 	CFReserveExpansion(ctx context.Context, key string, capacity int64, expansion int64) *StatusCmd
 	CFReserveBucketSize(ctx context.Context, key string, capacity int64, bucketsize int64) *StatusCmd
 	CFReserveMaxIterations(ctx context.Context, key string, capacity int64, maxiterations int64) *StatusCmd
 	CFScanDump(ctx context.Context, key string, iterator int64) *ScanDumpCmd
-	CFLoadChunk(ctx context.Context, key string, iterator int64, data interface{}) *StatusCmd
+	CFLoadChunk(ctx context.Context, key string, iterator int64, data any) *StatusCmd
 
-	CMSIncrBy(ctx context.Context, key string, elements ...interface{}) *IntSliceCmd
+	CMSIncrBy(ctx context.Context, key string, elements ...any) *IntSliceCmd
 	CMSInfo(ctx context.Context, key string) *CMSInfoCmd
 	CMSInitByDim(ctx context.Context, key string, width, height int64) *StatusCmd
 	CMSInitByProb(ctx context.Context, key string, errorRate, probability float64) *StatusCmd
 	CMSMerge(ctx context.Context, destKey string, sourceKeys ...string) *StatusCmd
 	CMSMergeWithWeight(ctx context.Context, destKey string, sourceKeys map[string]int64) *StatusCmd
-	CMSQuery(ctx context.Context, key string, elements ...interface{}) *IntSliceCmd
+	CMSQuery(ctx context.Context, key string, elements ...any) *IntSliceCmd
 
-	TopKAdd(ctx context.Context, key string, elements ...interface{}) *StringSliceCmd
-	TopKCount(ctx context.Context, key string, elements ...interface{}) *IntSliceCmd
-	TopKIncrBy(ctx context.Context, key string, elements ...interface{}) *StringSliceCmd
+	TopKAdd(ctx context.Context, key string, elements ...any) *StringSliceCmd
+	TopKCount(ctx context.Context, key string, elements ...any) *IntSliceCmd
+	TopKIncrBy(ctx context.Context, key string, elements ...any) *StringSliceCmd
 	TopKInfo(ctx context.Context, key string) *TopKInfoCmd
 	TopKList(ctx context.Context, key string) *StringSliceCmd
 	TopKListWithCount(ctx context.Context, key string) *MapStringIntCmd
-	TopKQuery(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd
+	TopKQuery(ctx context.Context, key string, elements ...any) *BoolSliceCmd
 	TopKReserve(ctx context.Context, key string, k int64) *StatusCmd
 	TopKReserveWithOptions(ctx context.Context, key string, k int64, width, depth int64, decay float64) *StatusCmd
 
@@ -115,7 +115,7 @@ type CFInsertOptions struct {
 // for the initial specified capacity and with an upper bound error_rate.
 // For more information - https://redis.io/commands/bf.reserve/
 func (c cmdable) BFReserve(ctx context.Context, key string, errorRate float64, capacity int64) *StatusCmd {
-	args := []interface{}{"BF.RESERVE", key, errorRate, capacity}
+	args := []any{"BF.RESERVE", key, errorRate, capacity}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -126,7 +126,7 @@ func (c cmdable) BFReserve(ctx context.Context, key string, errorRate float64, c
 // This function also allows for specifying an expansion rate for the filter.
 // For more information - https://redis.io/commands/bf.reserve/
 func (c cmdable) BFReserveExpansion(ctx context.Context, key string, errorRate float64, capacity, expansion int64) *StatusCmd {
-	args := []interface{}{"BF.RESERVE", key, errorRate, capacity, "EXPANSION", expansion}
+	args := []any{"BF.RESERVE", key, errorRate, capacity, "EXPANSION", expansion}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -137,7 +137,7 @@ func (c cmdable) BFReserveExpansion(ctx context.Context, key string, errorRate f
 // This function also allows for specifying that the filter should not scale.
 // For more information - https://redis.io/commands/bf.reserve/
 func (c cmdable) BFReserveNonScaling(ctx context.Context, key string, errorRate float64, capacity int64) *StatusCmd {
-	args := []interface{}{"BF.RESERVE", key, errorRate, capacity, "NONSCALING"}
+	args := []any{"BF.RESERVE", key, errorRate, capacity, "NONSCALING"}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -148,7 +148,7 @@ func (c cmdable) BFReserveNonScaling(ctx context.Context, key string, errorRate 
 // This function also allows for specifying additional options such as expansion rate and non-scaling behavior.
 // For more information - https://redis.io/commands/bf.reserve/
 func (c cmdable) BFReserveWithArgs(ctx context.Context, key string, options *BFReserveOptions) *StatusCmd {
-	args := []interface{}{"BF.RESERVE", key}
+	args := []any{"BF.RESERVE", key}
 	if options != nil {
 		args = append(args, options.Error, options.Capacity)
 		if options.Expansion != 0 {
@@ -165,8 +165,8 @@ func (c cmdable) BFReserveWithArgs(ctx context.Context, key string, options *BFR
 
 // BFAdd adds an item to a Bloom filter.
 // For more information - https://redis.io/commands/bf.add/
-func (c cmdable) BFAdd(ctx context.Context, key string, element interface{}) *BoolCmd {
-	args := []interface{}{"BF.ADD", key, element}
+func (c cmdable) BFAdd(ctx context.Context, key string, element any) *BoolCmd {
+	args := []any{"BF.ADD", key, element}
 	cmd := NewBoolCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -177,7 +177,7 @@ func (c cmdable) BFAdd(ctx context.Context, key string, element interface{}) *Bo
 // (items that caused at least one bit to be set in at least one sub-filter).
 // For more information - https://redis.io/commands/bf.card/
 func (c cmdable) BFCard(ctx context.Context, key string) *IntCmd {
-	args := []interface{}{"BF.CARD", key}
+	args := []any{"BF.CARD", key}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -185,8 +185,8 @@ func (c cmdable) BFCard(ctx context.Context, key string) *IntCmd {
 
 // BFExists determines whether a given item was added to a Bloom filter.
 // For more information - https://redis.io/commands/bf.exists/
-func (c cmdable) BFExists(ctx context.Context, key string, element interface{}) *BoolCmd {
-	args := []interface{}{"BF.EXISTS", key, element}
+func (c cmdable) BFExists(ctx context.Context, key string, element any) *BoolCmd {
+	args := []any{"BF.EXISTS", key, element}
 	cmd := NewBoolCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -194,8 +194,8 @@ func (c cmdable) BFExists(ctx context.Context, key string, element interface{}) 
 
 // BFLoadChunk restores a Bloom filter previously saved using BF.SCANDUMP.
 // For more information - https://redis.io/commands/bf.loadchunk/
-func (c cmdable) BFLoadChunk(ctx context.Context, key string, iterator int64, data interface{}) *StatusCmd {
-	args := []interface{}{"BF.LOADCHUNK", key, iterator, data}
+func (c cmdable) BFLoadChunk(ctx context.Context, key string, iterator int64, data any) *StatusCmd {
+	args := []any{"BF.LOADCHUNK", key, iterator, data}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -205,7 +205,7 @@ func (c cmdable) BFLoadChunk(ctx context.Context, key string, iterator int64, da
 // This command is useful for large Bloom filters that cannot fit into the DUMP and RESTORE model.
 // For more information - https://redis.io/commands/bf.scandump/
 func (c cmdable) BFScanDump(ctx context.Context, key string, iterator int64) *ScanDumpCmd {
-	args := []interface{}{"BF.SCANDUMP", key, iterator}
+	args := []any{"BF.SCANDUMP", key, iterator}
 	cmd := newScanDumpCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -222,7 +222,7 @@ type ScanDumpCmd struct {
 	val ScanDump
 }
 
-func newScanDumpCmd(ctx context.Context, args ...interface{}) *ScanDumpCmd {
+func newScanDumpCmd(ctx context.Context, args ...any) *ScanDumpCmd {
 	return &ScanDumpCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -273,7 +273,7 @@ func (cmd *ScanDumpCmd) readReply(rd *proto.Reader) (err error) {
 // Returns information about a Bloom filter.
 // For more information - https://redis.io/commands/bf.info/
 func (c cmdable) BFInfo(ctx context.Context, key string) *BFInfoCmd {
-	args := []interface{}{"BF.INFO", key}
+	args := []any{"BF.INFO", key}
 	cmd := NewBFInfoCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -293,7 +293,7 @@ type BFInfoCmd struct {
 	val BFInfo
 }
 
-func NewBFInfoCmd(ctx context.Context, args ...interface{}) *BFInfoCmd {
+func NewBFInfoCmd(ctx context.Context, args ...any) *BFInfoCmd {
 	return &BFInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -421,7 +421,7 @@ func (c cmdable) BFInfoExpansion(ctx context.Context, key string) *BFInfoCmd {
 // BFInfoArg returns information about a specific option of a Bloom filter.
 // For more information - https://redis.io/commands/bf.info/
 func (c cmdable) BFInfoArg(ctx context.Context, key, option string) *BFInfoCmd {
-	args := []interface{}{"BF.INFO", key, option}
+	args := []any{"BF.INFO", key, option}
 	cmd := NewBFInfoCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -431,8 +431,8 @@ func (c cmdable) BFInfoArg(ctx context.Context, key, option string) *BFInfoCmd {
 // This function also allows for specifying additional options such as:
 // capacity, error rate, expansion rate, and non-scaling behavior.
 // For more information - https://redis.io/commands/bf.insert/
-func (c cmdable) BFInsert(ctx context.Context, key string, options *BFInsertOptions, elements ...interface{}) *BoolSliceCmd {
-	args := []interface{}{"BF.INSERT", key}
+func (c cmdable) BFInsert(ctx context.Context, key string, options *BFInsertOptions, elements ...any) *BoolSliceCmd {
+	args := []any{"BF.INSERT", key}
 	if options != nil {
 		if options.Capacity != 0 {
 			args = append(args, "CAPACITY", options.Capacity)
@@ -461,8 +461,8 @@ func (c cmdable) BFInsert(ctx context.Context, key string, options *BFInsertOpti
 // BFMAdd adds multiple elements to a Bloom filter.
 // Returns an array of booleans indicating whether each element was added to the filter or not.
 // For more information - https://redis.io/commands/bf.madd/
-func (c cmdable) BFMAdd(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd {
-	args := []interface{}{"BF.MADD", key}
+func (c cmdable) BFMAdd(ctx context.Context, key string, elements ...any) *BoolSliceCmd {
+	args := []any{"BF.MADD", key}
 	args = append(args, elements...)
 	cmd := NewBoolSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -472,8 +472,8 @@ func (c cmdable) BFMAdd(ctx context.Context, key string, elements ...interface{}
 // BFMExists check if multiple elements exist in a Bloom filter.
 // Returns an array of booleans indicating whether each element exists in the filter or not.
 // For more information - https://redis.io/commands/bf.mexists/
-func (c cmdable) BFMExists(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd {
-	args := []interface{}{"BF.MEXISTS", key}
+func (c cmdable) BFMExists(ctx context.Context, key string, elements ...any) *BoolSliceCmd {
+	args := []any{"BF.MEXISTS", key}
 	args = append(args, elements...)
 
 	cmd := NewBoolSliceCmd(ctx, args...)
@@ -488,7 +488,7 @@ func (c cmdable) BFMExists(ctx context.Context, key string, elements ...interfac
 // CFReserve creates an empty Cuckoo filter with the specified capacity.
 // For more information - https://redis.io/commands/cf.reserve/
 func (c cmdable) CFReserve(ctx context.Context, key string, capacity int64) *StatusCmd {
-	args := []interface{}{"CF.RESERVE", key, capacity}
+	args := []any{"CF.RESERVE", key, capacity}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -497,7 +497,7 @@ func (c cmdable) CFReserve(ctx context.Context, key string, capacity int64) *Sta
 // CFReserveExpansion creates an empty Cuckoo filter with the specified capacity and expansion rate.
 // For more information - https://redis.io/commands/cf.reserve/
 func (c cmdable) CFReserveExpansion(ctx context.Context, key string, capacity int64, expansion int64) *StatusCmd {
-	args := []interface{}{"CF.RESERVE", key, capacity, "EXPANSION", expansion}
+	args := []any{"CF.RESERVE", key, capacity, "EXPANSION", expansion}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -506,7 +506,7 @@ func (c cmdable) CFReserveExpansion(ctx context.Context, key string, capacity in
 // CFReserveBucketSize creates an empty Cuckoo filter with the specified capacity and bucket size.
 // For more information - https://redis.io/commands/cf.reserve/
 func (c cmdable) CFReserveBucketSize(ctx context.Context, key string, capacity int64, bucketsize int64) *StatusCmd {
-	args := []interface{}{"CF.RESERVE", key, capacity, "BUCKETSIZE", bucketsize}
+	args := []any{"CF.RESERVE", key, capacity, "BUCKETSIZE", bucketsize}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -515,7 +515,7 @@ func (c cmdable) CFReserveBucketSize(ctx context.Context, key string, capacity i
 // CFReserveMaxIterations creates an empty Cuckoo filter with the specified capacity and maximum number of iterations.
 // For more information - https://redis.io/commands/cf.reserve/
 func (c cmdable) CFReserveMaxIterations(ctx context.Context, key string, capacity int64, maxiterations int64) *StatusCmd {
-	args := []interface{}{"CF.RESERVE", key, capacity, "MAXITERATIONS", maxiterations}
+	args := []any{"CF.RESERVE", key, capacity, "MAXITERATIONS", maxiterations}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -525,7 +525,7 @@ func (c cmdable) CFReserveMaxIterations(ctx context.Context, key string, capacit
 // This function allows for specifying additional options such as bucket size and maximum number of iterations.
 // For more information - https://redis.io/commands/cf.reserve/
 func (c cmdable) CFReserveWithArgs(ctx context.Context, key string, options *CFReserveOptions) *StatusCmd {
-	args := []interface{}{"CF.RESERVE", key, options.Capacity}
+	args := []any{"CF.RESERVE", key, options.Capacity}
 	if options.BucketSize != 0 {
 		args = append(args, "BUCKETSIZE", options.BucketSize)
 	}
@@ -543,8 +543,8 @@ func (c cmdable) CFReserveWithArgs(ctx context.Context, key string, options *CFR
 // CFAdd adds an element to a Cuckoo filter.
 // Returns true if the element was added to the filter or false if it already exists in the filter.
 // For more information - https://redis.io/commands/cf.add/
-func (c cmdable) CFAdd(ctx context.Context, key string, element interface{}) *BoolCmd {
-	args := []interface{}{"CF.ADD", key, element}
+func (c cmdable) CFAdd(ctx context.Context, key string, element any) *BoolCmd {
+	args := []any{"CF.ADD", key, element}
 	cmd := NewBoolCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -553,8 +553,8 @@ func (c cmdable) CFAdd(ctx context.Context, key string, element interface{}) *Bo
 // CFAddNX adds an element to a Cuckoo filter only if it does not already exist in the filter.
 // Returns true if the element was added to the filter or false if it already exists in the filter.
 // For more information - https://redis.io/commands/cf.addnx/
-func (c cmdable) CFAddNX(ctx context.Context, key string, element interface{}) *BoolCmd {
-	args := []interface{}{"CF.ADDNX", key, element}
+func (c cmdable) CFAddNX(ctx context.Context, key string, element any) *BoolCmd {
+	args := []any{"CF.ADDNX", key, element}
 	cmd := NewBoolCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -562,8 +562,8 @@ func (c cmdable) CFAddNX(ctx context.Context, key string, element interface{}) *
 
 // CFCount returns an estimate of the number of times an element may be in a Cuckoo Filter.
 // For more information - https://redis.io/commands/cf.count/
-func (c cmdable) CFCount(ctx context.Context, key string, element interface{}) *IntCmd {
-	args := []interface{}{"CF.COUNT", key, element}
+func (c cmdable) CFCount(ctx context.Context, key string, element any) *IntCmd {
+	args := []any{"CF.COUNT", key, element}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -571,8 +571,8 @@ func (c cmdable) CFCount(ctx context.Context, key string, element interface{}) *
 
 // CFDel deletes an item once from the cuckoo filter.
 // For more information - https://redis.io/commands/cf.del/
-func (c cmdable) CFDel(ctx context.Context, key string, element interface{}) *BoolCmd {
-	args := []interface{}{"CF.DEL", key, element}
+func (c cmdable) CFDel(ctx context.Context, key string, element any) *BoolCmd {
+	args := []any{"CF.DEL", key, element}
 	cmd := NewBoolCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -580,8 +580,8 @@ func (c cmdable) CFDel(ctx context.Context, key string, element interface{}) *Bo
 
 // CFExists determines whether an item may exist in the Cuckoo Filter or not.
 // For more information - https://redis.io/commands/cf.exists/
-func (c cmdable) CFExists(ctx context.Context, key string, element interface{}) *BoolCmd {
-	args := []interface{}{"CF.EXISTS", key, element}
+func (c cmdable) CFExists(ctx context.Context, key string, element any) *BoolCmd {
+	args := []any{"CF.EXISTS", key, element}
 	cmd := NewBoolCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -589,8 +589,8 @@ func (c cmdable) CFExists(ctx context.Context, key string, element interface{}) 
 
 // CFLoadChunk restores a filter previously saved using SCANDUMP.
 // For more information - https://redis.io/commands/cf.loadchunk/
-func (c cmdable) CFLoadChunk(ctx context.Context, key string, iterator int64, data interface{}) *StatusCmd {
-	args := []interface{}{"CF.LOADCHUNK", key, iterator, data}
+func (c cmdable) CFLoadChunk(ctx context.Context, key string, iterator int64, data any) *StatusCmd {
+	args := []any{"CF.LOADCHUNK", key, iterator, data}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -599,7 +599,7 @@ func (c cmdable) CFLoadChunk(ctx context.Context, key string, iterator int64, da
 // CFScanDump begins an incremental save of the cuckoo filter.
 // For more information - https://redis.io/commands/cf.scandump/
 func (c cmdable) CFScanDump(ctx context.Context, key string, iterator int64) *ScanDumpCmd {
-	args := []interface{}{"CF.SCANDUMP", key, iterator}
+	args := []any{"CF.SCANDUMP", key, iterator}
 	cmd := newScanDumpCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -622,7 +622,7 @@ type CFInfoCmd struct {
 	val CFInfo
 }
 
-func NewCFInfoCmd(ctx context.Context, args ...interface{}) *CFInfoCmd {
+func NewCFInfoCmd(ctx context.Context, args ...any) *CFInfoCmd {
 	return &CFInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -695,7 +695,7 @@ func (cmd *CFInfoCmd) readReply(rd *proto.Reader) (err error) {
 // CFInfo returns information about a Cuckoo filter.
 // For more information - https://redis.io/commands/cf.info/
 func (c cmdable) CFInfo(ctx context.Context, key string) *CFInfoCmd {
-	args := []interface{}{"CF.INFO", key}
+	args := []any{"CF.INFO", key}
 	cmd := NewCFInfoCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -705,8 +705,8 @@ func (c cmdable) CFInfo(ctx context.Context, key string) *CFInfoCmd {
 // This function also allows for specifying additional options such as capacity, error rate, expansion rate, and non-scaling behavior.
 // Returns an array of booleans indicating whether each element was added to the filter or not.
 // For more information - https://redis.io/commands/cf.insert/
-func (c cmdable) CFInsert(ctx context.Context, key string, options *CFInsertOptions, elements ...interface{}) *BoolSliceCmd {
-	args := []interface{}{"CF.INSERT", key}
+func (c cmdable) CFInsert(ctx context.Context, key string, options *CFInsertOptions, elements ...any) *BoolSliceCmd {
+	args := []any{"CF.INSERT", key}
 	args = c.getCfInsertWithArgs(args, options, elements...)
 
 	cmd := NewBoolSliceCmd(ctx, args...)
@@ -719,8 +719,8 @@ func (c cmdable) CFInsert(ctx context.Context, key string, options *CFInsertOpti
 // capacity, error rate, expansion rate, and non-scaling behavior.
 // Returns an array of integers indicating whether each element was added to the filter or not.
 // For more information - https://redis.io/commands/cf.insertnx/
-func (c cmdable) CFInsertNX(ctx context.Context, key string, options *CFInsertOptions, elements ...interface{}) *IntSliceCmd {
-	args := []interface{}{"CF.INSERTNX", key}
+func (c cmdable) CFInsertNX(ctx context.Context, key string, options *CFInsertOptions, elements ...any) *IntSliceCmd {
+	args := []any{"CF.INSERTNX", key}
 	args = c.getCfInsertWithArgs(args, options, elements...)
 
 	cmd := NewIntSliceCmd(ctx, args...)
@@ -728,7 +728,7 @@ func (c cmdable) CFInsertNX(ctx context.Context, key string, options *CFInsertOp
 	return cmd
 }
 
-func (c cmdable) getCfInsertWithArgs(args []interface{}, options *CFInsertOptions, elements ...interface{}) []interface{} {
+func (c cmdable) getCfInsertWithArgs(args []any, options *CFInsertOptions, elements ...any) []any {
 	if options != nil {
 		if options.Capacity != 0 {
 			args = append(args, "CAPACITY", options.Capacity)
@@ -746,8 +746,8 @@ func (c cmdable) getCfInsertWithArgs(args []interface{}, options *CFInsertOption
 // CFMExists check if multiple elements exist in a Cuckoo filter.
 // Returns an array of booleans indicating whether each element exists in the filter or not.
 // For more information - https://redis.io/commands/cf.mexists/
-func (c cmdable) CFMExists(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd {
-	args := []interface{}{"CF.MEXISTS", key}
+func (c cmdable) CFMExists(ctx context.Context, key string, elements ...any) *BoolSliceCmd {
+	args := []any{"CF.MEXISTS", key}
 	args = append(args, elements...)
 	cmd := NewBoolSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -761,8 +761,8 @@ func (c cmdable) CFMExists(ctx context.Context, key string, elements ...interfac
 // CMSIncrBy increments the count of one or more items in a Count-Min Sketch filter.
 // Returns an array of integers representing the updated count of each item.
 // For more information - https://redis.io/commands/cms.incrby/
-func (c cmdable) CMSIncrBy(ctx context.Context, key string, elements ...interface{}) *IntSliceCmd {
-	args := make([]interface{}, 2, 2+len(elements))
+func (c cmdable) CMSIncrBy(ctx context.Context, key string, elements ...any) *IntSliceCmd {
+	args := make([]any, 2, 2+len(elements))
 	args[0] = "CMS.INCRBY"
 	args[1] = key
 	args = appendArgs(args, elements)
@@ -784,7 +784,7 @@ type CMSInfoCmd struct {
 	val CMSInfo
 }
 
-func NewCMSInfoCmd(ctx context.Context, args ...interface{}) *CMSInfoCmd {
+func NewCMSInfoCmd(ctx context.Context, args ...any) *CMSInfoCmd {
 	return &CMSInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -846,7 +846,7 @@ func (cmd *CMSInfoCmd) readReply(rd *proto.Reader) (err error) {
 // CMSInfo returns information about a Count-Min Sketch filter.
 // For more information - https://redis.io/commands/cms.info/
 func (c cmdable) CMSInfo(ctx context.Context, key string) *CMSInfoCmd {
-	args := []interface{}{"CMS.INFO", key}
+	args := []any{"CMS.INFO", key}
 	cmd := NewCMSInfoCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -855,7 +855,7 @@ func (c cmdable) CMSInfo(ctx context.Context, key string) *CMSInfoCmd {
 // CMSInitByDim creates an empty Count-Min Sketch filter with the specified dimensions.
 // For more information - https://redis.io/commands/cms.initbydim/
 func (c cmdable) CMSInitByDim(ctx context.Context, key string, width, depth int64) *StatusCmd {
-	args := []interface{}{"CMS.INITBYDIM", key, width, depth}
+	args := []any{"CMS.INITBYDIM", key, width, depth}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -864,7 +864,7 @@ func (c cmdable) CMSInitByDim(ctx context.Context, key string, width, depth int6
 // CMSInitByProb creates an empty Count-Min Sketch filter with the specified error rate and probability.
 // For more information - https://redis.io/commands/cms.initbyprob/
 func (c cmdable) CMSInitByProb(ctx context.Context, key string, errorRate, probability float64) *StatusCmd {
-	args := []interface{}{"CMS.INITBYPROB", key, errorRate, probability}
+	args := []any{"CMS.INITBYPROB", key, errorRate, probability}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -876,7 +876,7 @@ func (c cmdable) CMSInitByProb(ctx context.Context, key string, errorRate, proba
 // Returns OK on success or an error if the filters could not be merged.
 // For more information - https://redis.io/commands/cms.merge/
 func (c cmdable) CMSMerge(ctx context.Context, destKey string, sourceKeys ...string) *StatusCmd {
-	args := []interface{}{"CMS.MERGE", destKey, len(sourceKeys)}
+	args := []any{"CMS.MERGE", destKey, len(sourceKeys)}
 	for _, s := range sourceKeys {
 		args = append(args, s)
 	}
@@ -891,12 +891,12 @@ func (c cmdable) CMSMerge(ctx context.Context, destKey string, sourceKeys ...str
 // Returns OK on success or an error if the filters could not be merged.
 // For more information - https://redis.io/commands/cms.merge/
 func (c cmdable) CMSMergeWithWeight(ctx context.Context, destKey string, sourceKeys map[string]int64) *StatusCmd {
-	args := make([]interface{}, 0, 4+(len(sourceKeys)*2+1))
+	args := make([]any, 0, 4+(len(sourceKeys)*2+1))
 	args = append(args, "CMS.MERGE", destKey, len(sourceKeys))
 
 	if len(sourceKeys) > 0 {
-		sk := make([]interface{}, len(sourceKeys))
-		sw := make([]interface{}, len(sourceKeys))
+		sk := make([]any, len(sourceKeys))
+		sw := make([]any, len(sourceKeys))
 
 		i := 0
 		for k, w := range sourceKeys {
@@ -917,8 +917,8 @@ func (c cmdable) CMSMergeWithWeight(ctx context.Context, destKey string, sourceK
 
 // CMSQuery returns count for item(s).
 // For more information - https://redis.io/commands/cms.query/
-func (c cmdable) CMSQuery(ctx context.Context, key string, elements ...interface{}) *IntSliceCmd {
-	args := []interface{}{"CMS.QUERY", key}
+func (c cmdable) CMSQuery(ctx context.Context, key string, elements ...any) *IntSliceCmd {
+	args := []any{"CMS.QUERY", key}
 	args = append(args, elements...)
 	cmd := NewIntSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -932,8 +932,8 @@ func (c cmdable) CMSQuery(ctx context.Context, key string, elements ...interface
 // TopKAdd adds one or more elements to a Top-K filter.
 // Returns an array of strings representing the items that were removed from the filter, if any.
 // For more information - https://redis.io/commands/topk.add/
-func (c cmdable) TopKAdd(ctx context.Context, key string, elements ...interface{}) *StringSliceCmd {
-	args := make([]interface{}, 2, 2+len(elements))
+func (c cmdable) TopKAdd(ctx context.Context, key string, elements ...any) *StringSliceCmd {
+	args := make([]any, 2, 2+len(elements))
 	args[0] = "TOPK.ADD"
 	args[1] = key
 	args = appendArgs(args, elements)
@@ -946,7 +946,7 @@ func (c cmdable) TopKAdd(ctx context.Context, key string, elements ...interface{
 // TopKReserve creates an empty Top-K filter with the specified number of top items to keep.
 // For more information - https://redis.io/commands/topk.reserve/
 func (c cmdable) TopKReserve(ctx context.Context, key string, k int64) *StatusCmd {
-	args := []interface{}{"TOPK.RESERVE", key, k}
+	args := []any{"TOPK.RESERVE", key, k}
 
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -957,7 +957,7 @@ func (c cmdable) TopKReserve(ctx context.Context, key string, k int64) *StatusCm
 // This function allows for specifying additional options such as width, depth and decay.
 // For more information - https://redis.io/commands/topk.reserve/
 func (c cmdable) TopKReserveWithOptions(ctx context.Context, key string, k int64, width, depth int64, decay float64) *StatusCmd {
-	args := []interface{}{"TOPK.RESERVE", key, k, width, depth, decay}
+	args := []any{"TOPK.RESERVE", key, k, width, depth, decay}
 
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -977,7 +977,7 @@ type TopKInfoCmd struct {
 	val TopKInfo
 }
 
-func NewTopKInfoCmd(ctx context.Context, args ...interface{}) *TopKInfoCmd {
+func NewTopKInfoCmd(ctx context.Context, args ...any) *TopKInfoCmd {
 	return &TopKInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1041,7 +1041,7 @@ func (cmd *TopKInfoCmd) readReply(rd *proto.Reader) (err error) {
 // TopKInfo returns information about a Top-K filter.
 // For more information - https://redis.io/commands/topk.info/
 func (c cmdable) TopKInfo(ctx context.Context, key string) *TopKInfoCmd {
-	args := []interface{}{"TOPK.INFO", key}
+	args := []any{"TOPK.INFO", key}
 
 	cmd := NewTopKInfoCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1051,8 +1051,8 @@ func (c cmdable) TopKInfo(ctx context.Context, key string) *TopKInfoCmd {
 // TopKQuery check if multiple elements exist in a Top-K filter.
 // Returns an array of booleans indicating whether each element exists in the filter or not.
 // For more information - https://redis.io/commands/topk.query/
-func (c cmdable) TopKQuery(ctx context.Context, key string, elements ...interface{}) *BoolSliceCmd {
-	args := make([]interface{}, 2, 2+len(elements))
+func (c cmdable) TopKQuery(ctx context.Context, key string, elements ...any) *BoolSliceCmd {
+	args := make([]any, 2, 2+len(elements))
 	args[0] = "TOPK.QUERY"
 	args[1] = key
 	args = appendArgs(args, elements)
@@ -1064,8 +1064,8 @@ func (c cmdable) TopKQuery(ctx context.Context, key string, elements ...interfac
 
 // TopKCount returns an estimate of the number of times an item may be in a Top-K filter.
 // For more information - https://redis.io/commands/topk.count/
-func (c cmdable) TopKCount(ctx context.Context, key string, elements ...interface{}) *IntSliceCmd {
-	args := make([]interface{}, 2, 2+len(elements))
+func (c cmdable) TopKCount(ctx context.Context, key string, elements ...any) *IntSliceCmd {
+	args := make([]any, 2, 2+len(elements))
 	args[0] = "TOPK.COUNT"
 	args[1] = key
 	args = appendArgs(args, elements)
@@ -1077,8 +1077,8 @@ func (c cmdable) TopKCount(ctx context.Context, key string, elements ...interfac
 
 // TopKIncrBy increases the count of one or more items in a Top-K filter.
 // For more information - https://redis.io/commands/topk.incrby/
-func (c cmdable) TopKIncrBy(ctx context.Context, key string, elements ...interface{}) *StringSliceCmd {
-	args := make([]interface{}, 2, 2+len(elements))
+func (c cmdable) TopKIncrBy(ctx context.Context, key string, elements ...any) *StringSliceCmd {
+	args := make([]any, 2, 2+len(elements))
 	args[0] = "TOPK.INCRBY"
 	args[1] = key
 	args = appendArgs(args, elements)
@@ -1091,7 +1091,7 @@ func (c cmdable) TopKIncrBy(ctx context.Context, key string, elements ...interfa
 // TopKList returns all items in Top-K list.
 // For more information - https://redis.io/commands/topk.list/
 func (c cmdable) TopKList(ctx context.Context, key string) *StringSliceCmd {
-	args := []interface{}{"TOPK.LIST", key}
+	args := []any{"TOPK.LIST", key}
 
 	cmd := NewStringSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1101,7 +1101,7 @@ func (c cmdable) TopKList(ctx context.Context, key string) *StringSliceCmd {
 // TopKListWithCount returns all items in Top-K list with their respective count.
 // For more information - https://redis.io/commands/topk.list/
 func (c cmdable) TopKListWithCount(ctx context.Context, key string) *MapStringIntCmd {
-	args := []interface{}{"TOPK.LIST", key, "WITHCOUNT"}
+	args := []any{"TOPK.LIST", key, "WITHCOUNT"}
 
 	cmd := NewMapStringIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1116,7 +1116,7 @@ func (c cmdable) TopKListWithCount(ctx context.Context, key string) *MapStringIn
 // Returns OK on success or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.add/
 func (c cmdable) TDigestAdd(ctx context.Context, key string, elements ...float64) *StatusCmd {
-	args := make([]interface{}, 2+len(elements))
+	args := make([]any, 2+len(elements))
 	args[0] = "TDIGEST.ADD"
 	args[1] = key
 
@@ -1134,7 +1134,7 @@ func (c cmdable) TDigestAdd(ctx context.Context, key string, elements ...float64
 // Returns an array of floats representing the values at the specified ranks or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.byrank/
 func (c cmdable) TDigestByRank(ctx context.Context, key string, rank ...uint64) *FloatSliceCmd {
-	args := make([]interface{}, 2+len(rank))
+	args := make([]any, 2+len(rank))
 	args[0] = "TDIGEST.BYRANK"
 	args[1] = key
 
@@ -1152,7 +1152,7 @@ func (c cmdable) TDigestByRank(ctx context.Context, key string, rank ...uint64) 
 // Returns an array of floats representing the values at the specified ranks or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.byrevrank/
 func (c cmdable) TDigestByRevRank(ctx context.Context, key string, rank ...uint64) *FloatSliceCmd {
-	args := make([]interface{}, 2+len(rank))
+	args := make([]any, 2+len(rank))
 	args[0] = "TDIGEST.BYREVRANK"
 	args[1] = key
 
@@ -1170,7 +1170,7 @@ func (c cmdable) TDigestByRevRank(ctx context.Context, key string, rank ...uint6
 // Returns an array of floats representing the CDF values for each element or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.cdf/
 func (c cmdable) TDigestCDF(ctx context.Context, key string, elements ...float64) *FloatSliceCmd {
-	args := make([]interface{}, 2+len(elements))
+	args := make([]any, 2+len(elements))
 	args[0] = "TDIGEST.CDF"
 	args[1] = key
 
@@ -1187,7 +1187,7 @@ func (c cmdable) TDigestCDF(ctx context.Context, key string, elements ...float64
 // Returns OK on success or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.create/
 func (c cmdable) TDigestCreate(ctx context.Context, key string) *StatusCmd {
-	args := []interface{}{"TDIGEST.CREATE", key}
+	args := []any{"TDIGEST.CREATE", key}
 
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1199,7 +1199,7 @@ func (c cmdable) TDigestCreate(ctx context.Context, key string) *StatusCmd {
 // Returns OK on success or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.create/
 func (c cmdable) TDigestCreateWithCompression(ctx context.Context, key string, compression int64) *StatusCmd {
-	args := []interface{}{"TDIGEST.CREATE", key, "COMPRESSION", compression}
+	args := []any{"TDIGEST.CREATE", key, "COMPRESSION", compression}
 
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1224,7 +1224,7 @@ type TDigestInfoCmd struct {
 	val TDigestInfo
 }
 
-func NewTDigestInfoCmd(ctx context.Context, args ...interface{}) *TDigestInfoCmd {
+func NewTDigestInfoCmd(ctx context.Context, args ...any) *TDigestInfoCmd {
 	return &TDigestInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1298,7 +1298,7 @@ func (cmd *TDigestInfoCmd) readReply(rd *proto.Reader) (err error) {
 // TDigestInfo returns information about a t-Digest data structure.
 // For more information - https://redis.io/commands/tdigest.info/
 func (c cmdable) TDigestInfo(ctx context.Context, key string) *TDigestInfoCmd {
-	args := []interface{}{"TDIGEST.INFO", key}
+	args := []any{"TDIGEST.INFO", key}
 
 	cmd := NewTDigestInfoCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1308,7 +1308,7 @@ func (c cmdable) TDigestInfo(ctx context.Context, key string) *TDigestInfoCmd {
 // TDigestMax returns the maximum value from a t-Digest data structure.
 // For more information - https://redis.io/commands/tdigest.max/
 func (c cmdable) TDigestMax(ctx context.Context, key string) *FloatCmd {
-	args := []interface{}{"TDIGEST.MAX", key}
+	args := []any{"TDIGEST.MAX", key}
 
 	cmd := NewFloatCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1325,7 +1325,7 @@ type TDigestMergeOptions struct {
 // Returns OK on success or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.merge/
 func (c cmdable) TDigestMerge(ctx context.Context, destKey string, options *TDigestMergeOptions, sourceKeys ...string) *StatusCmd {
-	args := []interface{}{"TDIGEST.MERGE", destKey, len(sourceKeys)}
+	args := []any{"TDIGEST.MERGE", destKey, len(sourceKeys)}
 
 	for _, sourceKey := range sourceKeys {
 		args = append(args, sourceKey)
@@ -1348,7 +1348,7 @@ func (c cmdable) TDigestMerge(ctx context.Context, destKey string, options *TDig
 // TDigestMin returns the minimum value from a t-Digest data structure.
 // For more information - https://redis.io/commands/tdigest.min/
 func (c cmdable) TDigestMin(ctx context.Context, key string) *FloatCmd {
-	args := []interface{}{"TDIGEST.MIN", key}
+	args := []any{"TDIGEST.MIN", key}
 
 	cmd := NewFloatCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1360,7 +1360,7 @@ func (c cmdable) TDigestMin(ctx context.Context, key string) *FloatCmd {
 // Returns an array of floats representing the quantile values for each element or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.quantile/
 func (c cmdable) TDigestQuantile(ctx context.Context, key string, elements ...float64) *FloatSliceCmd {
-	args := make([]interface{}, 2+len(elements))
+	args := make([]any, 2+len(elements))
 	args[0] = "TDIGEST.QUANTILE"
 	args[1] = key
 
@@ -1378,7 +1378,7 @@ func (c cmdable) TDigestQuantile(ctx context.Context, key string, elements ...fl
 // Returns an array of integers representing the rank values for each element or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.rank/
 func (c cmdable) TDigestRank(ctx context.Context, key string, values ...float64) *IntSliceCmd {
-	args := make([]interface{}, 2+len(values))
+	args := make([]any, 2+len(values))
 	args[0] = "TDIGEST.RANK"
 	args[1] = key
 
@@ -1395,7 +1395,7 @@ func (c cmdable) TDigestRank(ctx context.Context, key string, values ...float64)
 // Returns OK on success or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.reset/
 func (c cmdable) TDigestReset(ctx context.Context, key string) *StatusCmd {
-	args := []interface{}{"TDIGEST.RESET", key}
+	args := []any{"TDIGEST.RESET", key}
 
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1407,7 +1407,7 @@ func (c cmdable) TDigestReset(ctx context.Context, key string) *StatusCmd {
 // Returns an array of integers representing the reverse rank values for each element or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.revrank/
 func (c cmdable) TDigestRevRank(ctx context.Context, key string, values ...float64) *IntSliceCmd {
-	args := make([]interface{}, 2+len(values))
+	args := make([]any, 2+len(values))
 	args[0] = "TDIGEST.REVRANK"
 	args[1] = key
 
@@ -1425,7 +1425,7 @@ func (c cmdable) TDigestRevRank(ctx context.Context, key string, values ...float
 // Returns a float representing the trimmed mean value or an error if the operation could not be completed.
 // For more information - https://redis.io/commands/tdigest.trimmed_mean/
 func (c cmdable) TDigestTrimmedMean(ctx context.Context, key string, lowCutQuantile, highCutQuantile float64) *FloatCmd {
-	args := []interface{}{"TDIGEST.TRIMMED_MEAN", key, lowCutQuantile, highCutQuantile}
+	args := []any{"TDIGEST.TRIMMED_MEAN", key, lowCutQuantile, highCutQuantile}
 
 	cmd := NewFloatCmd(ctx, args...)
 	_ = c(ctx, cmd)

--- a/pubsub.go
+++ b/pubsub.go
@@ -144,7 +144,7 @@ func mapKeys(m map[string]struct{}) []string {
 func (c *PubSub) _subscribe(
 	ctx context.Context, cn *pool.Conn, redisCmd string, channels []string,
 ) error {
-	args := make([]interface{}, 0, 1+len(channels))
+	args := make([]any, 0, 1+len(channels))
 	args = append(args, redisCmd)
 	for _, channel := range channels {
 		args = append(args, channel)
@@ -346,7 +346,7 @@ func (c *PubSub) subscribe(ctx context.Context, redisCmd string, channels ...str
 }
 
 func (c *PubSub) Ping(ctx context.Context, payload ...string) error {
-	args := []interface{}{"ping"}
+	args := []any{"ping"}
 	if len(payload) == 1 {
 		args = append(args, payload[0])
 	}
@@ -403,13 +403,13 @@ func (p *Pong) String() string {
 	return "Pong"
 }
 
-func (c *PubSub) newMessage(reply interface{}) (interface{}, error) {
+func (c *PubSub) newMessage(reply any) (any, error) {
 	switch reply := reply.(type) {
 	case string:
 		return &Pong{
 			Payload: reply,
 		}, nil
-	case []interface{}:
+	case []any:
 		switch kind := reply[0].(string); kind {
 		case "subscribe", "unsubscribe", "psubscribe", "punsubscribe", "ssubscribe", "sunsubscribe":
 			// Can be nil in case of "unsubscribe".
@@ -426,7 +426,7 @@ func (c *PubSub) newMessage(reply interface{}) (interface{}, error) {
 					Channel: reply[1].(string),
 					Payload: payload,
 				}, nil
-			case []interface{}:
+			case []any:
 				ss := make([]string, len(payload))
 				for i, s := range payload {
 					ss[i] = s.(string)
@@ -459,7 +459,7 @@ func (c *PubSub) newMessage(reply interface{}) (interface{}, error) {
 // ReceiveTimeout acts like Receive but returns an error if message
 // is not received in time. This is low-level API and in most cases
 // Channel should be used instead.
-func (c *PubSub) ReceiveTimeout(ctx context.Context, timeout time.Duration) (interface{}, error) {
+func (c *PubSub) ReceiveTimeout(ctx context.Context, timeout time.Duration) (any, error) {
 	if c.cmd == nil {
 		c.cmd = NewCmd(ctx)
 	}
@@ -497,7 +497,7 @@ func (c *PubSub) ReceiveTimeout(ctx context.Context, timeout time.Duration) (int
 // This method blocks until a message is received or an error occurs.
 // It may return early with an error if the context is canceled, the connection fails,
 // or other internal errors occur.
-func (c *PubSub) Receive(ctx context.Context) (interface{}, error) {
+func (c *PubSub) Receive(ctx context.Context) (any, error) {
 	return c.ReceiveTimeout(ctx, 0)
 }
 
@@ -566,7 +566,7 @@ func (c *PubSub) ChannelSize(size int) <-chan *Message {
 // reconnections.
 //
 // ChannelWithSubscriptions can not be used together with Channel or ChannelSize.
-func (c *PubSub) ChannelWithSubscriptions(opts ...ChannelOption) <-chan interface{} {
+func (c *PubSub) ChannelWithSubscriptions(opts ...ChannelOption) <-chan any {
 	c.chOnce.Do(func() {
 		c.allCh = newChannel(c, opts...)
 		c.allCh.initAllChan()
@@ -635,7 +635,7 @@ type channel struct {
 	pubSub *PubSub
 
 	msgCh chan *Message
-	allCh chan interface{}
+	allCh chan any
 	ping  chan struct{}
 
 	chanSize        int
@@ -747,7 +747,7 @@ func (c *channel) initMsgChan() {
 // initAllChan must be in sync with initMsgChan.
 func (c *channel) initAllChan() {
 	ctx := context.TODO()
-	c.allCh = make(chan interface{}, c.chanSize)
+	c.allCh = make(chan any, c.chanSize)
 
 	go func() {
 		timer := time.NewTimer(time.Minute)

--- a/pubsub_commands.go
+++ b/pubsub_commands.go
@@ -3,8 +3,8 @@ package redis
 import "context"
 
 type PubSubCmdable interface {
-	Publish(ctx context.Context, channel string, message interface{}) *IntCmd
-	SPublish(ctx context.Context, channel string, message interface{}) *IntCmd
+	Publish(ctx context.Context, channel string, message any) *IntCmd
+	SPublish(ctx context.Context, channel string, message any) *IntCmd
 	PubSubChannels(ctx context.Context, pattern string) *StringSliceCmd
 	PubSubNumSub(ctx context.Context, channels ...string) *MapStringIntCmd
 	PubSubNumPat(ctx context.Context) *IntCmd
@@ -13,20 +13,20 @@ type PubSubCmdable interface {
 }
 
 // Publish posts the message to the channel.
-func (c cmdable) Publish(ctx context.Context, channel string, message interface{}) *IntCmd {
+func (c cmdable) Publish(ctx context.Context, channel string, message any) *IntCmd {
 	cmd := NewIntCmd(ctx, "publish", channel, message)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
-func (c cmdable) SPublish(ctx context.Context, channel string, message interface{}) *IntCmd {
+func (c cmdable) SPublish(ctx context.Context, channel string, message any) *IntCmd {
 	cmd := NewIntCmd(ctx, "spublish", channel, message)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
 func (c cmdable) PubSubChannels(ctx context.Context, pattern string) *StringSliceCmd {
-	args := []interface{}{"pubsub", "channels"}
+	args := []any{"pubsub", "channels"}
 	if pattern != "*" {
 		args = append(args, pattern)
 	}
@@ -36,7 +36,7 @@ func (c cmdable) PubSubChannels(ctx context.Context, pattern string) *StringSlic
 }
 
 func (c cmdable) PubSubNumSub(ctx context.Context, channels ...string) *MapStringIntCmd {
-	args := make([]interface{}, 2+len(channels))
+	args := make([]any, 2+len(channels))
 	args[0] = "pubsub"
 	args[1] = "numsub"
 	for i, channel := range channels {
@@ -48,7 +48,7 @@ func (c cmdable) PubSubNumSub(ctx context.Context, channels ...string) *MapStrin
 }
 
 func (c cmdable) PubSubShardChannels(ctx context.Context, pattern string) *StringSliceCmd {
-	args := []interface{}{"pubsub", "shardchannels"}
+	args := []any{"pubsub", "shardchannels"}
 	if pattern != "*" {
 		args = append(args, pattern)
 	}
@@ -58,7 +58,7 @@ func (c cmdable) PubSubShardChannels(ctx context.Context, pattern string) *Strin
 }
 
 func (c cmdable) PubSubShardNumSub(ctx context.Context, channels ...string) *MapStringIntCmd {
-	args := make([]interface{}, 2+len(channels))
+	args := make([]any, 2+len(channels))
 	args[0] = "pubsub"
 	args[1] = "shardnumsub"
 	for i, channel := range channels {

--- a/push/handler.go
+++ b/push/handler.go
@@ -10,5 +10,5 @@ type NotificationHandler interface {
 	// The handlerCtx provides information about the client, connection pool, and connection
 	// on which the notification was received, allowing handlers to make informed decisions.
 	// Returns an error if the notification could not be handled.
-	HandlePushNotification(ctx context.Context, handlerCtx NotificationHandlerContext, notification []interface{}) error
+	HandlePushNotification(ctx context.Context, handlerCtx NotificationHandlerContext, notification []any) error
 }

--- a/push/handler_context.go
+++ b/push/handler_context.go
@@ -14,7 +14,7 @@ type NotificationHandlerContext struct {
 	// - *redis.Client
 	// - *redis.ClusterClient
 	// - *redis.Conn
-	Client interface{}
+	Client any
 
 	// ConnPool is the connection pool from which the connection was obtained.
 	// It is interface to both allow for future expansion and to avoid
@@ -23,21 +23,21 @@ type NotificationHandlerContext struct {
 	// - *pool.ConnPool
 	// - *pool.SingleConnPool
 	// - *pool.StickyConnPool
-	ConnPool interface{}
+	ConnPool any
 
 	// PubSub is the PubSub instance that received the notification.
 	// It is interface to both allow for future expansion and to avoid
 	// circular dependencies. The developer is responsible for type assertion.
 	// It can be one of the following types:
 	// - *redis.PubSub
-	PubSub interface{}
+	PubSub any
 
 	// Conn is the specific connection on which the notification was received.
 	// It is interface to both allow for future expansion and to avoid
 	// circular dependencies. The developer is responsible for type assertion.
 	// It can be one of the following types:
 	// - *pool.Conn
-	Conn interface{}
+	Conn any
 
 	// IsBlocking indicates if the notification was received on a blocking connection.
 	IsBlocking bool

--- a/push/processor.go
+++ b/push/processor.go
@@ -88,7 +88,7 @@ func (p *Processor) ProcessPendingNotifications(ctx context.Context, handlerCtx 
 		}
 
 		// Convert to slice of interfaces
-		notification, ok := reply.([]interface{})
+		notification, ok := reply.([]any)
 		if !ok {
 			break
 		}

--- a/push/processor_unit_test.go
+++ b/push/processor_unit_test.go
@@ -156,9 +156,9 @@ func TestProcessPendingNotificationsNilReader(t *testing.T) {
 // TestWillHandleNotificationInClient tests the notification filtering logic
 func TestWillHandleNotificationInClient(t *testing.T) {
 	testCases := []struct {
-		name           string
+		name             string
 		notificationType string
-		shouldHandle   bool
+		shouldHandle     bool
 	}{
 		// Pub/Sub notifications (should be handled in client)
 		{"message", "message", true},
@@ -242,7 +242,7 @@ func TestProcessorErrorHandlingUnit(t *testing.T) {
 // TestProcessorConcurrentAccess tests concurrent access to processor
 func TestProcessorConcurrentAccess(t *testing.T) {
 	processor := NewProcessor()
-	
+
 	t.Run("ConcurrentRegisterAndGet", func(t *testing.T) {
 		done := make(chan bool, 2)
 
@@ -283,13 +283,13 @@ func TestProcessorInterfaceCompliance(t *testing.T) {
 
 // UnitTestHandler is a test implementation of NotificationHandler
 type UnitTestHandler struct {
-	name           string
-	lastNotification []interface{}
-	errorToReturn  error
-	callCount      int
+	name             string
+	lastNotification []any
+	errorToReturn    error
+	callCount        int
 }
 
-func (h *UnitTestHandler) HandlePushNotification(ctx context.Context, handlerCtx NotificationHandlerContext, notification []interface{}) error {
+func (h *UnitTestHandler) HandlePushNotification(ctx context.Context, handlerCtx NotificationHandlerContext, notification []any) error {
 	h.callCount++
 	h.lastNotification = notification
 	return h.errorToReturn
@@ -300,7 +300,7 @@ func (h *UnitTestHandler) GetCallCount() int {
 	return h.callCount
 }
 
-func (h *UnitTestHandler) GetLastNotification() []interface{} {
+func (h *UnitTestHandler) GetLastNotification() []any {
 	return h.lastNotification
 }
 

--- a/push/push_test.go
+++ b/push/push_test.go
@@ -17,14 +17,14 @@ import (
 // TestHandler implements NotificationHandler interface for testing
 type TestHandler struct {
 	name        string
-	handled     [][]interface{}
+	handled     [][]any
 	returnError error
 }
 
 func NewTestHandler(name string) *TestHandler {
 	return &TestHandler{
 		name:    name,
-		handled: make([][]interface{}, 0),
+		handled: make([][]any, 0),
 	}
 }
 
@@ -40,12 +40,12 @@ func (m *MockNetConn) SetDeadline(t time.Time) error      { return nil }
 func (m *MockNetConn) SetReadDeadline(t time.Time) error  { return nil }
 func (m *MockNetConn) SetWriteDeadline(t time.Time) error { return nil }
 
-func (h *TestHandler) HandlePushNotification(ctx context.Context, handlerCtx NotificationHandlerContext, notification []interface{}) error {
+func (h *TestHandler) HandlePushNotification(ctx context.Context, handlerCtx NotificationHandlerContext, notification []any) error {
 	h.handled = append(h.handled, notification)
 	return h.returnError
 }
 
-func (h *TestHandler) GetHandledNotifications() [][]interface{} {
+func (h *TestHandler) GetHandledNotifications() [][]any {
 	return h.handled
 }
 
@@ -54,7 +54,7 @@ func (h *TestHandler) SetReturnError(err error) {
 }
 
 func (h *TestHandler) Reset() {
-	h.handled = make([][]interface{}, 0)
+	h.handled = make([][]any, 0)
 	h.returnError = nil
 }
 
@@ -583,7 +583,7 @@ func TestNotificationHandlerInterface(t *testing.T) {
 		Conn:       nil,
 		IsBlocking: false,
 	}
-	notification := []interface{}{"TEST", "data"}
+	notification := []any{"TEST", "data"}
 
 	err := handler.HandlePushNotification(ctx, handlerCtx, notification)
 	if err != nil {
@@ -614,7 +614,7 @@ func TestNotificationHandlerError(t *testing.T) {
 		Conn:       nil,
 		IsBlocking: false,
 	}
-	notification := []interface{}{"TEST", "data"}
+	notification := []any{"TEST", "data"}
 
 	err := handler.HandlePushNotification(ctx, handlerCtx, notification)
 	if err != expectedError {

--- a/result.go
+++ b/result.go
@@ -3,7 +3,7 @@ package redis
 import "time"
 
 // NewCmdResult returns a Cmd initialised with val and err for testing.
-func NewCmdResult(val interface{}, err error) *Cmd {
+func NewCmdResult(val any, err error) *Cmd {
 	var cmd Cmd
 	cmd.val = val
 	cmd.SetErr(err)
@@ -11,7 +11,7 @@ func NewCmdResult(val interface{}, err error) *Cmd {
 }
 
 // NewSliceResult returns a SliceCmd initialised with val and err for testing.
-func NewSliceResult(val []interface{}, err error) *SliceCmd {
+func NewSliceResult(val []any, err error) *SliceCmd {
 	var cmd SliceCmd
 	cmd.val = val
 	cmd.SetErr(err)

--- a/script.go
+++ b/script.go
@@ -8,10 +8,10 @@ import (
 )
 
 type Scripter interface {
-	Eval(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd
-	EvalSha(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd
-	EvalRO(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd
-	EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd
+	Eval(ctx context.Context, script string, keys []string, args ...any) *Cmd
+	EvalSha(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd
+	EvalRO(ctx context.Context, script string, keys []string, args ...any) *Cmd
+	EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd
 	ScriptExists(ctx context.Context, hashes ...string) *BoolSliceCmd
 	ScriptLoad(ctx context.Context, script string) *StringCmd
 }
@@ -47,25 +47,25 @@ func (s *Script) Exists(ctx context.Context, c Scripter) *BoolSliceCmd {
 	return c.ScriptExists(ctx, s.hash)
 }
 
-func (s *Script) Eval(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
+func (s *Script) Eval(ctx context.Context, c Scripter, keys []string, args ...any) *Cmd {
 	return c.Eval(ctx, s.src, keys, args...)
 }
 
-func (s *Script) EvalRO(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
+func (s *Script) EvalRO(ctx context.Context, c Scripter, keys []string, args ...any) *Cmd {
 	return c.EvalRO(ctx, s.src, keys, args...)
 }
 
-func (s *Script) EvalSha(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
+func (s *Script) EvalSha(ctx context.Context, c Scripter, keys []string, args ...any) *Cmd {
 	return c.EvalSha(ctx, s.hash, keys, args...)
 }
 
-func (s *Script) EvalShaRO(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
+func (s *Script) EvalShaRO(ctx context.Context, c Scripter, keys []string, args ...any) *Cmd {
 	return c.EvalShaRO(ctx, s.hash, keys, args...)
 }
 
 // Run optimistically uses EVALSHA to run the script. If script does not exist
 // it is retried using EVAL.
-func (s *Script) Run(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
+func (s *Script) Run(ctx context.Context, c Scripter, keys []string, args ...any) *Cmd {
 	r := s.EvalSha(ctx, c, keys, args...)
 	if HasErrorPrefix(r.Err(), "NOSCRIPT") {
 		return s.Eval(ctx, c, keys, args...)
@@ -75,7 +75,7 @@ func (s *Script) Run(ctx context.Context, c Scripter, keys []string, args ...int
 
 // RunRO optimistically uses EVALSHA_RO to run the script. If script does not exist
 // it is retried using EVAL_RO.
-func (s *Script) RunRO(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
+func (s *Script) RunRO(ctx context.Context, c Scripter, keys []string, args ...any) *Cmd {
 	r := s.EvalShaRO(ctx, c, keys, args...)
 	if HasErrorPrefix(r.Err(), "NOSCRIPT") {
 		return s.EvalRO(ctx, c, keys, args...)

--- a/scripting_commands.go
+++ b/scripting_commands.go
@@ -3,10 +3,10 @@ package redis
 import "context"
 
 type ScriptingFunctionsCmdable interface {
-	Eval(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd
-	EvalSha(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd
-	EvalRO(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd
-	EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd
+	Eval(ctx context.Context, script string, keys []string, args ...any) *Cmd
+	EvalSha(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd
+	EvalRO(ctx context.Context, script string, keys []string, args ...any) *Cmd
+	EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd
 	ScriptExists(ctx context.Context, hashes ...string) *BoolSliceCmd
 	ScriptFlush(ctx context.Context) *StatusCmd
 	ScriptKill(ctx context.Context) *StatusCmd
@@ -22,29 +22,29 @@ type ScriptingFunctionsCmdable interface {
 	FunctionDump(ctx context.Context) *StringCmd
 	FunctionRestore(ctx context.Context, libDump string) *StringCmd
 	FunctionStats(ctx context.Context) *FunctionStatsCmd
-	FCall(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd
-	FCallRo(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd
-	FCallRO(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd
+	FCall(ctx context.Context, function string, keys []string, args ...any) *Cmd
+	FCallRo(ctx context.Context, function string, keys []string, args ...any) *Cmd
+	FCallRO(ctx context.Context, function string, keys []string, args ...any) *Cmd
 }
 
-func (c cmdable) Eval(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) Eval(ctx context.Context, script string, keys []string, args ...any) *Cmd {
 	return c.eval(ctx, "eval", script, keys, args...)
 }
 
-func (c cmdable) EvalRO(ctx context.Context, script string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) EvalRO(ctx context.Context, script string, keys []string, args ...any) *Cmd {
 	return c.eval(ctx, "eval_ro", script, keys, args...)
 }
 
-func (c cmdable) EvalSha(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) EvalSha(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd {
 	return c.eval(ctx, "evalsha", sha1, keys, args...)
 }
 
-func (c cmdable) EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) EvalShaRO(ctx context.Context, sha1 string, keys []string, args ...any) *Cmd {
 	return c.eval(ctx, "evalsha_ro", sha1, keys, args...)
 }
 
-func (c cmdable) eval(ctx context.Context, name, payload string, keys []string, args ...interface{}) *Cmd {
-	cmdArgs := make([]interface{}, 3+len(keys), 3+len(keys)+len(args))
+func (c cmdable) eval(ctx context.Context, name, payload string, keys []string, args ...any) *Cmd {
+	cmdArgs := make([]any, 3+len(keys), 3+len(keys)+len(args))
 	cmdArgs[0] = name
 	cmdArgs[1] = payload
 	cmdArgs[2] = len(keys)
@@ -64,7 +64,7 @@ func (c cmdable) eval(ctx context.Context, name, payload string, keys []string, 
 }
 
 func (c cmdable) ScriptExists(ctx context.Context, hashes ...string) *BoolSliceCmd {
-	args := make([]interface{}, 2+len(hashes))
+	args := make([]any, 2+len(hashes))
 	args[0] = "script"
 	args[1] = "exists"
 	for i, hash := range hashes {
@@ -143,7 +143,7 @@ func (c cmdable) FunctionFlushAsync(ctx context.Context) *StringCmd {
 }
 
 func (c cmdable) FunctionList(ctx context.Context, q FunctionListQuery) *FunctionListCmd {
-	args := make([]interface{}, 2, 5)
+	args := make([]any, 2, 5)
 	args[0] = "function"
 	args[1] = "list"
 	if q.LibraryNamePattern != "" {
@@ -175,7 +175,7 @@ func (c cmdable) FunctionStats(ctx context.Context) *FunctionStatsCmd {
 	return cmd
 }
 
-func (c cmdable) FCall(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) FCall(ctx context.Context, function string, keys []string, args ...any) *Cmd {
 	cmdArgs := fcallArgs("fcall", function, keys, args...)
 	cmd := NewCmd(ctx, cmdArgs...)
 	if len(keys) > 0 {
@@ -187,11 +187,11 @@ func (c cmdable) FCall(ctx context.Context, function string, keys []string, args
 
 // FCallRo this function simply calls FCallRO,
 // Deprecated: to maintain convention FCallRO.
-func (c cmdable) FCallRo(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) FCallRo(ctx context.Context, function string, keys []string, args ...any) *Cmd {
 	return c.FCallRO(ctx, function, keys, args...)
 }
 
-func (c cmdable) FCallRO(ctx context.Context, function string, keys []string, args ...interface{}) *Cmd {
+func (c cmdable) FCallRO(ctx context.Context, function string, keys []string, args ...any) *Cmd {
 	cmdArgs := fcallArgs("fcall_ro", function, keys, args...)
 	cmd := NewCmd(ctx, cmdArgs...)
 	if len(keys) > 0 {
@@ -201,8 +201,8 @@ func (c cmdable) FCallRO(ctx context.Context, function string, keys []string, ar
 	return cmd
 }
 
-func fcallArgs(command string, function string, keys []string, args ...interface{}) []interface{} {
-	cmdArgs := make([]interface{}, 3+len(keys), 3+len(keys)+len(args))
+func fcallArgs(command string, function string, keys []string, args ...any) []any {
+	cmdArgs := make([]any, 3+len(keys), 3+len(keys)+len(args))
 	cmdArgs[0] = command
 	cmdArgs[1] = function
 	cmdArgs[2] = len(keys)

--- a/search_builders.go
+++ b/search_builders.go
@@ -54,7 +54,7 @@ func (b *SearchBuilder) WithSortKeys() *SearchBuilder {
 }
 
 // Filter adds a FILTER clause: FILTER <field> <min> <max>.
-func (b *SearchBuilder) Filter(field string, min, max interface{}) *SearchBuilder {
+func (b *SearchBuilder) Filter(field string, min, max any) *SearchBuilder {
 	b.options.Filters = append(b.options.Filters, FTSearchFilter{
 		FieldName: field,
 		Min:       min,
@@ -76,13 +76,13 @@ func (b *SearchBuilder) GeoFilter(field string, lon, lat, radius float64, unit s
 }
 
 // InKeys restricts the search to the given keys.
-func (b *SearchBuilder) InKeys(keys ...interface{}) *SearchBuilder {
+func (b *SearchBuilder) InKeys(keys ...any) *SearchBuilder {
 	b.options.InKeys = append(b.options.InKeys, keys...)
 	return b
 }
 
 // InFields restricts the search to the given fields.
-func (b *SearchBuilder) InFields(fields ...interface{}) *SearchBuilder {
+func (b *SearchBuilder) InFields(fields ...any) *SearchBuilder {
 	b.options.InFields = append(b.options.InFields, fields...)
 	return b
 }
@@ -166,18 +166,18 @@ func (b *SearchBuilder) WithSortByCount() *SearchBuilder {
 }
 
 // Param adds a single PARAMS <k> <v>.
-func (b *SearchBuilder) Param(key string, value interface{}) *SearchBuilder {
+func (b *SearchBuilder) Param(key string, value any) *SearchBuilder {
 	if b.options.Params == nil {
-		b.options.Params = make(map[string]interface{}, 1)
+		b.options.Params = make(map[string]any, 1)
 	}
 	b.options.Params[key] = value
 	return b
 }
 
 // ParamsMap adds multiple PARAMS at once.
-func (b *SearchBuilder) ParamsMap(p map[string]interface{}) *SearchBuilder {
+func (b *SearchBuilder) ParamsMap(p map[string]any) *SearchBuilder {
 	if b.options.Params == nil {
-		b.options.Params = make(map[string]interface{}, len(p))
+		b.options.Params = make(map[string]any, len(p))
 	}
 	for k, v := range p {
 		b.options.Params[k] = v
@@ -270,7 +270,7 @@ func (b *AggregateBuilder) Apply(field string, alias ...string) *AggregateBuilde
 }
 
 // GroupBy starts a new GROUPBY <fields...> clause.
-func (b *AggregateBuilder) GroupBy(fields ...interface{}) *AggregateBuilder {
+func (b *AggregateBuilder) GroupBy(fields ...any) *AggregateBuilder {
 	b.options.GroupBy = append(b.options.GroupBy, FTAggregateGroupBy{
 		Fields: fields,
 	})
@@ -278,7 +278,7 @@ func (b *AggregateBuilder) GroupBy(fields ...interface{}) *AggregateBuilder {
 }
 
 // Reduce adds a REDUCE <fn> [<#args> <args...>] clause to the *last* GROUPBY.
-func (b *AggregateBuilder) Reduce(fn SearchAggregator, args ...interface{}) *AggregateBuilder {
+func (b *AggregateBuilder) Reduce(fn SearchAggregator, args ...any) *AggregateBuilder {
 	if len(b.options.GroupBy) == 0 {
 		// no GROUPBY yet — nothing to attach to
 		return b
@@ -292,7 +292,7 @@ func (b *AggregateBuilder) Reduce(fn SearchAggregator, args ...interface{}) *Agg
 }
 
 // ReduceAs does the same but also sets an alias: REDUCE <fn> … AS <alias>
-func (b *AggregateBuilder) ReduceAs(fn SearchAggregator, alias string, args ...interface{}) *AggregateBuilder {
+func (b *AggregateBuilder) ReduceAs(fn SearchAggregator, alias string, args ...any) *AggregateBuilder {
 	if len(b.options.GroupBy) == 0 {
 		return b
 	}
@@ -336,9 +336,9 @@ func (b *AggregateBuilder) WithCursor(count, maxIdle int) *AggregateBuilder {
 }
 
 // Params adds PARAMS <k v> pairs.
-func (b *AggregateBuilder) Params(p map[string]interface{}) *AggregateBuilder {
+func (b *AggregateBuilder) Params(p map[string]any) *AggregateBuilder {
 	if b.options.Params == nil {
-		b.options.Params = make(map[string]interface{}, len(p))
+		b.options.Params = make(map[string]any, len(p))
 	}
 	for k, v := range p {
 		b.options.Params[k] = v
@@ -384,7 +384,7 @@ func (b *CreateIndexBuilder) OnHash() *CreateIndexBuilder { b.options.OnHash = t
 func (b *CreateIndexBuilder) OnJSON() *CreateIndexBuilder { b.options.OnJSON = true; return b }
 
 // Prefix sets PREFIX.
-func (b *CreateIndexBuilder) Prefix(prefixes ...interface{}) *CreateIndexBuilder {
+func (b *CreateIndexBuilder) Prefix(prefixes ...any) *CreateIndexBuilder {
 	b.options.Prefix = prefixes
 	return b
 }
@@ -444,7 +444,7 @@ func (b *CreateIndexBuilder) NoFields() *CreateIndexBuilder { b.options.NoFields
 func (b *CreateIndexBuilder) NoFreqs() *CreateIndexBuilder { b.options.NoFreqs = true; return b }
 
 // StopWords sets STOPWORDS.
-func (b *CreateIndexBuilder) StopWords(words ...interface{}) *CreateIndexBuilder {
+func (b *CreateIndexBuilder) StopWords(words ...any) *CreateIndexBuilder {
 	b.options.StopWords = words
 	return b
 }
@@ -627,7 +627,7 @@ func (c *Client) NewSpellCheckBuilder(ctx context.Context, index, query string) 
 func (b *SpellCheckBuilder) Distance(d int) *SpellCheckBuilder { b.options.Distance = d; return b }
 
 // Terms sets INCLUDE or EXCLUDE terms.
-func (b *SpellCheckBuilder) Terms(include bool, dictionary string, terms ...interface{}) *SpellCheckBuilder {
+func (b *SpellCheckBuilder) Terms(include bool, dictionary string, terms ...any) *SpellCheckBuilder {
 	if b.options.Terms == nil {
 		b.options.Terms = &FTSpellCheckTerms{}
 	}
@@ -659,7 +659,7 @@ type DictBuilder struct {
 	c      *Client
 	ctx    context.Context
 	dict   string
-	terms  []interface{}
+	terms  []any
 	action string // add|del|dump
 }
 
@@ -676,14 +676,14 @@ func (b *DictBuilder) Action(action string) *DictBuilder {
 }
 
 // Add sets the action to "add" and requires terms.
-func (b *DictBuilder) Add(terms ...interface{}) *DictBuilder {
+func (b *DictBuilder) Add(terms ...any) *DictBuilder {
 	b.action = "add"
 	b.terms = terms
 	return b
 }
 
 // Del sets the action to "del" and requires terms.
-func (b *DictBuilder) Del(terms ...interface{}) *DictBuilder {
+func (b *DictBuilder) Del(terms ...any) *DictBuilder {
 	b.action = "del"
 	b.terms = terms
 	return b
@@ -696,7 +696,7 @@ func (b *DictBuilder) Dump() *DictBuilder {
 }
 
 // Run executes the configured dictionary command.
-func (b *DictBuilder) Run() (interface{}, error) {
+func (b *DictBuilder) Run() (any, error) {
 	switch b.action {
 	case "add":
 		cmd := b.c.FTDictAdd(b.ctx, b.dict, b.terms...)
@@ -777,7 +777,7 @@ func (b *CursorBuilder) Del() *CursorBuilder {
 func (b *CursorBuilder) Count(count int) *CursorBuilder { b.count = count; return b }
 
 // Run executes the cursor command.
-func (b *CursorBuilder) Run() (interface{}, error) {
+func (b *CursorBuilder) Run() (any, error) {
 	switch b.action {
 	case "read":
 		cmd := b.c.FTCursorRead(b.ctx, b.index, int(b.cursorId), b.count)
@@ -798,14 +798,14 @@ type SynUpdateBuilder struct {
 	c       *Client
 	ctx     context.Context
 	index   string
-	groupId interface{}
+	groupId any
 	options *FTSynUpdateOptions
-	terms   []interface{}
+	terms   []any
 }
 
 // NewSynUpdateBuilder creates a new SynUpdateBuilder for FT.SYNUPDATE commands.
 // EXPERIMENTAL: this API is subject to change, use with caution.
-func (c *Client) NewSynUpdateBuilder(ctx context.Context, index string, groupId interface{}) *SynUpdateBuilder {
+func (c *Client) NewSynUpdateBuilder(ctx context.Context, index string, groupId any) *SynUpdateBuilder {
 	return &SynUpdateBuilder{c: c, ctx: ctx, index: index, groupId: groupId, options: &FTSynUpdateOptions{}}
 }
 
@@ -816,7 +816,7 @@ func (b *SynUpdateBuilder) SkipInitialScan() *SynUpdateBuilder {
 }
 
 // Terms adds synonyms to the group.
-func (b *SynUpdateBuilder) Terms(terms ...interface{}) *SynUpdateBuilder { b.terms = terms; return b }
+func (b *SynUpdateBuilder) Terms(terms ...any) *SynUpdateBuilder { b.terms = terms; return b }
 
 // Run executes FT.SYNUPDATE.
 func (b *SynUpdateBuilder) Run() (string, error) {

--- a/search_builders_test.go
+++ b/search_builders_test.go
@@ -457,7 +457,7 @@ var _ = Describe("RediSearch Builders", Label("search", "builders"), func() {
 		Expect(res1.Docs[0].ID).To(Equal("doc1"))
 
 		// Test with multiple params using ParamsMap
-		params := map[string]interface{}{
+		params := map[string]any{
 			"name1": "Bob",
 			"name2": "Carol",
 		}
@@ -596,7 +596,7 @@ var _ = Describe("RediSearch Builders", Label("search", "builders"), func() {
 		Expect(res.Total).To(BeNumerically(">=", 1))
 
 		res2, err := client.NewSearchBuilder(ctx, "idx_complex", "@category:{$cat} @price:[$min $max]").
-			ParamsMap(map[string]interface{}{
+			ParamsMap(map[string]any{
 				"cat": "electronics",
 				"min": 150,
 				"max": 300,

--- a/search_commands.go
+++ b/search_commands.go
@@ -16,14 +16,14 @@ type SearchCmdable interface {
 	FTAliasAdd(ctx context.Context, index string, alias string) *StatusCmd
 	FTAliasDel(ctx context.Context, alias string) *StatusCmd
 	FTAliasUpdate(ctx context.Context, index string, alias string) *StatusCmd
-	FTAlter(ctx context.Context, index string, skipInitialScan bool, definition []interface{}) *StatusCmd
+	FTAlter(ctx context.Context, index string, skipInitialScan bool, definition []any) *StatusCmd
 	FTConfigGet(ctx context.Context, option string) *MapMapStringInterfaceCmd
-	FTConfigSet(ctx context.Context, option string, value interface{}) *StatusCmd
+	FTConfigSet(ctx context.Context, option string, value any) *StatusCmd
 	FTCreate(ctx context.Context, index string, options *FTCreateOptions, schema ...*FieldSchema) *StatusCmd
 	FTCursorDel(ctx context.Context, index string, cursorId int) *StatusCmd
 	FTCursorRead(ctx context.Context, index string, cursorId int, count int) *MapStringInterfaceCmd
-	FTDictAdd(ctx context.Context, dict string, term ...interface{}) *IntCmd
-	FTDictDel(ctx context.Context, dict string, term ...interface{}) *IntCmd
+	FTDictAdd(ctx context.Context, dict string, term ...any) *IntCmd
+	FTDictDel(ctx context.Context, dict string, term ...any) *IntCmd
 	FTDictDump(ctx context.Context, dict string) *StringSliceCmd
 	FTDropIndex(ctx context.Context, index string) *StatusCmd
 	FTDropIndexWithArgs(ctx context.Context, index string, options *FTDropIndexOptions) *StatusCmd
@@ -35,15 +35,15 @@ type SearchCmdable interface {
 	FTSearch(ctx context.Context, index string, query string) *FTSearchCmd
 	FTSearchWithArgs(ctx context.Context, index string, query string, options *FTSearchOptions) *FTSearchCmd
 	FTSynDump(ctx context.Context, index string) *FTSynDumpCmd
-	FTSynUpdate(ctx context.Context, index string, synGroupId interface{}, terms []interface{}) *StatusCmd
-	FTSynUpdateWithArgs(ctx context.Context, index string, synGroupId interface{}, options *FTSynUpdateOptions, terms []interface{}) *StatusCmd
+	FTSynUpdate(ctx context.Context, index string, synGroupId any, terms []any) *StatusCmd
+	FTSynUpdateWithArgs(ctx context.Context, index string, synGroupId any, options *FTSynUpdateOptions, terms []any) *StatusCmd
 	FTTagVals(ctx context.Context, index string, field string) *StringSliceCmd
 }
 
 type FTCreateOptions struct {
 	OnHash          bool
 	OnJSON          bool
-	Prefix          []interface{}
+	Prefix          []any
 	Filter          string
 	DefaultLanguage string
 	LanguageField   string
@@ -56,7 +56,7 @@ type FTCreateOptions struct {
 	NoHL            bool
 	NoFields        bool
 	NoFreqs         bool
-	StopWords       []interface{}
+	StopWords       []any
 	SkipInitialScan bool
 }
 
@@ -224,12 +224,12 @@ func (t SearchFieldType) String() string {
 // Please follow https://redis.io/docs/interact/search-and-query/search/aggregations/#supported-groupby-reducers for more information.
 type FTAggregateReducer struct {
 	Reducer SearchAggregator
-	Args    []interface{}
+	Args    []any
 	As      string
 }
 
 type FTAggregateGroupBy struct {
-	Fields []interface{}
+	Fields []any
 	Reduce []FTAggregateReducer
 }
 
@@ -275,15 +275,15 @@ type FTAggregateOptions struct {
 	Filter            string
 	WithCursor        bool
 	WithCursorOptions *FTAggregateWithCursor
-	Params            map[string]interface{}
+	Params            map[string]any
 	// Dialect 1,3 and 4 are deprecated since redis 8.0
 	DialectVersion int
 }
 
 type FTSearchFilter struct {
-	FieldName interface{}
-	Min       interface{}
-	Max       interface{}
+	FieldName any
+	Min       any
+	Max       any
 }
 
 type FTSearchGeoFilter struct {
@@ -317,8 +317,8 @@ type FTSearchOptions struct {
 	WithSortKeys bool
 	Filters      []FTSearchFilter
 	GeoFilter    []FTSearchGeoFilter
-	InKeys       []interface{}
-	InFields     []interface{}
+	InKeys       []any
+	InFields     []any
 	Return       []FTSearchReturn
 	Slop         int
 	Timeout      int
@@ -339,7 +339,7 @@ type FTSearchOptions struct {
 	// CountOnly sets LIMIT 0 0 to get the count - number of documents in the result set without actually returning the result set.
 	// When using this option, the Limit and LimitOffset options are ignored.
 	CountOnly bool
-	Params    map[string]interface{}
+	Params    map[string]any
 	// Dialect 1,3 and 4 are deprecated since redis 8.0
 	DialectVersion int
 }
@@ -360,7 +360,7 @@ type FTAggregateResult struct {
 }
 
 type AggregateRow struct {
-	Fields map[string]interface{}
+	Fields map[string]any
 }
 
 type AggregateCmd struct {
@@ -464,7 +464,7 @@ type FTSpellCheckOptions struct {
 type FTSpellCheckTerms struct {
 	Inclusion  string // Either "INCLUDE" or "EXCLUDE"
 	Dictionary string
-	Terms      []interface{}
+	Terms      []any
 }
 
 type SpellCheckResult struct {
@@ -491,7 +491,7 @@ type Document struct {
 	Error   error
 }
 
-type AggregateQuery []interface{}
+type AggregateQuery []any
 
 // FT_List - Lists all the existing indexes in the database.
 // For more information, please refer to the Redis documentation:
@@ -507,14 +507,14 @@ func (c cmdable) FT_List(ctx context.Context) *StringSliceCmd {
 // For more information, please refer to the Redis documentation:
 // [FT.AGGREGATE]: (https://redis.io/commands/ft.aggregate/)
 func (c cmdable) FTAggregate(ctx context.Context, index string, query string) *MapStringInterfaceCmd {
-	args := []interface{}{"FT.AGGREGATE", index, query}
+	args := []any{"FT.AGGREGATE", index, query}
 	cmd := NewMapStringInterfaceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
 func FTAggregateQuery(query string, options *FTAggregateOptions) (AggregateQuery, error) {
-	queryArgs := []interface{}{query}
+	queryArgs := []any{query}
 	if options != nil {
 		if options.Verbatim {
 			queryArgs = append(queryArgs, "VERBATIM")
@@ -581,7 +581,7 @@ func FTAggregateQuery(query string, options *FTAggregateOptions) (AggregateQuery
 		}
 		if options.SortBy != nil {
 			queryArgs = append(queryArgs, "SORTBY")
-			sortByOptions := []interface{}{}
+			sortByOptions := []any{}
 			for _, sortBy := range options.SortBy {
 				sortByOptions = append(sortByOptions, sortBy.FieldName)
 				if sortBy.Asc && sortBy.Desc {
@@ -633,7 +633,7 @@ func FTAggregateQuery(query string, options *FTAggregateOptions) (AggregateQuery
 	return queryArgs, nil
 }
 
-func ProcessAggregateResult(data []interface{}) (*FTAggregateResult, error) {
+func ProcessAggregateResult(data []any) (*FTAggregateResult, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("no data returned")
 	}
@@ -645,12 +645,12 @@ func ProcessAggregateResult(data []interface{}) (*FTAggregateResult, error) {
 
 	rows := make([]AggregateRow, 0, len(data)-1)
 	for _, row := range data[1:] {
-		fields, ok := row.([]interface{})
+		fields, ok := row.([]any)
 		if !ok {
 			return nil, fmt.Errorf("invalid row format")
 		}
 
-		rowMap := make(map[string]interface{})
+		rowMap := make(map[string]any)
 		for i := 0; i < len(fields); i += 2 {
 			key, ok := fields[i].(string)
 			if !ok {
@@ -669,7 +669,7 @@ func ProcessAggregateResult(data []interface{}) (*FTAggregateResult, error) {
 	return result, nil
 }
 
-func NewAggregateCmd(ctx context.Context, args ...interface{}) *AggregateCmd {
+func NewAggregateCmd(ctx context.Context, args ...any) *AggregateCmd {
 	return &AggregateCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -690,11 +690,11 @@ func (cmd *AggregateCmd) Result() (*FTAggregateResult, error) {
 	return cmd.val, cmd.err
 }
 
-func (cmd *AggregateCmd) RawVal() interface{} {
+func (cmd *AggregateCmd) RawVal() any {
 	return cmd.rawVal
 }
 
-func (cmd *AggregateCmd) RawResult() (interface{}, error) {
+func (cmd *AggregateCmd) RawResult() (any, error) {
 	return cmd.rawVal, cmd.err
 }
 
@@ -720,7 +720,7 @@ func (cmd *AggregateCmd) readReply(rd *proto.Reader) (err error) {
 // For more information, please refer to the Redis documentation:
 // [FT.AGGREGATE]: (https://redis.io/commands/ft.aggregate/)
 func (c cmdable) FTAggregateWithArgs(ctx context.Context, index string, query string, options *FTAggregateOptions) *AggregateCmd {
-	args := []interface{}{"FT.AGGREGATE", index, query}
+	args := []any{"FT.AGGREGATE", index, query}
 	if options != nil {
 		if options.Verbatim {
 			args = append(args, "VERBATIM")
@@ -783,7 +783,7 @@ func (c cmdable) FTAggregateWithArgs(ctx context.Context, index string, query st
 		}
 		if options.SortBy != nil {
 			args = append(args, "SORTBY")
-			sortByOptions := []interface{}{}
+			sortByOptions := []any{}
 			for _, sortBy := range options.SortBy {
 				sortByOptions = append(sortByOptions, sortBy.FieldName)
 				if sortBy.Asc && sortBy.Desc {
@@ -844,7 +844,7 @@ func (c cmdable) FTAggregateWithArgs(ctx context.Context, index string, query st
 // For more information, please refer to the Redis documentation:
 // [FT.ALIASADD]: (https://redis.io/commands/ft.aliasadd/)
 func (c cmdable) FTAliasAdd(ctx context.Context, index string, alias string) *StatusCmd {
-	args := []interface{}{"FT.ALIASADD", alias, index}
+	args := []any{"FT.ALIASADD", alias, index}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -876,8 +876,8 @@ func (c cmdable) FTAliasUpdate(ctx context.Context, index string, alias string) 
 // The 'definition' parameter specifies the new definition for the index.
 // For more information, please refer to the Redis documentation:
 // [FT.ALTER]: (https://redis.io/commands/ft.alter/)
-func (c cmdable) FTAlter(ctx context.Context, index string, skipInitialScan bool, definition []interface{}) *StatusCmd {
-	args := []interface{}{"FT.ALTER", index}
+func (c cmdable) FTAlter(ctx context.Context, index string, skipInitialScan bool, definition []any) *StatusCmd {
+	args := []any{"FT.ALTER", index}
 	if skipInitialScan {
 		args = append(args, "SKIPINITIALSCAN")
 	}
@@ -914,7 +914,7 @@ func (c cmdable) FTConfigGet(ctx context.Context, option string) *MapMapStringIn
 //
 // [CONFIG SET Documentation]: https://redis.io/commands/config-set/
 // [FT.CONFIG SET]: https://redis.io/commands/ft.config-set/
-func (c cmdable) FTConfigSet(ctx context.Context, option string, value interface{}) *StatusCmd {
+func (c cmdable) FTConfigSet(ctx context.Context, option string, value any) *StatusCmd {
 	cmd := NewStatusCmd(ctx, "FT.CONFIG", "SET", option, value)
 	_ = c(ctx, cmd)
 	return cmd
@@ -928,7 +928,7 @@ func (c cmdable) FTConfigSet(ctx context.Context, option string, value interface
 // For more information, please refer to the Redis documentation:
 // [FT.CREATE]: (https://redis.io/commands/ft.create/)
 func (c cmdable) FTCreate(ctx context.Context, index string, options *FTCreateOptions, schema ...*FieldSchema) *StatusCmd {
-	args := []interface{}{"FT.CREATE", index}
+	args := []any{"FT.CREATE", index}
 	if options != nil {
 		if options.OnHash && !options.OnJSON {
 			args = append(args, "ON", "HASH")
@@ -1035,7 +1035,7 @@ func (c cmdable) FTCreate(ctx context.Context, index string, options *FTCreateOp
 					cmd.SetErr(fmt.Errorf("FT.CREATE: Type, Dim and DistanceMetric are required for VECTOR FLAT"))
 					return cmd
 				}
-				flatArgs := []interface{}{
+				flatArgs := []any{
 					"TYPE", schema.VectorArgs.FlatOptions.Type,
 					"DIM", schema.VectorArgs.FlatOptions.Dim,
 					"DISTANCE_METRIC", schema.VectorArgs.FlatOptions.DistanceMetric,
@@ -1056,7 +1056,7 @@ func (c cmdable) FTCreate(ctx context.Context, index string, options *FTCreateOp
 					cmd.SetErr(fmt.Errorf("FT.CREATE: Type, Dim and DistanceMetric are required for VECTOR HNSW"))
 					return cmd
 				}
-				hnswArgs := []interface{}{
+				hnswArgs := []any{
 					"TYPE", schema.VectorArgs.HNSWOptions.Type,
 					"DIM", schema.VectorArgs.HNSWOptions.Dim,
 					"DISTANCE_METRIC", schema.VectorArgs.HNSWOptions.DistanceMetric,
@@ -1086,7 +1086,7 @@ func (c cmdable) FTCreate(ctx context.Context, index string, options *FTCreateOp
 					cmd.SetErr(fmt.Errorf("FT.CREATE: Type, Dim and DistanceMetric are required for VECTOR VAMANA"))
 					return cmd
 				}
-				vamanaArgs := []interface{}{
+				vamanaArgs := []any{
 					"TYPE", schema.VectorArgs.VamanaOptions.Type,
 					"DIM", schema.VectorArgs.VamanaOptions.Dim,
 					"DISTANCE_METRIC", schema.VectorArgs.VamanaOptions.DistanceMetric,
@@ -1179,7 +1179,7 @@ func (c cmdable) FTCursorDel(ctx context.Context, index string, cursorId int) *S
 // For more information, please refer to the Redis documentation:
 // [FT.CURSOR READ]: (https://redis.io/commands/ft.cursor-read/)
 func (c cmdable) FTCursorRead(ctx context.Context, index string, cursorId int, count int) *MapStringInterfaceCmd {
-	args := []interface{}{"FT.CURSOR", "READ", index, cursorId}
+	args := []any{"FT.CURSOR", "READ", index, cursorId}
 	if count > 0 {
 		args = append(args, "COUNT", count)
 	}
@@ -1192,8 +1192,8 @@ func (c cmdable) FTCursorRead(ctx context.Context, index string, cursorId int, c
 // The 'dict' parameter specifies the dictionary to which to add the terms, and the 'term' parameter specifies the terms to add.
 // For more information, please refer to the Redis documentation:
 // [FT.DICTADD]: (https://redis.io/commands/ft.dictadd/)
-func (c cmdable) FTDictAdd(ctx context.Context, dict string, term ...interface{}) *IntCmd {
-	args := []interface{}{"FT.DICTADD", dict}
+func (c cmdable) FTDictAdd(ctx context.Context, dict string, term ...any) *IntCmd {
+	args := []any{"FT.DICTADD", dict}
 	args = append(args, term...)
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1204,8 +1204,8 @@ func (c cmdable) FTDictAdd(ctx context.Context, dict string, term ...interface{}
 // The 'dict' parameter specifies the dictionary from which to delete the terms, and the 'term' parameter specifies the terms to delete.
 // For more information, please refer to the Redis documentation:
 // [FT.DICTDEL]: (https://redis.io/commands/ft.dictdel/)
-func (c cmdable) FTDictDel(ctx context.Context, dict string, term ...interface{}) *IntCmd {
-	args := []interface{}{"FT.DICTDEL", dict}
+func (c cmdable) FTDictDel(ctx context.Context, dict string, term ...any) *IntCmd {
+	args := []any{"FT.DICTDEL", dict}
 	args = append(args, term...)
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -1227,7 +1227,7 @@ func (c cmdable) FTDictDump(ctx context.Context, dict string) *StringSliceCmd {
 // For more information, please refer to the Redis documentation:
 // [FT.DROPINDEX]: (https://redis.io/commands/ft.dropindex/)
 func (c cmdable) FTDropIndex(ctx context.Context, index string) *StatusCmd {
-	args := []interface{}{"FT.DROPINDEX", index}
+	args := []any{"FT.DROPINDEX", index}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -1238,7 +1238,7 @@ func (c cmdable) FTDropIndex(ctx context.Context, index string) *StatusCmd {
 // For more information, please refer to the Redis documentation:
 // [FT.DROPINDEX]: (https://redis.io/commands/ft.dropindex/)
 func (c cmdable) FTDropIndexWithArgs(ctx context.Context, index string, options *FTDropIndexOptions) *StatusCmd {
-	args := []interface{}{"FT.DROPINDEX", index}
+	args := []any{"FT.DROPINDEX", index}
 	if options != nil {
 		if options.DeleteDocs {
 			args = append(args, "DD")
@@ -1264,7 +1264,7 @@ func (c cmdable) FTExplain(ctx context.Context, index string, query string) *Str
 // For more information, please refer to the Redis documentation:
 // [FT.EXPLAIN]: (https://redis.io/commands/ft.explain/)
 func (c cmdable) FTExplainWithArgs(ctx context.Context, index string, query string, options *FTExplainOptions) *StringCmd {
-	args := []interface{}{"FT.EXPLAIN", index, query}
+	args := []any{"FT.EXPLAIN", index, query}
 	if options.Dialect != "" {
 		args = append(args, "DIALECT", options.Dialect)
 	} else {
@@ -1281,10 +1281,10 @@ func (c cmdable) FTExplainCli(ctx context.Context, key, path string) error {
 	return fmt.Errorf("FTExplainCli is not implemented")
 }
 
-func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
+func parseFTInfo(data map[string]any) (FTInfoResult, error) {
 	var ftInfo FTInfoResult
 	// Manually parse each field from the map
-	if indexErrors, ok := data["Index Errors"].([]interface{}); ok {
+	if indexErrors, ok := data["Index Errors"].([]any); ok {
 		ftInfo.IndexErrors = IndexErrors{
 			IndexingFailures:     internal.ToInteger(indexErrors[1]),
 			LastIndexingError:    internal.ToString(indexErrors[3]),
@@ -1292,9 +1292,9 @@ func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
 		}
 	}
 
-	if attributes, ok := data["attributes"].([]interface{}); ok {
+	if attributes, ok := data["attributes"].([]any); ok {
 		for _, attr := range attributes {
-			if attrMap, ok := attr.([]interface{}); ok {
+			if attrMap, ok := attr.([]any); ok {
 				att := FTAttribute{}
 				for i := 0; i < len(attrMap); i++ {
 					if internal.ToLower(internal.ToString(attrMap[i])) == "attribute" {
@@ -1351,7 +1351,7 @@ func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
 	ftInfo.BytesPerRecordAvg = internal.ToString(data["bytes_per_record_avg"])
 	ftInfo.Cleaning = internal.ToInteger(data["cleaning"])
 
-	if cursorStats, ok := data["cursor_stats"].([]interface{}); ok {
+	if cursorStats, ok := data["cursor_stats"].([]any); ok {
 		ftInfo.CursorStats = CursorStats{
 			GlobalIdle:    internal.ToInteger(cursorStats[1]),
 			GlobalTotal:   internal.ToInteger(cursorStats[3]),
@@ -1360,7 +1360,7 @@ func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
 		}
 	}
 
-	if dialectStats, ok := data["dialect_stats"].([]interface{}); ok {
+	if dialectStats, ok := data["dialect_stats"].([]any); ok {
 		ftInfo.DialectStats = make(map[string]int)
 		for i := 0; i < len(dialectStats); i += 2 {
 			ftInfo.DialectStats[internal.ToString(dialectStats[i])] = internal.ToInteger(dialectStats[i+1])
@@ -1369,23 +1369,23 @@ func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
 
 	ftInfo.DocTableSizeMB = internal.ToFloat(data["doc_table_size_mb"])
 
-	if fieldStats, ok := data["field statistics"].([]interface{}); ok {
+	if fieldStats, ok := data["field statistics"].([]any); ok {
 		for _, stat := range fieldStats {
-			if statMap, ok := stat.([]interface{}); ok {
+			if statMap, ok := stat.([]any); ok {
 				ftInfo.FieldStatistics = append(ftInfo.FieldStatistics, FieldStatistic{
 					Identifier: internal.ToString(statMap[1]),
 					Attribute:  internal.ToString(statMap[3]),
 					IndexErrors: IndexErrors{
-						IndexingFailures:     internal.ToInteger(statMap[5].([]interface{})[1]),
-						LastIndexingError:    internal.ToString(statMap[5].([]interface{})[3]),
-						LastIndexingErrorKey: internal.ToString(statMap[5].([]interface{})[5]),
+						IndexingFailures:     internal.ToInteger(statMap[5].([]any)[1]),
+						LastIndexingError:    internal.ToString(statMap[5].([]any)[3]),
+						LastIndexingErrorKey: internal.ToString(statMap[5].([]any)[5]),
 					},
 				})
 			}
 		}
 	}
 
-	if gcStats, ok := data["gc_stats"].([]interface{}); ok {
+	if gcStats, ok := data["gc_stats"].([]any); ok {
 		ftInfo.GCStats = GCStats{}
 		for i := 0; i < len(gcStats); i += 2 {
 			if internal.ToLower(internal.ToString(gcStats[i])) == "bytes_collected" {
@@ -1422,7 +1422,7 @@ func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
 	ftInfo.GeoshapesSzMB = internal.ToFloat(data["geoshapes_sz_mb"])
 	ftInfo.HashIndexingFailures = internal.ToInteger(data["hash_indexing_failures"])
 
-	if indexDef, ok := data["index_definition"].([]interface{}); ok {
+	if indexDef, ok := data["index_definition"].([]any); ok {
 		ftInfo.IndexDefinition = IndexDefinition{
 			KeyType:      internal.ToString(indexDef[1]),
 			Prefixes:     internal.ToStringSlice(indexDef[3]),
@@ -1431,7 +1431,7 @@ func parseFTInfo(data map[string]interface{}) (FTInfoResult, error) {
 	}
 
 	ftInfo.IndexName = internal.ToString(data["index_name"])
-	ftInfo.IndexOptions = internal.ToStringSlice(data["index_options"].([]interface{}))
+	ftInfo.IndexOptions = internal.ToStringSlice(data["index_options"].([]any))
 	ftInfo.Indexing = internal.ToInteger(data["indexing"])
 	ftInfo.InvertedSzMB = internal.ToFloat(data["inverted_sz_mb"])
 	ftInfo.KeyTableSizeMB = internal.ToFloat(data["key_table_size_mb"])
@@ -1461,7 +1461,7 @@ type FTInfoCmd struct {
 	val FTInfoResult
 }
 
-func newFTInfoCmd(ctx context.Context, args ...interface{}) *FTInfoCmd {
+func newFTInfoCmd(ctx context.Context, args ...any) *FTInfoCmd {
 	return &FTInfoCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1486,11 +1486,11 @@ func (cmd *FTInfoCmd) Val() FTInfoResult {
 	return cmd.val
 }
 
-func (cmd *FTInfoCmd) RawVal() interface{} {
+func (cmd *FTInfoCmd) RawVal() any {
 	return cmd.rawVal
 }
 
-func (cmd *FTInfoCmd) RawResult() (interface{}, error) {
+func (cmd *FTInfoCmd) RawResult() (any, error) {
 	return cmd.rawVal, cmd.err
 }
 func (cmd *FTInfoCmd) readReply(rd *proto.Reader) (err error) {
@@ -1499,7 +1499,7 @@ func (cmd *FTInfoCmd) readReply(rd *proto.Reader) (err error) {
 		return err
 	}
 
-	data := make(map[string]interface{}, n)
+	data := make(map[string]any, n)
 	for i := 0; i < n; i++ {
 		k, err := rd.ReadString()
 		if err != nil {
@@ -1543,7 +1543,7 @@ func (c cmdable) FTInfo(ctx context.Context, index string) *FTInfoCmd {
 // For more information, please refer to the Redis documentation:
 // [FT.SPELLCHECK]: (https://redis.io/commands/ft.spellcheck/)
 func (c cmdable) FTSpellCheck(ctx context.Context, index string, query string) *FTSpellCheckCmd {
-	args := []interface{}{"FT.SPELLCHECK", index, query}
+	args := []any{"FT.SPELLCHECK", index, query}
 	cmd := newFTSpellCheckCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -1555,7 +1555,7 @@ func (c cmdable) FTSpellCheck(ctx context.Context, index string, query string) *
 // For more information, please refer to the Redis documentation:
 // [FT.SPELLCHECK]: (https://redis.io/commands/ft.spellcheck/)
 func (c cmdable) FTSpellCheckWithArgs(ctx context.Context, index string, query string, options *FTSpellCheckOptions) *FTSpellCheckCmd {
-	args := []interface{}{"FT.SPELLCHECK", index, query}
+	args := []any{"FT.SPELLCHECK", index, query}
 	if options != nil {
 		if options.Distance > 0 {
 			args = append(args, "DISTANCE", options.Distance)
@@ -1580,7 +1580,7 @@ type FTSpellCheckCmd struct {
 	val []SpellCheckResult
 }
 
-func newFTSpellCheckCmd(ctx context.Context, args ...interface{}) *FTSpellCheckCmd {
+func newFTSpellCheckCmd(ctx context.Context, args ...any) *FTSpellCheckCmd {
 	return &FTSpellCheckCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1605,11 +1605,11 @@ func (cmd *FTSpellCheckCmd) Val() []SpellCheckResult {
 	return cmd.val
 }
 
-func (cmd *FTSpellCheckCmd) RawVal() interface{} {
+func (cmd *FTSpellCheckCmd) RawVal() any {
 	return cmd.rawVal
 }
 
-func (cmd *FTSpellCheckCmd) RawResult() (interface{}, error) {
+func (cmd *FTSpellCheckCmd) RawResult() (any, error) {
 	return cmd.rawVal, cmd.err
 }
 
@@ -1625,11 +1625,11 @@ func (cmd *FTSpellCheckCmd) readReply(rd *proto.Reader) (err error) {
 	return nil
 }
 
-func parseFTSpellCheck(data []interface{}) ([]SpellCheckResult, error) {
+func parseFTSpellCheck(data []any) ([]SpellCheckResult, error) {
 	results := make([]SpellCheckResult, 0, len(data))
 
 	for _, termData := range data {
-		termInfo, ok := termData.([]interface{})
+		termInfo, ok := termData.([]any)
 		if !ok || len(termInfo) != 3 {
 			return nil, fmt.Errorf("invalid term format")
 		}
@@ -1639,14 +1639,14 @@ func parseFTSpellCheck(data []interface{}) ([]SpellCheckResult, error) {
 			return nil, fmt.Errorf("invalid term format")
 		}
 
-		suggestionsData, ok := termInfo[2].([]interface{})
+		suggestionsData, ok := termInfo[2].([]any)
 		if !ok {
 			return nil, fmt.Errorf("invalid suggestions format")
 		}
 
 		suggestions := make([]SpellCheckSuggestion, 0, len(suggestionsData))
 		for _, suggestionData := range suggestionsData {
-			suggestionInfo, ok := suggestionData.([]interface{})
+			suggestionInfo, ok := suggestionData.([]any)
 			if !ok || len(suggestionInfo) != 2 {
 				return nil, fmt.Errorf("invalid suggestion format")
 			}
@@ -1680,7 +1680,7 @@ func parseFTSpellCheck(data []interface{}) ([]SpellCheckResult, error) {
 	return results, nil
 }
 
-func parseFTSearch(data []interface{}, noContent, withScores, withPayloads, withSortKeys bool) (FTSearchResult, error) {
+func parseFTSearch(data []any, noContent, withScores, withPayloads, withSortKeys bool) (FTSearchResult, error) {
 	if len(data) < 1 {
 		return FTSearchResult{}, fmt.Errorf("unexpected search result format")
 	}
@@ -1734,12 +1734,12 @@ func parseFTSearch(data []interface{}, noContent, withScores, withPayloads, with
 		}
 
 		if i < len(data) {
-			fields, ok := data[i].([]interface{})
+			fields, ok := data[i].([]any)
 			if !ok {
 				if data[i] == proto.Nil || data[i] == nil {
 					doc.Error = proto.Nil
 					doc.Fields = map[string]string{}
-					fields = []interface{}{}
+					fields = []any{}
 				} else {
 					return FTSearchResult{}, fmt.Errorf("invalid document fields format")
 				}
@@ -1773,7 +1773,7 @@ type FTSearchCmd struct {
 	options *FTSearchOptions
 }
 
-func newFTSearchCmd(ctx context.Context, options *FTSearchOptions, args ...interface{}) *FTSearchCmd {
+func newFTSearchCmd(ctx context.Context, options *FTSearchOptions, args ...any) *FTSearchCmd {
 	return &FTSearchCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -1799,11 +1799,11 @@ func (cmd *FTSearchCmd) Val() FTSearchResult {
 	return cmd.val
 }
 
-func (cmd *FTSearchCmd) RawVal() interface{} {
+func (cmd *FTSearchCmd) RawVal() any {
 	return cmd.rawVal
 }
 
-func (cmd *FTSearchCmd) RawResult() (interface{}, error) {
+func (cmd *FTSearchCmd) RawResult() (any, error) {
 	return cmd.rawVal, cmd.err
 }
 
@@ -1825,13 +1825,13 @@ func (cmd *FTSearchCmd) readReply(rd *proto.Reader) (err error) {
 //
 // [FT.SEARCH]: (https://redis.io/commands/ft.search/)
 func (c cmdable) FTSearch(ctx context.Context, index string, query string) *FTSearchCmd {
-	args := []interface{}{"FT.SEARCH", index, query}
+	args := []any{"FT.SEARCH", index, query}
 	cmd := newFTSearchCmd(ctx, &FTSearchOptions{}, args...)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
-type SearchQuery []interface{}
+type SearchQuery []any
 
 // FTSearchQuery - Executes a search query on an index with additional options.
 // The 'index' parameter specifies the index to search, the 'query' parameter specifies the search query,
@@ -1840,7 +1840,7 @@ type SearchQuery []interface{}
 //
 // [FT.SEARCH]: (https://redis.io/commands/ft.search/)
 func FTSearchQuery(query string, options *FTSearchOptions) (SearchQuery, error) {
-	queryArgs := []interface{}{query}
+	queryArgs := []any{query}
 	if options != nil {
 		if options.NoContent {
 			queryArgs = append(queryArgs, "NOCONTENT")
@@ -1880,7 +1880,7 @@ func FTSearchQuery(query string, options *FTSearchOptions) (SearchQuery, error) 
 		}
 		if options.Return != nil {
 			queryArgs = append(queryArgs, "RETURN")
-			queryArgsReturn := []interface{}{}
+			queryArgsReturn := []any{}
 			for _, ret := range options.Return {
 				queryArgsReturn = append(queryArgsReturn, ret.FieldName)
 				if ret.As != "" {
@@ -1957,7 +1957,7 @@ func FTSearchQuery(query string, options *FTSearchOptions) (SearchQuery, error) 
 //
 // [FT.SEARCH]: (https://redis.io/commands/ft.search/)
 func (c cmdable) FTSearchWithArgs(ctx context.Context, index string, query string, options *FTSearchOptions) *FTSearchCmd {
-	args := []interface{}{"FT.SEARCH", index, query}
+	args := []any{"FT.SEARCH", index, query}
 	if options != nil {
 		if options.NoContent {
 			args = append(args, "NOCONTENT")
@@ -1997,7 +1997,7 @@ func (c cmdable) FTSearchWithArgs(ctx context.Context, index string, query strin
 		}
 		if options.Return != nil {
 			args = append(args, "RETURN")
-			argsReturn := []interface{}{}
+			argsReturn := []any{}
 			for _, ret := range options.Return {
 				argsReturn = append(argsReturn, ret.FieldName)
 				if ret.As != "" {
@@ -2075,7 +2075,7 @@ func (c cmdable) FTSearchWithArgs(ctx context.Context, index string, query strin
 	return cmd
 }
 
-func NewFTSynDumpCmd(ctx context.Context, args ...interface{}) *FTSynDumpCmd {
+func NewFTSynDumpCmd(ctx context.Context, args ...any) *FTSynDumpCmd {
 	return &FTSynDumpCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -2100,11 +2100,11 @@ func (cmd *FTSynDumpCmd) Result() ([]FTSynDumpResult, error) {
 	return cmd.val, cmd.err
 }
 
-func (cmd *FTSynDumpCmd) RawVal() interface{} {
+func (cmd *FTSynDumpCmd) RawVal() any {
 	return cmd.rawVal
 }
 
-func (cmd *FTSynDumpCmd) RawResult() (interface{}, error) {
+func (cmd *FTSynDumpCmd) RawResult() (any, error) {
 	return cmd.rawVal, cmd.err
 }
 
@@ -2121,7 +2121,7 @@ func (cmd *FTSynDumpCmd) readReply(rd *proto.Reader) error {
 			return fmt.Errorf("invalid term format")
 		}
 
-		synonyms, ok := termSynonymPairs[i+1].([]interface{})
+		synonyms, ok := termSynonymPairs[i+1].([]any)
 		if !ok {
 			return fmt.Errorf("invalid synonyms format")
 		}
@@ -2159,8 +2159,8 @@ func (c cmdable) FTSynDump(ctx context.Context, index string) *FTSynDumpCmd {
 // The 'index' parameter specifies the index to update, the 'synGroupId' parameter specifies the synonym group id, and the 'terms' parameter specifies the additional terms.
 // For more information, please refer to the Redis documentation:
 // [FT.SYNUPDATE]: (https://redis.io/commands/ft.synupdate/)
-func (c cmdable) FTSynUpdate(ctx context.Context, index string, synGroupId interface{}, terms []interface{}) *StatusCmd {
-	args := []interface{}{"FT.SYNUPDATE", index, synGroupId}
+func (c cmdable) FTSynUpdate(ctx context.Context, index string, synGroupId any, terms []any) *StatusCmd {
+	args := []any{"FT.SYNUPDATE", index, synGroupId}
 	args = append(args, terms...)
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
@@ -2171,8 +2171,8 @@ func (c cmdable) FTSynUpdate(ctx context.Context, index string, synGroupId inter
 // The 'index' parameter specifies the index to update, the 'synGroupId' parameter specifies the synonym group id, the 'options' parameter specifies additional options for the update, and the 'terms' parameter specifies the additional terms.
 // For more information, please refer to the Redis documentation:
 // [FT.SYNUPDATE]: (https://redis.io/commands/ft.synupdate/)
-func (c cmdable) FTSynUpdateWithArgs(ctx context.Context, index string, synGroupId interface{}, options *FTSynUpdateOptions, terms []interface{}) *StatusCmd {
-	args := []interface{}{"FT.SYNUPDATE", index, synGroupId}
+func (c cmdable) FTSynUpdateWithArgs(ctx context.Context, index string, synGroupId any, options *FTSynUpdateOptions, terms []any) *StatusCmd {
+	args := []any{"FT.SYNUPDATE", index, synGroupId}
 	if options.SkipInitialScan {
 		args = append(args, "SKIPINITIALSCAN")
 	}

--- a/search_test.go
+++ b/search_test.go
@@ -80,7 +80,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should FTCreate and FTSearch stopwords", Label("search", "ftcreate", "ftsearch"), func() {
-		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{StopWords: []interface{}{"foo", "bar", "baz"}}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
+		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{StopWords: []any{"foo", "bar", "baz"}}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "txt")
@@ -119,7 +119,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		res4, err := client.FTSearchWithArgs(ctx, "txt", "foo", &redis.FTSearchOptions{GeoFilter: []redis.FTSearchGeoFilter{geoFilter2}, NoContent: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res4.Total).To(BeEquivalentTo(int64(2)))
-		docs := []interface{}{res4.Docs[0].ID, res4.Docs[1].ID}
+		docs := []any{res4.Docs[0].ID, res4.Docs[1].ID}
 		Expect(docs).To(ContainElement("doc1"))
 		Expect(docs).To(ContainElement("doc2"))
 
@@ -226,11 +226,11 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	It("should FTAlias", Label("search", "ftexplain"), func() {
 		text1 := &redis.FieldSchema{FieldName: "name", FieldType: redis.SearchFieldTypeText}
 		text2 := &redis.FieldSchema{FieldName: "name", FieldType: redis.SearchFieldTypeText}
-		val1, err := client.FTCreate(ctx, "testAlias", &redis.FTCreateOptions{Prefix: []interface{}{"index1:"}}, text1).Result()
+		val1, err := client.FTCreate(ctx, "testAlias", &redis.FTCreateOptions{Prefix: []any{"index1:"}}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val1).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "testAlias")
-		val2, err := client.FTCreate(ctx, "testAlias2", &redis.FTCreateOptions{Prefix: []interface{}{"index2:"}}, text2).Result()
+		val2, err := client.FTCreate(ctx, "testAlias2", &redis.FTCreateOptions{Prefix: []any{"index2:"}}, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val2).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "testAlias2")
@@ -283,7 +283,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
 
-		resAlter, err := client.FTAlter(ctx, "idx1", false, []interface{}{"body", redis.SearchFieldTypeText.String()}).Result()
+		resAlter, err := client.FTAlter(ctx, "idx1", false, []any{"body", redis.SearchFieldTypeText.String()}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resAlter).To(BeEquivalentTo("OK"))
 
@@ -396,7 +396,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		res2, err := client.FTSearch(ctx, "idx1", "Jon").Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res2.Total).To(BeEquivalentTo(int64(2)))
-		names := []interface{}{res2.Docs[0].Fields["name"], res2.Docs[1].Fields["name"]}
+		names := []any{res2.Docs[0].Fields["name"], res2.Docs[1].Fields["name"]}
 		Expect(names).To(ContainElement("Jon"))
 		Expect(names).To(ContainElement("John"))
 	})
@@ -497,7 +497,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		res, err = client.FTConfigGet(ctx, "MINPREFIX").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res).To(BeEquivalentTo(map[string]interface{}{"MINPREFIX": "1"}))
+		Expect(res).To(BeEquivalentTo(map[string]any{"MINPREFIX": "1"}))
 
 	})
 
@@ -525,77 +525,77 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			"random_num", 8)
 
 		reducer := redis.FTAggregateReducer{Reducer: redis.SearchCount}
-		options := &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		options := &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err := client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliascount"]).To(BeEquivalentTo("3"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchCountDistinct, Args: []interface{}{"@title"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchCountDistinct, Args: []any{"@title"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliascount_distincttitle"]).To(BeEquivalentTo("3"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchSum, Args: []interface{}{"@random_num"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchSum, Args: []any{"@random_num"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliassumrandom_num"]).To(BeEquivalentTo("21"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchMin, Args: []interface{}{"@random_num"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchMin, Args: []any{"@random_num"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliasminrandom_num"]).To(BeEquivalentTo("3"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchMax, Args: []interface{}{"@random_num"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchMax, Args: []any{"@random_num"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliasmaxrandom_num"]).To(BeEquivalentTo("10"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchAvg, Args: []interface{}{"@random_num"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchAvg, Args: []any{"@random_num"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliasavgrandom_num"]).To(BeEquivalentTo("7"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchStdDev, Args: []interface{}{"@random_num"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchStdDev, Args: []any{"@random_num"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliasstddevrandom_num"]).To(BeEquivalentTo("3.60555127546"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchQuantile, Args: []interface{}{"@random_num", 0.5}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchQuantile, Args: []any{"@random_num", 0.5}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliasquantilerandom_num,0.5"]).To(BeEquivalentTo("8"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchToList, Args: []interface{}{"@title"}}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchToList, Args: []any{"@title"}}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["__generated_aliastolisttitle"]).To(ContainElements("RediSearch", "RedisAI", "RedisJson"))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchFirstValue, Args: []interface{}{"@title"}, As: "first"}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchFirstValue, Args: []any{"@title"}, As: "first"}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
 		Expect(res.Rows[0].Fields["first"]).To(Or(BeEquivalentTo("RediSearch"), BeEquivalentTo("RedisAI"), BeEquivalentTo("RedisJson")))
 
-		reducer = redis.FTAggregateReducer{Reducer: redis.SearchRandomSample, Args: []interface{}{"@title", 2}, As: "random"}
-		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []interface{}{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
+		reducer = redis.FTAggregateReducer{Reducer: redis.SearchRandomSample, Args: []any{"@title", 2}, As: "random"}
+		options = &redis.FTAggregateOptions{GroupBy: []redis.FTAggregateGroupBy{{Fields: []any{"@parent"}, Reduce: []redis.FTAggregateReducer{reducer}}}}
 		res, err = client.FTAggregateWithArgs(ctx, "idx1", "redis", options).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Rows[0].Fields["parent"]).To(BeEquivalentTo("redis"))
@@ -693,7 +693,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		SkipBeforeRedisVersion(7.4, "no addscores support")
 		title := &redis.FieldSchema{FieldName: "title", FieldType: redis.SearchFieldTypeText, Sortable: false}
 		description := &redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText, Sortable: false}
-		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnHash: true, Prefix: []interface{}{"product:"}}, title, description).Result()
+		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnHash: true, Prefix: []any{"product:"}}, title, description).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
@@ -766,7 +766,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		options := &redis.FTAggregateOptions{
 			Apply: []redis.FTAggregateApply{{Field: "floor(@CreatedDateTimeUTC /(60*60*24))", As: "TimestampAsDay"}},
 			GroupBy: []redis.FTAggregateGroupBy{{
-				Fields: []interface{}{"@TimestampAsDay"},
+				Fields: []any{"@TimestampAsDay"},
 				Reduce: []redis.FTAggregateReducer{reducer},
 			}},
 			SortBy: []redis.FTAggregateSortBy{{
@@ -919,7 +919,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	It("should FTCreate json", Label("search", "ftcreate"), func() {
 
 		text1 := &redis.FieldSchema{FieldName: "$.name", FieldType: redis.SearchFieldTypeText}
-		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []interface{}{"king:"}}, text1).Result()
+		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []any{"king:"}}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
@@ -1021,12 +1021,12 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
 
-		resSynUpdate, err := client.FTSynUpdateWithArgs(ctx, "idx1", "id1", &redis.FTSynUpdateOptions{SkipInitialScan: true}, []interface{}{"boy", "child", "offspring"}).Result()
+		resSynUpdate, err := client.FTSynUpdateWithArgs(ctx, "idx1", "id1", &redis.FTSynUpdateOptions{SkipInitialScan: true}, []any{"boy", "child", "offspring"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 		client.HSet(ctx, "doc1", "title", "he is a baby", "body", "this is a test")
 
-		resSynUpdate, err = client.FTSynUpdateWithArgs(ctx, "idx1", "id1", &redis.FTSynUpdateOptions{SkipInitialScan: true}, []interface{}{"baby"}).Result()
+		resSynUpdate, err = client.FTSynUpdateWithArgs(ctx, "idx1", "id1", &redis.FTSynUpdateOptions{SkipInitialScan: true}, []any{"baby"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 		client.HSet(ctx, "doc2", "title", "he is another baby", "body", "another test")
@@ -1047,15 +1047,15 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
 
-		resSynUpdate, err := client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"boy", "child", "offspring"}).Result()
+		resSynUpdate, err := client.FTSynUpdate(ctx, "idx1", "id1", []any{"boy", "child", "offspring"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 
-		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"baby", "child"}).Result()
+		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []any{"baby", "child"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 
-		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"tree", "wood"}).Result()
+		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []any{"tree", "wood"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 
@@ -1080,7 +1080,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		text1 := &redis.FieldSchema{FieldName: "$.name", FieldType: redis.SearchFieldTypeText, As: "name"}
 		num1 := &redis.FieldSchema{FieldName: "$.num", FieldType: redis.SearchFieldTypeNumeric, As: "num"}
-		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []interface{}{"king:"}}, text1, num1).Result()
+		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []any{"king:"}}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
@@ -1104,7 +1104,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	It("should FTCreate json with multipath", Label("search", "ftcreate"), func() {
 
 		tag1 := &redis.FieldSchema{FieldName: "$..name", FieldType: redis.SearchFieldTypeTag, As: "name"}
-		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []interface{}{"king:"}}, tag1).Result()
+		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []any{"king:"}}, tag1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
@@ -1164,7 +1164,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			Return:         []redis.FTSearchReturn{{FieldName: "__v_score"}},
 			SortBy:         []redis.FTSearchSortBy{{FieldName: "__v_score", Asc: true}},
 			DialectVersion: 2,
-			Params:         map[string]interface{}{"vec": "aaaaaaaa"},
+			Params:         map[string]any{"vec": "aaaaaaaa"},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 2 @v $vec]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1213,7 +1213,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			Return: []redis.FTSearchReturn{{FieldName: "__v_score"}},
 			SortBy: []redis.FTSearchSortBy{{FieldName: "__v_score", Asc: true}},
-			Params: map[string]interface{}{"vec": "aaaaaaaa"},
+			Params: map[string]any{"vec": "aaaaaaaa"},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 2 @v $vec]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1231,7 +1231,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc2", "name", "Bob")
 		client.HSet(ctx, "doc3", "name", "Carol")
 
-		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@name:($name1 | $name2 )", &redis.FTSearchOptions{Params: map[string]interface{}{"name1": "Alice", "name2": "Bob"}, DialectVersion: 2}).Result()
+		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@name:($name1 | $name2 )", &redis.FTSearchOptions{Params: map[string]any{"name1": "Alice", "name2": "Bob"}, DialectVersion: 2}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res1.Total).To(BeEquivalentTo(int64(2)))
 		Expect(res1.Docs[0].ID).To(BeEquivalentTo("doc1"))
@@ -1249,7 +1249,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc2", "numval", 102)
 		client.HSet(ctx, "doc3", "numval", 103)
 
-		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@numval:[$min $max]", &redis.FTSearchOptions{Params: map[string]interface{}{"min": 101, "max": 102}, DialectVersion: 2}).Result()
+		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@numval:[$min $max]", &redis.FTSearchOptions{Params: map[string]any{"min": 101, "max": 102}, DialectVersion: 2}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res1.Total).To(BeEquivalentTo(int64(2)))
 		Expect(res1.Docs[0].ID).To(BeEquivalentTo("doc1"))
@@ -1267,7 +1267,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc2", "g", "29.69350, 34.94737")
 		client.HSet(ctx, "doc3", "g", "29.68746, 34.94882")
 
-		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@g:[$lon $lat $radius $units]", &redis.FTSearchOptions{Params: map[string]interface{}{"lat": "34.95126", "lon": "29.69465", "radius": 1000, "units": "km"}, DialectVersion: 2}).Result()
+		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@g:[$lon $lat $radius $units]", &redis.FTSearchOptions{Params: map[string]any{"lat": "34.95126", "lon": "29.69465", "radius": 1000, "units": "km"}, DialectVersion: 2}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res1.Total).To(BeEquivalentTo(int64(3)))
 		Expect(res1.Docs[0].ID).To(BeEquivalentTo("doc1"))
@@ -1283,7 +1283,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		defDialect, err := client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "1"}))
+		Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "1"}))
 
 		res, err = client.FTConfigSet(ctx, "DEFAULT_DIALECT", "2").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1291,7 +1291,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		defDialect, err = client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "2"}))
+		Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "2"}))
 	})
 
 	It("should FTConfigSet and FTConfigGet dialect", Label("search", "ftconfigget", "ftconfigset", "NonRedisEnterprise"), func() {
@@ -1301,7 +1301,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		defDialect, err := client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "1"}))
+		Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "1"}))
 
 		res, err = client.FTConfigSet(ctx, "DEFAULT_DIALECT", "2").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1309,7 +1309,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		defDialect, err = client.FTConfigGet(ctx, "DEFAULT_DIALECT").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "2"}))
+		Expect(defDialect).To(BeEquivalentTo(map[string]any{"DEFAULT_DIALECT": "2"}))
 	})
 
 	It("should FTCreate WithSuffixtrie", Label("search", "ftcreate", "ftinfo"), func() {
@@ -1354,7 +1354,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	It("should test dialect 4", Label("search", "ftcreate", "ftsearch", "NonRedisEnterprise"), func() {
 		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{
-			Prefix: []interface{}{"resource:"},
+			Prefix: []any{"resource:"},
 		}, &redis.FieldSchema{
 			FieldName: "uuid",
 			FieldType: redis.SearchFieldTypeTag,
@@ -1371,13 +1371,13 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 
-		client.HSet(ctx, "resource:1", map[string]interface{}{
+		client.HSet(ctx, "resource:1", map[string]any{
 			"uuid":        "123e4567-e89b-12d3-a456-426614174000",
 			"tags":        "finance|crypto|$btc|blockchain",
 			"description": "Analysis of blockchain technologies & Bitcoin's potential.",
 			"rating":      5,
 		})
-		client.HSet(ctx, "resource:2", map[string]interface{}{
+		client.HSet(ctx, "resource:2", map[string]any{
 			"uuid":        "987e6543-e21c-12d3-a456-426614174999",
 			"tags":        "health|well-being|fitness|new-year's-resolutions",
 			"description": "Health trends for the new year, including fitness regimes.",
@@ -1387,7 +1387,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "@uuid:{$uuid}",
 			&redis.FTSearchOptions{
 				DialectVersion: 2,
-				Params:         map[string]interface{}{"uuid": "123e4567-e89b-12d3-a456-426614174000"},
+				Params:         map[string]any{"uuid": "123e4567-e89b-12d3-a456-426614174000"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Total).To(BeEquivalentTo(int64(1)))
@@ -1396,13 +1396,13 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		res, err = client.FTSearchWithArgs(ctx, "idx1", "@uuid:{$uuid}",
 			&redis.FTSearchOptions{
 				DialectVersion: 4,
-				Params:         map[string]interface{}{"uuid": "123e4567-e89b-12d3-a456-426614174000"},
+				Params:         map[string]any{"uuid": "123e4567-e89b-12d3-a456-426614174000"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Total).To(BeEquivalentTo(int64(1)))
 		Expect(res.Docs[0].ID).To(BeEquivalentTo("resource:1"))
 
-		client.HSet(ctx, "test:1", map[string]interface{}{
+		client.HSet(ctx, "test:1", map[string]any{
 			"uuid":  "3d3586fe-0416-4572-8ce",
 			"email": "adriano@acme.com.ie",
 			"num":   5,
@@ -1410,7 +1410,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		// Create the index
 		ftCreateOptions := &redis.FTCreateOptions{
-			Prefix: []interface{}{"test:"},
+			Prefix: []any{"test:"},
 		}
 		schema := []*redis.FieldSchema{
 			{
@@ -1434,7 +1434,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		ftSearchOptions := &redis.FTSearchOptions{
 			DialectVersion: 4,
-			Params: map[string]interface{}{
+			Params: map[string]any{
 				"uuid":  "3d3586fe-0416-4572-8ce",
 				"email": "adriano@acme.com.ie",
 			},
@@ -1450,7 +1450,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(res.Docs[0].ID).To(BeEquivalentTo("test:1"))
 		Expect(res.Docs[0].Fields["email"]).To(BeEquivalentTo("adriano@acme.com.ie"))
 
-		ftSearchOptions.Params = map[string]interface{}{"num": 5}
+		ftSearchOptions.Params = map[string]any{"num": 5}
 		res, err = client.FTSearchWithArgs(ctx, "idx_hash", "@num:[5]", ftSearchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Docs[0].ID).To(BeEquivalentTo("test:1"))
@@ -1469,7 +1469,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		res1, err := client.FTSearchWithArgs(ctx, "idx1", "@geom:[WITHIN $poly]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"poly": "POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))"},
+				Params:         map[string]any{"poly": "POLYGON((0 0, 0 150, 150 150, 150 0, 0 0))"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res1.Total).To(BeEquivalentTo(int64(1)))
@@ -1478,7 +1478,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		res2, err := client.FTSearchWithArgs(ctx, "idx1", "@geom:[CONTAINS $poly]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"poly": "POLYGON((2 2, 2 50, 50 50, 50 2, 2 2))"},
+				Params:         map[string]any{"poly": "POLYGON((2 2, 2 50, 50 50, 50 2, 2 2))"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res2.Total).To(BeEquivalentTo(int64(2)))
@@ -1512,7 +1512,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		intersection, err := client.FTSearchWithArgs(ctx, "idx1", "@g:[intersects $shape]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"shape": "POLYGON((15 15, 75 15, 50 70, 20 40, 15 15))"},
+				Params:         map[string]any{"shape": "POLYGON((15 15, 75 15, 50 70, 20 40, 15 15))"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		_assert_geosearch_result(&intersection, []string{"doc_point2", "doc_polygon1"})
@@ -1520,7 +1520,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		disjunction, err := client.FTSearchWithArgs(ctx, "idx1", "@g:[disjoint $shape]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"shape": "POLYGON((15 15, 75 15, 50 70, 20 40, 15 15))"},
+				Params:         map[string]any{"shape": "POLYGON((15 15, 75 15, 50 70, 20 40, 15 15))"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		_assert_geosearch_result(&disjunction, []string{"doc_point1", "doc_polygon2"})
@@ -1542,7 +1542,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		containsA, err := client.FTSearchWithArgs(ctx, "idx2", "@g:[contains $shape]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"shape": "POINT(25 25)"},
+				Params:         map[string]any{"shape": "POINT(25 25)"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		_assert_geosearch_result(&containsA, []string{"doc_polygon1"})
@@ -1550,7 +1550,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		containsB, err := client.FTSearchWithArgs(ctx, "idx2", "@g:[contains $shape]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"shape": "POLYGON((24 24, 24 26, 25 25, 24 24))"},
+				Params:         map[string]any{"shape": "POLYGON((24 24, 24 26, 25 25, 24 24))"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		_assert_geosearch_result(&containsB, []string{"doc_polygon1"})
@@ -1558,7 +1558,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		within, err := client.FTSearchWithArgs(ctx, "idx2", "@g:[within $shape]",
 			&redis.FTSearchOptions{
 				DialectVersion: 3,
-				Params:         map[string]interface{}{"shape": "POLYGON((15 15, 75 15, 50 70, 20 40, 15 15))"},
+				Params:         map[string]any{"shape": "POLYGON((15 15, 75 15, 50 70, 20 40, 15 15))"},
 			}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		_assert_geosearch_result(&within, []string{"doc_point2", "doc_polygon1"})
@@ -1566,7 +1566,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 	It("should search missing fields", Label("search", "ftcreate", "ftsearch", "NonRedisEnterprise"), func() {
 		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
-		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{Prefix: []interface{}{"property:"}},
+		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{Prefix: []any{"property:"}},
 			&redis.FieldSchema{FieldName: "title", FieldType: redis.SearchFieldTypeText, Sortable: true},
 			&redis.FieldSchema{FieldName: "features", FieldType: redis.SearchFieldTypeTag, IndexMissing: true},
 			&redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText, IndexMissing: true}).Result()
@@ -1574,18 +1574,18 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
 
-		client.HSet(ctx, "property:1", map[string]interface{}{
+		client.HSet(ctx, "property:1", map[string]any{
 			"title":       "Luxury Villa in Malibu",
 			"features":    "pool,sea view,modern",
 			"description": "A stunning modern villa overlooking the Pacific Ocean.",
 		})
 
-		client.HSet(ctx, "property:2", map[string]interface{}{
+		client.HSet(ctx, "property:2", map[string]any{
 			"title":       "Downtown Flat",
 			"description": "Modern flat in central Paris with easy access to metro.",
 		})
 
-		client.HSet(ctx, "property:3", map[string]interface{}{
+		client.HSet(ctx, "property:3", map[string]any{
 			"title":    "Beachfront Bungalow",
 			"features": "beachfront,sun deck",
 		})
@@ -1611,7 +1611,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 	It("should search empty fields", Label("search", "ftcreate", "ftsearch", "NonRedisEnterprise"), func() {
 		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
-		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{Prefix: []interface{}{"property:"}},
+		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{Prefix: []any{"property:"}},
 			&redis.FieldSchema{FieldName: "title", FieldType: redis.SearchFieldTypeText, Sortable: true},
 			&redis.FieldSchema{FieldName: "features", FieldType: redis.SearchFieldTypeTag, IndexEmpty: true},
 			&redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText, IndexEmpty: true}).Result()
@@ -1619,19 +1619,19 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
 
-		client.HSet(ctx, "property:1", map[string]interface{}{
+		client.HSet(ctx, "property:1", map[string]any{
 			"title":       "Luxury Villa in Malibu",
 			"features":    "pool,sea view,modern",
 			"description": "A stunning modern villa overlooking the Pacific Ocean.",
 		})
 
-		client.HSet(ctx, "property:2", map[string]interface{}{
+		client.HSet(ctx, "property:2", map[string]any{
 			"title":       "Downtown Flat",
 			"features":    "",
 			"description": "Modern flat in central Paris with easy access to metro.",
 		})
 
-		client.HSet(ctx, "property:3", map[string]interface{}{
+		client.HSet(ctx, "property:3", map[string]any{
 			"title":       "Beachfront Bungalow",
 			"features":    "beachfront,sun deck",
 			"description": "",
@@ -1692,7 +1692,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			Return:         []redis.FTSearchReturn{{FieldName: "int8_vector"}},
 			SortBy:         []redis.FTSearchSortBy{{FieldName: "int8_vector", Asc: true}},
 			DialectVersion: 2,
-			Params:         map[string]interface{}{"vec": "\x01\x02"},
+			Params:         map[string]any{"vec": "\x01\x02"},
 		}
 
 		resInt8, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 1 @int8_vector $vec]", searchOptionsInt8).Result()
@@ -1704,7 +1704,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			Return:         []redis.FTSearchReturn{{FieldName: "uint8_vector"}},
 			SortBy:         []redis.FTSearchSortBy{{FieldName: "uint8_vector", Asc: true}},
 			DialectVersion: 2,
-			Params:         map[string]interface{}{"vec": "\x01\x02"},
+			Params:         map[string]any{"vec": "\x01\x02"},
 		}
 
 		resUint8, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 1 @uint8_vector $vec]", searchOptionsUint8).Result()
@@ -1721,7 +1721,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			DistanceMetric: "IP",
 		}
 		_, err := client.FTCreate(ctx, "idx_vec",
-			&redis.FTCreateOptions{OnHash: true, Prefix: []interface{}{"doc:"}},
+			&redis.FTCreateOptions{OnHash: true, Prefix: []any{"doc:"}},
 			&redis.FieldSchema{FieldName: "vector", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{FlatOptions: vecField}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		WaitForIndexing(client, "idx_vec")
@@ -1736,7 +1736,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc:3", "vector", encodeFloat32Vector(nanVec))
 		client.HSet(ctx, "doc:4", "vector", encodeFloat32Vector(negNanVec))
 
-		searchOptions := &redis.FTSearchOptions{WithScores: true, Params: map[string]interface{}{"vec": encodeFloat32Vector(bigPos)}}
+		searchOptions := &redis.FTSearchOptions{WithScores: true, Params: map[string]any{"vec": encodeFloat32Vector(bigPos)}}
 		res, err := client.FTSearchWithArgs(ctx, "idx_vec", "*=>[KNN 4 @vector $vec]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Total).To(BeEquivalentTo(4))
@@ -1784,7 +1784,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			Return:         []redis.FTSearchReturn{{FieldName: "__v_score"}},
 			SortBy:         []redis.FTSearchSortBy{{FieldName: "__v_score", Asc: true}},
 			DialectVersion: 2,
-			Params:         map[string]interface{}{"vec": "aaaaaaaa"},
+			Params:         map[string]any{"vec": "aaaaaaaa"},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 2 @v $vec]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1915,7 +1915,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			SortBy:         []redis.FTSearchSortBy{{FieldName: "score", Asc: true}},
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 3 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1953,7 +1953,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			SortBy:         []redis.FTSearchSortBy{{FieldName: "score", Asc: true}},
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 3 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1991,7 +1991,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			SortBy:         []redis.FTSearchSortBy{{FieldName: "score", Asc: true}},
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 3 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2028,7 +2028,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			Return:         []redis.FTSearchReturn{{FieldName: "__v_score"}},
 			SortBy:         []redis.FTSearchSortBy{{FieldName: "__v_score", Asc: true}},
 			DialectVersion: 2,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 3 @v $vec]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2064,7 +2064,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat16Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat16Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 2 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2099,7 +2099,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 2 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2128,7 +2128,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			Return: []redis.FTSearchReturn{{FieldName: "__v_score"}},
 			SortBy: []redis.FTSearchSortBy{{FieldName: "__v_score", Asc: true}},
-			Params: map[string]interface{}{"vec": "aaaaaaaa"},
+			Params: map[string]any{"vec": "aaaaaaaa"},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 2 @v $vec]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2164,7 +2164,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 5 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2221,7 +2221,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions16 := &redis.FTSearchOptions{
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat16Vector(queryVec)},
+			Params:         map[string]any{"vec": encodeFloat16Vector(queryVec)},
 		}
 		res16, err := client.FTSearchWithArgs(ctx, "idx16", "*=>[KNN 3 @v16 $vec as score]", searchOptions16).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2231,7 +2231,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions32 := &redis.FTSearchOptions{
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(queryVec)},
+			Params:         map[string]any{"vec": encodeFloat32Vector(queryVec)},
 		}
 		res32, err := client.FTSearchWithArgs(ctx, "idx32", "*=>[KNN 3 @v32 $vec as score]", searchOptions32).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2266,7 +2266,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 5 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2302,7 +2302,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 6 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2338,7 +2338,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 8 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2379,7 +2379,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 5 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2467,10 +2467,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc1", "grp", "g1")
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchAvg, Args: []interface{}{"@n"}, As: "avg"},
+			{Reducer: redis.SearchAvg, Args: []any{"@n"}, As: "avg"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestAvg", "*", options).Result()
@@ -2496,7 +2496,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			{Reducer: redis.SearchCount, As: "cnt"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestCount", "*", options).Result()
@@ -2519,10 +2519,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc1", "grp", "g1")
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchSum, Args: []interface{}{"@n"}, As: "sum"},
+			{Reducer: redis.SearchSum, Args: []any{"@n"}, As: "sum"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestSum", "*", options).Result()
@@ -2608,10 +2608,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		client.HSet(ctx, "doc1", "grp", "g1")
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchCountDistinct, Args: []interface{}{"@x"}, As: "distinct_count"},
+			{Reducer: redis.SearchCountDistinct, Args: []any{"@x"}, As: "distinct_count"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 
@@ -2635,10 +2635,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchCountDistinctish, Args: []interface{}{"@y"}, As: "distinctish_count"},
+			{Reducer: redis.SearchCountDistinctish, Args: []any{"@y"}, As: "distinctish_count"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestCountDistinctIsh", "*", options).Result()
@@ -2687,10 +2687,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchStdDev, Args: []interface{}{"@n"}, As: "stddev"},
+			{Reducer: redis.SearchStdDev, Args: []any{"@n"}, As: "stddev"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestStddev", "*", options).Result()
@@ -2714,10 +2714,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchQuantile, Args: []interface{}{"@n", 0.5}, As: "quantile"},
+			{Reducer: redis.SearchQuantile, Args: []any{"@n", 0.5}, As: "quantile"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestQuantile", "*", options).Result()
@@ -2740,10 +2740,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchFirstValue, Args: []interface{}{"@t"}, As: "first_val"},
+			{Reducer: redis.SearchFirstValue, Args: []any{"@t"}, As: "first_val"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestFirstValue", "*", options).Result()
@@ -2889,11 +2889,11 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		reducers := []redis.FTAggregateReducer{
-			{Reducer: redis.SearchMin, Args: []interface{}{"@n"}, As: "minValue"},
-			{Reducer: redis.SearchMax, Args: []interface{}{"@n"}, As: "maxValue"},
+			{Reducer: redis.SearchMin, Args: []any{"@n"}, As: "minValue"},
+			{Reducer: redis.SearchMax, Args: []any{"@n"}, As: "maxValue"},
 		}
 		groupBy := []redis.FTAggregateGroupBy{
-			{Fields: []interface{}{"@grp"}, Reduce: reducers},
+			{Fields: []any{"@grp"}, Reduce: reducers},
 		}
 		options := &redis.FTAggregateOptions{GroupBy: groupBy}
 		res, err := client.FTAggregateWithArgs(ctx, "aggTestMinMax", "*", options).Result()
@@ -2933,7 +2933,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 5 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2972,7 +2972,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 5 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -3020,7 +3020,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			searchOptions := &redis.FTSearchOptions{
 				DialectVersion: 2,
 				NoContent:      true,
-				Params:         map[string]interface{}{"vec": encodeFloat16Vector(queryVec)},
+				Params:         map[string]any{"vec": encodeFloat16Vector(queryVec)},
 			}
 			res, err := client.FTSearchWithArgs(ctx, indexName, "*=>[KNN 3 @v $vec as score]", searchOptions).Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -3067,7 +3067,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			searchOptions := &redis.FTSearchOptions{
 				DialectVersion: 2,
 				NoContent:      true,
-				Params:         map[string]interface{}{"vec": encodeFloat32Vector(queryVec)},
+				Params:         map[string]any{"vec": encodeFloat32Vector(queryVec)},
 			}
 			res, err := client.FTSearchWithArgs(ctx, indexName, "*=>[KNN 3 @v $vec as score]", searchOptions).Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -3116,7 +3116,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 				searchOptions := &redis.FTSearchOptions{
 					DialectVersion: 2,
 					NoContent:      true,
-					Params:         map[string]interface{}{"vec": encodeFloat32Vector(queryVec)},
+					Params:         map[string]any{"vec": encodeFloat32Vector(queryVec)},
 				}
 				res, err := client.FTSearchWithArgs(ctx, indexName, "*=>[KNN 3 @v $vec as score]", searchOptions).Result()
 				Expect(err).NotTo(HaveOccurred())
@@ -3168,7 +3168,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			searchOptions := &redis.FTSearchOptions{
 				DialectVersion: 2,
 				NoContent:      true,
-				Params:         map[string]interface{}{"vec": encodeFloat32Vector(queryVec)},
+				Params:         map[string]any{"vec": encodeFloat32Vector(queryVec)},
 			}
 			res, err := client.FTSearchWithArgs(ctx, indexName, "*=>[KNN 5 @v $vec as score]", searchOptions).Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -3221,7 +3221,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 5 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -3260,7 +3260,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		searchOptions := &redis.FTSearchOptions{
 			DialectVersion: 2,
 			NoContent:      true,
-			Params:         map[string]interface{}{"vec": encodeFloat32Vector(vectors[0])},
+			Params:         map[string]any{"vec": encodeFloat32Vector(vectors[0])},
 		}
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*=>[KNN 5 @v $vec as score]", searchOptions).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -3309,7 +3309,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			searchOptions := &redis.FTSearchOptions{
 				DialectVersion: 2,
 				NoContent:      true,
-				Params:         map[string]interface{}{"vec": encodeFloat16Vector(queryVec)},
+				Params:         map[string]any{"vec": encodeFloat16Vector(queryVec)},
 			}
 			res, err := client.FTSearchWithArgs(ctx, indexName, "*=>[KNN 3 @v $vec as score]", searchOptions).Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -3349,11 +3349,11 @@ var _ = Describe("RediSearch FT.Config with Resp2 and Resp3", Label("search", "N
 
 		res2, err := clientResp2.FTConfigGet(ctx, "MINPREFIX").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res2).To(BeEquivalentTo(map[string]interface{}{"MINPREFIX": "1"}))
+		Expect(res2).To(BeEquivalentTo(map[string]any{"MINPREFIX": "1"}))
 
 		res3, err := clientResp3.FTConfigGet(ctx, "MINPREFIX").Result()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res3).To(BeEquivalentTo(map[string]interface{}{"MINPREFIX": "1"}))
+		Expect(res3).To(BeEquivalentTo(map[string]any{"MINPREFIX": "1"}))
 	})
 
 	It("should FTConfigGet all resp2 and resp3", Label("search", "NonRedisEnterprise"), func() {
@@ -3395,14 +3395,14 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 
 		options := &redis.FTAggregateOptions{Apply: []redis.FTAggregateApply{{Field: "@CreatedDateTimeUTC * 10", As: "CreatedDateTimeUTC"}}}
 		res, err := client.FTAggregateWithArgs(ctx, "idx1", "*", options).RawResult()
-		results := res.(map[interface{}]interface{})["results"].([]interface{})
-		Expect(results[0].(map[interface{}]interface{})["extra_attributes"].(map[interface{}]interface{})["CreatedDateTimeUTC"]).
+		results := res.(map[any]any)["results"].([]any)
+		Expect(results[0].(map[any]any)["extra_attributes"].(map[any]any)["CreatedDateTimeUTC"]).
 			To(Or(BeEquivalentTo("6373878785249699840"), BeEquivalentTo("6373878758592700416")))
-		Expect(results[1].(map[interface{}]interface{})["extra_attributes"].(map[interface{}]interface{})["CreatedDateTimeUTC"]).
+		Expect(results[1].(map[any]any)["extra_attributes"].(map[any]any)["CreatedDateTimeUTC"]).
 			To(Or(BeEquivalentTo("6373878785249699840"), BeEquivalentTo("6373878758592700416")))
 
 		rawVal := client.FTAggregateWithArgs(ctx, "idx1", "*", options).RawVal()
-		rawValResults := rawVal.(map[interface{}]interface{})["results"].([]interface{})
+		rawValResults := rawVal.(map[any]any)["results"].([]any)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(rawValResults[0]).To(Or(BeEquivalentTo(results[0]), BeEquivalentTo(results[1])))
 		Expect(rawValResults[1]).To(Or(BeEquivalentTo(results[0]), BeEquivalentTo(results[1])))
@@ -3428,13 +3428,13 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 
 		resInfo, err := client.FTInfo(ctx, "idx1").RawResult()
 		Expect(err).NotTo(HaveOccurred())
-		attributes := resInfo.(map[interface{}]interface{})["attributes"].([]interface{})
-		flags := attributes[0].(map[interface{}]interface{})["flags"].([]interface{})
+		attributes := resInfo.(map[any]any)["attributes"].([]any)
+		flags := attributes[0].(map[any]any)["flags"].([]any)
 		Expect(flags).To(ConsistOf("SORTABLE", "NOSTEM"))
 
 		valInfo := client.FTInfo(ctx, "idx1").RawVal()
-		attributes = valInfo.(map[interface{}]interface{})["attributes"].([]interface{})
-		flags = attributes[0].(map[interface{}]interface{})["flags"].([]interface{})
+		attributes = valInfo.(map[any]any)["attributes"].([]any)
+		flags = attributes[0].(map[any]any)["flags"].([]any)
 		Expect(flags).To(ConsistOf("SORTABLE", "NOSTEM"))
 
 		// Test with UnstableResp3 false - should return error instead of panic
@@ -3463,8 +3463,8 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		valSpellCheck := client.FTSpellCheck(ctx, "idx1", "impornant").RawVal()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(valSpellCheck).To(BeEquivalentTo(resSpellCheck))
-		results := resSpellCheck.(map[interface{}]interface{})["results"].(map[interface{}]interface{})
-		Expect(results["impornant"].([]interface{})[0].(map[interface{}]interface{})["important"]).To(BeEquivalentTo(0.5))
+		results := resSpellCheck.(map[any]any)["results"].(map[any]any)
+		Expect(results["impornant"].([]any)[0].(map[any]any)["important"]).To(BeEquivalentTo(0.5))
 
 		// Test with UnstableResp3 false - should return error instead of panic
 		rawResSpellCheck, err := client2.FTSpellCheck(ctx, "idx1", "impornant").RawResult()
@@ -3478,7 +3478,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 	})
 
 	It("should handle FTSearch with Unstable RESP3 Search Module and without stability", Label("search", "ftcreate", "ftsearch"), func() {
-		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{StopWords: []interface{}{"foo", "bar", "baz"}}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
+		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{StopWords: []any{"foo", "bar", "baz"}}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "txt")
@@ -3488,11 +3488,11 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val1 := client.FTSearchWithArgs(ctx, "txt", "foo bar", &redis.FTSearchOptions{NoContent: true}).RawVal()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val1).To(BeEquivalentTo(res1))
-		totalResults := res1.(map[interface{}]interface{})["total_results"]
+		totalResults := res1.(map[any]any)["total_results"]
 		Expect(totalResults).To(BeEquivalentTo(int64(0)))
 		res2, err := client.FTSearchWithArgs(ctx, "txt", "foo bar hello world", &redis.FTSearchOptions{NoContent: true}).RawResult()
 		Expect(err).NotTo(HaveOccurred())
-		totalResults2 := res2.(map[interface{}]interface{})["total_results"]
+		totalResults2 := res2.(map[any]any)["total_results"]
 		Expect(totalResults2).To(BeEquivalentTo(int64(1)))
 
 		// Test with UnstableResp3 false - should return error instead of panic
@@ -3513,15 +3513,15 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		Expect(val).To(BeEquivalentTo("OK"))
 		WaitForIndexing(client, "idx1")
 
-		resSynUpdate, err := client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"boy", "child", "offspring"}).Result()
+		resSynUpdate, err := client.FTSynUpdate(ctx, "idx1", "id1", []any{"boy", "child", "offspring"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 
-		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"baby", "child"}).Result()
+		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []any{"baby", "child"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 
-		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"tree", "wood"}).Result()
+		resSynUpdate, err = client.FTSynUpdate(ctx, "idx1", "id1", []any{"tree", "wood"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resSynUpdate).To(BeEquivalentTo("OK"))
 
@@ -3529,7 +3529,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		valSynDump := client.FTSynDump(ctx, "idx1").RawVal()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(valSynDump).To(BeEquivalentTo(resSynDump))
-		Expect(resSynDump.(map[interface{}]interface{})["baby"]).To(BeEquivalentTo([]interface{}{"id1"}))
+		Expect(resSynDump.(map[any]any)["baby"]).To(BeEquivalentTo([]any{"id1"}))
 
 		// Test with UnstableResp3 false - should return error instead of panic
 		rawResSynDump, err := client2.FTSynDump(ctx, "idx1").RawResult()

--- a/set_commands.go
+++ b/set_commands.go
@@ -7,23 +7,23 @@ import (
 )
 
 type SetCmdable interface {
-	SAdd(ctx context.Context, key string, members ...interface{}) *IntCmd
+	SAdd(ctx context.Context, key string, members ...any) *IntCmd
 	SCard(ctx context.Context, key string) *IntCmd
 	SDiff(ctx context.Context, keys ...string) *StringSliceCmd
 	SDiffStore(ctx context.Context, destination string, keys ...string) *IntCmd
 	SInter(ctx context.Context, keys ...string) *StringSliceCmd
 	SInterCard(ctx context.Context, limit int64, keys ...string) *IntCmd
 	SInterStore(ctx context.Context, destination string, keys ...string) *IntCmd
-	SIsMember(ctx context.Context, key string, member interface{}) *BoolCmd
-	SMIsMember(ctx context.Context, key string, members ...interface{}) *BoolSliceCmd
+	SIsMember(ctx context.Context, key string, member any) *BoolCmd
+	SMIsMember(ctx context.Context, key string, members ...any) *BoolSliceCmd
 	SMembers(ctx context.Context, key string) *StringSliceCmd
 	SMembersMap(ctx context.Context, key string) *StringStructMapCmd
-	SMove(ctx context.Context, source, destination string, member interface{}) *BoolCmd
+	SMove(ctx context.Context, source, destination string, member any) *BoolCmd
 	SPop(ctx context.Context, key string) *StringCmd
 	SPopN(ctx context.Context, key string, count int64) *StringSliceCmd
 	SRandMember(ctx context.Context, key string) *StringCmd
 	SRandMemberN(ctx context.Context, key string, count int64) *StringSliceCmd
-	SRem(ctx context.Context, key string, members ...interface{}) *IntCmd
+	SRem(ctx context.Context, key string, members ...any) *IntCmd
 	SScan(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd
 	SUnion(ctx context.Context, keys ...string) *StringSliceCmd
 	SUnionStore(ctx context.Context, destination string, keys ...string) *IntCmd
@@ -31,8 +31,8 @@ type SetCmdable interface {
 
 //------------------------------------------------------------------------------
 
-func (c cmdable) SAdd(ctx context.Context, key string, members ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(members))
+func (c cmdable) SAdd(ctx context.Context, key string, members ...any) *IntCmd {
+	args := make([]any, 2, 2+len(members))
 	args[0] = "sadd"
 	args[1] = key
 	args = appendArgs(args, members)
@@ -48,7 +48,7 @@ func (c cmdable) SCard(ctx context.Context, key string) *IntCmd {
 }
 
 func (c cmdable) SDiff(ctx context.Context, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "sdiff"
 	for i, key := range keys {
 		args[1+i] = key
@@ -59,7 +59,7 @@ func (c cmdable) SDiff(ctx context.Context, keys ...string) *StringSliceCmd {
 }
 
 func (c cmdable) SDiffStore(ctx context.Context, destination string, keys ...string) *IntCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]any, 2+len(keys))
 	args[0] = "sdiffstore"
 	args[1] = destination
 	for i, key := range keys {
@@ -71,7 +71,7 @@ func (c cmdable) SDiffStore(ctx context.Context, destination string, keys ...str
 }
 
 func (c cmdable) SInter(ctx context.Context, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "sinter"
 	for i, key := range keys {
 		args[1+i] = key
@@ -83,7 +83,7 @@ func (c cmdable) SInter(ctx context.Context, keys ...string) *StringSliceCmd {
 
 func (c cmdable) SInterCard(ctx context.Context, limit int64, keys ...string) *IntCmd {
 	numKeys := len(keys)
-	args := make([]interface{}, 4+numKeys)
+	args := make([]any, 4+numKeys)
 	args[0] = "sintercard"
 	args[1] = numKeys
 	for i, key := range keys {
@@ -97,7 +97,7 @@ func (c cmdable) SInterCard(ctx context.Context, limit int64, keys ...string) *I
 }
 
 func (c cmdable) SInterStore(ctx context.Context, destination string, keys ...string) *IntCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]any, 2+len(keys))
 	args[0] = "sinterstore"
 	args[1] = destination
 	for i, key := range keys {
@@ -108,15 +108,15 @@ func (c cmdable) SInterStore(ctx context.Context, destination string, keys ...st
 	return cmd
 }
 
-func (c cmdable) SIsMember(ctx context.Context, key string, member interface{}) *BoolCmd {
+func (c cmdable) SIsMember(ctx context.Context, key string, member any) *BoolCmd {
 	cmd := NewBoolCmd(ctx, "sismember", key, member)
 	_ = c(ctx, cmd)
 	return cmd
 }
 
 // SMIsMember Redis `SMISMEMBER key member [member ...]` command.
-func (c cmdable) SMIsMember(ctx context.Context, key string, members ...interface{}) *BoolSliceCmd {
-	args := make([]interface{}, 2, 2+len(members))
+func (c cmdable) SMIsMember(ctx context.Context, key string, members ...any) *BoolSliceCmd {
+	args := make([]any, 2, 2+len(members))
 	args[0] = "smismember"
 	args[1] = key
 	args = appendArgs(args, members)
@@ -139,7 +139,7 @@ func (c cmdable) SMembersMap(ctx context.Context, key string) *StringStructMapCm
 	return cmd
 }
 
-func (c cmdable) SMove(ctx context.Context, source, destination string, member interface{}) *BoolCmd {
+func (c cmdable) SMove(ctx context.Context, source, destination string, member any) *BoolCmd {
 	cmd := NewBoolCmd(ctx, "smove", source, destination, member)
 	_ = c(ctx, cmd)
 	return cmd
@@ -173,8 +173,8 @@ func (c cmdable) SRandMemberN(ctx context.Context, key string, count int64) *Str
 	return cmd
 }
 
-func (c cmdable) SRem(ctx context.Context, key string, members ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(members))
+func (c cmdable) SRem(ctx context.Context, key string, members ...any) *IntCmd {
+	args := make([]any, 2, 2+len(members))
 	args[0] = "srem"
 	args[1] = key
 	args = appendArgs(args, members)
@@ -184,7 +184,7 @@ func (c cmdable) SRem(ctx context.Context, key string, members ...interface{}) *
 }
 
 func (c cmdable) SUnion(ctx context.Context, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "sunion"
 	for i, key := range keys {
 		args[1+i] = key
@@ -195,7 +195,7 @@ func (c cmdable) SUnion(ctx context.Context, keys ...string) *StringSliceCmd {
 }
 
 func (c cmdable) SUnionStore(ctx context.Context, destination string, keys ...string) *IntCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]any, 2+len(keys))
 	args[0] = "sunionstore"
 	args[1] = destination
 	for i, key := range keys {
@@ -207,7 +207,7 @@ func (c cmdable) SUnionStore(ctx context.Context, destination string, keys ...st
 }
 
 func (c cmdable) SScan(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd {
-	args := []interface{}{"sscan", key, cursor}
+	args := []any{"sscan", key, cursor}
 	if match != "" {
 		args = append(args, "match", match)
 	}

--- a/sortedset_commands.go
+++ b/sortedset_commands.go
@@ -41,7 +41,7 @@ type SortedSetCmdable interface {
 	ZRangeStore(ctx context.Context, dst string, z ZRangeArgs) *IntCmd
 	ZRank(ctx context.Context, key, member string) *IntCmd
 	ZRankWithScore(ctx context.Context, key, member string) *RankWithScoreCmd
-	ZRem(ctx context.Context, key string, members ...interface{}) *IntCmd
+	ZRem(ctx context.Context, key string, members ...any) *IntCmd
 	ZRemRangeByRank(ctx context.Context, key string, start, stop int64) *IntCmd
 	ZRemRangeByScore(ctx context.Context, key, min, max string) *IntCmd
 	ZRemRangeByLex(ctx context.Context, key, min, max string) *IntCmd
@@ -66,7 +66,7 @@ type SortedSetCmdable interface {
 
 // BZPopMax Redis `BZPOPMAX key [key ...] timeout` command.
 func (c cmdable) BZPopMax(ctx context.Context, timeout time.Duration, keys ...string) *ZWithKeyCmd {
-	args := make([]interface{}, 1+len(keys)+1)
+	args := make([]any, 1+len(keys)+1)
 	args[0] = "bzpopmax"
 	for i, key := range keys {
 		args[1+i] = key
@@ -80,7 +80,7 @@ func (c cmdable) BZPopMax(ctx context.Context, timeout time.Duration, keys ...st
 
 // BZPopMin Redis `BZPOPMIN key [key ...] timeout` command.
 func (c cmdable) BZPopMin(ctx context.Context, timeout time.Duration, keys ...string) *ZWithKeyCmd {
-	args := make([]interface{}, 1+len(keys)+1)
+	args := make([]any, 1+len(keys)+1)
 	args[0] = "bzpopmin"
 	for i, key := range keys {
 		args[1+i] = key
@@ -98,7 +98,7 @@ func (c cmdable) BZPopMin(ctx context.Context, timeout time.Duration, keys ...st
 // A timeout of zero can be used to block indefinitely.
 // example: client.BZMPop(ctx, 0,"max", 1, "set")
 func (c cmdable) BZMPop(ctx context.Context, timeout time.Duration, order string, count int64, keys ...string) *ZSliceWithKeyCmd {
-	args := make([]interface{}, 3+len(keys), 6+len(keys))
+	args := make([]any, 3+len(keys), 6+len(keys))
 	args[0] = "bzmpop"
 	args[1] = formatSec(ctx, timeout)
 	args[2] = len(keys)
@@ -122,8 +122,8 @@ type ZAddArgs struct {
 	Members []Z
 }
 
-func (c cmdable) zAddArgs(key string, args ZAddArgs, incr bool) []interface{} {
-	a := make([]interface{}, 0, 6+2*len(args.Members))
+func (c cmdable) zAddArgs(key string, args ZAddArgs, incr bool) []any {
+	a := make([]any, 0, 6+2*len(args.Members))
 	a = append(a, "zadd", key)
 
 	// The GT, LT and NX options are mutually exclusive.
@@ -228,7 +228,7 @@ func (c cmdable) ZIncrBy(ctx context.Context, key string, increment float64, mem
 }
 
 func (c cmdable) ZInterStore(ctx context.Context, destination string, store *ZStore) *IntCmd {
-	args := make([]interface{}, 0, 3+store.len())
+	args := make([]any, 0, 3+store.len())
 	args = append(args, "zinterstore", destination, len(store.Keys))
 	args = store.appendArgs(args)
 	cmd := NewIntCmd(ctx, args...)
@@ -238,7 +238,7 @@ func (c cmdable) ZInterStore(ctx context.Context, destination string, store *ZSt
 }
 
 func (c cmdable) ZInter(ctx context.Context, store *ZStore) *StringSliceCmd {
-	args := make([]interface{}, 0, 2+store.len())
+	args := make([]any, 0, 2+store.len())
 	args = append(args, "zinter", len(store.Keys))
 	args = store.appendArgs(args)
 	cmd := NewStringSliceCmd(ctx, args...)
@@ -248,7 +248,7 @@ func (c cmdable) ZInter(ctx context.Context, store *ZStore) *StringSliceCmd {
 }
 
 func (c cmdable) ZInterWithScores(ctx context.Context, store *ZStore) *ZSliceCmd {
-	args := make([]interface{}, 0, 3+store.len())
+	args := make([]any, 0, 3+store.len())
 	args = append(args, "zinter", len(store.Keys))
 	args = store.appendArgs(args)
 	args = append(args, "withscores")
@@ -260,7 +260,7 @@ func (c cmdable) ZInterWithScores(ctx context.Context, store *ZStore) *ZSliceCmd
 
 func (c cmdable) ZInterCard(ctx context.Context, limit int64, keys ...string) *IntCmd {
 	numKeys := len(keys)
-	args := make([]interface{}, 4+numKeys)
+	args := make([]any, 4+numKeys)
 	args[0] = "zintercard"
 	args[1] = numKeys
 	for i, key := range keys {
@@ -277,7 +277,7 @@ func (c cmdable) ZInterCard(ctx context.Context, limit int64, keys ...string) *I
 // direction: "max" (highest score) or "min" (lowest score), count: > 0
 // example: client.ZMPop(ctx, "max", 5, "set1", "set2")
 func (c cmdable) ZMPop(ctx context.Context, order string, count int64, keys ...string) *ZSliceWithKeyCmd {
-	args := make([]interface{}, 2+len(keys), 5+len(keys))
+	args := make([]any, 2+len(keys), 5+len(keys))
 	args[0] = "zmpop"
 	args[1] = len(keys)
 	for i, key := range keys {
@@ -290,7 +290,7 @@ func (c cmdable) ZMPop(ctx context.Context, order string, count int64, keys ...s
 }
 
 func (c cmdable) ZMScore(ctx context.Context, key string, members ...string) *FloatSliceCmd {
-	args := make([]interface{}, 2+len(members))
+	args := make([]any, 2+len(members))
 	args[0] = "zmscore"
 	args[1] = key
 	for i, member := range members {
@@ -302,7 +302,7 @@ func (c cmdable) ZMScore(ctx context.Context, key string, members ...string) *Fl
 }
 
 func (c cmdable) ZPopMax(ctx context.Context, key string, count ...int64) *ZSliceCmd {
-	args := []interface{}{
+	args := []any{
 		"zpopmax",
 		key,
 	}
@@ -322,7 +322,7 @@ func (c cmdable) ZPopMax(ctx context.Context, key string, count ...int64) *ZSlic
 }
 
 func (c cmdable) ZPopMin(ctx context.Context, key string, count ...int64) *ZSliceCmd {
-	args := []interface{}{
+	args := []any{
 		"zpopmin",
 		key,
 	}
@@ -380,8 +380,8 @@ type ZRangeArgs struct {
 	//
 	// For normal cases (ByScore==false && ByLex==false), <Start> and <Stop> should be set to the index range (int).
 	// You can read the documentation for more information: https://redis.io/commands/zrange
-	Start interface{}
-	Stop  interface{}
+	Start any
+	Stop  any
 
 	// The ByScore and ByLex options are mutually exclusive.
 	ByScore bool
@@ -394,7 +394,7 @@ type ZRangeArgs struct {
 	Count  int64
 }
 
-func (z ZRangeArgs) appendArgs(args []interface{}) []interface{} {
+func (z ZRangeArgs) appendArgs(args []any) []any {
 	// For Rev+ByScore/ByLex, we need to adjust the position of <Start> and <Stop>.
 	if z.Rev && (z.ByScore || z.ByLex) {
 		args = append(args, z.Key, z.Stop, z.Start)
@@ -417,7 +417,7 @@ func (z ZRangeArgs) appendArgs(args []interface{}) []interface{} {
 }
 
 func (c cmdable) ZRangeArgs(ctx context.Context, z ZRangeArgs) *StringSliceCmd {
-	args := make([]interface{}, 0, 9)
+	args := make([]any, 0, 9)
 	args = append(args, "zrange")
 	args = z.appendArgs(args)
 	cmd := NewStringSliceCmd(ctx, args...)
@@ -426,7 +426,7 @@ func (c cmdable) ZRangeArgs(ctx context.Context, z ZRangeArgs) *StringSliceCmd {
 }
 
 func (c cmdable) ZRangeArgsWithScores(ctx context.Context, z ZRangeArgs) *ZSliceCmd {
-	args := make([]interface{}, 0, 10)
+	args := make([]any, 0, 10)
 	args = append(args, "zrange")
 	args = z.appendArgs(args)
 	args = append(args, "withscores")
@@ -457,7 +457,7 @@ type ZRangeBy struct {
 }
 
 func (c cmdable) zRangeBy(ctx context.Context, zcmd, key string, opt *ZRangeBy, withScores bool) *StringSliceCmd {
-	args := []interface{}{zcmd, key, opt.Min, opt.Max}
+	args := []any{zcmd, key, opt.Min, opt.Max}
 	if withScores {
 		args = append(args, "withscores")
 	}
@@ -483,7 +483,7 @@ func (c cmdable) ZRangeByLex(ctx context.Context, key string, opt *ZRangeBy) *St
 }
 
 func (c cmdable) ZRangeByScoreWithScores(ctx context.Context, key string, opt *ZRangeBy) *ZSliceCmd {
-	args := []interface{}{"zrangebyscore", key, opt.Min, opt.Max, "withscores"}
+	args := []any{"zrangebyscore", key, opt.Min, opt.Max, "withscores"}
 	if opt.Offset != 0 || opt.Count != 0 {
 		args = append(
 			args,
@@ -498,7 +498,7 @@ func (c cmdable) ZRangeByScoreWithScores(ctx context.Context, key string, opt *Z
 }
 
 func (c cmdable) ZRangeStore(ctx context.Context, dst string, z ZRangeArgs) *IntCmd {
-	args := make([]interface{}, 0, 10)
+	args := make([]any, 0, 10)
 	args = append(args, "zrangestore", dst)
 	args = z.appendArgs(args)
 	cmd := NewIntCmd(ctx, args...)
@@ -520,8 +520,8 @@ func (c cmdable) ZRankWithScore(ctx context.Context, key, member string) *RankWi
 	return cmd
 }
 
-func (c cmdable) ZRem(ctx context.Context, key string, members ...interface{}) *IntCmd {
-	args := make([]interface{}, 2, 2+len(members))
+func (c cmdable) ZRem(ctx context.Context, key string, members ...any) *IntCmd {
+	args := make([]any, 2, 2+len(members))
 	args[0] = "zrem"
 	args[1] = key
 	args = appendArgs(args, members)
@@ -569,7 +569,7 @@ func (c cmdable) ZRevRangeWithScores(ctx context.Context, key string, start, sto
 }
 
 func (c cmdable) zRevRangeBy(ctx context.Context, zcmd, key string, opt *ZRangeBy) *StringSliceCmd {
-	args := []interface{}{zcmd, key, opt.Max, opt.Min}
+	args := []any{zcmd, key, opt.Max, opt.Min}
 	if opt.Offset != 0 || opt.Count != 0 {
 		args = append(
 			args,
@@ -592,7 +592,7 @@ func (c cmdable) ZRevRangeByLex(ctx context.Context, key string, opt *ZRangeBy) 
 }
 
 func (c cmdable) ZRevRangeByScoreWithScores(ctx context.Context, key string, opt *ZRangeBy) *ZSliceCmd {
-	args := []interface{}{"zrevrangebyscore", key, opt.Max, opt.Min, "withscores"}
+	args := []any{"zrevrangebyscore", key, opt.Max, opt.Min, "withscores"}
 	if opt.Offset != 0 || opt.Count != 0 {
 		args = append(
 			args,
@@ -625,7 +625,7 @@ func (c cmdable) ZScore(ctx context.Context, key, member string) *FloatCmd {
 }
 
 func (c cmdable) ZUnion(ctx context.Context, store ZStore) *StringSliceCmd {
-	args := make([]interface{}, 0, 2+store.len())
+	args := make([]any, 0, 2+store.len())
 	args = append(args, "zunion", len(store.Keys))
 	args = store.appendArgs(args)
 	cmd := NewStringSliceCmd(ctx, args...)
@@ -635,7 +635,7 @@ func (c cmdable) ZUnion(ctx context.Context, store ZStore) *StringSliceCmd {
 }
 
 func (c cmdable) ZUnionWithScores(ctx context.Context, store ZStore) *ZSliceCmd {
-	args := make([]interface{}, 0, 3+store.len())
+	args := make([]any, 0, 3+store.len())
 	args = append(args, "zunion", len(store.Keys))
 	args = store.appendArgs(args)
 	args = append(args, "withscores")
@@ -646,7 +646,7 @@ func (c cmdable) ZUnionWithScores(ctx context.Context, store ZStore) *ZSliceCmd 
 }
 
 func (c cmdable) ZUnionStore(ctx context.Context, dest string, store *ZStore) *IntCmd {
-	args := make([]interface{}, 0, 3+store.len())
+	args := make([]any, 0, 3+store.len())
 	args = append(args, "zunionstore", dest, len(store.Keys))
 	args = store.appendArgs(args)
 	cmd := NewIntCmd(ctx, args...)
@@ -671,7 +671,7 @@ func (c cmdable) ZRandMemberWithScores(ctx context.Context, key string, count in
 
 // ZDiff redis-server version >= 6.2.0.
 func (c cmdable) ZDiff(ctx context.Context, keys ...string) *StringSliceCmd {
-	args := make([]interface{}, 2+len(keys))
+	args := make([]any, 2+len(keys))
 	args[0] = "zdiff"
 	args[1] = len(keys)
 	for i, key := range keys {
@@ -686,7 +686,7 @@ func (c cmdable) ZDiff(ctx context.Context, keys ...string) *StringSliceCmd {
 
 // ZDiffWithScores redis-server version >= 6.2.0.
 func (c cmdable) ZDiffWithScores(ctx context.Context, keys ...string) *ZSliceCmd {
-	args := make([]interface{}, 3+len(keys))
+	args := make([]any, 3+len(keys))
 	args[0] = "zdiff"
 	args[1] = len(keys)
 	for i, key := range keys {
@@ -702,7 +702,7 @@ func (c cmdable) ZDiffWithScores(ctx context.Context, keys ...string) *ZSliceCmd
 
 // ZDiffStore redis-server version >=6.2.0.
 func (c cmdable) ZDiffStore(ctx context.Context, destination string, keys ...string) *IntCmd {
-	args := make([]interface{}, 0, 3+len(keys))
+	args := make([]any, 0, 3+len(keys))
 	args = append(args, "zdiffstore", destination, len(keys))
 	for _, key := range keys {
 		args = append(args, key)
@@ -713,7 +713,7 @@ func (c cmdable) ZDiffStore(ctx context.Context, destination string, keys ...str
 }
 
 func (c cmdable) ZScan(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd {
-	args := []interface{}{"zscan", key, cursor}
+	args := []any{"zscan", key, cursor}
 	if match != "" {
 		args = append(args, "match", match)
 	}
@@ -731,7 +731,7 @@ func (c cmdable) ZScan(ctx context.Context, key string, cursor uint64, match str
 // Z represents sorted set member.
 type Z struct {
 	Score  float64
-	Member interface{}
+	Member any
 }
 
 // ZWithKey represents sorted set member including the name of the key where it was popped.
@@ -759,7 +759,7 @@ func (z ZStore) len() (n int) {
 	return n
 }
 
-func (z ZStore) appendArgs(args []interface{}) []interface{} {
+func (z ZStore) appendArgs(args []any) []any {
 	for _, key := range z.Keys {
 		args = append(args, key)
 	}

--- a/stream_commands.go
+++ b/stream_commands.go
@@ -46,9 +46,9 @@ type StreamCmdable interface {
 }
 
 // XAddArgs accepts values in the following formats:
-//   - XAddArgs.Values = []interface{}{"key1", "value1", "key2", "value2"}
+//   - XAddArgs.Values = []any{"key1", "value1", "key2", "value2"}
 //   - XAddArgs.Values = []string("key1", "value1", "key2", "value2")
-//   - XAddArgs.Values = map[string]interface{}{"key1": "value1", "key2": "value2"}
+//   - XAddArgs.Values = map[string]any{"key1": "value1", "key2": "value2"}
 //
 // Note that map will not preserve the order of key-value pairs.
 // MaxLen/MaxLenApprox and MinID are in conflict, only one of them can be used.
@@ -62,11 +62,11 @@ type XAddArgs struct {
 	Limit  int64
 	Mode   string
 	ID     string
-	Values interface{}
+	Values any
 }
 
 func (c cmdable) XAdd(ctx context.Context, a *XAddArgs) *StringCmd {
-	args := make([]interface{}, 0, 11)
+	args := make([]any, 0, 11)
 	args = append(args, "xadd", a.Stream)
 	if a.NoMkStream {
 		args = append(args, "nomkstream")
@@ -106,7 +106,7 @@ func (c cmdable) XAdd(ctx context.Context, a *XAddArgs) *StringCmd {
 }
 
 func (c cmdable) XAckDel(ctx context.Context, stream string, group string, mode string, ids ...string) *SliceCmd {
-	args := []interface{}{"xackdel", stream, group, mode, "ids", len(ids)}
+	args := []any{"xackdel", stream, group, mode, "ids", len(ids)}
 	for _, id := range ids {
 		args = append(args, id)
 	}
@@ -116,7 +116,7 @@ func (c cmdable) XAckDel(ctx context.Context, stream string, group string, mode 
 }
 
 func (c cmdable) XDel(ctx context.Context, stream string, ids ...string) *IntCmd {
-	args := []interface{}{"xdel", stream}
+	args := []any{"xdel", stream}
 	for _, id := range ids {
 		args = append(args, id)
 	}
@@ -126,7 +126,7 @@ func (c cmdable) XDel(ctx context.Context, stream string, ids ...string) *IntCmd
 }
 
 func (c cmdable) XDelEx(ctx context.Context, stream string, mode string, ids ...string) *SliceCmd {
-	args := []interface{}{"xdelex", stream, mode, "ids", len(ids)}
+	args := []any{"xdelex", stream, mode, "ids", len(ids)}
 	for _, id := range ids {
 		args = append(args, id)
 	}
@@ -173,7 +173,7 @@ type XReadArgs struct {
 }
 
 func (c cmdable) XRead(ctx context.Context, a *XReadArgs) *XStreamSliceCmd {
-	args := make([]interface{}, 0, 2*len(a.Streams)+6)
+	args := make([]any, 0, 2*len(a.Streams)+6)
 	args = append(args, "xread")
 
 	keyPos := int8(1)
@@ -266,7 +266,7 @@ type XReadGroupArgs struct {
 }
 
 func (c cmdable) XReadGroup(ctx context.Context, a *XReadGroupArgs) *XStreamSliceCmd {
-	args := make([]interface{}, 0, 10+len(a.Streams))
+	args := make([]any, 0, 10+len(a.Streams))
 	args = append(args, "xreadgroup", "group", a.Group, a.Consumer)
 
 	keyPos := int8(4)
@@ -298,7 +298,7 @@ func (c cmdable) XReadGroup(ctx context.Context, a *XReadGroupArgs) *XStreamSlic
 }
 
 func (c cmdable) XAck(ctx context.Context, stream, group string, ids ...string) *IntCmd {
-	args := []interface{}{"xack", stream, group}
+	args := []any{"xack", stream, group}
 	for _, id := range ids {
 		args = append(args, id)
 	}
@@ -324,7 +324,7 @@ type XPendingExtArgs struct {
 }
 
 func (c cmdable) XPendingExt(ctx context.Context, a *XPendingExtArgs) *XPendingExtCmd {
-	args := make([]interface{}, 0, 9)
+	args := make([]any, 0, 9)
 	args = append(args, "xpending", a.Stream, a.Group)
 	if a.Idle != 0 {
 		args = append(args, "idle", formatMs(ctx, a.Idle))
@@ -362,8 +362,8 @@ func (c cmdable) XAutoClaimJustID(ctx context.Context, a *XAutoClaimArgs) *XAuto
 	return cmd
 }
 
-func xAutoClaimArgs(ctx context.Context, a *XAutoClaimArgs) []interface{} {
-	args := make([]interface{}, 0, 8)
+func xAutoClaimArgs(ctx context.Context, a *XAutoClaimArgs) []any {
+	args := make([]any, 0, 8)
 	args = append(args, "xautoclaim", a.Stream, a.Group, a.Consumer, formatMs(ctx, a.MinIdle), a.Start)
 	if a.Count > 0 {
 		args = append(args, "count", a.Count)
@@ -394,8 +394,8 @@ func (c cmdable) XClaimJustID(ctx context.Context, a *XClaimArgs) *StringSliceCm
 	return cmd
 }
 
-func xClaimArgs(a *XClaimArgs) []interface{} {
-	args := make([]interface{}, 0, 5+len(a.Messages))
+func xClaimArgs(a *XClaimArgs) []any {
+	args := make([]any, 0, 5+len(a.Messages))
 	args = append(args,
 		"xclaim",
 		a.Stream,
@@ -418,9 +418,9 @@ func xClaimArgs(a *XClaimArgs) []interface{} {
 // The redis-server version is lower than 6.2, please set limit to 0.
 func (c cmdable) xTrim(
 	ctx context.Context, key, strategy string,
-	approx bool, threshold interface{}, limit int64,
+	approx bool, threshold any, limit int64,
 ) *IntCmd {
-	args := make([]interface{}, 0, 7)
+	args := make([]any, 0, 7)
 	args = append(args, "xtrim", key, strategy)
 	if approx {
 		args = append(args, "~")
@@ -454,10 +454,10 @@ func (c cmdable) XTrimMinIDApprox(ctx context.Context, key string, minID string,
 
 func (c cmdable) xTrimMode(
 	ctx context.Context, key, strategy string,
-	approx bool, threshold interface{}, limit int64,
+	approx bool, threshold any, limit int64,
 	mode string,
 ) *IntCmd {
-	args := make([]interface{}, 0, 7)
+	args := make([]any, 0, 7)
 	args = append(args, "xtrim", key, strategy)
 	if approx {
 		args = append(args, "~")
@@ -509,7 +509,7 @@ func (c cmdable) XInfoStream(ctx context.Context, key string) *XInfoStreamCmd {
 // XInfoStreamFull XINFO STREAM FULL [COUNT count]
 // redis-server >= 6.0.
 func (c cmdable) XInfoStreamFull(ctx context.Context, key string, count int) *XInfoStreamFullCmd {
-	args := make([]interface{}, 0, 6)
+	args := make([]any, 0, 6)
 	args = append(args, "xinfo", "stream", key, "full")
 	if count > 0 {
 		args = append(args, "count", count)

--- a/timeseries_commands.go
+++ b/timeseries_commands.go
@@ -8,8 +8,8 @@ import (
 )
 
 type TimeseriesCmdable interface {
-	TSAdd(ctx context.Context, key string, timestamp interface{}, value float64) *IntCmd
-	TSAddWithArgs(ctx context.Context, key string, timestamp interface{}, value float64, options *TSOptions) *IntCmd
+	TSAdd(ctx context.Context, key string, timestamp any, value float64) *IntCmd
+	TSAddWithArgs(ctx context.Context, key string, timestamp any, value float64, options *TSOptions) *IntCmd
 	TSCreate(ctx context.Context, key string) *StatusCmd
 	TSCreateWithArgs(ctx context.Context, key string, options *TSOptions) *StatusCmd
 	TSAlter(ctx context.Context, key string, options *TSAlterOptions) *StatusCmd
@@ -25,7 +25,7 @@ type TimeseriesCmdable interface {
 	TSGetWithArgs(ctx context.Context, key string, options *TSGetOptions) *TSTimestampValueCmd
 	TSInfo(ctx context.Context, key string) *MapStringInterfaceCmd
 	TSInfoWithArgs(ctx context.Context, key string, options *TSInfoOptions) *MapStringInterfaceCmd
-	TSMAdd(ctx context.Context, ktvSlices [][]interface{}) *IntSliceCmd
+	TSMAdd(ctx context.Context, ktvSlices [][]any) *IntSliceCmd
 	TSQueryIndex(ctx context.Context, filterExpr []string) *StringSliceCmd
 	TSRevRange(ctx context.Context, key string, fromTimestamp int, toTimestamp int) *TSTimestampValueSliceCmd
 	TSRevRangeWithArgs(ctx context.Context, key string, fromTimestamp int, toTimestamp int, options *TSRevRangeOptions) *TSTimestampValueSliceCmd
@@ -138,10 +138,10 @@ type TSRangeOptions struct {
 	FilterByTS      []int
 	FilterByValue   []int
 	Count           int
-	Align           interface{}
+	Align           any
 	Aggregator      Aggregator
 	BucketDuration  int
-	BucketTimestamp interface{}
+	BucketTimestamp any
 	Empty           bool
 }
 
@@ -150,10 +150,10 @@ type TSRevRangeOptions struct {
 	FilterByTS      []int
 	FilterByValue   []int
 	Count           int
-	Align           interface{}
+	Align           any
 	Aggregator      Aggregator
 	BucketDuration  int
-	BucketTimestamp interface{}
+	BucketTimestamp any
 	Empty           bool
 }
 
@@ -162,15 +162,15 @@ type TSMRangeOptions struct {
 	FilterByTS      []int
 	FilterByValue   []int
 	WithLabels      bool
-	SelectedLabels  []interface{}
+	SelectedLabels  []any
 	Count           int
-	Align           interface{}
+	Align           any
 	Aggregator      Aggregator
 	BucketDuration  int
-	BucketTimestamp interface{}
+	BucketTimestamp any
 	Empty           bool
-	GroupByLabel    interface{}
-	Reducer         interface{}
+	GroupByLabel    any
+	Reducer         any
 }
 
 type TSMRevRangeOptions struct {
@@ -178,27 +178,27 @@ type TSMRevRangeOptions struct {
 	FilterByTS      []int
 	FilterByValue   []int
 	WithLabels      bool
-	SelectedLabels  []interface{}
+	SelectedLabels  []any
 	Count           int
-	Align           interface{}
+	Align           any
 	Aggregator      Aggregator
 	BucketDuration  int
-	BucketTimestamp interface{}
+	BucketTimestamp any
 	Empty           bool
-	GroupByLabel    interface{}
-	Reducer         interface{}
+	GroupByLabel    any
+	Reducer         any
 }
 
 type TSMGetOptions struct {
 	Latest         bool
 	WithLabels     bool
-	SelectedLabels []interface{}
+	SelectedLabels []any
 }
 
 // TSAdd - Adds one or more observations to a t-digest sketch.
 // For more information - https://redis.io/commands/ts.add/
-func (c cmdable) TSAdd(ctx context.Context, key string, timestamp interface{}, value float64) *IntCmd {
-	args := []interface{}{"TS.ADD", key, timestamp, value}
+func (c cmdable) TSAdd(ctx context.Context, key string, timestamp any, value float64) *IntCmd {
+	args := []any{"TS.ADD", key, timestamp, value}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -208,8 +208,8 @@ func (c cmdable) TSAdd(ctx context.Context, key string, timestamp interface{}, v
 // This function also allows for specifying additional options such as:
 // Retention, ChunkSize, Encoding, DuplicatePolicy and Labels.
 // For more information - https://redis.io/commands/ts.add/
-func (c cmdable) TSAddWithArgs(ctx context.Context, key string, timestamp interface{}, value float64, options *TSOptions) *IntCmd {
-	args := []interface{}{"TS.ADD", key, timestamp, value}
+func (c cmdable) TSAddWithArgs(ctx context.Context, key string, timestamp any, value float64, options *TSOptions) *IntCmd {
+	args := []any{"TS.ADD", key, timestamp, value}
 	if options != nil {
 		if options.Retention != 0 {
 			args = append(args, "RETENTION", options.Retention)
@@ -242,7 +242,7 @@ func (c cmdable) TSAddWithArgs(ctx context.Context, key string, timestamp interf
 // TSCreate - Creates a new time-series key.
 // For more information - https://redis.io/commands/ts.create/
 func (c cmdable) TSCreate(ctx context.Context, key string) *StatusCmd {
-	args := []interface{}{"TS.CREATE", key}
+	args := []any{"TS.CREATE", key}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -253,7 +253,7 @@ func (c cmdable) TSCreate(ctx context.Context, key string) *StatusCmd {
 // Retention, ChunkSize, Encoding, DuplicatePolicy and Labels.
 // For more information - https://redis.io/commands/ts.create/
 func (c cmdable) TSCreateWithArgs(ctx context.Context, key string, options *TSOptions) *StatusCmd {
-	args := []interface{}{"TS.CREATE", key}
+	args := []any{"TS.CREATE", key}
 	if options != nil {
 		if options.Retention != 0 {
 			args = append(args, "RETENTION", options.Retention)
@@ -288,7 +288,7 @@ func (c cmdable) TSCreateWithArgs(ctx context.Context, key string, options *TSOp
 // Retention, ChunkSize and DuplicatePolicy.
 // For more information - https://redis.io/commands/ts.alter/
 func (c cmdable) TSAlter(ctx context.Context, key string, options *TSAlterOptions) *StatusCmd {
-	args := []interface{}{"TS.ALTER", key}
+	args := []any{"TS.ALTER", key}
 	if options != nil {
 		if options.Retention != 0 {
 			args = append(args, "RETENTION", options.Retention)
@@ -317,7 +317,7 @@ func (c cmdable) TSAlter(ctx context.Context, key string, options *TSAlterOption
 // TSCreateRule - Creates a compaction rule from sourceKey to destKey.
 // For more information - https://redis.io/commands/ts.createrule/
 func (c cmdable) TSCreateRule(ctx context.Context, sourceKey string, destKey string, aggregator Aggregator, bucketDuration int) *StatusCmd {
-	args := []interface{}{"TS.CREATERULE", sourceKey, destKey, "AGGREGATION", aggregator.String(), bucketDuration}
+	args := []any{"TS.CREATERULE", sourceKey, destKey, "AGGREGATION", aggregator.String(), bucketDuration}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -328,7 +328,7 @@ func (c cmdable) TSCreateRule(ctx context.Context, sourceKey string, destKey str
 // alignTimestamp.
 // For more information - https://redis.io/commands/ts.createrule/
 func (c cmdable) TSCreateRuleWithArgs(ctx context.Context, sourceKey string, destKey string, aggregator Aggregator, bucketDuration int, options *TSCreateRuleOptions) *StatusCmd {
-	args := []interface{}{"TS.CREATERULE", sourceKey, destKey, "AGGREGATION", aggregator.String(), bucketDuration}
+	args := []any{"TS.CREATERULE", sourceKey, destKey, "AGGREGATION", aggregator.String(), bucketDuration}
 	if options != nil {
 		if options.alignTimestamp != 0 {
 			args = append(args, options.alignTimestamp)
@@ -342,7 +342,7 @@ func (c cmdable) TSCreateRuleWithArgs(ctx context.Context, sourceKey string, des
 // TSIncrBy - Increments the value of a time-series key by the specified timestamp.
 // For more information - https://redis.io/commands/ts.incrby/
 func (c cmdable) TSIncrBy(ctx context.Context, Key string, timestamp float64) *IntCmd {
-	args := []interface{}{"TS.INCRBY", Key, timestamp}
+	args := []any{"TS.INCRBY", Key, timestamp}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -353,7 +353,7 @@ func (c cmdable) TSIncrBy(ctx context.Context, Key string, timestamp float64) *I
 // Timestamp, Retention, ChunkSize, Uncompressed and Labels.
 // For more information - https://redis.io/commands/ts.incrby/
 func (c cmdable) TSIncrByWithArgs(ctx context.Context, key string, timestamp float64, options *TSIncrDecrOptions) *IntCmd {
-	args := []interface{}{"TS.INCRBY", key, timestamp}
+	args := []any{"TS.INCRBY", key, timestamp}
 	if options != nil {
 		if options.Timestamp != 0 {
 			args = append(args, "TIMESTAMP", options.Timestamp)
@@ -388,7 +388,7 @@ func (c cmdable) TSIncrByWithArgs(ctx context.Context, key string, timestamp flo
 // TSDecrBy - Decrements the value of a time-series key by the specified timestamp.
 // For more information - https://redis.io/commands/ts.decrby/
 func (c cmdable) TSDecrBy(ctx context.Context, Key string, timestamp float64) *IntCmd {
-	args := []interface{}{"TS.DECRBY", Key, timestamp}
+	args := []any{"TS.DECRBY", Key, timestamp}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -399,7 +399,7 @@ func (c cmdable) TSDecrBy(ctx context.Context, Key string, timestamp float64) *I
 // Timestamp, Retention, ChunkSize, Uncompressed and Labels.
 // For more information - https://redis.io/commands/ts.decrby/
 func (c cmdable) TSDecrByWithArgs(ctx context.Context, key string, timestamp float64, options *TSIncrDecrOptions) *IntCmd {
-	args := []interface{}{"TS.DECRBY", key, timestamp}
+	args := []any{"TS.DECRBY", key, timestamp}
 	if options != nil {
 		if options.Timestamp != 0 {
 			args = append(args, "TIMESTAMP", options.Timestamp)
@@ -434,7 +434,7 @@ func (c cmdable) TSDecrByWithArgs(ctx context.Context, key string, timestamp flo
 // TSDel - Deletes a range of samples from a time-series key.
 // For more information - https://redis.io/commands/ts.del/
 func (c cmdable) TSDel(ctx context.Context, Key string, fromTimestamp int, toTimestamp int) *IntCmd {
-	args := []interface{}{"TS.DEL", Key, fromTimestamp, toTimestamp}
+	args := []any{"TS.DEL", Key, fromTimestamp, toTimestamp}
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -443,7 +443,7 @@ func (c cmdable) TSDel(ctx context.Context, Key string, fromTimestamp int, toTim
 // TSDeleteRule - Deletes a compaction rule from sourceKey to destKey.
 // For more information - https://redis.io/commands/ts.deleterule/
 func (c cmdable) TSDeleteRule(ctx context.Context, sourceKey string, destKey string) *StatusCmd {
-	args := []interface{}{"TS.DELETERULE", sourceKey, destKey}
+	args := []any{"TS.DELETERULE", sourceKey, destKey}
 	cmd := NewStatusCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -454,7 +454,7 @@ func (c cmdable) TSDeleteRule(ctx context.Context, sourceKey string, destKey str
 // Latest.
 // For more information - https://redis.io/commands/ts.get/
 func (c cmdable) TSGetWithArgs(ctx context.Context, key string, options *TSGetOptions) *TSTimestampValueCmd {
-	args := []interface{}{"TS.GET", key}
+	args := []any{"TS.GET", key}
 	if options != nil {
 		if options.Latest {
 			args = append(args, "LATEST")
@@ -468,7 +468,7 @@ func (c cmdable) TSGetWithArgs(ctx context.Context, key string, options *TSGetOp
 // TSGet - Gets the last sample of a time-series key.
 // For more information - https://redis.io/commands/ts.get/
 func (c cmdable) TSGet(ctx context.Context, key string) *TSTimestampValueCmd {
-	args := []interface{}{"TS.GET", key}
+	args := []any{"TS.GET", key}
 	cmd := newTSTimestampValueCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -483,7 +483,7 @@ type TSTimestampValueCmd struct {
 	val TSTimestampValue
 }
 
-func newTSTimestampValueCmd(ctx context.Context, args ...interface{}) *TSTimestampValueCmd {
+func newTSTimestampValueCmd(ctx context.Context, args ...any) *TSTimestampValueCmd {
 	return &TSTimestampValueCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -536,7 +536,7 @@ func (cmd *TSTimestampValueCmd) readReply(rd *proto.Reader) (err error) {
 // TSInfo - Returns information about a time-series key.
 // For more information - https://redis.io/commands/ts.info/
 func (c cmdable) TSInfo(ctx context.Context, key string) *MapStringInterfaceCmd {
-	args := []interface{}{"TS.INFO", key}
+	args := []any{"TS.INFO", key}
 	cmd := NewMapStringInterfaceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -547,7 +547,7 @@ func (c cmdable) TSInfo(ctx context.Context, key string) *MapStringInterfaceCmd 
 // Debug.
 // For more information - https://redis.io/commands/ts.info/
 func (c cmdable) TSInfoWithArgs(ctx context.Context, key string, options *TSInfoOptions) *MapStringInterfaceCmd {
-	args := []interface{}{"TS.INFO", key}
+	args := []any{"TS.INFO", key}
 	if options != nil {
 		if options.Debug {
 			args = append(args, "DEBUG")
@@ -562,8 +562,8 @@ func (c cmdable) TSInfoWithArgs(ctx context.Context, key string, options *TSInfo
 // It accepts a slice of 'ktv' slices, each containing exactly three elements: key, timestamp, and value.
 // This struct must be provided for this command to work.
 // For more information - https://redis.io/commands/ts.madd/
-func (c cmdable) TSMAdd(ctx context.Context, ktvSlices [][]interface{}) *IntSliceCmd {
-	args := []interface{}{"TS.MADD"}
+func (c cmdable) TSMAdd(ctx context.Context, ktvSlices [][]any) *IntSliceCmd {
+	args := []any{"TS.MADD"}
 	for _, ktv := range ktvSlices {
 		args = append(args, ktv...)
 	}
@@ -575,7 +575,7 @@ func (c cmdable) TSMAdd(ctx context.Context, ktvSlices [][]interface{}) *IntSlic
 // TSQueryIndex - Returns all the keys matching the filter expression.
 // For more information - https://redis.io/commands/ts.queryindex/
 func (c cmdable) TSQueryIndex(ctx context.Context, filterExpr []string) *StringSliceCmd {
-	args := []interface{}{"TS.QUERYINDEX"}
+	args := []any{"TS.QUERYINDEX"}
 	for _, f := range filterExpr {
 		args = append(args, f)
 	}
@@ -587,7 +587,7 @@ func (c cmdable) TSQueryIndex(ctx context.Context, filterExpr []string) *StringS
 // TSRevRange - Returns a range of samples from a time-series key in reverse order.
 // For more information - https://redis.io/commands/ts.revrange/
 func (c cmdable) TSRevRange(ctx context.Context, key string, fromTimestamp int, toTimestamp int) *TSTimestampValueSliceCmd {
-	args := []interface{}{"TS.REVRANGE", key, fromTimestamp, toTimestamp}
+	args := []any{"TS.REVRANGE", key, fromTimestamp, toTimestamp}
 	cmd := newTSTimestampValueSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -599,7 +599,7 @@ func (c cmdable) TSRevRange(ctx context.Context, key string, fromTimestamp int, 
 // BucketDuration, BucketTimestamp and Empty.
 // For more information - https://redis.io/commands/ts.revrange/
 func (c cmdable) TSRevRangeWithArgs(ctx context.Context, key string, fromTimestamp int, toTimestamp int, options *TSRevRangeOptions) *TSTimestampValueSliceCmd {
-	args := []interface{}{"TS.REVRANGE", key, fromTimestamp, toTimestamp}
+	args := []any{"TS.REVRANGE", key, fromTimestamp, toTimestamp}
 	if options != nil {
 		if options.Latest {
 			args = append(args, "LATEST")
@@ -643,7 +643,7 @@ func (c cmdable) TSRevRangeWithArgs(ctx context.Context, key string, fromTimesta
 // TSRange - Returns a range of samples from a time-series key.
 // For more information - https://redis.io/commands/ts.range/
 func (c cmdable) TSRange(ctx context.Context, key string, fromTimestamp int, toTimestamp int) *TSTimestampValueSliceCmd {
-	args := []interface{}{"TS.RANGE", key, fromTimestamp, toTimestamp}
+	args := []any{"TS.RANGE", key, fromTimestamp, toTimestamp}
 	cmd := newTSTimestampValueSliceCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -655,7 +655,7 @@ func (c cmdable) TSRange(ctx context.Context, key string, fromTimestamp int, toT
 // BucketDuration, BucketTimestamp and Empty.
 // For more information - https://redis.io/commands/ts.range/
 func (c cmdable) TSRangeWithArgs(ctx context.Context, key string, fromTimestamp int, toTimestamp int, options *TSRangeOptions) *TSTimestampValueSliceCmd {
-	args := []interface{}{"TS.RANGE", key, fromTimestamp, toTimestamp}
+	args := []any{"TS.RANGE", key, fromTimestamp, toTimestamp}
 	if options != nil {
 		if options.Latest {
 			args = append(args, "LATEST")
@@ -701,7 +701,7 @@ type TSTimestampValueSliceCmd struct {
 	val []TSTimestampValue
 }
 
-func newTSTimestampValueSliceCmd(ctx context.Context, args ...interface{}) *TSTimestampValueSliceCmd {
+func newTSTimestampValueSliceCmd(ctx context.Context, args ...any) *TSTimestampValueSliceCmd {
 	return &TSTimestampValueSliceCmd{
 		baseCmd: baseCmd{
 			ctx:  ctx,
@@ -755,7 +755,7 @@ func (cmd *TSTimestampValueSliceCmd) readReply(rd *proto.Reader) (err error) {
 // TSMRange - Returns a range of samples from multiple time-series keys.
 // For more information - https://redis.io/commands/ts.mrange/
 func (c cmdable) TSMRange(ctx context.Context, fromTimestamp int, toTimestamp int, filterExpr []string) *MapStringSliceInterfaceCmd {
-	args := []interface{}{"TS.MRANGE", fromTimestamp, toTimestamp, "FILTER"}
+	args := []any{"TS.MRANGE", fromTimestamp, toTimestamp, "FILTER"}
 	for _, f := range filterExpr {
 		args = append(args, f)
 	}
@@ -771,7 +771,7 @@ func (c cmdable) TSMRange(ctx context.Context, fromTimestamp int, toTimestamp in
 // Empty, GroupByLabel and Reducer.
 // For more information - https://redis.io/commands/ts.mrange/
 func (c cmdable) TSMRangeWithArgs(ctx context.Context, fromTimestamp int, toTimestamp int, filterExpr []string, options *TSMRangeOptions) *MapStringSliceInterfaceCmd {
-	args := []interface{}{"TS.MRANGE", fromTimestamp, toTimestamp}
+	args := []any{"TS.MRANGE", fromTimestamp, toTimestamp}
 	if options != nil {
 		if options.Latest {
 			args = append(args, "LATEST")
@@ -834,7 +834,7 @@ func (c cmdable) TSMRangeWithArgs(ctx context.Context, fromTimestamp int, toTime
 // TSMRevRange - Returns a range of samples from multiple time-series keys in reverse order.
 // For more information - https://redis.io/commands/ts.mrevrange/
 func (c cmdable) TSMRevRange(ctx context.Context, fromTimestamp int, toTimestamp int, filterExpr []string) *MapStringSliceInterfaceCmd {
-	args := []interface{}{"TS.MREVRANGE", fromTimestamp, toTimestamp, "FILTER"}
+	args := []any{"TS.MREVRANGE", fromTimestamp, toTimestamp, "FILTER"}
 	for _, f := range filterExpr {
 		args = append(args, f)
 	}
@@ -850,7 +850,7 @@ func (c cmdable) TSMRevRange(ctx context.Context, fromTimestamp int, toTimestamp
 // Empty, GroupByLabel and Reducer.
 // For more information - https://redis.io/commands/ts.mrevrange/
 func (c cmdable) TSMRevRangeWithArgs(ctx context.Context, fromTimestamp int, toTimestamp int, filterExpr []string, options *TSMRevRangeOptions) *MapStringSliceInterfaceCmd {
-	args := []interface{}{"TS.MREVRANGE", fromTimestamp, toTimestamp}
+	args := []any{"TS.MREVRANGE", fromTimestamp, toTimestamp}
 	if options != nil {
 		if options.Latest {
 			args = append(args, "LATEST")
@@ -913,7 +913,7 @@ func (c cmdable) TSMRevRangeWithArgs(ctx context.Context, fromTimestamp int, toT
 // TSMGet - Returns the last sample of multiple time-series keys.
 // For more information - https://redis.io/commands/ts.mget/
 func (c cmdable) TSMGet(ctx context.Context, filters []string) *MapStringSliceInterfaceCmd {
-	args := []interface{}{"TS.MGET", "FILTER"}
+	args := []any{"TS.MGET", "FILTER"}
 	for _, f := range filters {
 		args = append(args, f)
 	}
@@ -927,7 +927,7 @@ func (c cmdable) TSMGet(ctx context.Context, filters []string) *MapStringSliceIn
 // Latest, WithLabels and SelectedLabels.
 // For more information - https://redis.io/commands/ts.mget/
 func (c cmdable) TSMGetWithArgs(ctx context.Context, filters []string, options *TSMGetOptions) *MapStringSliceInterfaceCmd {
-	args := []interface{}{"TS.MGET"}
+	args := []any{"TS.MGET"}
 	if options != nil {
 		if options.Latest {
 			args = append(args, "LATEST")

--- a/timeseries_commands_test.go
+++ b/timeseries_commands_test.go
@@ -63,9 +63,9 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				resultInfo, err := client.TSInfo(ctx, "4").Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(resultInfo["labels"].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"Time", "Series"}))
+					Expect(resultInfo["labels"].([]any)[0]).To(BeEquivalentTo([]any{"Time", "Series"}))
 				} else {
-					Expect(resultInfo["labels"].(map[interface{}]interface{})["Time"]).To(BeEquivalentTo("Series"))
+					Expect(resultInfo["labels"].(map[any]any)["Time"]).To(BeEquivalentTo("Series"))
 				}
 				// Test chunk size
 				opt = &redis.TSOptions{ChunkSize: 128}
@@ -160,9 +160,9 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				resultInfo, err := client.TSInfo(ctx, "4").Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(resultInfo["labels"].([]interface{})).To(ContainElement([]interface{}{"Time", "Series"}))
+					Expect(resultInfo["labels"].([]any)).To(ContainElement([]any{"Time", "Series"}))
 				} else {
-					Expect(resultInfo["labels"].(map[interface{}]interface{})["Time"]).To(BeEquivalentTo("Series"))
+					Expect(resultInfo["labels"].(map[any]any)["Time"]).To(BeEquivalentTo("Series"))
 				}
 				// Test chunk size
 				opt = &redis.TSOptions{ChunkSize: 128}
@@ -254,9 +254,9 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				resultInfo, err = client.TSInfo(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(resultInfo["labels"]).To(BeEquivalentTo([]interface{}{}))
+					Expect(resultInfo["labels"]).To(BeEquivalentTo([]any{}))
 				} else {
-					Expect(resultInfo["labels"]).To(BeEquivalentTo(map[interface{}]interface{}{}))
+					Expect(resultInfo["labels"]).To(BeEquivalentTo(map[any]any{}))
 				}
 
 				opt = &redis.TSAlterOptions{Labels: map[string]string{"Time": "Series"}}
@@ -267,7 +267,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				resultInfo, err = client.TSInfo(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(resultInfo["labels"].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"Time", "Series"}))
+					Expect(resultInfo["labels"].([]any)[0]).To(BeEquivalentTo([]any{"Time", "Series"}))
 					Expect(resultInfo["retentionTime"]).To(BeEquivalentTo(10))
 					if RedisVersion >= 8 {
 						Expect(resultInfo["duplicatePolicy"]).To(BeEquivalentTo("block"))
@@ -276,7 +276,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 						Expect(resultInfo["duplicatePolicy"]).To(BeEquivalentTo(redis.Nil))
 					}
 				} else {
-					Expect(resultInfo["labels"].(map[interface{}]interface{})["Time"]).To(BeEquivalentTo("Series"))
+					Expect(resultInfo["labels"].(map[any]any)["Time"]).To(BeEquivalentTo("Series"))
 					Expect(resultInfo["retentionTime"]).To(BeEquivalentTo(10))
 					if RedisVersion >= 8 {
 						Expect(resultInfo["duplicatePolicy"]).To(BeEquivalentTo("block"))
@@ -355,9 +355,9 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				resultInfo, err := client.TSInfo(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(resultInfo["rules"]).To(BeEquivalentTo([]interface{}{}))
+					Expect(resultInfo["rules"]).To(BeEquivalentTo([]any{}))
 				} else {
-					Expect(resultInfo["rules"]).To(BeEquivalentTo(map[interface{}]interface{}{}))
+					Expect(resultInfo["rules"]).To(BeEquivalentTo(map[any]any{}))
 				}
 			})
 
@@ -527,9 +527,9 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				resultGet, err := client.TSCreate(ctx, "a").Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resultGet).To(BeEquivalentTo("OK"))
-				ktvSlices := make([][]interface{}, 3)
+				ktvSlices := make([][]any, 3)
 				for i := 0; i < 3; i++ {
-					ktvSlices[i] = make([]interface{}, 3)
+					ktvSlices[i] = make([]any, 3)
 					ktvSlices[i][0] = "a"
 					for j := 1; j < 3; j++ {
 						ktvSlices[i][j] = (i + j) * j
@@ -557,19 +557,19 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err := client.TSMGet(ctx, []string{"Test=This"}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1].([]interface{})[1]).To(BeEquivalentTo("15"))
-					Expect(result["b"][1].([]interface{})[1]).To(BeEquivalentTo("25"))
+					Expect(result["a"][1].([]any)[1]).To(BeEquivalentTo("15"))
+					Expect(result["b"][1].([]any)[1]).To(BeEquivalentTo("25"))
 				} else {
-					Expect(result["a"][1].([]interface{})[1]).To(BeEquivalentTo(15))
-					Expect(result["b"][1].([]interface{})[1]).To(BeEquivalentTo(25))
+					Expect(result["a"][1].([]any)[1]).To(BeEquivalentTo(15))
+					Expect(result["b"][1].([]any)[1]).To(BeEquivalentTo(25))
 				}
 				mgetOpt := &redis.TSMGetOptions{WithLabels: true}
 				result, err = client.TSMGetWithArgs(ctx, []string{"Test=This"}, mgetOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["b"][0]).To(ConsistOf([]interface{}{"Test", "This"}, []interface{}{"Taste", "That"}))
+					Expect(result["b"][0]).To(ConsistOf([]any{"Test", "This"}, []any{"Taste", "That"}))
 				} else {
-					Expect(result["b"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"Test": "This", "Taste": "That"}))
+					Expect(result["b"][0]).To(BeEquivalentTo(map[any]any{"Test": "This", "Taste": "That"}))
 				}
 
 				resultCreate, err = client.TSCreate(ctx, "c").Result()
@@ -593,17 +593,17 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMGet(ctx, []string{"is_compaction=true"}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(0), "4"}))
+					Expect(result["d"][1]).To(BeEquivalentTo([]any{int64(0), "4"}))
 				} else {
-					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(0), 4.0}))
+					Expect(result["d"][1]).To(BeEquivalentTo([]any{int64(0), 4.0}))
 				}
 				mgetOpt = &redis.TSMGetOptions{Latest: true}
 				result, err = client.TSMGetWithArgs(ctx, []string{"is_compaction=true"}, mgetOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(10), "8"}))
+					Expect(result["d"][1]).To(BeEquivalentTo([]any{int64(10), "8"}))
 				} else {
-					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(10), 8.0}))
+					Expect(result["d"][1]).To(BeEquivalentTo([]any{int64(10), 8.0}))
 				}
 			})
 
@@ -903,18 +903,18 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
 				if client.Options().Protocol == 2 {
-					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(100))
+					Expect(len(result["a"][1].([]any))).To(BeEquivalentTo(100))
 				} else {
-					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(100))
+					Expect(len(result["a"][2].([]any))).To(BeEquivalentTo(100))
 				}
 				// Test Count
 				mrangeOpt := &redis.TSMRangeOptions{Count: 10}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(10))
+					Expect(len(result["a"][1].([]any))).To(BeEquivalentTo(10))
 				} else {
-					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(10))
+					Expect(len(result["a"][2].([]any))).To(BeEquivalentTo(10))
 				}
 				// Test Aggregation and BucketDuration
 				for i := 0; i < 100; i++ {
@@ -926,34 +926,34 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
 				if client.Options().Protocol == 2 {
-					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(20))
+					Expect(len(result["a"][1].([]any))).To(BeEquivalentTo(20))
 				} else {
-					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(20))
+					Expect(len(result["a"][2].([]any))).To(BeEquivalentTo(20))
 				}
 				// Test WithLabels
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][0]).To(BeEquivalentTo([]interface{}{}))
+					Expect(result["a"][0]).To(BeEquivalentTo([]any{}))
 				} else {
-					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{}))
+					Expect(result["a"][0]).To(BeEquivalentTo(map[any]any{}))
 				}
 				mrangeOpt = &redis.TSMRangeOptions{WithLabels: true}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][0]).To(ConsistOf([]interface{}{[]interface{}{"Test", "This"}, []interface{}{"team", "ny"}}))
+					Expect(result["a"][0]).To(ConsistOf([]any{[]any{"Test", "This"}, []any{"team", "ny"}}))
 				} else {
-					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"Test": "This", "team": "ny"}))
+					Expect(result["a"][0]).To(BeEquivalentTo(map[any]any{"Test": "This", "team": "ny"}))
 				}
 				// Test SelectedLabels
-				mrangeOpt = &redis.TSMRangeOptions{SelectedLabels: []interface{}{"team"}}
+				mrangeOpt = &redis.TSMRangeOptions{SelectedLabels: []any{"team"}}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "ny"}))
-					Expect(result["b"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "sf"}))
+					Expect(result["a"][0].([]any)[0]).To(BeEquivalentTo([]any{"team", "ny"}))
+					Expect(result["b"][0].([]any)[0]).To(BeEquivalentTo([]any{"team", "sf"}))
 				} else {
-					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"team": "ny"}))
-					Expect(result["b"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"team": "sf"}))
+					Expect(result["a"][0]).To(BeEquivalentTo(map[any]any{"team": "ny"}))
+					Expect(result["b"][0]).To(BeEquivalentTo(map[any]any{"team": "sf"}))
 				}
 				// Test FilterBy
 				fts := make([]int, 0)
@@ -964,26 +964,26 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1].([]interface{})).To(BeEquivalentTo([]interface{}{[]interface{}{int64(15), "1"}, []interface{}{int64(16), "2"}}))
+					Expect(result["a"][1].([]any)).To(BeEquivalentTo([]any{[]any{int64(15), "1"}, []any{int64(16), "2"}}))
 				} else {
-					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(15), 1.0}, []interface{}{int64(16), 2.0}}))
+					Expect(result["a"][2]).To(BeEquivalentTo([]any{[]any{int64(15), 1.0}, []any{int64(16), 2.0}}))
 				}
 				// Test GroupBy
 				mrangeOpt = &redis.TSMRangeOptions{GroupByLabel: "Test", Reducer: "sum"}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "2"}, []interface{}{int64(2), "4"}, []interface{}{int64(3), "6"}}))
+					Expect(result["Test=This"][1]).To(BeEquivalentTo([]any{[]any{int64(0), "0"}, []any{int64(1), "2"}, []any{int64(2), "4"}, []any{int64(3), "6"}}))
 				} else {
-					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 0.0}, []interface{}{int64(1), 2.0}, []interface{}{int64(2), 4.0}, []interface{}{int64(3), 6.0}}))
+					Expect(result["Test=This"][3]).To(BeEquivalentTo([]any{[]any{int64(0), 0.0}, []any{int64(1), 2.0}, []any{int64(2), 4.0}, []any{int64(3), 6.0}}))
 				}
 				mrangeOpt = &redis.TSMRangeOptions{GroupByLabel: "Test", Reducer: "max"}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "1"}, []interface{}{int64(2), "2"}, []interface{}{int64(3), "3"}}))
+					Expect(result["Test=This"][1]).To(BeEquivalentTo([]any{[]any{int64(0), "0"}, []any{int64(1), "1"}, []any{int64(2), "2"}, []any{int64(3), "3"}}))
 				} else {
-					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 0.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(3), 3.0}}))
+					Expect(result["Test=This"][3]).To(BeEquivalentTo([]any{[]any{int64(0), 0.0}, []any{int64(1), 1.0}, []any{int64(2), 2.0}, []any{int64(3), 3.0}}))
 				}
 
 				mrangeOpt = &redis.TSMRangeOptions{GroupByLabel: "team", Reducer: "min"}
@@ -991,29 +991,29 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
 				if client.Options().Protocol == 2 {
-					Expect(result["team=ny"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "1"}, []interface{}{int64(2), "2"}, []interface{}{int64(3), "3"}}))
-					Expect(result["team=sf"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "1"}, []interface{}{int64(2), "2"}, []interface{}{int64(3), "3"}}))
+					Expect(result["team=ny"][1]).To(BeEquivalentTo([]any{[]any{int64(0), "0"}, []any{int64(1), "1"}, []any{int64(2), "2"}, []any{int64(3), "3"}}))
+					Expect(result["team=sf"][1]).To(BeEquivalentTo([]any{[]any{int64(0), "0"}, []any{int64(1), "1"}, []any{int64(2), "2"}, []any{int64(3), "3"}}))
 				} else {
-					Expect(result["team=ny"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 0.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(3), 3.0}}))
-					Expect(result["team=sf"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 0.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(3), 3.0}}))
+					Expect(result["team=ny"][3]).To(BeEquivalentTo([]any{[]any{int64(0), 0.0}, []any{int64(1), 1.0}, []any{int64(2), 2.0}, []any{int64(3), 3.0}}))
+					Expect(result["team=sf"][3]).To(BeEquivalentTo([]any{[]any{int64(0), 0.0}, []any{int64(1), 1.0}, []any{int64(2), 2.0}, []any{int64(3), 3.0}}))
 				}
 				// Test Align
 				mrangeOpt = &redis.TSMRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: "-"}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "10"}, []interface{}{int64(10), "1"}}))
+					Expect(result["a"][1]).To(BeEquivalentTo([]any{[]any{int64(0), "10"}, []any{int64(10), "1"}}))
 				} else {
-					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 10.0}, []interface{}{int64(10), 1.0}}))
+					Expect(result["a"][2]).To(BeEquivalentTo([]any{[]any{int64(0), 10.0}, []any{int64(10), 1.0}}))
 				}
 
 				mrangeOpt = &redis.TSMRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: 5}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "5"}, []interface{}{int64(5), "6"}}))
+					Expect(result["a"][1]).To(BeEquivalentTo([]any{[]any{int64(0), "5"}, []any{int64(5), "6"}}))
 				} else {
-					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 5.0}, []interface{}{int64(5), 6.0}}))
+					Expect(result["a"][2]).To(BeEquivalentTo([]any{[]any{int64(0), 5.0}, []any{int64(5), 6.0}}))
 				}
 			})
 
@@ -1062,11 +1062,11 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err := client.TSMRangeWithArgs(ctx, 0, 10, []string{"is_compaction=true"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["b"][1]).To(ConsistOf([]interface{}{int64(0), "4"}, []interface{}{int64(10), "8"}))
-					Expect(result["d"][1]).To(ConsistOf([]interface{}{int64(0), "4"}, []interface{}{int64(10), "8"}))
+					Expect(result["b"][1]).To(ConsistOf([]any{int64(0), "4"}, []any{int64(10), "8"}))
+					Expect(result["d"][1]).To(ConsistOf([]any{int64(0), "4"}, []any{int64(10), "8"}))
 				} else {
-					Expect(result["b"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 4.0}, []interface{}{int64(10), 8.0}}))
-					Expect(result["d"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 4.0}, []interface{}{int64(10), 8.0}}))
+					Expect(result["b"][2]).To(BeEquivalentTo([]any{[]any{int64(0), 4.0}, []any{int64(10), 8.0}}))
+					Expect(result["d"][2]).To(BeEquivalentTo([]any{[]any{int64(0), 4.0}, []any{int64(10), 8.0}}))
 				}
 			})
 			It("should TSMRevRange and TSMRevRangeWithArgs", Label("timeseries", "tsmrevrange", "tsmrevrangeWithArgs"), func() {
@@ -1089,18 +1089,18 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
 				if client.Options().Protocol == 2 {
-					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(100))
+					Expect(len(result["a"][1].([]any))).To(BeEquivalentTo(100))
 				} else {
-					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(100))
+					Expect(len(result["a"][2].([]any))).To(BeEquivalentTo(100))
 				}
 				// Test Count
 				mrangeOpt := &redis.TSMRevRangeOptions{Count: 10}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(10))
+					Expect(len(result["a"][1].([]any))).To(BeEquivalentTo(10))
 				} else {
-					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(10))
+					Expect(len(result["a"][2].([]any))).To(BeEquivalentTo(10))
 				}
 				// Test Aggregation and BucketDuration
 				for i := 0; i < 100; i++ {
@@ -1112,30 +1112,30 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
 				if client.Options().Protocol == 2 {
-					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(20))
-					Expect(result["a"][0]).To(BeEquivalentTo([]interface{}{}))
+					Expect(len(result["a"][1].([]any))).To(BeEquivalentTo(20))
+					Expect(result["a"][0]).To(BeEquivalentTo([]any{}))
 				} else {
-					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(20))
-					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{}))
+					Expect(len(result["a"][2].([]any))).To(BeEquivalentTo(20))
+					Expect(result["a"][0]).To(BeEquivalentTo(map[any]any{}))
 				}
 				mrangeOpt = &redis.TSMRevRangeOptions{WithLabels: true}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][0]).To(ConsistOf([]interface{}{[]interface{}{"Test", "This"}, []interface{}{"team", "ny"}}))
+					Expect(result["a"][0]).To(ConsistOf([]any{[]any{"Test", "This"}, []any{"team", "ny"}}))
 				} else {
-					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"Test": "This", "team": "ny"}))
+					Expect(result["a"][0]).To(BeEquivalentTo(map[any]any{"Test": "This", "team": "ny"}))
 				}
 				// Test SelectedLabels
-				mrangeOpt = &redis.TSMRevRangeOptions{SelectedLabels: []interface{}{"team"}}
+				mrangeOpt = &redis.TSMRevRangeOptions{SelectedLabels: []any{"team"}}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "ny"}))
-					Expect(result["b"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "sf"}))
+					Expect(result["a"][0].([]any)[0]).To(BeEquivalentTo([]any{"team", "ny"}))
+					Expect(result["b"][0].([]any)[0]).To(BeEquivalentTo([]any{"team", "sf"}))
 				} else {
-					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"team": "ny"}))
-					Expect(result["b"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"team": "sf"}))
+					Expect(result["a"][0]).To(BeEquivalentTo(map[any]any{"team": "ny"}))
+					Expect(result["b"][0]).To(BeEquivalentTo(map[any]any{"team": "sf"}))
 				}
 				// Test FilterBy
 				fts := make([]int, 0)
@@ -1146,54 +1146,54 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1].([]interface{})).To(ConsistOf([]interface{}{int64(16), "2"}, []interface{}{int64(15), "1"}))
+					Expect(result["a"][1].([]any)).To(ConsistOf([]any{int64(16), "2"}, []any{int64(15), "1"}))
 				} else {
-					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(16), 2.0}, []interface{}{int64(15), 1.0}}))
+					Expect(result["a"][2]).To(BeEquivalentTo([]any{[]any{int64(16), 2.0}, []any{int64(15), 1.0}}))
 				}
 				// Test GroupBy
 				mrangeOpt = &redis.TSMRevRangeOptions{GroupByLabel: "Test", Reducer: "sum"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "6"}, []interface{}{int64(2), "4"}, []interface{}{int64(1), "2"}, []interface{}{int64(0), "0"}}))
+					Expect(result["Test=This"][1]).To(BeEquivalentTo([]any{[]any{int64(3), "6"}, []any{int64(2), "4"}, []any{int64(1), "2"}, []any{int64(0), "0"}}))
 				} else {
-					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), 6.0}, []interface{}{int64(2), 4.0}, []interface{}{int64(1), 2.0}, []interface{}{int64(0), 0.0}}))
+					Expect(result["Test=This"][3]).To(BeEquivalentTo([]any{[]any{int64(3), 6.0}, []any{int64(2), 4.0}, []any{int64(1), 2.0}, []any{int64(0), 0.0}}))
 				}
 				mrangeOpt = &redis.TSMRevRangeOptions{GroupByLabel: "Test", Reducer: "max"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "3"}, []interface{}{int64(2), "2"}, []interface{}{int64(1), "1"}, []interface{}{int64(0), "0"}}))
+					Expect(result["Test=This"][1]).To(BeEquivalentTo([]any{[]any{int64(3), "3"}, []any{int64(2), "2"}, []any{int64(1), "1"}, []any{int64(0), "0"}}))
 				} else {
-					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), 3.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(0), 0.0}}))
+					Expect(result["Test=This"][3]).To(BeEquivalentTo([]any{[]any{int64(3), 3.0}, []any{int64(2), 2.0}, []any{int64(1), 1.0}, []any{int64(0), 0.0}}))
 				}
 				mrangeOpt = &redis.TSMRevRangeOptions{GroupByLabel: "team", Reducer: "min"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
 				if client.Options().Protocol == 2 {
-					Expect(result["team=ny"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "3"}, []interface{}{int64(2), "2"}, []interface{}{int64(1), "1"}, []interface{}{int64(0), "0"}}))
-					Expect(result["team=sf"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "3"}, []interface{}{int64(2), "2"}, []interface{}{int64(1), "1"}, []interface{}{int64(0), "0"}}))
+					Expect(result["team=ny"][1]).To(BeEquivalentTo([]any{[]any{int64(3), "3"}, []any{int64(2), "2"}, []any{int64(1), "1"}, []any{int64(0), "0"}}))
+					Expect(result["team=sf"][1]).To(BeEquivalentTo([]any{[]any{int64(3), "3"}, []any{int64(2), "2"}, []any{int64(1), "1"}, []any{int64(0), "0"}}))
 				} else {
-					Expect(result["team=ny"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), 3.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(0), 0.0}}))
-					Expect(result["team=sf"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), 3.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(0), 0.0}}))
+					Expect(result["team=ny"][3]).To(BeEquivalentTo([]any{[]any{int64(3), 3.0}, []any{int64(2), 2.0}, []any{int64(1), 1.0}, []any{int64(0), 0.0}}))
+					Expect(result["team=sf"][3]).To(BeEquivalentTo([]any{[]any{int64(3), 3.0}, []any{int64(2), 2.0}, []any{int64(1), 1.0}, []any{int64(0), 0.0}}))
 				}
 				// Test Align
 				mrangeOpt = &redis.TSMRevRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: "-"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), "1"}, []interface{}{int64(0), "10"}}))
+					Expect(result["a"][1]).To(BeEquivalentTo([]any{[]any{int64(10), "1"}, []any{int64(0), "10"}}))
 				} else {
-					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), 1.0}, []interface{}{int64(0), 10.0}}))
+					Expect(result["a"][2]).To(BeEquivalentTo([]any{[]any{int64(10), 1.0}, []any{int64(0), 10.0}}))
 				}
 				mrangeOpt = &redis.TSMRevRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: 1}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(1), "10"}, []interface{}{int64(0), "1"}}))
+					Expect(result["a"][1]).To(BeEquivalentTo([]any{[]any{int64(1), "10"}, []any{int64(0), "1"}}))
 				} else {
-					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(1), 10.0}, []interface{}{int64(0), 1.0}}))
+					Expect(result["a"][2]).To(BeEquivalentTo([]any{[]any{int64(1), 10.0}, []any{int64(0), 1.0}}))
 				}
 			})
 
@@ -1242,11 +1242,11 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err := client.TSMRevRangeWithArgs(ctx, 0, 10, []string{"is_compaction=true"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				if client.Options().Protocol == 2 {
-					Expect(result["b"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), "8"}, []interface{}{int64(0), "4"}}))
-					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), "8"}, []interface{}{int64(0), "4"}}))
+					Expect(result["b"][1]).To(BeEquivalentTo([]any{[]any{int64(10), "8"}, []any{int64(0), "4"}}))
+					Expect(result["d"][1]).To(BeEquivalentTo([]any{[]any{int64(10), "8"}, []any{int64(0), "4"}}))
 				} else {
-					Expect(result["b"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), 8.0}, []interface{}{int64(0), 4.0}}))
-					Expect(result["d"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), 8.0}, []interface{}{int64(0), 4.0}}))
+					Expect(result["b"][2]).To(BeEquivalentTo([]any{[]any{int64(10), 8.0}, []any{int64(0), 4.0}}))
+					Expect(result["d"][2]).To(BeEquivalentTo([]any{[]any{int64(10), 8.0}, []any{int64(0), 4.0}}))
 				}
 			})
 		})

--- a/tx.go
+++ b/tx.go
@@ -76,7 +76,7 @@ func (c *Tx) Close(ctx context.Context) error {
 // Watch marks the keys to be watched for conditional execution
 // of a transaction.
 func (c *Tx) Watch(ctx context.Context, keys ...string) *StatusCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "watch"
 	for i, key := range keys {
 		args[1+i] = key
@@ -88,7 +88,7 @@ func (c *Tx) Watch(ctx context.Context, keys ...string) *StatusCmd {
 
 // Unwatch flushes all the previously watched keys for a transaction.
 func (c *Tx) Unwatch(ctx context.Context, keys ...string) *StatusCmd {
-	args := make([]interface{}, 1+len(keys))
+	args := make([]any, 1+len(keys))
 	args[0] = "unwatch"
 	for i, key := range keys {
 		args[1+i] = key

--- a/universal.go
+++ b/universal.go
@@ -308,7 +308,7 @@ type UniversalClient interface {
 	Cmdable
 	AddHook(Hook)
 	Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error
-	Do(ctx context.Context, args ...interface{}) *Cmd
+	Do(ctx context.Context, args ...any) *Cmd
 	Process(ctx context.Context, cmd Cmder) error
 	Subscribe(ctx context.Context, channels ...string) *PubSub
 	PSubscribe(ctx context.Context, channels ...string) *PubSub

--- a/universal_test.go
+++ b/universal_test.go
@@ -82,7 +82,7 @@ var _ = Describe("UniversalClient", func() {
 		role, err := roleCmd.Result()
 		Expect(err).NotTo(HaveOccurred())
 
-		roleSlice, ok := role.([]interface{})
+		roleSlice, ok := role.([]any)
 		Expect(ok).To(BeTrue())
 		Expect(roleSlice[0]).To(Equal("slave"))
 

--- a/vectorset_commands.go
+++ b/vectorset_commands.go
@@ -20,7 +20,7 @@ type VectorSetCmdable interface {
 	VRandMember(ctx context.Context, key string) *StringCmd
 	VRandMemberCount(ctx context.Context, key string, count int) *StringSliceCmd
 	VRem(ctx context.Context, key, element string) *BoolCmd
-	VSetAttr(ctx context.Context, key, element string, attr interface{}) *BoolCmd
+	VSetAttr(ctx context.Context, key, element string, attr any) *BoolCmd
 	VClearAttributes(ctx context.Context, key, element string) *BoolCmd
 	VSim(ctx context.Context, key string, val Vector) *StringSliceCmd
 	VSimWithScores(ctx context.Context, key string, val Vector) *VectorScoreSliceCmd
@@ -235,7 +235,7 @@ func (c cmdable) VRem(ctx context.Context, key, element string) *BoolCmd {
 // the argument is a string or []byte when we assume that it can be passed directly as JSON.
 //
 // note: the API is experimental and may be subject to change.
-func (c cmdable) VSetAttr(ctx context.Context, key, element string, attr interface{}) *BoolCmd {
+func (c cmdable) VSetAttr(ctx context.Context, key, element string, attr any) *BoolCmd {
 	var attrStr string
 	var err error
 	switch v := attr.(type) {


### PR DESCRIPTION
Refactored all instances of interface{} to use the Go 1.18+ alias any for improved readability and modern Go style. This change affects function signatures, type declarations, and variable initializations across all command, adapter, and utility files.