### PR TITLE
refactor(pool): remove redundant Conn.closed atomic field

### DIFF
--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -102,7 +102,6 @@ type Conn struct {
 
 	pooled    bool
 	pubsub    bool
-	closed    atomic.Bool
 	createdAt time.Time
 	expiresAt time.Time
 	poolName  string // Name of the pool this connection belongs to (for metrics)
@@ -882,12 +881,10 @@ func (cn *Conn) WithWriter(
 }
 
 func (cn *Conn) IsClosed() bool {
-	return cn.closed.Load() || cn.stateMachine.GetState() == StateClosed
+	return cn.stateMachine.GetState() == StateClosed
 }
 
 func (cn *Conn) Close() error {
-	cn.closed.Store(true)
-
 	// Transition to CLOSED state
 	cn.stateMachine.Transition(StateClosed)
 


### PR DESCRIPTION
The closed field was redundant with stateMachine's StateClosed state. Now IsClosed() and Close() only use the state machine for consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor that consolidates close-state tracking to the existing state machine; minimal behavioral change but could affect edge cases if any code relied on the atomic flag being set independently of state transitions.
> 
> **Overview**
> Removes the redundant `Conn.closed` atomic field from `Conn` and eliminates all reads/writes to it.
> 
> `Conn.IsClosed()` and `Conn.Close()` now rely exclusively on the state machine (`StateClosed`) to determine and mark closed status, ensuring a single source of truth for connection closure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09edbfc326a9e2266485c7bbe9d777d753301394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->