### PR TITLE
docs: Add doc comment to HGetAll describing behavior and complexity

### DIFF
--- a/hash_commands.go
+++ b/hash_commands.go
@@ -70,6 +70,15 @@ func (c cmdable) HGet(ctx context.Context, key, field string) *StringCmd {
 	return cmd
 }
 
+// HGetAll returns all fields and values of the hash stored at key.
+// In the returned value, every field name is followed by its value,
+// so the length of the reply is twice the size of the hash.
+//
+// Returns an empty map when key does not exist.
+//
+// Time complexity: O(N) where N is the size of the hash.
+//
+// See https://redis.io/commands/hgetall/
 func (c cmdable) HGetAll(ctx context.Context, key string) *MapStringStringCmd {
 	cmd := NewMapStringStringCmd(ctx, "hgetall", key)
 	_ = c(ctx, cmd)

--- a/hash_commands.go
+++ b/hash_commands.go
@@ -70,9 +70,7 @@ func (c cmdable) HGet(ctx context.Context, key, field string) *StringCmd {
 	return cmd
 }
 
-// HGetAll returns all fields and values of the hash stored at key.
-// In the returned value, every field name is followed by its value,
-// so the length of the reply is twice the size of the hash.
+// HGetAll returns a map of all fields and values stored at key.
 //
 // Returns an empty map when key does not exist.
 //


### PR DESCRIPTION
### Summary
- Add Go doc comment to `HGetAll` method describing its behavior, return value, time complexity, and linking to official Redis documentation

### Motivation
The `HGetAll` function on `cmdable` was missing a doc comment, so hovering over it in IDEs (e.g., VS Code, GoLand, Cursor) showed no documentation. This makes it harder for developers to understand the command's behavior without leaving their editor.
<img width="643" height="134" alt="image" src="https://github.com/user-attachments/assets/1443f5c8-e410-46ef-802f-ea0eced50784" />

### Changes
Added a doc comment to HGetAll in hash_commands.go covering:
- What the command returns (all fields and values of a hash)
- Behavior when the key does not exist (empty map)
- Time complexity: `O(N)`
- Link to the official Redis docs: https://redis.io/commands/hgetall/

### Test plan
 - Verify the comment renders correctly on hover in the IDE
- Confirm `go build ./... `still passes with no errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime logic or APIs are modified.
> 
> **Overview**
> Adds a GoDoc comment to `cmdable.HGetAll` describing what it returns, behavior for missing keys (empty map), its `O(N)` complexity, and a link to the official Redis `HGETALL` command documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9908e8650b1072ad19f7cd5f42817048a8ce00b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->