### PR TITLE
fix: suppress pool Close() errors for stale connections

### DIFF
--- a/internal/pool/main_test.go
+++ b/internal/pool/main_test.go
@@ -130,6 +130,10 @@ type failCloseConn struct {
 }
 
 func (f *failCloseConn) Close() error {
+	// Close the underlying raw conn so that connCheck sees a closed fd,
+	// matching real-world behavior (e.g., TLS closeNotify failure after
+	// the OS-level socket is torn down).
+	f.dummyConn.rawConn.Close()
 	return f.closeErr
 }
 

--- a/internal/pool/main_test.go
+++ b/internal/pool/main_test.go
@@ -121,3 +121,18 @@ func (d *dummyRawConn) Close() {
 	d.closed = true
 	d.mu.Unlock()
 }
+
+// failCloseConn wraps a dummyConn but returns a configured error on Close().
+// This is used to simulate TLS closeNotify errors or network timeouts during connection close.
+type failCloseConn struct {
+	*dummyConn
+	closeErr error
+}
+
+func (f *failCloseConn) Close() error {
+	return f.closeErr
+}
+
+func (f *failCloseConn) SyscallConn() (syscall.RawConn, error) {
+	return f.dummyConn.SyscallConn()
+}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1403,10 +1403,14 @@ func (p *ConnPool) Close() error {
 	nowNs := time.Now().UnixNano()
 	p.connsMu.Lock()
 	for _, cn := range p.conns {
+		// Check health before closing, since closeConn invalidates the
+		// underlying fd and would make connCheck (inside isHealthyConn)
+		// always fail with EBADF.
+		healthy := p.isHealthyConn(cn, nowNs)
 		if err := p.closeConn(cn); err != nil && firstErr == nil {
 			// Suppress close errors for stale connections, consistent
 			// with how Get() handles them (see CloseReasonStale path).
-			if p.isHealthyConn(cn, nowNs) {
+			if healthy {
 				firstErr = err
 			}
 		}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1400,10 +1400,15 @@ func (p *ConnPool) Close() error {
 	}
 
 	var firstErr error
+	nowNs := time.Now().UnixNano()
 	p.connsMu.Lock()
 	for _, cn := range p.conns {
 		if err := p.closeConn(cn); err != nil && firstErr == nil {
-			firstErr = err
+			// Suppress close errors for stale connections, consistent
+			// with how Get() handles them (see CloseReasonStale path).
+			if p.isHealthyConn(cn, nowNs) {
+				firstErr = err
+			}
 		}
 	}
 	p.conns = nil

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -1397,6 +1397,65 @@ var _ = Describe("queuedNewConn", func() {
 			"dialsQueue should be empty after all requests complete")
 	})
 
+	Describe("Close suppresses errors for stale connections", func() {
+		It("should not return close error when connection is stale due to ConnMaxIdleTime", func() {
+			closeErr := fmt.Errorf("tls: failed to send closeNotify alert (but connection was closed anyway): write tcp: connection timed out")
+
+			testPool := pool.NewConnPool(&pool.Options{
+				Dialer: func(ctx context.Context) (net.Conn, error) {
+					return &failCloseConn{
+						dummyConn: &dummyConn{rawConn: new(dummyRawConn)},
+						closeErr:  closeErr,
+					}, nil
+				},
+				PoolSize:           1,
+				MaxConcurrentDials: 1,
+				DialTimeout:        1 * time.Second,
+				PoolTimeout:        1 * time.Second,
+				ConnMaxIdleTime:    50 * time.Millisecond,
+			})
+
+			// Get a connection, put it back, then wait for it to become stale
+			cn, err := testPool.Get(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			testPool.Put(ctx, cn)
+
+			// Wait for the connection to exceed ConnMaxIdleTime
+			time.Sleep(100 * time.Millisecond)
+
+			// Close the pool — stale connection close errors should be suppressed
+			err = testPool.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return close error when connection is still healthy", func() {
+			closeErr := fmt.Errorf("tls: failed to send closeNotify alert")
+
+			testPool := pool.NewConnPool(&pool.Options{
+				Dialer: func(ctx context.Context) (net.Conn, error) {
+					return &failCloseConn{
+						dummyConn: &dummyConn{rawConn: new(dummyRawConn)},
+						closeErr:  closeErr,
+					}, nil
+				},
+				PoolSize:           1,
+				MaxConcurrentDials: 1,
+				DialTimeout:        1 * time.Second,
+				PoolTimeout:        1 * time.Second,
+				ConnMaxIdleTime:    10 * time.Minute, // Long idle time — connection stays healthy
+			})
+
+			// Get a connection and put it back
+			cn, err := testPool.Get(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			testPool.Put(ctx, cn)
+
+			// Close the pool — healthy connection close error should be returned
+			err = testPool.Close()
+			Expect(err).To(MatchError(closeErr))
+		})
+	})
+
 	Describe("calcConnExpiresAt", func() {
 		// Case 1: lifetime <= 0 returns noExpiration
 		It("returns noExpiration when ConnMaxLifetime is not positive", func() {


### PR DESCRIPTION
Fixes #3775

`pool.Close()` now checks `isHealthyConn` before propagating connection close errors, aligning its behavior with the existing error suppression in `Get()` where stale connections are silently discarded. 
This prevents spurious errors (e.g., TLS `closeNotify` timeouts) from being returned when closing a pool whose connections have already been dropped by the server due to idle timeout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `ConnPool.Close()` error propagation semantics by suppressing close errors for connections deemed stale via `isHealthyConn`, which could mask some real shutdown-close failures if the health check misclassifies a connection.
> 
> **Overview**
> `ConnPool.Close()` now evaluates each connection with `isHealthyConn` *before* closing it and only propagates the first `Close()` error when the connection is still considered healthy; close errors from stale/expired connections are suppressed to match `Get()`’s stale-connection handling.
> 
> Tests add a `failCloseConn` helper to simulate TLS/network close failures and verify that `Close()` returns no error for idle-timeout-stale conns, but still returns the close error for healthy ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9329719791e4dfbd20d9557936e09ac3be708511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->