### PR TITLE
feat: add support for binary UUID encoding in scan

### DIFF
--- a/internal/hscan/structmap.go
+++ b/internal/hscan/structmap.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/redis/go-redis/v9/internal/util"
 )
@@ -107,6 +108,10 @@ func (s StructValue) Scan(key string, value string) error {
 		switch scan := v.Interface().(type) {
 		case Scanner:
 			return scan.ScanRedis(value)
+		case *time.Time:
+			return scan.UnmarshalText(util.StringToBytes(value))
+		case encoding.BinaryUnmarshaler:
+			return scan.UnmarshalBinary(util.StringToBytes(value))
 		case encoding.TextUnmarshaler:
 			return scan.UnmarshalText(util.StringToBytes(value))
 		}


### PR DESCRIPTION
fixes: #3139 

Adds support to read UUID via `encoding.BinaryUnmarshaler`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `hscan` struct field scanning behavior to prefer `encoding.BinaryUnmarshaler` when present, which could affect existing types that implement multiple unmarshal interfaces. Impact is scoped to Redis hash/scan decoding paths but touches core decoding logic.
> 
> **Overview**
> Adds support for scanning Redis hash values into struct fields that implement `encoding.BinaryUnmarshaler`, enabling binary UUID-style decoding during `Scan`/`HGetAll().Scan()`.
> 
> Updates the `hscan` struct scanner dispatch in `internal/hscan/structmap.go` and adds coverage in both `internal/hscan/hscan_test.go` and `commands_test.go` to validate round-tripping a 16-byte ID via binary marshal/unmarshal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 815d7bc65a2194a9aebad9b83a868d03fee1931e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->