### PR TITLE
pubsub: add ClientSetName method to PubSub

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -366,6 +366,25 @@ func (c *PubSub) Ping(ctx context.Context, payload ...string) error {
 	return err
 }
 
+// ClientSetName assigns  a namee to the PubSub connection using  CLIENT SETNAME,
+// The name is visible in CLIENT LIST output and is useful for debugging
+// and identifying connections in a redis instance.
+func (c *PubSub) ClientSetName(ctx context.Context, name string) error {
+	cmd := NewStatusCmd(ctx, "client", "setname", name)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	cn, err := c.conn(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	err = c.writeCmd(ctx, cn, cmd)
+	c.releaseConn(ctx, cn, err, false)
+	return err
+}
+
 // Subscription received after a successful subscription to channel.
 type Subscription struct {
 	// Can be "subscribe", "unsubscribe", "psubscribe" or "punsubscribe".

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -559,6 +559,23 @@ var _ = Describe("PubSub", func() {
 		}
 	})
 
+	It("should ClientSetName on PubSub connection", func() {
+		pubsub := client.Subscribe(ctx, "test-channel")
+		defer pubsub.Close()
+
+		// Wait for subscription to be established
+		_, err := pubsub.Receive(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = pubsub.ClientSetName(ctx, "my-subscriber")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify the name is set via CLIENT LIST
+		clientList, err := client.ClientList(ctx).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clientList).To(ContainSubstring("name=my-subscriber"))
+	})
+
 	It("should ChannelMessage", func() {
 		pubsub := client.Subscribe(ctx, "mychannel")
 		defer pubsub.Close()


### PR DESCRIPTION
Fixes #3708

## What
Adds `ClientSetName(ctx context.Context, name string) error` to `*PubSub`,
allowing callers to label the underlying connection using `CLIENT SETNAME`.

## Why
Currently there is no way to name a PubSub connection, making it
impossible to identify it in `CLIENT LIST` output. This is useful
for debugging environments with many concurrent connections.

## How
Follows the same pattern as `Ping()` — acquires the mutex, gets the
connection, writes the command, releases the connection.

## Known Limitation
If the connection drops and reconnects, the name will be lost and
must be set again by the caller. A future improvement could store
the name in the `PubSub` struct and re-apply it in `resubscribe()`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small, mutex-protected helper that issues `CLIENT SETNAME` and a single integration test; no changes to message handling or reconnect logic.
> 
> **Overview**
> Adds `(*PubSub).ClientSetName(ctx, name)` to label the underlying PubSub connection via Redis `CLIENT SETNAME`, following the existing `Ping()` write/lock/release pattern.
> 
> Adds a new test that subscribes, calls `ClientSetName`, and asserts the name appears in `CLIENT LIST` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20a9ab8681beddcbb8a65e08307b01b4aa917f50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->