### PR TITLE
chore(docs): fix irrelevant docs links

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -58,7 +58,7 @@ func ExampleParseURL() {
 }
 
 func ExampleNewFailoverClient() {
-	// See http://redis.io/topics/sentinel for instructions how to
+	// See https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel for instructions how to
 	// setup Redis Sentinel.
 	rdb := redis.NewFailoverClient(&redis.FailoverOptions{
 		MasterName:    "master",
@@ -68,7 +68,7 @@ func ExampleNewFailoverClient() {
 }
 
 func ExampleNewClusterClient() {
-	// See http://redis.io/topics/cluster-tutorial for instructions
+	// See https://redis.io/docs/latest/operate/oss_and_stack/management/scaling for instructions
 	// how to setup Redis Cluster.
 	rdb := redis.NewClusterClient(&redis.ClusterOptions{
 		Addrs: []string{":7000", ":7001", ":7002", ":7003", ":7004", ":7005"},

--- a/internal/hashtag/hashtag.go
+++ b/internal/hashtag/hashtag.go
@@ -11,7 +11,7 @@ const slotNumber = 16384
 // CRC16 implementation according to CCITT standards.
 // Copyright 2001-2010 Georges Menie (www.menie.org)
 // Copyright 2013 The Go Authors. All rights reserved.
-// http://redis.io/topics/cluster-spec#appendix-a-crc16-reference-implementation-in-ansi-c
+// https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec#appendix-a-crc16-reference-implementation-in-ansi-c.
 var crc16tab = [256]uint16{
 	0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7,
 	0x8108, 0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef,

--- a/internal/hashtag/hashtag_test.go
+++ b/internal/hashtag/hashtag_test.go
@@ -15,7 +15,7 @@ func TestGinkgoSuite(t *testing.T) {
 }
 
 var _ = Describe("CRC16", func() {
-	// http://redis.io/topics/cluster-spec#keys-distribution-model
+	// https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec#key-distribution-model.
 	It("should calculate CRC16", func() {
 		tests := []struct {
 			s string

--- a/osscluster.go
+++ b/osscluster.go
@@ -1139,7 +1139,7 @@ type ClusterClient struct {
 }
 
 // NewClusterClient returns a Redis Cluster client as described in
-// http://redis.io/topics/cluster-spec.
+// https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec.
 func NewClusterClient(opt *ClusterOptions) *ClusterClient {
 	opt.init()
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -49,7 +49,7 @@ type Pipeliner interface {
 var _ Pipeliner = (*Pipeline)(nil)
 
 // Pipeline implements pipelining as described in
-// http://redis.io/topics/pipelining.
+// https://redis.io/docs/latest/develop/using-commands/pipelining.
 // Please note: it is not safe for concurrent use by multiple goroutines.
 type Pipeline struct {
 	cmdable

--- a/pubsub.go
+++ b/pubsub.go
@@ -15,7 +15,7 @@ import (
 )
 
 // PubSub implements Pub/Sub commands as described in
-// http://redis.io/topics/pubsub. Message receiving is NOT safe
+// https://redis.io/docs/latest/develop/pubsub. Message receiving is NOT safe
 // for concurrent use by multiple goroutines.
 //
 // PubSub automatically reconnects to Redis Server and resubscribes

--- a/tx.go
+++ b/tx.go
@@ -11,7 +11,7 @@ import (
 const TxFailedErr = proto.RedisError("redis: transaction failed")
 
 // Tx implements Redis transactions as described in
-// http://redis.io/topics/transactions. It's NOT safe for concurrent use
+// https://redis.io/docs/latest/develop/using-commands/transactions. It's NOT safe for concurrent use
 // by multiple goroutines, because Exec resets list of watched keys.
 //
 // If you don't need WATCH, use Pipeline instead.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates comment/example links to newer Redis documentation URLs with no functional or behavioral code changes.
> 
> **Overview**
> Updates various inline documentation references (examples and package comments) from legacy `http://redis.io/topics/*` URLs to the current `https://redis.io/docs/latest/...` pages for Sentinel, Cluster, CRC16/cluster spec, pipelining, pubsub, and transactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ae3aba199324e89cb7aad1bf6c49b28ea098cd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->