### PR TITLE
Typed error for `NOSCRIPT` replies from Redis

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -2,6 +2,8 @@ package redis_test
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -8648,6 +8650,21 @@ var _ = Describe("Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vals).To(BeEmpty())
 		})
+
+		It("propagates NOSCRIPT errors on EVALSHA of an unknown digest", func() {
+			digest := make([]byte, 32)
+			_, err := rand.Read(digest)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = client.EvalSha(
+				ctx,
+				fmt.Sprintf("%x", sha1.Sum(digest)),
+				[]string{},
+				nil,
+			).Result()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(redis.ErrNoScript))
+		})
 	})
 
 	Describe("EvalRO", func() {
@@ -8681,6 +8698,21 @@ var _ = Describe("Commands", func() {
 			).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vals).To(BeEmpty())
+		})
+
+		It("propagates NOSCRIPT errors on EVALSHA_RO of an unknown digest", func() {
+			digest := make([]byte, 32)
+			_, err := rand.Read(digest)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = client.EvalShaRO(
+				ctx,
+				fmt.Sprintf("%x", sha1.Sum(digest)),
+				[]string{},
+				nil,
+			).Result()
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(redis.ErrNoScript))
 		})
 	})
 

--- a/error.go
+++ b/error.go
@@ -28,6 +28,11 @@ var ErrPoolTimeout = pool.ErrPoolTimeout
 // is used on a ClusterClient with keys in different slots.
 var ErrCrossSlot = proto.RedisError("CROSSSLOT Keys in request don't hash to the same slot")
 
+// ErrNoScript is returned when EVALSHA is requested for a script digest that
+// is not available in the script cache. Note that this error text is reproduced
+// literally from that used by Redis.
+var ErrNoScript = proto.RedisError("NOSCRIPT No matching script. Please use EVAL.")
+
 // HasErrorPrefix checks if the err is a Redis error and the message contains a prefix.
 func HasErrorPrefix(err error, prefix string) bool {
 	var rErr Error

--- a/script.go
+++ b/script.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"io"
 )
 
@@ -67,7 +68,7 @@ func (s *Script) EvalShaRO(ctx context.Context, c Scripter, keys []string, args 
 // it is retried using EVAL.
 func (s *Script) Run(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
 	r := s.EvalSha(ctx, c, keys, args...)
-	if HasErrorPrefix(r.Err(), "NOSCRIPT") {
+	if errors.Is(r.Err(), ErrNoScript) {
 		return s.Eval(ctx, c, keys, args...)
 	}
 	return r
@@ -77,7 +78,7 @@ func (s *Script) Run(ctx context.Context, c Scripter, keys []string, args ...int
 // it is retried using EVAL_RO.
 func (s *Script) RunRO(ctx context.Context, c Scripter, keys []string, args ...interface{}) *Cmd {
 	r := s.EvalShaRO(ctx, c, keys, args...)
-	if HasErrorPrefix(r.Err(), "NOSCRIPT") {
+	if errors.Is(r.Err(), ErrNoScript) {
 		return s.EvalRO(ctx, c, keys, args...)
 	}
 	return r

--- a/scripting_commands.go
+++ b/scripting_commands.go
@@ -60,6 +60,11 @@ func (c cmdable) eval(ctx context.Context, name, payload string, keys []string, 
 		cmd.SetFirstKeyPos(3)
 	}
 	_ = c(ctx, cmd)
+	if err := cmd.Err(); err != nil {
+		if HasErrorPrefix(err, "NOSCRIPT") {
+			cmd.SetErr(ErrNoScript)
+		}
+	}
 	return cmd
 }
 


### PR DESCRIPTION
This PR proposes exposing a typed error `ErrNoScript` that indicates a `NOSCRIPT` reply from Redis during script execution.

This allows library consumers who directly use the `EvalSha` API (as opposed to the `*redis.Script` abstraction) to explicitly detect and handle this case, without needing to roll their own error introspection logic:

```go
ctx := ...
rdb := redis.NewClient(...)

r, err := rdb.EvalSha(ctx, sha1, []string{...}).Result()
if errors.Is(err, redis.ErrNoScript) {
    ...
}

...
```

This change also makes the internal implementation of `*redis.Script` less fragile, in that the `EvalSha` and `EvalShaRO` callsites can check for a typed error rather than performing error string prefix matching.

I have added two new unit tests to exercise the behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the error value returned from `EvalSha`/`EvalShaRO` when Redis replies `NOSCRIPT`, which could affect consumers that compare error strings or types. Scope is limited to scripting command error handling plus new tests.
> 
> **Overview**
> Adds a new exported typed error `redis.ErrNoScript` to represent Redis `NOSCRIPT` replies for missing script digests.
> 
> Updates the scripting command path so `EvalSha`/`EvalShaRO` normalize `NOSCRIPT` responses to `ErrNoScript`, and updates `(*Script).Run`/`RunRO` to use `errors.Is` against this typed error instead of string-prefix matching. Adds unit tests asserting `NOSCRIPT` is propagated as `redis.ErrNoScript` for unknown digests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27fd86fe2205201c5e1de5630c95578ad7fde8e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->