### PR TITLE
  feat(redisotel): add WithSkipSpanIfNotRecording option

### DIFF
--- a/extra/redisotel/config.go
+++ b/extra/redisotel/config.go
@@ -14,8 +14,9 @@ import (
 type config struct {
 	// Common options.
 
-	dbSystem string
-	attrs    []attribute.KeyValue
+	dbSystem               string
+	attrs                  []attribute.KeyValue
+	skipSpanIfNotRecording bool
 
 	// Tracing options.
 
@@ -159,6 +160,14 @@ func WithCommandFilter(filter func(cmd redis.Cmder) bool) TracingOption {
 func WithCommandsFilter(filter func(cmds []redis.Cmder) bool) TracingOption {
 	return tracingOption(func(conf *config) {
 		conf.filterProcessPipeline = filter
+	})
+}
+
+// WithSkipSpanIfNotRecording tells the tracing hook to skip creating a new span
+// when the span in context is not recording.
+func WithSkipSpanIfNotRecording(on bool) TracingOption {
+	return tracingOption(func(conf *config) {
+		conf.skipSpanIfNotRecording = on
 	})
 }
 

--- a/extra/redisotel/tracing.go
+++ b/extra/redisotel/tracing.go
@@ -92,6 +92,10 @@ func (th *tracingHook) DialHook(hook redis.DialHook) redis.DialHook {
 			return hook(ctx, network, addr)
 		}
 
+		if th.conf.skipSpanIfNotRecording && !trace.SpanFromContext(ctx).IsRecording() {
+			return hook(ctx, network, addr)
+		}
+
 		ctx, span := th.conf.tracer.Start(ctx, "redis.dial", th.spanOpts...)
 		defer span.End()
 

--- a/extra/redisotel/tracing.go
+++ b/extra/redisotel/tracing.go
@@ -113,6 +113,10 @@ func (th *tracingHook) ProcessHook(hook redis.ProcessHook) redis.ProcessHook {
 			return hook(ctx, cmd)
 		}
 
+		if th.conf.skipSpanIfNotRecording && !trace.SpanFromContext(ctx).IsRecording() {
+			return hook(ctx, cmd)
+		}
+
 		attrs := make([]attribute.KeyValue, 0, 8)
 		if th.conf.callerEnabled {
 			fn, file, line := funcFileLine("github.com/redis/go-redis")
@@ -148,6 +152,10 @@ func (th *tracingHook) ProcessPipelineHook(
 	return func(ctx context.Context, cmds []redis.Cmder) error {
 
 		if th.conf.filterProcessPipeline != nil && th.conf.filterProcessPipeline(cmds) {
+			return hook(ctx, cmds)
+		}
+
+		if th.conf.skipSpanIfNotRecording && !trace.SpanFromContext(ctx).IsRecording() {
 			return hook(ctx, cmds)
 		}
 

--- a/extra/redisotel/tracing_test.go
+++ b/extra/redisotel/tracing_test.go
@@ -661,6 +661,160 @@ func TestTracingHook_ProcessPipelineHook_LongCommands(t *testing.T) {
 	}
 }
 
+func TestWithSkipSpanIfNotRecording(t *testing.T) {
+	t.Run("process: skips span when no parent and flag is true", func(t *testing.T) {
+		imsb := tracetest.NewInMemoryExporter()
+		provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(imsb))
+		hook := newTracingHook(
+			"",
+			WithTracerProvider(provider),
+			WithSkipSpanIfNotRecording(true),
+		)
+
+		cmd := redis.NewCmd(context.Background(), "ping")
+		processHook := hook.ProcessHook(func(ctx context.Context, cmd redis.Cmder) error {
+			return nil
+		})
+		if err := processHook(context.Background(), cmd); err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, 0, len(imsb.GetSpans()))
+	})
+
+	t.Run("process: creates span when parent is recording and flag is true", func(t *testing.T) {
+		imsb := tracetest.NewInMemoryExporter()
+		provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(imsb))
+		hook := newTracingHook(
+			"",
+			WithTracerProvider(provider),
+			WithSkipSpanIfNotRecording(true),
+		)
+
+		ctx, parentSpan := provider.Tracer("test").Start(context.Background(), "parent")
+		cmd := redis.NewCmd(ctx, "ping")
+		processHook := hook.ProcessHook(func(ctx context.Context, cmd redis.Cmder) error {
+			return nil
+		})
+		if err := processHook(ctx, cmd); err != nil {
+			t.Fatal(err)
+		}
+		parentSpan.End()
+
+		spans := imsb.GetSpans()
+		found := false
+		for _, s := range spans {
+			if s.Name == "ping" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatal("expected ping span to be created when parent is recording")
+		}
+	})
+
+	t.Run("process: creates span when flag is false (default behavior preserved)", func(t *testing.T) {
+		imsb := tracetest.NewInMemoryExporter()
+		provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(imsb))
+		hook := newTracingHook(
+			"",
+			WithTracerProvider(provider),
+			WithSkipSpanIfNotRecording(false),
+		)
+
+		cmd := redis.NewCmd(context.Background(), "ping")
+		processHook := hook.ProcessHook(func(ctx context.Context, cmd redis.Cmder) error {
+			return nil
+		})
+		if err := processHook(context.Background(), cmd); err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, 1, len(imsb.GetSpans()))
+	})
+
+	t.Run("process: skips span when parent is sampled out and flag is true", func(t *testing.T) {
+		imsb := tracetest.NewInMemoryExporter()
+		sampledOutProvider := sdktrace.NewTracerProvider(
+			sdktrace.WithSyncer(imsb),
+			sdktrace.WithSampler(sdktrace.NeverSample()),
+		)
+		hook := newTracingHook(
+			"",
+			WithTracerProvider(sampledOutProvider),
+			WithSkipSpanIfNotRecording(true),
+		)
+
+		ctx, parentSpan := sampledOutProvider.Tracer("test").Start(context.Background(), "parent")
+		defer parentSpan.End()
+
+		cmd := redis.NewCmd(ctx, "ping")
+		processHook := hook.ProcessHook(func(ctx context.Context, cmd redis.Cmder) error {
+			return nil
+		})
+		if err := processHook(ctx, cmd); err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, 0, len(imsb.GetSpans()))
+	})
+
+	t.Run("pipeline: skips span when no parent and flag is true", func(t *testing.T) {
+		imsb := tracetest.NewInMemoryExporter()
+		provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(imsb))
+		hook := newTracingHook(
+			"",
+			WithTracerProvider(provider),
+			WithSkipSpanIfNotRecording(true),
+		)
+
+		cmds := []redis.Cmder{
+			redis.NewCmd(context.Background(), "ping"),
+			redis.NewCmd(context.Background(), "get"),
+		}
+		processHook := hook.ProcessPipelineHook(func(ctx context.Context, cmds []redis.Cmder) error {
+			return nil
+		})
+		if err := processHook(context.Background(), cmds); err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, 0, len(imsb.GetSpans()))
+	})
+
+	t.Run("pipeline: creates span when parent is recording and flag is true", func(t *testing.T) {
+		imsb := tracetest.NewInMemoryExporter()
+		provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(imsb))
+		hook := newTracingHook(
+			"",
+			WithTracerProvider(provider),
+			WithSkipSpanIfNotRecording(true),
+		)
+
+		ctx, parentSpan := provider.Tracer("test").Start(context.Background(), "parent")
+		cmds := []redis.Cmder{
+			redis.NewCmd(ctx, "ping"),
+			redis.NewCmd(ctx, "get"),
+		}
+		processHook := hook.ProcessPipelineHook(func(ctx context.Context, cmds []redis.Cmder) error {
+			return nil
+		})
+		if err := processHook(ctx, cmds); err != nil {
+			t.Fatal(err)
+		}
+		parentSpan.End()
+
+		spans := imsb.GetSpans()
+		found := false
+		for _, s := range spans {
+			if strings.HasPrefix(s.Name, "redis.pipeline") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatal("expected pipeline span to be created when parent is recording")
+		}
+	})
+}
+
 func assertEqual(t *testing.T, expected, actual interface{}) {
 	t.Helper()
 	if expected != actual {

--- a/extra/redisotel/tracing_test.go
+++ b/extra/redisotel/tracing_test.go
@@ -662,6 +662,79 @@ func TestTracingHook_ProcessPipelineHook_LongCommands(t *testing.T) {
 }
 
 func TestWithSkipSpanIfNotRecording(t *testing.T) {
+	t.Run("dial: skips span when no parent and flag is true", func(t *testing.T) {
+		imsb := tracetest.NewInMemoryExporter()
+		provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(imsb))
+		hook := newTracingHook(
+			"",
+			WithTracerProvider(provider),
+			WithSkipSpanIfNotRecording(true),
+		)
+
+		dialHook := hook.DialHook(func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return nil, nil
+		})
+		if _, err := dialHook(context.Background(), "tcp", "localhost:6379"); err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, 0, len(imsb.GetSpans()))
+	})
+
+	t.Run("dial: creates span when parent is recording and flag is true", func(t *testing.T) {
+		imsb := tracetest.NewInMemoryExporter()
+		provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(imsb))
+		hook := newTracingHook(
+			"",
+			WithTracerProvider(provider),
+			WithSkipSpanIfNotRecording(true),
+		)
+
+		ctx, parentSpan := provider.Tracer("test").Start(context.Background(), "parent")
+		dialHook := hook.DialHook(func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return nil, nil
+		})
+		if _, err := dialHook(ctx, "tcp", "localhost:6379"); err != nil {
+			t.Fatal(err)
+		}
+		parentSpan.End()
+
+		spans := imsb.GetSpans()
+		found := false
+		for _, s := range spans {
+			if s.Name == "redis.dial" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatal("expected dial span to be created when parent is recording")
+		}
+	})
+
+	t.Run("dial: skips span when parent is sampled out and flag is true", func(t *testing.T) {
+		imsb := tracetest.NewInMemoryExporter()
+		sampledOutProvider := sdktrace.NewTracerProvider(
+			sdktrace.WithSyncer(imsb),
+			sdktrace.WithSampler(sdktrace.NeverSample()),
+		)
+		hook := newTracingHook(
+			"",
+			WithTracerProvider(sampledOutProvider),
+			WithSkipSpanIfNotRecording(true),
+		)
+
+		ctx, parentSpan := sampledOutProvider.Tracer("test").Start(context.Background(), "parent")
+		defer parentSpan.End()
+
+		dialHook := hook.DialHook(func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return nil, nil
+		})
+		if _, err := dialHook(ctx, "tcp", "localhost:6379"); err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, 0, len(imsb.GetSpans()))
+	})
+
 	t.Run("process: skips span when no parent and flag is true", func(t *testing.T) {
 		imsb := tracetest.NewInMemoryExporter()
 		provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(imsb))


### PR DESCRIPTION
This PR was motivated by https://github.com/redis/go-redis/issues/3760 and addresses it by adding an option to skip span recording, which makes the change backward compatible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk and opt-in: only changes tracing behavior when `WithSkipSpanIfNotRecording(true)` is set, reducing unnecessary span creation when tracing is disabled or sampled out.
> 
> **Overview**
> Adds a new tracing option, `WithSkipSpanIfNotRecording`, that prevents `redisotel` hooks from starting `redis.dial`, command, and pipeline spans when the span in the incoming context is not recording.
> 
> Includes comprehensive tests covering dial/process/pipeline behavior for no parent span, sampled-out parents, and preserving the existing default behavior when the option is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6910b26b41b6ec24f871ce6fb8de1a1ce261586. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->