### PR TITLE
fix(pool): two fixes for closed connection handling

### DIFF
--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -14,6 +14,7 @@ import (
 	"github.com/redis/go-redis/v9/internal"
 	"github.com/redis/go-redis/v9/internal/maintnotifications/logs"
 	"github.com/redis/go-redis/v9/internal/proto"
+	uberatomic "go.uber.org/atomic"
 )
 
 var noDeadline = time.Time{}
@@ -109,7 +110,7 @@ type Conn struct {
 	// When a goroutine closes a connection, it usually knows the reason, so closeReason is not needed.
 	// closeReason is only used when an in-use connection is closed by another goroutine,
 	// to inform the goroutine using the connection why the connection was closed.
-	closeReason string
+	closeReason uberatomic.String
 
 	// maintenanceNotifications upgrade support: relaxed timeouts during migrations/failovers
 

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -926,7 +926,7 @@ func (cn *Conn) IsClosed() bool {
 }
 
 func (cn *Conn) Close() error {
-	if cn.stateMachine.GetState() == StateClosed {
+	if cn.IsClosed() {
 		return nil
 	}
 	// Transition to CLOSED state
@@ -935,6 +935,7 @@ func (cn *Conn) Close() error {
 	if cn.onClose != nil {
 		// ignore error
 		_ = cn.onClose()
+		cn.onClose = nil
 	}
 
 	// Lock-free netConn access for better performance

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -106,6 +106,11 @@ type Conn struct {
 	expiresAt time.Time
 	poolName  string // Name of the pool this connection belongs to (for metrics)
 
+	// When a goroutine closes a connection, it usually knows the reason, so closeReason is not needed.
+	// closeReason is only used when an in-use connection is closed by another goroutine,
+	// to inform the goroutine using the connection why the connection was closed.
+	closeReason string
+
 	// maintenanceNotifications upgrade support: relaxed timeouts during migrations/failovers
 
 	// Using atomic operations for lock-free access to avoid mutex contention
@@ -920,6 +925,9 @@ func (cn *Conn) IsClosed() bool {
 }
 
 func (cn *Conn) Close() error {
+	if cn.stateMachine.GetState() == StateClosed {
+		return nil
+	}
 	// Transition to CLOSED state
 	cn.stateMachine.Transition(StateClosed)
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1345,6 +1345,19 @@ func (p *ConnPool) putConn(ctx context.Context, cn *Conn, freeTurn bool) {
 		}
 	} else {
 		shouldCloseConn = true
+		removedFromPool = p.removeConnWithLock(cn)
+
+		// Only emit if we actually removed it from the map (not already taken by Close()).
+		if removedFromPool {
+			// Notify metrics: connection removed (used -> nothing)
+			if cb := getMetricConnectionStateChangeCallback(); cb != nil {
+				cb(ctx, cn, MetricStateUsed, "")
+			}
+			// Record connection count decrement (connection removed while in used state)
+			if cb := getMetricConnectionCountCallback(); cb != nil {
+				cb(ctx, -1, cn, "used", false)
+			}
+		}
 	}
 
 	if freeTurn {
@@ -1365,6 +1378,8 @@ func (p *ConnPool) putConn(ctx context.Context, cn *Conn, freeTurn bool) {
 		}
 		_ = p.closeConn(cn)
 	}
+
+	cn.SetLastPutAtNs(getCachedTimeNs())
 }
 
 func (p *ConnPool) Remove(ctx context.Context, cn *Conn, reason error) {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -30,6 +30,9 @@ const (
 
 	// CloseReasonTest is used in tests when closing connections.
 	CloseReasonTest = "test"
+
+	// CloseReasonFailover indicates the connection was closed due to a failover event.
+	CloseReasonFailover = "failover"
 )
 
 // Metric state constants for connection state tracking.
@@ -1366,7 +1369,11 @@ func (p *ConnPool) putConn(ctx context.Context, cn *Conn, freeTurn bool) {
 		// If removedFromPool is false, Close() already emitted connectionClosed for this conn.
 		if removedFromPool {
 			if cb := getMetricConnectionClosedCallback(); cb != nil {
-				cb(ctx, cn, "conn_pool_close", nil)
+				reason := "conn_pool_close"
+				if cn.closeReason != "" {
+					reason = cn.closeReason
+				}
+				cb(ctx, cn, reason, nil)
 			}
 		}
 		_ = p.closeConn(cn)
@@ -1444,27 +1451,29 @@ func (p *ConnPool) CloseConn(ctx context.Context, cn *Conn, reason string, fromS
 
 	// Only emit UpDownCounter decrements if we actually removed the connection.
 	// If removed is false, Close() already removed it and emitted the -1 delta.
-	if removed {
-		// Record connection state change: connection is being removed from the specified state
-		if cb := getMetricConnectionStateChangeCallback(); cb != nil && fromState != "" {
-			cb(ctx, cn, fromState, "")
-		}
-
-		// Record connection count decrement (UpDownCounter) for the state the connection was in
-		if cb := getMetricConnectionCountCallback(); cb != nil && fromState != "" {
-			cb(ctx, -1, cn, fromState, false)
-		}
-	}
-
 	// Only emit connection closed if we actually owned the removal.
 	// If removed is false, Close() already emitted connectionClosed for this conn.
 	if removed {
-		if cb := getMetricConnectionClosedCallback(); cb != nil {
-			cb(ctx, cn, reason, nil)
-		}
+		p.recordConectionMetrics(ctx, cn, reason, fromState)
 	}
 
 	return p.closeConn(cn)
+}
+
+func (p *ConnPool) recordConectionMetrics(ctx context.Context, cn *Conn, reason string, fromState string) {
+	// Record connection state change: connection is being removed from the specified state
+	if cb := getMetricConnectionStateChangeCallback(); cb != nil && fromState != "" {
+		cb(ctx, cn, fromState, "")
+	}
+
+	// Record connection count decrement (UpDownCounter) for the state the connection was in
+	if cb := getMetricConnectionCountCallback(); cb != nil && fromState != "" {
+		cb(ctx, -1, cn, fromState, false)
+	}
+
+	if cb := getMetricConnectionClosedCallback(); cb != nil {
+		cb(ctx, cn, reason, nil)
+	}
 }
 
 // removeConnWithLock removes a connection from the pool under the connsMu lock.
@@ -1552,13 +1561,33 @@ func (p *ConnPool) closed() bool {
 }
 
 func (p *ConnPool) Filter(fn func(*Conn) bool) error {
+	ctx := context.Background()
+
 	p.connsMu.Lock()
 	defer p.connsMu.Unlock()
+
+	idleConnSet := make(map[*Conn]struct{}, len(p.idleConns))
+	for _, ic := range p.idleConns {
+		idleConnSet[ic] = struct{}{}
+	}
 
 	var firstErr error
 	for _, cn := range p.conns {
 		if fn(cn) {
-			if err := p.closeConn(cn); err != nil && firstErr == nil {
+			var err error
+			if _, isIdle := idleConnSet[cn]; isIdle {
+				// Idle connection - remove from pool and close.
+				p.removeConn(cn)
+				p.recordConectionMetrics(ctx, cn, CloseReasonFailover, MetricStateIdle)
+				err = p.closeConn(cn)
+			} else {
+				// Used connection - set closeReason and close the connection.
+				// The connection remains in p.conns. When putConn() is called later,
+				// it will close the connection instead of pooling it.
+				cn.closeReason = CloseReasonFailover
+				err = cn.Close()
+			}
+			if err != nil && firstErr == nil {
 				firstErr = err
 			}
 		}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1345,19 +1345,6 @@ func (p *ConnPool) putConn(ctx context.Context, cn *Conn, freeTurn bool) {
 		}
 	} else {
 		shouldCloseConn = true
-		removedFromPool = p.removeConnWithLock(cn)
-
-		// Only emit if we actually removed it from the map (not already taken by Close()).
-		if removedFromPool {
-			// Notify metrics: connection removed (used -> nothing)
-			if cb := getMetricConnectionStateChangeCallback(); cb != nil {
-				cb(ctx, cn, MetricStateUsed, "")
-			}
-			// Record connection count decrement (connection removed while in used state)
-			if cb := getMetricConnectionCountCallback(); cb != nil {
-				cb(ctx, -1, cn, "used", false)
-			}
-		}
 	}
 
 	if freeTurn {
@@ -1378,8 +1365,6 @@ func (p *ConnPool) putConn(ctx context.Context, cn *Conn, freeTurn bool) {
 		}
 		_ = p.closeConn(cn)
 	}
-
-	cn.SetLastPutAtNs(getCachedTimeNs())
 }
 
 func (p *ConnPool) Remove(ctx context.Context, cn *Conn, reason error) {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1454,13 +1454,13 @@ func (p *ConnPool) CloseConn(ctx context.Context, cn *Conn, reason string, fromS
 	// Only emit connection closed if we actually owned the removal.
 	// If removed is false, Close() already emitted connectionClosed for this conn.
 	if removed {
-		p.recordConectionMetrics(ctx, cn, reason, fromState)
+		p.recordConnectionMetrics(ctx, cn, reason, fromState)
 	}
 
 	return p.closeConn(cn)
 }
 
-func (p *ConnPool) recordConectionMetrics(ctx context.Context, cn *Conn, reason string, fromState string) {
+func (p *ConnPool) recordConnectionMetrics(ctx context.Context, cn *Conn, reason string, fromState string) {
 	// Record connection state change: connection is being removed from the specified state
 	if cb := getMetricConnectionStateChangeCallback(); cb != nil && fromState != "" {
 		cb(ctx, cn, fromState, "")
@@ -1578,7 +1578,7 @@ func (p *ConnPool) Filter(fn func(*Conn) bool) error {
 			if _, isIdle := idleConnSet[cn]; isIdle {
 				// Idle connection - remove from pool and close.
 				p.removeConn(cn)
-				p.recordConectionMetrics(ctx, cn, CloseReasonFailover, MetricStateIdle)
+				p.recordConnectionMetrics(ctx, cn, CloseReasonFailover, MetricStateIdle)
 				err = p.closeConn(cn)
 			} else {
 				// Used connection - set closeReason and close the connection.

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1357,8 +1357,8 @@ func (p *ConnPool) putConn(ctx context.Context, cn *Conn, freeTurn bool) {
 		if removedFromPool {
 			if cb := getMetricConnectionClosedCallback(); cb != nil {
 				reason := "conn_pool_close"
-				if cn.closeReason != "" {
-					reason = cn.closeReason
+				if r := cn.closeReason.Load(); r != "" {
+					reason = r
 				}
 				cb(ctx, cn, reason, nil)
 			}
@@ -1569,7 +1569,7 @@ func (p *ConnPool) Filter(fn func(*Conn) bool) error {
 				// Used connection - set closeReason and close the connection.
 				// The connection remains in p.conns. When putConn() is called later,
 				// it will close the connection instead of pooling it.
-				cn.closeReason = CloseReasonFailover
+				cn.closeReason.Store(CloseReasonFailover)
 				err = cn.Close()
 			}
 			if err != nil && firstErr == nil {

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -692,7 +693,7 @@ func compareSlices(t *testing.T, a, b []string, name string) {
 	}
 }
 
-var _ = Describe("Sentinel Failover with Idle Conns", func() {
+var _ = Describe("Sentinel Failover with Conns", Serial, func() {
 	testFailoverWithMaxActiveConns := func(maxActiveConns int) {
 		var client *redis.Client
 		var sentinel *redis.SentinelClient
@@ -704,7 +705,8 @@ var _ = Describe("Sentinel Failover with Idle Conns", func() {
 			// Set up metric callback to count CloseReasonFailover
 			pool.SetAllMetricCallbacks(&pool.MetricCallbacks{
 				ConnectionClosed: func(ctx context.Context, cn *pool.Conn, reason string, err error) {
-					if reason == "failover" {
+					fmt.Println("call ConnectionClosed metric callback with reason:", reason)
+					if reason == pool.CloseReasonFailover {
 						failoverCloseCount++
 					}
 				},
@@ -745,32 +747,38 @@ var _ = Describe("Sentinel Failover with Idle Conns", func() {
 		})
 
 		It(fmt.Sprintf("should handle failover with MaxActiveConns=%d", maxActiveConns), func() {
-			err := client.Set(ctx, "key", "100", 0).Err()
+			err := client.Set(ctx, "failover", "100", 0).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			// Sleep 1 second for replication
-			time.Sleep(1 * time.Second)
+			// Sleep 2 second for replication
+			time.Sleep(2 * time.Second)
 
 			// Trigger failover
 			err = sentinel.Failover(ctx, sentinelName).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			// Wait for failover to complete
-			time.Sleep(3 * time.Second)
+			for range 120 {
+				masterInfo, _ := sentinel.Master(ctx, sentinelName).Result()
+				if !strings.Contains(masterInfo["flags"], "failover") {
+					fmt.Println("Failover successful, new master:", masterInfo["ip"]+":"+masterInfo["port"])
+					break
+				}
+				time.Sleep(500 * time.Millisecond)
+			}
 
 			multi, err := client.Do(ctx, "MULTI").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(multi).To(Equal("OK"))
 
-			incr, err := client.Do(ctx, "INCR", "key").Result()
+			incr, err := client.Do(ctx, "INCR", "failover").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(incr).To(Equal("QUEUED"))
 
 			execResult, err := client.Do(ctx, "EXEC").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(execResult).To(Equal([]interface{}{int64(101)}))
-			// Verify CloseReasonFailover was counted exactly once
-			Expect(failoverCloseCount).To(Equal(1), "Expected exactly 1 CloseReasonFailover metric, got %d", failoverCloseCount)
+			Expect(execResult).To(Equal([]any{int64(101)}))
+			Expect(failoverCloseCount).To(Equal(1),
+				"Expected exactly 1 CloseReasonFailover metric, got %d", failoverCloseCount)
 		})
 	}
 

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net"
 	"slices"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"
 	"github.com/redis/go-redis/v9"
+	"github.com/redis/go-redis/v9/internal/pool"
 )
 
 var _ = Describe("Sentinel PROTO 2", func() {
@@ -689,3 +691,98 @@ func compareSlices(t *testing.T, a, b []string, name string) {
 		}
 	}
 }
+
+var _ = Describe("Sentinel Failover with Idle Conns", func() {
+	testFailoverWithMaxActiveConns := func(maxActiveConns int) {
+		var client *redis.Client
+		var sentinel *redis.SentinelClient
+		var failoverCloseCount int
+
+		BeforeEach(func() {
+			failoverCloseCount = 0
+
+			// Set up metric callback to count CloseReasonFailover
+			pool.SetAllMetricCallbacks(&pool.MetricCallbacks{
+				ConnectionClosed: func(ctx context.Context, cn *pool.Conn, reason string, err error) {
+					if reason == "failover" {
+						failoverCloseCount++
+					}
+				},
+			})
+
+			client = redis.NewFailoverClient(&redis.FailoverOptions{
+				MasterName:      sentinelName,
+				SentinelAddrs:   sentinelAddrs,
+				PoolSize:        1,
+				DisableIdentity: true,
+				MaxActiveConns:  maxActiveConns,
+				ReplicaOnly:     false,
+				MaxRetries:      -1,
+			})
+			Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+
+			sentinel = redis.NewSentinelClient(&redis.Options{
+				Addr:       ":" + sentinelPort1,
+				MaxRetries: -1,
+			})
+
+			// Wait until slaves are picked up by sentinel.
+			Eventually(func() string {
+				return sentinel1.Info(ctx).Val()
+			}, "20s", "100ms").Should(ContainSubstring("slaves=2"))
+			Eventually(func() string {
+				return sentinel2.Info(ctx).Val()
+			}, "20s", "100ms").Should(ContainSubstring("slaves=2"))
+			Eventually(func() string {
+				return sentinel3.Info(ctx).Val()
+			}, "20s", "100ms").Should(ContainSubstring("slaves=2"))
+		})
+
+		AfterEach(func() {
+			_ = client.Close()
+			_ = sentinel.Close()
+			pool.SetAllMetricCallbacks(nil)
+		})
+
+		It(fmt.Sprintf("should handle failover with MaxActiveConns=%d", maxActiveConns), func() {
+			err := client.Set(ctx, "key", "100", 0).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Sleep 1 second for replication
+			time.Sleep(1 * time.Second)
+
+			// Trigger failover
+			err = sentinel.Failover(ctx, sentinelName).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Wait for failover to complete
+			time.Sleep(3 * time.Second)
+
+			multi, err := client.Do(ctx, "MULTI").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(multi).To(Equal("OK"))
+
+			incr, err := client.Do(ctx, "INCR", "key").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(incr).To(Equal("QUEUED"))
+
+			execResult, err := client.Do(ctx, "EXEC").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(execResult).To(Equal(int64(101)))
+			// Verify CloseReasonFailover was counted exactly once
+			Expect(failoverCloseCount).To(Equal(1), "Expected exactly 1 CloseReasonFailover metric, got %d", failoverCloseCount)
+		})
+	}
+
+	Context("with MaxActiveConns=0", func() {
+		testFailoverWithMaxActiveConns(0)
+	})
+
+	Context("with MaxActiveConns=1", func() {
+		testFailoverWithMaxActiveConns(1)
+	})
+
+	Context("with MaxActiveConns=2", func() {
+		testFailoverWithMaxActiveConns(2)
+	})
+})

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/atomic"
+
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"
 	"github.com/redis/go-redis/v9"
@@ -693,21 +695,71 @@ func compareSlices(t *testing.T, a, b []string, name string) {
 	}
 }
 
-var _ = Describe("Sentinel Failover with Conns", Serial, func() {
+func waitForSentinelClusterStable() {
+	sentinel1 := redis.NewSentinelClient(&redis.Options{
+		Addr: ":" + sentinelPort1,
+	})
+	defer sentinel1.Close()
+
+	sentinel2 := redis.NewSentinelClient(&redis.Options{
+		Addr: ":" + sentinelPort2,
+	})
+	defer sentinel2.Close()
+
+	sentinel3 := redis.NewSentinelClient(&redis.Options{
+		Addr: ":" + sentinelPort3,
+	})
+	defer sentinel3.Close()
+
+	Eventually(func() bool {
+		masterInfo1, err1 := sentinel1.Master(ctx, sentinelName).Result()
+		masterInfo2, err2 := sentinel2.Master(ctx, sentinelName).Result()
+		masterInfo3, err3 := sentinel3.Master(ctx, sentinelName).Result()
+
+		if err1 != nil || err2 != nil || err3 != nil {
+			return false
+		}
+		// Check master ip and port are consistent across all sentinels
+		if masterInfo1["ip"] != masterInfo2["ip"] ||
+			masterInfo1["port"] != masterInfo2["port"] ||
+			masterInfo2["ip"] != masterInfo3["ip"] ||
+			masterInfo2["port"] != masterInfo3["port"] {
+			return false
+		}
+
+		// Also check replicas are consistent and we have at least 2 slaves
+		// (important for ReadOnly tests - if no slaves found, RandomReplicaAddr falls back to master)
+		replicas1, err1 := sentinel1.Replicas(ctx, sentinelName).Result()
+		replicas2, err2 := sentinel2.Replicas(ctx, sentinelName).Result()
+		replicas3, err3 := sentinel3.Replicas(ctx, sentinelName).Result()
+
+		if err1 != nil || err2 != nil || err3 != nil {
+			return false
+		}
+		if len(replicas1) < 2 || len(replicas2) < 2 || len(replicas3) < 2 {
+			return false
+		}
+		return len(replicas1) == len(replicas2) && len(replicas2) == len(replicas3)
+	}, "30s", "1s").Should(BeTrue())
+
+	time.Sleep(10 * time.Second)
+}
+
+var _ = Describe("Sentinel Failover with Conns", Serial, Ordered, func() {
 	testFailoverWithMaxActiveConns := func(maxActiveConns int) {
 		var client *redis.Client
 		var sentinel *redis.SentinelClient
-		var failoverCloseCount int
+		var failoverCloseCount atomic.Int32
 
 		BeforeEach(func() {
-			failoverCloseCount = 0
+			failoverCloseCount.Store(0)
 
 			// Set up metric callback to count CloseReasonFailover
 			pool.SetAllMetricCallbacks(&pool.MetricCallbacks{
 				ConnectionClosed: func(ctx context.Context, cn *pool.Conn, reason string, err error) {
 					fmt.Println("call ConnectionClosed metric callback with reason:", reason)
 					if reason == pool.CloseReasonFailover {
-						failoverCloseCount++
+						failoverCloseCount.Add(1)
 					}
 				},
 			})
@@ -766,6 +818,9 @@ var _ = Describe("Sentinel Failover with Conns", Serial, func() {
 				time.Sleep(500 * time.Millisecond)
 			}
 
+			Expect(failoverCloseCount.Load()).To(Equal(int32(1)),
+				"Expected exactly 1 CloseReasonFailover metric, got %d", failoverCloseCount.Load())
+
 			multi, err := client.Do(ctx, "MULTI").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(multi).To(Equal("OK"))
@@ -777,8 +832,6 @@ var _ = Describe("Sentinel Failover with Conns", Serial, func() {
 			execResult, err := client.Do(ctx, "EXEC").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(execResult).To(Equal([]any{int64(101)}))
-			Expect(failoverCloseCount).To(Equal(1),
-				"Expected exactly 1 CloseReasonFailover metric, got %d", failoverCloseCount)
 		})
 	}
 
@@ -792,5 +845,11 @@ var _ = Describe("Sentinel Failover with Conns", Serial, func() {
 
 	Context("with MaxActiveConns=2", func() {
 		testFailoverWithMaxActiveConns(2)
+	})
+
+	AfterAll(func() {
+		fmt.Println("Waiting for sentinel cluster to stabilize after all failover tests...")
+		waitForSentinelClusterStable()
+		fmt.Println("Sentinel cluster is now stable")
 	})
 })

--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -768,7 +768,7 @@ var _ = Describe("Sentinel Failover with Idle Conns", func() {
 
 			execResult, err := client.Do(ctx, "EXEC").Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(execResult).To(Equal(int64(101)))
+			Expect(execResult).To(Equal([]interface{}{int64(101)}))
 			// Verify CloseReasonFailover was counted exactly once
 			Expect(failoverCloseCount).To(Equal(1), "Expected exactly 1 CloseReasonFailover metric, got %d", failoverCloseCount)
 		})

--- a/universal_test.go
+++ b/universal_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-var _ = Describe("UniversalClient", func() {
+var _ = Describe("UniversalClient", Serial, func() {
 	var client redis.UniversalClient
 
 	AfterEach(func() {


### PR DESCRIPTION
Closes #3703 

1. In putConn(): prevent CLOSED state conns from being added to idleConns

2. In Filter(): ensure closed conns are removed from idleConns during failover


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connection pool close/removal behavior and metrics emission paths, which can affect connection lifecycle correctness under concurrency (especially during failover). Risk is moderated by added targeted sentinel failover tests and mostly localized changes to pooling/metrics codepaths.
> 
> **Overview**
> Improves closed-connection handling in the pool, especially around failover and concurrent closes.
> 
> `Conn.Close()` is now idempotent and ensures `onClose` runs at most once. The pool introduces a per-conn atomic `closeReason` (plus new `CloseReasonFailover`) so an in-use conn closed by another goroutine can later emit the correct `ConnectionClosed` metric reason when it’s returned.
> 
> `ConnPool.Filter()` is updated to properly distinguish *idle* vs *in-use* conns: idle conns are removed from `idleConns`/pool and closed immediately with failover metrics, while in-use conns are marked with `closeReason` and closed without corrupting idle lists. Metrics emission for `CloseConn` is refactored into `recordConnectionMetrics()`.
> 
> Adds a new serial/ordered sentinel failover test that asserts exactly one `failover` close metric across different `MaxActiveConns` settings, and marks the `UniversalClient` test suite as `Serial` to reduce inter-test interference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7500d2911e3a26e1255d28c8b49e2e3463d660a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->