### PR TITLE
redis: stop chaining baseClient.onClose on every initConn with StreamingCredentialsProvider

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -496,7 +496,14 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 			return fmt.Errorf("failed to subscribe to streaming credentials: %w", initErr)
 		}
 
-		c.onClose = c.wrappedOnClose(unsubscribeFromCredentialsProvider)
+		// Attaching the unsubscribe callback to the per-connection
+		// SetOnClose hook below is sufficient: it runs exactly when the
+		// connection that owns this subscription goes away. Wrapping
+		// c.onClose here as well rebuilds the shared baseClient.onClose
+		// chain on every initConn, which grows unbounded under token
+		// rotation storms and retains each dead *pool.Conn via the
+		// captured closure (#3772). baseClient.Close walks the chain
+		// only once at shutdown, so it never trimmed live entries.
 		cn.SetOnClose(unsubscribeFromCredentialsProvider)
 
 		username, password = credentials.BasicAuth()


### PR DESCRIPTION
## Summary

Fixes #3772.

`initConn` attached `unsubscribeFromCredentialsProvider` to the connection two ways:

```go
c.onClose = c.wrappedOnClose(unsubscribeFromCredentialsProvider)
cn.SetOnClose(unsubscribeFromCredentialsProvider)
```

`cn.SetOnClose` on the per-connection `pool.Conn` is the one that actually runs when that connection leaves the pool. `wrappedOnClose` wraps the prior `c.onClose` in a new closure, so every `initConn` extends a linked list on the shared `baseClient`. A token rotation storm (`ReAuthPoolHook` rejects the whole pool simultaneously and forces `initConn` for every replacement Conn) grows that list by one link per rotation, each retaining a dead `*pool.Conn` via the captured unsubscribe callback (~70 KB of TLS buffers per link). The chain is only walked at `baseClient.Close` — never trimmed during normal operation. Production heap grew ~600 MB per rotation and the process OOM'd every 18-22h.

## Fix

Drop the `c.onClose` assignment; `cn.SetOnClose` already covers the per-connection unsubscribe. The `wrappedOnClose` helper itself is retained — `internal_test.go`'s `Ring` shard-close counter test still uses it for the intended fan-out pattern, so no public API changes.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -short -run "TestStreamingCredentialsProvider|TestReAuthCredentialsListener|TestInitConnNilMaintNotificationsConfig"` green
- [ ] Repro from #3772 (PoolSize=10, 50 workers, 15s rotation): heap should stay flat at ~3 MB instead of growing ~600 MB per rotation.

Retains behaviour for non-streaming credential providers entirely — the changed branch only fires when `c.opt.StreamingCredentialsProvider != nil`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts connection close-hook wiring for streaming credential subscriptions; while scoped to `StreamingCredentialsProvider`, it affects connection lifecycle and cleanup behavior under rotation/reconnect scenarios.
> 
> **Overview**
> Fixes a leak/retention issue when `StreamingCredentialsProvider` is enabled by **removing the per-`initConn` wrapping of `baseClient.onClose`** and relying only on the owning `pool.Conn`’s `SetOnClose(unsubscribe)` callback.
> 
> This prevents the shared `baseClient.onClose` chain from growing without bound during frequent re-auth/token-rotation events, avoiding retention of dead connections via captured unsubscribe closures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8a2ce9089ec3f54962a75b74fe1cbcaf6ac6689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->