### PR TITLE
fix(pool): prevent FIFO ordering violation in notifyWaiters by tracking state locally

### DIFF
--- a/hash_commands.go
+++ b/hash_commands.go
@@ -70,6 +70,15 @@ func (c cmdable) HGet(ctx context.Context, key, field string) *StringCmd {
 	return cmd
 }
 
+// HGetAll returns all fields and values of the hash stored at key.
+// In the returned value, every field name is followed by its value,
+// so the length of the reply is twice the size of the hash.
+//
+// Returns an empty map when key does not exist.
+//
+// Time complexity: O(N) where N is the size of the hash.
+//
+// See https://redis.io/commands/hgetall/
 func (c cmdable) HGetAll(ctx context.Context, key string) *MapStringStringCmd {
 	cmd := NewMapStringStringCmd(ctx, "hgetall", key)
 	_ = c(ctx, cmd)

--- a/hash_commands.go
+++ b/hash_commands.go
@@ -70,15 +70,6 @@ func (c cmdable) HGet(ctx context.Context, key, field string) *StringCmd {
 	return cmd
 }
 
-// HGetAll returns all fields and values of the hash stored at key.
-// In the returned value, every field name is followed by its value,
-// so the length of the reply is twice the size of the hash.
-//
-// Returns an empty map when key does not exist.
-//
-// Time complexity: O(N) where N is the size of the hash.
-//
-// See https://redis.io/commands/hgetall/
 func (c cmdable) HGetAll(ctx context.Context, key string) *MapStringStringCmd {
 	cmd := NewMapStringStringCmd(ctx, "hgetall", key)
 	_ = c(ctx, cmd)

--- a/internal/pool/conn_state.go
+++ b/internal/pool/conn_state.go
@@ -297,45 +297,38 @@ func (sm *ConnStateMachine) notifyWaiters() {
 		return
 	}
 
-	// Process waiters in FIFO order until no more can be processed
-	// We loop instead of recursing to avoid stack overflow and mutex issues
+	// Track state locally so we only consider transitions made within this
+	// call, not concurrent transitions from woken goroutines. Re-reading the
+	// atomic would let a fast goroutine's Transition(StateIdle) leak into our
+	// view, causing us to wake multiple waiters at once and breaking FIFO
+	// execution ordering.
+	currentState := sm.GetState()
+
 	for {
 		processed := false
 
-		// Find the first waiter that can proceed
 		for elem := sm.waiters.Front(); elem != nil; elem = elem.Next() {
 			w := elem.Value.(*waiter)
 
-			// Read current state inside the loop to get the latest value
-			currentState := sm.GetState()
-
-			// Check if current state is valid for this waiter
 			if _, valid := w.validStates[currentState]; valid {
-				// Remove from queue first
 				sm.waiters.Remove(elem)
 				sm.waiterCount.Add(-1)
 
-				// Use CAS to ensure state hasn't changed since we checked
-				// This prevents race condition where another thread changes state
-				// between our check and our transition
 				if sm.state.CompareAndSwap(uint32(currentState), uint32(w.targetState)) {
-					// Successfully transitioned - notify waiter
 					w.done <- nil
+					currentState = w.targetState
 					processed = true
 					break
 				} else {
-					// State changed - re-add waiter to front of queue to maintain FIFO ordering
-					// This waiter was first in line and should retain priority
 					sm.waiters.PushFront(w)
 					sm.waiterCount.Add(1)
-					// Continue to next iteration to re-read state
+					currentState = sm.GetState()
 					processed = true
 					break
 				}
 			}
 		}
 
-		// If we didn't process any waiter, we're done
 		if !processed {
 			break
 		}


### PR DESCRIPTION
### Summary
- Fix a race condition in `ConnStateMachine.notifyWaiters()` that breaks FIFO execution ordering of queued waiters

### Problem
- `notifyWaiters()` re-reads the atomic state (`sm.GetState()`) on every iteration of its outer loop. When a woken goroutine runs fast enough to call `Transition(StateIdle)` before the loop iterates again, the function sees the new state and wakes the next waiter within the same mutex hold. This cascades — potentially notifying all queued waiters in a single call. Since they all become runnable simultaneously, the Go scheduler executes them in arbitrary order, violating the FIFO guarantee.

- Example: With waiters queued as `[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]`, the observed execution order was `[0, 1, 9, 2, 3, 4, 5, 6, 7, 8]`.

- This caused flaky failures in TestConnStateMachine_FIFOOrdering across multiple CI matrix entries (8.0.x stable, 8.2.x 1.25.x, 8.4.x stable).

### Fix
Read the state once at entry, and after a successful CAS, update a local state variable to `w.targetState` instead of re-reading the atomic. This ensures `notifyWaiters` only considers transitions made within its own call, not concurrent transitions from woken goroutines. The CAS failure path still re-reads the atomic (correctly — an external change requires the real value).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency/state-transition logic in `notifyWaiters`, where subtle ordering or CAS behavior changes could impact pool fairness or cause missed wakeups under load.
> 
> **Overview**
> Fixes a race in `ConnStateMachine.notifyWaiters` that could wake multiple queued waiters in a single mutex hold and let the scheduler run them out of FIFO order.
> 
> `notifyWaiters` now snapshots state once per call and updates a local `currentState` only on successful CAS transitions, only re-reading the atomic state on CAS failure so concurrent transitions by woken goroutines don’t cascade additional wakeups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4381942a5d8007aa698904a08e431309d4f308b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->