### PR TITLE
fix: prevent non-timeout errors from being treated as timeouts (Fixes #3664)

### DIFF
--- a/error.go
+++ b/error.go
@@ -63,13 +63,13 @@ func isContextError(err error) bool {
 func isTimeoutError(err error) (isTimeout bool, hasTimeoutFlag bool) {
 	// Check for timeoutError interface (works with wrapped errors)
 	var te timeoutError
-	if errors.As(err, &te) {
+	if errors.As(err, &te) && te.Timeout() {
 		return true, te.Timeout()
 	}
 
 	// Check for net.Error specifically (common case for network timeouts)
 	var netErr net.Error
-	if errors.As(err, &netErr) {
+	if errors.As(err, &netErr) && netErr.Timeout() {
 		return true, netErr.Timeout()
 	}
 

--- a/error_test.go
+++ b/error_test.go
@@ -61,7 +61,7 @@ var _ = Describe("error", func() {
 		Expect(redis.ShouldRetry(t1, false)).To(Equal(false))
 
 		t2 := testTimeout{timeout: false}
-		Expect(redis.ShouldRetry(t2, true)).To(Equal(true))
-		Expect(redis.ShouldRetry(t2, false)).To(Equal(true))
+		Expect(redis.ShouldRetry(t2, true)).To(Equal(false))
+		Expect(redis.ShouldRetry(t2, false)).To(Equal(false))
 	})
 })


### PR DESCRIPTION
## Summary
Fixes an architectural bug where isTimeoutError falsely categorized non-timeout network errors (such as net.ErrClosed or custom user HTTP errors) as transient timeouts.

## Problem
Previously, isTimeoutError used errors.As(err, &netErr) to catch any error implementing the net.Error interface. However, because errors like net.ErrClosed implement this interface but return false for .Timeout(), they were incorrectly allowed to pass through the timeout safety checks in shouldRetry.

If a user's Watch transaction function returned one of these non-timeout network errors, shouldRetry mistakenly returned true, causing the client to unnecessarily retry the transaction until it completely exhausted the `MaxRedirects` limit. (as reported in #3664)

## Solution
Refactored isTimeoutError to strictly evaluate the boolean return value of .Timeout() inline.

Added `&& te.Timeout()` and `&& netErr.Timeout()` to the `errors.As` blocks.

This ensures that only actual timeouts are retried, while cleanly aborting the loop for safely closed connections or custom application network errors.

Related Issues:
Fixes #3664