### PR TITLE
Optimize for Go 1.24: use slices/maps/clear built-ins 

### DIFF
--- a/command.go
+++ b/command.go
@@ -2218,10 +2218,7 @@ func (cmd *XMessageSliceCmd) Clone() Cmder {
 				ID: msg.ID,
 			}
 			if msg.Values != nil {
-				val[i].Values = make(map[string]interface{}, len(msg.Values))
-				for k, v := range msg.Values {
-					val[i].Values[k] = v
-				}
+				val[i].Values = maps.Clone(msg.Values)
 			}
 		}
 	}

--- a/maintnotifications/e2e/proxy_fault_injector_server.go
+++ b/maintnotifications/e2e/proxy_fault_injector_server.go
@@ -636,14 +636,6 @@ func (s *ProxyFaultInjectorServer) injectNotification(notification string) error
 	return nil
 }
 
-// Helper function for min
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func (s *ProxyFaultInjectorServer) executeFailover(action *actionState) {
 	fmt.Printf("[ProxyFI] Executing failover\n")
 

--- a/options.go
+++ b/options.go
@@ -5,10 +5,11 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"maps"
 	"net"
 	"net/url"
 	"runtime"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -651,11 +652,8 @@ func (o *queryOptions) remaining() []string {
 	if len(o.q) == 0 {
 		return nil
 	}
-	keys := make([]string, 0, len(o.q))
-	for k := range o.q {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+	keys := slices.Collect(maps.Keys(o.q))
+	slices.Sort(keys)
 	return keys
 }
 

--- a/osscluster.go
+++ b/osscluster.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -9,6 +10,7 @@ import (
 	"net"
 	"net/url"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -791,20 +793,6 @@ type clusterSlot struct {
 	nodes []*clusterNode
 }
 
-type clusterSlotSlice []*clusterSlot
-
-func (p clusterSlotSlice) Len() int {
-	return len(p)
-}
-
-func (p clusterSlotSlice) Less(i, j int) bool {
-	return p[i].start < p[j].start
-}
-
-func (p clusterSlotSlice) Swap(i, j int) {
-	p[i], p[j] = p[j], p[i]
-}
-
 type clusterState struct {
 	nodes   *clusterNodes
 	Masters []*clusterNode
@@ -863,7 +851,9 @@ func newClusterState(
 		})
 	}
 
-	sort.Sort(clusterSlotSlice(c.slots))
+	slices.SortFunc(c.slots, func(a, b *clusterSlot) int {
+		return cmp.Compare(a.start, b.start)
+	})
 
 	time.AfterFunc(time.Minute, func() {
 		nodes.GC(c.generation)

--- a/pubsub.go
+++ b/pubsub.go
@@ -284,9 +284,7 @@ func (c *PubSub) Unsubscribe(ctx context.Context, channels ...string) error {
 		}
 	} else {
 		// Unsubscribe from all channels.
-		for channel := range c.channels {
-			delete(c.channels, channel)
-		}
+		clear(c.channels)
 	}
 
 	err := c.subscribe(ctx, "unsubscribe", channels...)
@@ -305,9 +303,7 @@ func (c *PubSub) PUnsubscribe(ctx context.Context, patterns ...string) error {
 		}
 	} else {
 		// Unsubscribe from all patterns.
-		for pattern := range c.patterns {
-			delete(c.patterns, pattern)
-		}
+		clear(c.patterns)
 	}
 
 	err := c.subscribe(ctx, "punsubscribe", patterns...)
@@ -326,9 +322,7 @@ func (c *PubSub) SUnsubscribe(ctx context.Context, channels ...string) error {
 		}
 	} else {
 		// Unsubscribe from all channels.
-		for channel := range c.schannels {
-			delete(c.schannels, channel)
-		}
+		clear(c.schannels)
 	}
 
 	err := c.subscribe(ctx, "sunsubscribe", channels...)

--- a/search_commands.go
+++ b/search_commands.go
@@ -3,6 +3,8 @@ package redis
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"strconv"
 
 	"github.com/redis/go-redis/v9/internal"
@@ -1728,26 +1730,19 @@ func (cmd *FTInfoCmd) Clone() Cmder {
 	}
 	// Clone slices and maps
 	if cmd.val.Attributes != nil {
-		val.Attributes = make([]FTAttribute, len(cmd.val.Attributes))
-		copy(val.Attributes, cmd.val.Attributes)
+		val.Attributes = slices.Clone(cmd.val.Attributes)
 	}
 	if cmd.val.DialectStats != nil {
-		val.DialectStats = make(map[string]int, len(cmd.val.DialectStats))
-		for k, v := range cmd.val.DialectStats {
-			val.DialectStats[k] = v
-		}
+		val.DialectStats = maps.Clone(cmd.val.DialectStats)
 	}
 	if cmd.val.FieldStatistics != nil {
-		val.FieldStatistics = make([]FieldStatistic, len(cmd.val.FieldStatistics))
-		copy(val.FieldStatistics, cmd.val.FieldStatistics)
+		val.FieldStatistics = slices.Clone(cmd.val.FieldStatistics)
 	}
 	if cmd.val.IndexOptions != nil {
-		val.IndexOptions = make([]string, len(cmd.val.IndexOptions))
-		copy(val.IndexOptions, cmd.val.IndexOptions)
+		val.IndexOptions = slices.Clone(cmd.val.IndexOptions)
 	}
 	if cmd.val.IndexDefinition.Prefixes != nil {
-		val.IndexDefinition.Prefixes = make([]string, len(cmd.val.IndexDefinition.Prefixes))
-		copy(val.IndexDefinition.Prefixes, cmd.val.IndexDefinition.Prefixes)
+		val.IndexDefinition.Prefixes = slices.Clone(cmd.val.IndexDefinition.Prefixes)
 	}
 	return &FTInfoCmd{
 		baseCmd: cmd.cloneBaseCmd(),
@@ -1918,8 +1913,7 @@ func (cmd *FTSpellCheckCmd) Clone() Cmder {
 				Term: result.Term,
 			}
 			if result.Suggestions != nil {
-				val[i].Suggestions = make([]SpellCheckSuggestion, len(result.Suggestions))
-				copy(val[i].Suggestions, result.Suggestions)
+				val[i].Suggestions = slices.Clone(result.Suggestions)
 			}
 		}
 	}
@@ -2115,34 +2109,25 @@ func (cmd *FTSearchCmd) Clone() Cmder {
 		}
 		// Clone slices and maps
 		if cmd.options.Filters != nil {
-			options.Filters = make([]FTSearchFilter, len(cmd.options.Filters))
-			copy(options.Filters, cmd.options.Filters)
+			options.Filters = slices.Clone(cmd.options.Filters)
 		}
 		if cmd.options.GeoFilter != nil {
-			options.GeoFilter = make([]FTSearchGeoFilter, len(cmd.options.GeoFilter))
-			copy(options.GeoFilter, cmd.options.GeoFilter)
+			options.GeoFilter = slices.Clone(cmd.options.GeoFilter)
 		}
 		if cmd.options.InKeys != nil {
-			options.InKeys = make([]interface{}, len(cmd.options.InKeys))
-			copy(options.InKeys, cmd.options.InKeys)
+			options.InKeys = slices.Clone(cmd.options.InKeys)
 		}
 		if cmd.options.InFields != nil {
-			options.InFields = make([]interface{}, len(cmd.options.InFields))
-			copy(options.InFields, cmd.options.InFields)
+			options.InFields = slices.Clone(cmd.options.InFields)
 		}
 		if cmd.options.Return != nil {
-			options.Return = make([]FTSearchReturn, len(cmd.options.Return))
-			copy(options.Return, cmd.options.Return)
+			options.Return = slices.Clone(cmd.options.Return)
 		}
 		if cmd.options.SortBy != nil {
-			options.SortBy = make([]FTSearchSortBy, len(cmd.options.SortBy))
-			copy(options.SortBy, cmd.options.SortBy)
+			options.SortBy = slices.Clone(cmd.options.SortBy)
 		}
 		if cmd.options.Params != nil {
-			options.Params = make(map[string]interface{}, len(cmd.options.Params))
-			for k, v := range cmd.options.Params {
-				options.Params[k] = v
-			}
+			options.Params = maps.Clone(cmd.options.Params)
 		}
 	}
 	return &FTSearchCmd{
@@ -2368,8 +2353,7 @@ func (cmd *FTHybridCmd) Clone() Cmder {
 		}
 	}
 	if cmd.val.Warnings != nil {
-		val.Warnings = make([]string, len(cmd.val.Warnings))
-		copy(val.Warnings, cmd.val.Warnings)
+		val.Warnings = slices.Clone(cmd.val.Warnings)
 	}
 
 	var cursorVal *FTHybridCursorResult


### PR DESCRIPTION
- pubsub.go: use clear() to empty maps
- search_commands.go: use slices.Clone() and maps.Clone()
- command.go: use maps.Clone() in XMessageSliceCmd.Clone()
- options.go: use maps.Keys() + slices.Collect() + slices.Sort()
- osscluster.go: use slices.SortFunc() instead of custom sort type
- proxy_fault_injector_server.go: remove custom min() function

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that swaps hand-written clone/sort/map-clear logic for Go stdlib/built-ins; behavior should remain the same but could surface subtle ordering/copy semantics issues in edge cases.
> 
> **Overview**
> Modernizes several internals to use Go 1.21+ helpers: `maps.Clone`/`slices.Clone` for command result cloning (streams/search), `clear()` for PubSub unsubscribe state, and `maps.Keys`+`slices.Sort` / `slices.SortFunc` (with `cmp.Compare`) for deterministic option parsing and cluster slot ordering.
> 
> Also removes a local `min()` helper in the e2e proxy fault injector in favor of the built-in `min`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4de1270b13ff49a229655899cb86dc9068f2741. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->