### PR TITLE
fix(error): detect READONLY errors from Lua scripts on read-only replicas

### DIFF
--- a/error.go
+++ b/error.go
@@ -144,6 +144,9 @@ func shouldRetry(err error, retryTimeout bool) bool {
 	if strings.HasPrefix(s, "READONLY ") {
 		return true
 	}
+	if strings.Contains(s, "-READONLY You can't write against a read only replica") {
+		return true
+	}
 	if strings.HasPrefix(s, "CLUSTERDOWN ") {
 		return true
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -42,7 +42,8 @@ var _ = Describe("error", func() {
 			// Use typed errors instead of plain errors.New()
 			proto.ParseErrorReply([]byte("-ERR max number of clients reached")):                      true,
 			proto.ParseErrorReply([]byte("-LOADING Redis is loading the dataset in memory")):         true,
-			proto.ParseErrorReply([]byte("-READONLY You can't write against a read only replica")):   true,
+			proto.ParseErrorReply([]byte("-READONLY You can't write against a read only replica")):                                                                                      true,
+			proto.ParseErrorReply([]byte("-ERR Error running script (call to f_abc123): @user_script:1: -READONLY You can't write against a read only replica.")): true,
 			proto.ParseErrorReply([]byte("-CLUSTERDOWN The cluster is down")):                        true,
 			proto.ParseErrorReply([]byte("-TRYAGAIN Command cannot be processed, please try again")): true,
 			proto.ParseErrorReply([]byte("-NOREPLICAS Not enough good replicas to write")):           true,

--- a/error_wrapping_test.go
+++ b/error_wrapping_test.go
@@ -257,6 +257,12 @@ func TestShouldRetryWithTypedErrors(t *testing.T) {
 			retryTimeout: false,
 		},
 		{
+			name:         "Lua script READONLY error should retry",
+			errorMsg:     "ERR Error running script (call to f_abc123): @user_script:1: -READONLY You can't write against a read only replica.",
+			shouldRetry:  true,
+			retryTimeout: false,
+		},
+		{
 			name:         "CLUSTERDOWN error should retry",
 			errorMsg:     "CLUSTERDOWN The cluster is down",
 			shouldRetry:  true,
@@ -302,6 +308,51 @@ func TestShouldRetryWithTypedErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestLuaScriptReadOnlyError tests that READONLY errors from Lua scripts
+// are correctly detected by IsReadOnlyError and ShouldRetry.
+func TestLuaScriptReadOnlyError(t *testing.T) {
+	luaReadOnlyMsg := "ERR Error running script (call to f_abc123): @user_script:1: -READONLY You can't write against a read only replica."
+
+	t.Run("IsReadOnlyError detects Lua script READONLY", func(t *testing.T) {
+		err := proto.ParseErrorReply([]byte("-" + luaReadOnlyMsg))
+		if !redis.IsReadOnlyError(err) {
+			t.Errorf("IsReadOnlyError should detect Lua script READONLY error: %v", err)
+		}
+	})
+
+	t.Run("ShouldRetry retries Lua script READONLY", func(t *testing.T) {
+		err := proto.ParseErrorReply([]byte("-" + luaReadOnlyMsg))
+		if !redis.ShouldRetry(err, false) {
+			t.Errorf("ShouldRetry should retry Lua script READONLY error: %v", err)
+		}
+	})
+
+	t.Run("wrapped Lua script READONLY detected", func(t *testing.T) {
+		err := proto.ParseErrorReply([]byte("-" + luaReadOnlyMsg))
+		wrappedErr := fmt.Errorf("hook wrapper: %w", err)
+		if !redis.IsReadOnlyError(wrappedErr) {
+			t.Errorf("IsReadOnlyError should detect wrapped Lua script READONLY error: %v", wrappedErr)
+		}
+		if !redis.ShouldRetry(wrappedErr, false) {
+			t.Errorf("ShouldRetry should retry wrapped Lua script READONLY error: %v", wrappedErr)
+		}
+	})
+
+	t.Run("false positive: non-script error with -READONLY not matched", func(t *testing.T) {
+		err := proto.ParseErrorReply([]byte("-ERR something-READONLY-key"))
+		if redis.IsReadOnlyError(err) {
+			t.Errorf("IsReadOnlyError should NOT match non-script error containing -READONLY: %v", err)
+		}
+	})
+
+	t.Run("false positive: script error without -READONLY not matched", func(t *testing.T) {
+		err := proto.ParseErrorReply([]byte("-ERR Error running script (call to f_abc): @user_script:1: some other error"))
+		if redis.IsReadOnlyError(err) {
+			t.Errorf("IsReadOnlyError should NOT match script error without -READONLY: %v", err)
+		}
+	})
 }
 
 // TestSetErrWithWrappedError tests that when a hook wraps an error and sets it

--- a/internal/proto/redis_errors.go
+++ b/internal/proto/redis_errors.go
@@ -309,13 +309,25 @@ func IsReadOnlyError(err error) bool {
 	if errors.As(err, &readOnlyErr) {
 		return true
 	}
-	// Check if wrapped error is a RedisError with READONLY prefix
+	// Check if wrapped error is a RedisError with READONLY prefix or Lua script READONLY
 	var redisErr RedisError
-	if errors.As(err, &redisErr) && strings.HasPrefix(redisErr.Error(), "READONLY ") {
-		return true
+	if errors.As(err, &redisErr) {
+		s := redisErr.Error()
+		if strings.HasPrefix(s, "READONLY ") {
+			return true
+		}
+		// Lua script wrapped READONLY errors:
+		//   "ERR Error running script (call to f_<sha>): @user_script:N: -READONLY You can't write against a read only replica."
+		if strings.Contains(s, "-READONLY You can't write against a read only replica") {
+			return true
+		}
 	}
 	// Fallback to string checking for backward compatibility
-	return strings.HasPrefix(err.Error(), "READONLY ")
+	s := err.Error()
+	if strings.HasPrefix(s, "READONLY ") {
+		return true
+	}
+	return strings.Contains(s, "-READONLY You can't write against a read only replica")
 }
 
 // IsMovedError checks if an error is a MovedError, even if wrapped.

--- a/internal/proto/redis_errors_test.go
+++ b/internal/proto/redis_errors_test.go
@@ -369,6 +369,71 @@ func TestGenericRedisError(t *testing.T) {
 	}
 }
 
+// TestIsReadOnlyErrorWithLuaScriptErrors tests that READONLY errors from Lua scripts are detected.
+// When a Lua script executes a write command on a read-only replica, Redis wraps the error:
+// "ERR Error running script (call to f_<sha>): @user_script:<line>: -READONLY ..."
+func TestIsReadOnlyErrorWithLuaScriptErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		errorMsg string
+		expected bool
+	}{
+		{
+			name:     "standard READONLY error",
+			errorMsg: "READONLY You can't write against a read only replica",
+			expected: true,
+		},
+		{
+			name:     "Lua script READONLY error",
+			errorMsg: "ERR Error running script (call to f_abc123): @user_script:1: -READONLY You can't write against a read only replica.",
+			expected: true,
+		},
+		{
+			name:     "Lua script READONLY error with different line number",
+			errorMsg: "ERR Error running script (call to f_def456): @user_script:42: -READONLY You can't write against a read only replica.",
+			expected: true,
+		},
+		{
+			name:     "unrelated error should not match",
+			errorMsg: "ERR unknown command",
+			expected: false,
+		},
+		{
+			name:     "error with key containing READONLY should not match",
+			errorMsg: "WRONGTYPE Operation against a key holding the wrong kind of value",
+			expected: false,
+		},
+		{
+			name:     "non-script error with -READONLY should not match",
+			errorMsg: "ERR something-READONLY-something",
+			expected: false,
+		},
+		{
+			name:     "script error without -READONLY should not match",
+			errorMsg: "ERR Error running script (call to f_abc123): @user_script:1: some other error",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := parseTypedRedisError(tt.errorMsg)
+
+			result := IsReadOnlyError(err)
+			if result != tt.expected {
+				t.Errorf("IsReadOnlyError(%q) = %v, want %v", tt.errorMsg, result, tt.expected)
+			}
+
+			// Also test with wrapped errors
+			wrappedErr := fmt.Errorf("hook wrapper: %w", err)
+			wrappedResult := IsReadOnlyError(wrappedErr)
+			if wrappedResult != tt.expected {
+				t.Errorf("IsReadOnlyError(wrapped %q) = %v, want %v", tt.errorMsg, wrappedResult, tt.expected)
+			}
+		})
+	}
+}
+
 // TestBackwardCompatibility tests that error messages remain unchanged
 func TestBackwardCompatibility(t *testing.T) {
 	// This test ensures that the error messages are exactly the same as before


### PR DESCRIPTION
## Summary

- Detect `READONLY` errors embedded in Lua script error messages on read-only replicas
- Check for the exact substring `"-READONLY You can't write against a read only replica"` to avoid false positives
- Add comprehensive unit tests for both direct and wrapped error detection

Supersedes #2770 — incorporates reviewer feedback from @ndyakov (stricter matching) and @ofekshenawa (unit tests).

## Problem

When a Lua script containing a write command executes against a read-only replica in a Redis Cluster, the error may contain `-READONLY You can't write against a read only replica` embedded within a larger error message rather than starting with `READONLY `:

```
ERR Error running script (call to f_<sha>): @user_script:<line>: -READONLY You can't write against a read only replica.
```

The existing code only checks `strings.HasPrefix(s, "READONLY ")`, missing this embedded format. This causes:
- `shouldRetry()` to not retry the command
- `isReadOnlyError()` to not detect it, preventing connection pool cleanup via `isBadConn()`
- `LazyReload()` to not trigger cluster state refresh

## Changes

| File | Change |
|------|--------|
| `internal/proto/redis_errors.go` | Extended `IsReadOnlyError()` to check for `"-READONLY You can't write against a read only replica"` substring |
| `error.go` | Added same fallback check in `shouldRetry()` |
| `internal/proto/redis_errors_test.go` | Added `TestIsReadOnlyErrorWithLuaScriptErrors` with 7 test cases |
| `error_wrapping_test.go` | Added `TestLuaScriptReadOnlyError` with 5 test cases + retry test |
| `error_test.go` | Added Lua READONLY error to existing `shouldRetry` ginkgo test |

## Addressing PR #2770 Reviewer Feedback

**@ndyakov's concern**: The original PR used `strings.Contains(s, "-READONLY")` which is too broad — could match keys like `"something-READONLY"`.

**This fix**: Checks for the exact substring `"-READONLY You can't write against a read only replica"` — specific enough to only match actual READONLY errors without any false positives.

## Integration Test Report (Redis 7.2.7 Cluster)

Tested against a local 6-node Redis Cluster (3 masters + 3 replicas):

```
======================================================================
REDIS CLUSTER INTEGRATION TEST REPORT
======================================================================
Redis version: 7.2.7
Replica: 127.0.0.1:7104 -> Master: 127.0.0.1:7101 (slots: 5461-10922)
Test key: "testkey-12591" (slot 5462)

Test 1: EVAL with write command on replica (Lua READONLY)
  Error:          "READONLY You can't write against a read only replica.
                   script: d8f2fad9f8e86a53d2a6ebd960b33c4972cacc37,
                   on @user_script:1."
  IsReadOnlyError: true
  ShouldRetry:     true
  Result:          PASS

Test 2: Script.Run with write command on replica
  Error:          "READONLY You can't write against a read only replica.
                   script: d8f2fad9f8e86a53d2a6ebd960b33c4972cacc37,
                   on @user_script:1."
  IsReadOnlyError: true
  ShouldRetry:     true
  Result:          PASS

Test 3: Multi-command Lua script on replica
  Error:          "READONLY You can't write against a read only replica.
                   script: 02c9e874aad609b773e015a3025d0e43fb7b732b,
                   on @user_script:3."
  IsReadOnlyError: true
  ShouldRetry:     true
  Result:          PASS

Test 4: Simulated old-format Lua READONLY
  Error:          "ERR Error running script (call to f_abc123):
                   @user_script:1: -READONLY You can't write against
                   a read only replica."
  IsReadOnlyError: true
  ShouldRetry:     true
  Result:          PASS

======================================================================
ALL TESTS PASSED
======================================================================
```

## Test plan

- [x] Unit tests for `IsReadOnlyError` with Lua script error format (proto package)
- [x] Unit tests for `ShouldRetry` with Lua script READONLY error
- [x] Unit tests for wrapped Lua script READONLY error detection
- [x] False positive tests (non-script errors, script errors without READONLY)
- [x] Integration test against local Redis 7.2.7 Cluster
- [x] All existing tests pass (`go test ./internal/proto/` and `go test -run Test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)