### PR TITLE
Release automation integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Go
 
 on:
   push:
-    branches: [master, v9, 'v9.*', 'RED-187316*']
+    branches: [master, v9, 'v9.*']
   pull_request:
     branches: [master, v9, v9.7, v9.8, 'ndyakov/**', 'ofekshenawa/**', 'ce/**']
 
@@ -10,6 +10,66 @@ permissions:
   contents: read
 
 jobs:
+
+  benchmark:
+    name: benchmark
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        redis-version:
+          - "8.6.x" # Redis CE 8.6
+          - "8.4.x" # Redis CE 8.4
+          - "8.2.x" # Redis CE 8.2
+          - "8.0.x" # Redis CE 8.0
+        go-version:
+          - "1.24.x"
+          - oldstable
+          - stable
+
+    steps:
+      - name: Set up ${{ matrix.go-version }}
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Test environment
+        env:
+          REDIS_VERSION: ${{ matrix.redis-version }}
+          CLIENT_LIBS_TEST_IMAGE: "redislabs/client-libs-test:${{ matrix.redis-version }}"
+        run: |
+          set -e
+          redis_version_np=$(echo "$REDIS_VERSION" | grep -oP '^\d+.\d+')
+          
+          # Mapping of redis version to redis testing containers
+          declare -A redis_version_mapping=(
+            ["8.6.x"]="custom-21860421418-debian-amd64"
+            ["8.4.x"]="8.4.0"
+            ["8.2.x"]="8.2.1-pre"
+            ["8.0.x"]="8.0.2"
+          )
+          if [[ -v redis_version_mapping[$REDIS_VERSION] ]]; then
+            echo "REDIS_VERSION=${redis_version_np}" >> $GITHUB_ENV
+            echo "REDIS_IMAGE=redis:${{ matrix.redis-version }}" >> $GITHUB_ENV
+            echo "CLIENT_LIBS_TEST_IMAGE=redislabs/client-libs-test:${redis_version_mapping[$REDIS_VERSION]}" >> $GITHUB_ENV
+          else
+            echo "Version not found in the mapping."
+            exit 1
+          fi
+        shell: bash
+      - name: Set up Docker Compose environment with redis ${{ matrix.redis-version }}
+        run: make docker.start
+        shell: bash
+      - name: Benchmark Tests
+        env:
+          RCE_DOCKER: "true"
+          RE_CLUSTER: "false"
+        run: make bench
+        shell: bash
+
   test-redis-ce:
     name: test-redis-ce
     runs-on: ubuntu-latest
@@ -18,8 +78,13 @@ jobs:
         matrix:
           redis-version:
             - "8.6.x" # Redis CE 8.6
+            - "8.4.x" # Redis CE 8.4
+            - "8.2.x" # Redis CE 8.2
+            - "8.0.x" # Redis CE 8.0
           go-version:
             - "1.24.x"
+            - oldstable
+            - stable
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
* Added repository, ref and client-libs-test-image-tag inputs
* Changed redis-version to be not required so unstable builds will use REDIS_VERSION from Makefile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the composite GitHub Action used by CI, which could alter test environment setup and break pipelines if inputs are omitted or image mapping is wrong.
> 
> **Overview**
> Updates the `run-tests` composite GitHub Action to support release/automation use cases by adding optional `repository`, `ref`, and `client-libs-test-image-tag` inputs and performing an explicit `actions/checkout`.
> 
> Makes `redis-version` optional and adjusts the env setup script to only derive `REDIS_VERSION`/`CLIENT_LIBS_TEST_IMAGE` when inputs are provided, allowing callers to override the client-libs test image directly or fall back to the existing version-to-image mapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df865134463e7ab2c4e0a69fd74643b77ba426a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->