### PR TITLE
chore(docs): add default to MaxActiveConns

### DIFF
--- a/options.go
+++ b/options.go
@@ -200,6 +200,8 @@ type Options struct {
 	// MaxActiveConns is the maximum number of connections allocated by the pool at a given time.
 	// When zero, there is no limit on the number of connections in the pool.
 	// If the pool is full, the next call to Get() will block until a connection is released.
+	//
+	// default: 0
 	MaxActiveConns int
 
 	// ConnMaxIdleTime is the maximum amount of time a connection may be idle.


### PR DESCRIPTION
I was looking through the docs around connection pools and came across `MaxActiveConns` but it didn't say what the default value should be so I had to go searching around just to be sure. To prevent others from doing the same thing, I added it!