### PR TITLE
Fix issue 3139 feat(hscan): add support for encoding.BinaryUnmarshaler

### DIFF
--- a/internal/hscan/hscan_test.go
+++ b/internal/hscan/hscan_test.go
@@ -48,6 +48,19 @@ type TimeData struct {
 	Time *TimeRFC3339Nano `redis:"login"`
 }
 
+type binaryUnmarshaler struct {
+	s string
+}
+
+func (b *binaryUnmarshaler) UnmarshalBinary(data []byte) error {
+	b.s = string(data)
+	return nil
+}
+
+type BinaryData struct {
+	Binary *binaryUnmarshaler `redis:"binary"`
+}
+
 type i []interface{}
 
 func TestGinkgoSuite(t *testing.T) {
@@ -216,5 +229,10 @@ var _ = Describe("Scan", func() {
 		var tt TimeTime
 		Expect(Scan(&tt, i{"time"}, i{now.Format(time.RFC3339Nano)})).NotTo(HaveOccurred())
 		Expect(now.Unix()).To(Equal(tt.Time.Unix()))
+	})
+	It("Implements BinaryUnmarshaler", func() {
+		var bd BinaryData
+		Expect(Scan(&bd, i{"binary"}, i{"hello"})).NotTo(HaveOccurred())
+		Expect(bd.Binary.s).To(Equal("hello"))
 	})
 })

--- a/internal/hscan/structmap.go
+++ b/internal/hscan/structmap.go
@@ -109,7 +109,9 @@ func (s StructValue) Scan(key string, value string) error {
 			return scan.ScanRedis(value)
 		case encoding.TextUnmarshaler:
 			return scan.UnmarshalText(util.StringToBytes(value))
-		}
+		case encoding.BinaryUnmarshaler:
+			return scan.UnmarshalBinary(util.StringToBytes(value))			
+			}
 	}
 
 	if isPtr {

--- a/internal/hscan/structmap.go
+++ b/internal/hscan/structmap.go
@@ -110,8 +110,8 @@ func (s StructValue) Scan(key string, value string) error {
 		case encoding.TextUnmarshaler:
 			return scan.UnmarshalText(util.StringToBytes(value))
 		case encoding.BinaryUnmarshaler:
-			return scan.UnmarshalBinary(util.StringToBytes(value))			
-			}
+			return scan.UnmarshalBinary(util.StringToBytes(value))
+		}
 	}
 
 	if isPtr {


### PR DESCRIPTION
Fixes #3139.
Added support for encoding.BinaryUnmarshaler in hscan.Scan to allow scanning into types like UUID.
Included unit test in hscan_test.go to verify the functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `hscan` struct field scanning path, which is widely used and could subtly change decoding precedence for custom types. Change is small and covered by a focused unit test.
> 
> **Overview**
> Adds support for scanning Redis hash values into struct fields whose types implement `encoding.BinaryUnmarshaler`, calling `UnmarshalBinary([]byte)` during `hscan` decoding.
> 
> Extends the `hscan` test suite with a new case that verifies a `BinaryUnmarshaler` implementation is invoked and receives the raw value bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a2d65b4611d429056c4b9d8f1df040a534c0f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->