### PR TITLE
ReportResult should be given the result if it is a success

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -270,10 +270,10 @@ func (c *baseClient) getConn(ctx context.Context) (*pool.Conn, error) {
 	}
 
 	cn, err := c._getConn(ctx)
+	if c.opt.Limiter != nil {
+		c.opt.Limiter.ReportResult(err)
+	}
 	if err != nil {
-		if c.opt.Limiter != nil {
-			c.opt.Limiter.ReportResult(err)
-		}
 		return nil, err
 	}
 
@@ -329,6 +329,7 @@ func (c *baseClient) reAuthConnection() func(poolCn *pool.Conn, credentials auth
 		return err
 	}
 }
+
 func (c *baseClient) onAuthenticationErr() func(poolCn *pool.Conn, err error) {
 	return func(poolCn *pool.Conn, err error) {
 		if err != nil {


### PR DESCRIPTION
according to the Limiter [interface](https://github.com/redis/go-redis/blob/master/options.go#L25), successes will be given to ReportResult as err == nil.

In [releaseConn](https://github.com/redis/go-redis/blob/master/redis.go#L626) it's given the err regardless of nil or non nil - expected
But with [getConn](https://github.com/redis/go-redis/blob/master/redis.go#L273), it is only given err if `err != nil` - not expected, this means we don't get success

I don't think this should be the behaviour because right before `getConn` is called, there's an `Allow()` call. I can't speak for everyone's use-case, but I'm setting `Allow()` to return `true`, and looking for a success call next - and this usually works - but sometimes the code gets stuck, and I think it's because in the case where `Allow()` returns true for a `_getConn`, if this function succeeds, `ReportResult` is not given the success