### PR TITLE
Add retry mechanism for NOREPLICAS error

### DIFF
--- a/error.go
+++ b/error.go
@@ -124,6 +124,9 @@ func shouldRetry(err error, retryTimeout bool) bool {
 	if proto.IsTryAgainError(err) {
 		return true
 	}
+	if proto.IsNoReplicasError(err) {
+		return true
+	}
 
 	// Fallback to string checking for backward compatibility with plain errors
 	s := err.Error()
@@ -143,6 +146,9 @@ func shouldRetry(err error, retryTimeout bool) bool {
 		return true
 	}
 	if strings.HasPrefix(s, "MASTERDOWN ") {
+		return true
+	}
+	if strings.HasPrefix(s, "NOREPLICAS ") {
 		return true
 	}
 
@@ -340,6 +346,14 @@ func IsExecAbortError(err error) bool {
 // OOM errors occur when Redis is out of memory.
 func IsOOMError(err error) bool {
 	return proto.IsOOMError(err)
+}
+
+// IsNoReplicasError checks if an error is a Redis NOREPLICAS error, even if wrapped.
+// NOREPLICAS errors occur when not enough replicas acknowledge a write operation.
+// This typically happens with WAIT/WAITAOF commands or CLUSTER SETSLOT with synchronous
+// replication when the required number of replicas cannot confirm the write within the timeout.
+func IsNoReplicasError(err error) bool {
+	return proto.IsNoReplicasError(err)
 }
 
 //------------------------------------------------------------------------------

--- a/error_test.go
+++ b/error_test.go
@@ -45,7 +45,8 @@ var _ = Describe("error", func() {
 			proto.ParseErrorReply([]byte("-READONLY You can't write against a read only replica")):   true,
 			proto.ParseErrorReply([]byte("-CLUSTERDOWN The cluster is down")):                        true,
 			proto.ParseErrorReply([]byte("-TRYAGAIN Command cannot be processed, please try again")): true,
-			proto.ParseErrorReply([]byte("-ERR other")): false,
+			proto.ParseErrorReply([]byte("-NOREPLICAS Not enough good replicas to write")):           true,
+			proto.ParseErrorReply([]byte("-ERR other")):                                              false,
 		}
 
 		for err, expected := range data {

--- a/error_wrapping_test.go
+++ b/error_wrapping_test.go
@@ -239,10 +239,10 @@ func TestErrorWrappingInHookScenario(t *testing.T) {
 // TestShouldRetryWithTypedErrors tests that shouldRetry works with typed errors
 func TestShouldRetryWithTypedErrors(t *testing.T) {
 	tests := []struct {
-		name          string
-		errorMsg      string
-		shouldRetry   bool
-		retryTimeout  bool
+		name         string
+		errorMsg     string
+		shouldRetry  bool
+		retryTimeout bool
 	}{
 		{
 			name:         "LOADING error should retry",
@@ -277,6 +277,12 @@ func TestShouldRetryWithTypedErrors(t *testing.T) {
 		{
 			name:         "Max clients error should retry",
 			errorMsg:     "ERR max number of clients reached",
+			shouldRetry:  true,
+			retryTimeout: false,
+		},
+		{
+			name:         "NOREPLICAS error should retry",
+			errorMsg:     "NOREPLICAS Not enough good replicas to write",
 			shouldRetry:  true,
 			retryTimeout: false,
 		},

--- a/internal/proto/redis_errors_test.go
+++ b/internal/proto/redis_errors_test.go
@@ -9,12 +9,12 @@ import (
 // TestTypedRedisErrors tests that typed Redis errors are created correctly
 func TestTypedRedisErrors(t *testing.T) {
 	tests := []struct {
-		name          string
-		errorMsg      string
-		expectedType  interface{}
-		expectedMsg   string
-		checkFunc     func(error) bool
-		extractAddr   func(error) string
+		name         string
+		errorMsg     string
+		expectedType interface{}
+		expectedMsg  string
+		checkFunc    func(error) bool
+		extractAddr  func(error) string
 	}{
 		{
 			name:         "LOADING error",
@@ -131,6 +131,13 @@ func TestTypedRedisErrors(t *testing.T) {
 			expectedType: &OOMError{},
 			expectedMsg:  "OOM command not allowed when used memory > 'maxmemory'",
 			checkFunc:    IsOOMError,
+		},
+		{
+			name:         "NOREPLICAS error",
+			errorMsg:     "NOREPLICAS Not enough good replicas to write",
+			expectedType: &NoReplicasError{},
+			expectedMsg:  "NOREPLICAS Not enough good replicas to write",
+			checkFunc:    IsNoReplicasError,
 		},
 	}
 
@@ -389,4 +396,3 @@ func TestBackwardCompatibility(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
Whitelist NOREPLICAS as a retryable error, following the same pattern as other transient errors like LOADING, READONLY, CLUSTERDOWN, TRYAGAIN, and MASTERDOWN.
fix #3636 