### PR TITLE
ring: inline rendezvous hashing and remove external dependency

### DIFF
--- a/example/cluster-mget/go.mod
+++ b/example/cluster-mget/go.mod
@@ -8,6 +8,5 @@ require github.com/redis/go-redis/v9 v9.16.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/example/cluster-mget/go.sum
+++ b/example/cluster-mget/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/example/del-keys-without-ttl/go.mod
+++ b/example/del-keys-without-ttl/go.mod
@@ -11,7 +11,6 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 )

--- a/example/del-keys-without-ttl/go.sum
+++ b/example/del-keys-without-ttl/go.sum
@@ -8,8 +8,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/example/digest-optimistic-locking/go.mod
+++ b/example/digest-optimistic-locking/go.mod
@@ -8,7 +8,6 @@ require github.com/redis/go-redis/v9 v9.18.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/example/digest-optimistic-locking/go.sum
+++ b/example/digest-optimistic-locking/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/example/disable-maintnotifications/go.mod
+++ b/example/disable-maintnotifications/go.mod
@@ -8,6 +8,5 @@ require github.com/redis/go-redis/v9 v9.7.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/example/disable-maintnotifications/go.sum
+++ b/example/disable-maintnotifications/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/example/hll/go.mod
+++ b/example/hll/go.mod
@@ -8,6 +8,5 @@ require github.com/redis/go-redis/v9 v9.18.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/example/hll/go.sum
+++ b/example/hll/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/example/hset-struct/go.mod
+++ b/example/hset-struct/go.mod
@@ -11,6 +11,5 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/example/hset-struct/go.sum
+++ b/example/hset-struct/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/example/lua-scripting/go.mod
+++ b/example/lua-scripting/go.mod
@@ -8,6 +8,5 @@ require github.com/redis/go-redis/v9 v9.18.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/example/lua-scripting/go.sum
+++ b/example/lua-scripting/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/example/maintnotifiations-pubsub/go.mod
+++ b/example/maintnotifiations-pubsub/go.mod
@@ -8,6 +8,5 @@ require github.com/redis/go-redis/v9 v9.11.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/example/maintnotifiations-pubsub/go.sum
+++ b/example/maintnotifiations-pubsub/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/example/otel-metrics/go.mod
+++ b/example/otel-metrics/go.mod
@@ -19,7 +19,6 @@ require (
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/example/otel-metrics/go.sum
+++ b/example/otel-metrics/go.sum
@@ -8,8 +8,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/example/otel/go.mod
+++ b/example/otel/go.mod
@@ -20,7 +20,6 @@ require (
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/example/otel/go.sum
+++ b/example/otel/go.sum
@@ -8,8 +8,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/example/redis-bloom/go.mod
+++ b/example/redis-bloom/go.mod
@@ -8,6 +8,5 @@ require github.com/redis/go-redis/v9 v9.18.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/example/redis-bloom/go.sum
+++ b/example/redis-bloom/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/example/scan-struct/go.mod
+++ b/example/scan-struct/go.mod
@@ -11,6 +11,5 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/example/scan-struct/go.sum
+++ b/example/scan-struct/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/example/tls-cert-auth/go.mod
+++ b/example/tls-cert-auth/go.mod
@@ -8,6 +8,5 @@ require github.com/redis/go-redis/v9 v9.18.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/example/tls-cert-auth/go.sum
+++ b/example/tls-cert-auth/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/example/tls-connection/go.mod
+++ b/example/tls-connection/go.mod
@@ -8,6 +8,5 @@ require github.com/redis/go-redis/v9 v9.18.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/example/tls-connection/go.sum
+++ b/example/tls-connection/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/extra/rediscensus/go.mod
+++ b/extra/rediscensus/go.mod
@@ -14,7 +14,6 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )

--- a/extra/rediscensus/go.sum
+++ b/extra/rediscensus/go.sum
@@ -12,8 +12,6 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/extra/rediscmd/go.mod
+++ b/extra/rediscmd/go.mod
@@ -12,7 +12,6 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 )
 

--- a/extra/rediscmd/go.sum
+++ b/extra/rediscmd/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/extra/redisotel-native/go.mod
+++ b/extra/redisotel-native/go.mod
@@ -13,7 +13,6 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/extra/redisotel-native/go.sum
+++ b/extra/redisotel-native/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/extra/redisotel/go.mod
+++ b/extra/redisotel/go.mod
@@ -17,7 +17,6 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/extra/redisotel/go.sum
+++ b/extra/redisotel/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/extra/redisprometheus/go.mod
+++ b/extra/redisprometheus/go.mod
@@ -12,7 +12,6 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect

--- a/extra/redisprometheus/go.sum
+++ b/extra/redisprometheus/go.sum
@@ -8,8 +8,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,9 @@ require (
 	github.com/bsm/ginkgo/v2 v2.12.0
 	github.com/bsm/gomega v1.27.10
 	github.com/cespare/xxhash/v2 v2.3.0
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f
 	github.com/zeebo/xxh3 v1.1.0
 	go.uber.org/atomic v1.11.0
 )
-
-
 
 require (
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
 github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/hashtag/rendezvous.go
+++ b/internal/hashtag/rendezvous.go
@@ -1,0 +1,54 @@
+package hashtag
+
+import "github.com/cespare/xxhash/v2"
+
+// RendezvousHash implements HRW (Highest Random Weight) hashing.
+type RendezvousHash struct {
+	nodes []node
+}
+
+type node struct {
+	name string
+	hash uint64
+}
+
+// NewRendezvousHash builds a hash from shard names.
+func NewRendezvousHash(shards []string) *RendezvousHash {
+	n := make([]node, len(shards))
+	for i, s := range shards {
+		n[i] = node{
+			name: s,
+			hash: xxhash.Sum64String(s),
+		}
+	}
+	return &RendezvousHash{nodes: n}
+}
+
+// Get returns the shard name for the given key.
+func (r *RendezvousHash) Get(key string) string {
+	if len(r.nodes) == 0 {
+		return ""
+	}
+
+	kh := xxhash.Sum64String(key)
+
+	bestIdx := 0
+	bestScore := mix64(kh ^ r.nodes[0].hash)
+
+	for i := 1; i < len(r.nodes); i++ {
+		if score := mix64(kh ^ r.nodes[i].hash); score > bestScore {
+			bestScore = score
+			bestIdx = i
+		}
+	}
+
+	return r.nodes[bestIdx].name
+}
+
+// mix64 is a xorshift-based mixing function.
+func mix64(x uint64) uint64 {
+	x ^= x >> 12
+	x ^= x << 25
+	x ^= x >> 27
+	return x * 2685821657736338717
+}

--- a/internal/hashtag/rendezvous_test.go
+++ b/internal/hashtag/rendezvous_test.go
@@ -46,28 +46,27 @@ var _ = Describe("RendezvousHash", func() {
 		}
 	})
 
-	It("should handle node ordering consistently (tie-breaker semantics)", func() {
-		// Test that node order doesn't affect determinism
-		nodesA := []string{"node-a", "node-b", "node-c"}
-		nodesB := []string{"node-c", "node-a", "node-b"}
-		nodesC := []string{"node-b", "node-c", "node-a"}
-
-		hA := NewRendezvousHash(nodesA)
-		hB := NewRendezvousHash(nodesB)
-		hC := NewRendezvousHash(nodesC)
+	It("should be consistent within a single instance (per-instance determinism)", func() {
+		// This test verifies per-instance determinism: the same RendezvousHash instance
+		// returns consistent results for the same key across multiple calls.
+		// Note: Node order in the input may affect results due to first-match tie-breaking
+		// when multiple nodes produce equal scores (uses > not >= in score comparison).
+		nodes := []string{"node-a", "node-b", "node-c"}
+		h := NewRendezvousHash(nodes)
 
 		testKeys := []string{"key-1", "key-2", "key-3", "test", "foo", "bar"}
 
 		for _, testKey := range testKeys {
-			resultA := hA.Get(testKey)
-			resultB := hB.Get(testKey)
-			resultC := hC.Get(testKey)
+			// Same instance should consistently return the same node for the same key
+			result1 := h.Get(testKey)
+			result2 := h.Get(testKey)
+			result3 := h.Get(testKey)
 
-			// HRW should map to the same logical node regardless of input order
-			Expect(resultA).To(Equal(resultB),
-				"key %q should map to same node regardless of node order", testKey)
-			Expect(resultB).To(Equal(resultC),
-				"key %q should map to same node regardless of node order", testKey)
+			Expect(result1).To(Equal(result2),
+				"key %q should return same node on repeated calls", testKey)
+			Expect(result2).To(Equal(result3),
+				"key %q should return same node on repeated calls", testKey)
+			Expect(result1).To(BeElementOf(nodes))
 		}
 	})
 
@@ -76,7 +75,7 @@ var _ = Describe("RendezvousHash", func() {
 		h := NewRendezvousHash(nodes)
 
 		distribution := make(map[string]int)
-		numKeys := 1000
+		numKeys := 100000
 
 		for i := 0; i < numKeys; i++ {
 			node := h.Get("key-" + strconv.Itoa(i))
@@ -89,15 +88,17 @@ var _ = Describe("RendezvousHash", func() {
 				"node %q should receive at least one key", node)
 		}
 
-		// Distribution should be reasonably balanced
-		// Each node should get roughly 20% of keys (10% tolerance)
+		// Distribution should be reasonably balanced.
+		// With 100k keys across 5 nodes, we expect roughly 20% per node.
+		// Use a loose 10% tolerance to account for natural statistical variance
+		// while still verifying the hash distributes fairly uniformly.
 		expectedPerNode := float64(numKeys) / float64(len(nodes))
 		tolerance := expectedPerNode * 0.1
 
 		for _, node := range nodes {
 			count := float64(distribution[node])
 			Expect(count).To(BeNumerically("~", expectedPerNode, tolerance),
-				"node %q distribution should be balanced", node)
+				"node %q distribution should be reasonably balanced", node)
 		}
 	})
 

--- a/internal/hashtag/rendezvous_test.go
+++ b/internal/hashtag/rendezvous_test.go
@@ -40,9 +40,12 @@ var _ = Describe("RendezvousHash", func() {
 		}
 
 		// Verify distribution is roughly even (allowing some variance)
+		// With 100 keys and 3 nodes, expect roughly 33 keys per node.
+		// Check that each node receives more than 25 keys to verify fairly even distribution.
 		for _, node := range nodes {
 			count := results[node]
-			Expect(count).To(BeNumerically(">", 0), "node %s should receive at least one key", node)
+			Expect(count).To(BeNumerically(">", 25),
+				"node %s should receive more than 25 keys (got %d)", node, count)
 		}
 	})
 

--- a/internal/hashtag/rendezvous_test.go
+++ b/internal/hashtag/rendezvous_test.go
@@ -2,23 +2,160 @@ package hashtag
 
 import (
 	"strconv"
-	"testing"
+
+	. "github.com/bsm/ginkgo/v2"
+	. "github.com/bsm/gomega"
 )
 
-func TestRendezvous_Empty(t *testing.T) {
-	h := NewRendezvousHash(nil)
+var _ = Describe("RendezvousHash", func() {
+	It("should return empty string for empty nodes", func() {
+		h := NewRendezvousHash(nil)
+		Expect(h.Get("any")).To(Equal(""))
+	})
 
-	if h.Get("any") != "" {
-		t.Fatal("expected empty result")
-	}
-}
+	It("should return the single node for all keys", func() {
+		h := NewRendezvousHash([]string{"only"})
 
-func TestRendezvous_SingleNode(t *testing.T) {
-	h := NewRendezvousHash([]string{"only"})
-
-	for i := 0; i < 100; i++ {
-		if h.Get("key-"+strconv.Itoa(i)) != "only" {
-			t.Fatal("single node should always return itself")
+		for i := 0; i < 100; i++ {
+			Expect(h.Get("key-" + strconv.Itoa(i))).To(Equal("only"))
 		}
-	}
-}
+	})
+
+	It("should be deterministic with multiple nodes", func() {
+		nodes := []string{"node-0", "node-1", "node-2"}
+		h := NewRendezvousHash(nodes)
+
+		// Same key should always map to the same node
+		expected := h.Get("consistent-key")
+		for i := 0; i < 10; i++ {
+			Expect(h.Get("consistent-key")).To(Equal(expected))
+		}
+
+		// Different keys may map to different nodes
+		results := make(map[string]int)
+		for i := 0; i < 100; i++ {
+			node := h.Get("key-" + strconv.Itoa(i))
+			Expect(node).To(BeElementOf(nodes))
+			results[node]++
+		}
+
+		// Verify distribution is roughly even (allowing some variance)
+		for _, node := range nodes {
+			count := results[node]
+			Expect(count).To(BeNumerically(">", 0), "node %s should receive at least one key", node)
+		}
+	})
+
+	It("should handle node ordering consistently (tie-breaker semantics)", func() {
+		// Test that node order doesn't affect determinism
+		nodesA := []string{"node-a", "node-b", "node-c"}
+		nodesB := []string{"node-c", "node-a", "node-b"}
+		nodesC := []string{"node-b", "node-c", "node-a"}
+
+		hA := NewRendezvousHash(nodesA)
+		hB := NewRendezvousHash(nodesB)
+		hC := NewRendezvousHash(nodesC)
+
+		testKeys := []string{"key-1", "key-2", "key-3", "test", "foo", "bar"}
+
+		for _, testKey := range testKeys {
+			resultA := hA.Get(testKey)
+			resultB := hB.Get(testKey)
+			resultC := hC.Get(testKey)
+
+			// HRW should map to the same logical node regardless of input order
+			Expect(resultA).To(Equal(resultB),
+				"key %q should map to same node regardless of node order", testKey)
+			Expect(resultB).To(Equal(resultC),
+				"key %q should map to same node regardless of node order", testKey)
+		}
+	})
+
+	It("should distribute keys across multiple nodes", func() {
+		nodes := []string{"node-0", "node-1", "node-2", "node-3", "node-4"}
+		h := NewRendezvousHash(nodes)
+
+		distribution := make(map[string]int)
+		numKeys := 1000
+
+		for i := 0; i < numKeys; i++ {
+			node := h.Get("key-" + strconv.Itoa(i))
+			distribution[node]++
+		}
+
+		// All nodes should receive some keys
+		for _, node := range nodes {
+			Expect(distribution[node]).To(BeNumerically(">", 0),
+				"node %q should receive at least one key", node)
+		}
+
+		// Distribution should be reasonably balanced
+		// Each node should get roughly 20% of keys (10% tolerance)
+		expectedPerNode := float64(numKeys) / float64(len(nodes))
+		tolerance := expectedPerNode * 0.1
+
+		for _, node := range nodes {
+			count := float64(distribution[node])
+			Expect(count).To(BeNumerically("~", expectedPerNode, tolerance),
+				"node %q distribution should be balanced", node)
+		}
+	})
+
+	It("should handle arbitrary string names as nodes", func() {
+		nodes := []string{
+			"redis-cluster-node-1.example.com:6379",
+			"redis-cluster-node-2.example.com:6379",
+			"redis-cluster-node-3.example.com:6379",
+		}
+		h := NewRendezvousHash(nodes)
+
+		// Verify all keys map to valid nodes
+		for i := 0; i < 50; i++ {
+			result := h.Get("key-" + strconv.Itoa(i))
+			Expect(result).To(BeElementOf(nodes))
+		}
+
+		// Verify consistency
+		key := "test-key"
+		firstResult := h.Get(key)
+		Expect(h.Get(key)).To(Equal(firstResult))
+	})
+
+	It("should be stable when nodes change minimally", func() {
+		// When removing one node, keys should redistribute to other nodes
+		nodes := []string{"node-0", "node-1", "node-2"}
+		h1 := NewRendezvousHash(nodes)
+
+		// Get initial distribution
+		initialMapping := make(map[string]string)
+		for i := 0; i < 100; i++ {
+			key := "key-" + strconv.Itoa(i)
+			initialMapping[key] = h1.Get(key)
+		}
+
+		// Remove one node
+		nodesReduced := []string{"node-0", "node-1"}
+		h2 := NewRendezvousHash(nodesReduced)
+
+		// Keys should still map to valid nodes
+		moved := 0
+		stayed := 0
+
+		for i := 0; i < 100; i++ {
+			key := "key-" + strconv.Itoa(i)
+			newNode := h2.Get(key)
+
+			Expect(newNode).To(BeElementOf(nodesReduced))
+
+			if newNode != initialMapping[key] {
+				moved++
+			} else {
+				stayed++
+			}
+		}
+
+		// Some keys should stay, some should move to other available nodes
+		Expect(moved).To(BeNumerically(">", 0), "some keys should move when node is removed")
+		Expect(stayed).To(BeNumerically(">", 0), "some keys should stay with same node")
+	})
+})

--- a/internal/hashtag/rendezvous_test.go
+++ b/internal/hashtag/rendezvous_test.go
@@ -5,10 +5,6 @@ import (
 	"testing"
 )
 
-func randomString(i int) string {
-	return "key-" + strconv.Itoa(i)
-}
-
 func TestRendezvous_Empty(t *testing.T) {
 	h := NewRendezvousHash(nil)
 
@@ -21,7 +17,7 @@ func TestRendezvous_SingleNode(t *testing.T) {
 	h := NewRendezvousHash([]string{"only"})
 
 	for i := 0; i < 100; i++ {
-		if h.Get(randomString(i)) != "only" {
+		if h.Get("key-"+strconv.Itoa(i)) != "only" {
 			t.Fatal("single node should always return itself")
 		}
 	}

--- a/internal/hashtag/rendezvous_test.go
+++ b/internal/hashtag/rendezvous_test.go
@@ -1,0 +1,28 @@
+package hashtag
+
+import (
+	"strconv"
+	"testing"
+)
+
+func randomString(i int) string {
+	return "key-" + strconv.Itoa(i)
+}
+
+func TestRendezvous_Empty(t *testing.T) {
+	h := NewRendezvousHash(nil)
+
+	if h.Get("any") != "" {
+		t.Fatal("expected empty result")
+	}
+}
+
+func TestRendezvous_SingleNode(t *testing.T) {
+	h := NewRendezvousHash([]string{"only"})
+
+	for i := 0; i < 100; i++ {
+		if h.Get(randomString(i)) != "only" {
+			t.Fatal("single node should always return itself")
+		}
+	}
+}

--- a/ring.go
+++ b/ring.go
@@ -11,8 +11,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cespare/xxhash/v2"
-	"github.com/dgryski/go-rendezvous" //nolint
 	"github.com/redis/go-redis/v9/auth"
 
 	"github.com/redis/go-redis/v9/internal"
@@ -36,16 +34,8 @@ type ConsistentHash interface {
 	Get(string) string
 }
 
-type rendezvousWrapper struct {
-	*rendezvous.Rendezvous
-}
-
-func (w rendezvousWrapper) Get(key string) string {
-	return w.Lookup(key)
-}
-
 func newRendezvous(shards []string) ConsistentHash {
-	return rendezvousWrapper{rendezvous.New(shards, xxhash.Sum64String)}
+	return hashtag.NewRendezvousHash(shards)
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
## Why not keep the dependency?

The original implementation is small (~50 LOC) and stable. Inlining it:
- avoids pulling an extra dependency into go-redis
- removes license management overhead
- keeps behavior fully deterministic and test-covered

Additionally, avoiding a single-purpose dependency helps keep the
dependency graph minimal and easier to maintain.

## Changes

- Inline a minimal rendezvous hashing implementation
- Remove dependency on github.com/dgryski/go-rendezvous
- Keep algorithm identical to upstream:
  - same hash combination (khash ^ nodehash)
  - same xorshift* mixing function
  - same iteration/order semantics

## Compatibility

No behavior changes are intended.

## Notes

The implementation is intentionally minimal and mirrors the original
algorithm to ensure deterministic behavior.

## Checklist

- [x] No public API changes
- [x] No behavior changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the ring sharding hash implementation and removes an external dependency; any subtle mismatch could alter key-to-shard mapping and affect routing in `Ring` deployments.
> 
> **Overview**
> Replaces the `Ring` consistent-hash implementation with an in-repo rendezvous (HRW) hash (`internal/hashtag/RendezvousHash`) and updates `ring.go` to use it instead of `github.com/dgryski/go-rendezvous`.
> 
> Removes the `go-rendezvous` dependency from the root module plus all `example/*` and `extra/*` modules, and adds a new test suite (`internal/hashtag/rendezvous_test.go`) to validate determinism, distribution, and basic stability characteristics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08832cc9a32f8e3899bb6a4a89e44fd49f7088db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->