### PR TITLE
Remove metrics with empty data

### DIFF
--- a/extra/redisotel/metrics.go
+++ b/extra/redisotel/metrics.go
@@ -329,7 +329,10 @@ func milliseconds(d time.Duration) float64 {
 }
 
 func statusAttr(err error) attribute.KeyValue {
-	if err != nil && err != redis.Nil {
+	if err != nil {
+		if  err == redis.Nil {
+			return attribute.String("status", "nil")
+		}
 		return attribute.String("status", "error")
 	}
 	return attribute.String("status", "ok")


### PR DESCRIPTION
Because empty data cannot be considered an error.