### PR TITLE
fix: make dial tcp error redirectable (#3786)

### DIFF
--- a/error.go
+++ b/error.go
@@ -105,6 +105,12 @@ func shouldRetry(err error, retryTimeout bool) bool {
 	// Check for timeout errors (works with wrapped errors)
 	if isTimeout, hasTimeoutFlag := isTimeoutError(err); isTimeout {
 		if hasTimeoutFlag {
+			// A dial error means the TCP connection was never established and the
+			// command was never sent to the server, so retry is always safe
+			var opErr *net.OpError
+			if errors.As(err, &opErr) && opErr.Op == "dial" {
+				return true
+			}
 			return retryTimeout
 		}
 		return true

--- a/error_test.go
+++ b/error_test.go
@@ -3,9 +3,11 @@ package redis_test
 import (
 	"context"
 	"io"
+	"net"
 
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"
+
 	"github.com/redis/go-redis/v9"
 	"github.com/redis/go-redis/v9/internal/proto"
 )
@@ -24,11 +26,9 @@ func (t testTimeout) Error() string {
 
 var _ = Describe("error", func() {
 	BeforeEach(func() {
-
 	})
 
 	AfterEach(func() {
-
 	})
 
 	It("should retry", func() {
@@ -39,15 +39,16 @@ var _ = Describe("error", func() {
 			context.Canceled:         false,
 			context.DeadlineExceeded: false,
 			redis.ErrPoolTimeout:     true,
+			&net.OpError{Op: "dial"}: true,
 			// Use typed errors instead of plain errors.New()
-			proto.ParseErrorReply([]byte("-ERR max number of clients reached")):                      true,
-			proto.ParseErrorReply([]byte("-LOADING Redis is loading the dataset in memory")):         true,
-			proto.ParseErrorReply([]byte("-READONLY You can't write against a read only replica")):                                                                                      true,
+			proto.ParseErrorReply([]byte("-ERR max number of clients reached")):                                                                                   true,
+			proto.ParseErrorReply([]byte("-LOADING Redis is loading the dataset in memory")):                                                                      true,
+			proto.ParseErrorReply([]byte("-READONLY You can't write against a read only replica")):                                                                true,
 			proto.ParseErrorReply([]byte("-ERR Error running script (call to f_abc123): @user_script:1: -READONLY You can't write against a read only replica.")): true,
-			proto.ParseErrorReply([]byte("-CLUSTERDOWN The cluster is down")):                        true,
-			proto.ParseErrorReply([]byte("-TRYAGAIN Command cannot be processed, please try again")): true,
-			proto.ParseErrorReply([]byte("-NOREPLICAS Not enough good replicas to write")):           true,
-			proto.ParseErrorReply([]byte("-ERR other")):                                              false,
+			proto.ParseErrorReply([]byte("-CLUSTERDOWN The cluster is down")):                                                                                     true,
+			proto.ParseErrorReply([]byte("-TRYAGAIN Command cannot be processed, please try again")):                                                              true,
+			proto.ParseErrorReply([]byte("-NOREPLICAS Not enough good replicas to write")):                                                                        true,
+			proto.ParseErrorReply([]byte("-ERR other")):                                                                                                           false,
 		}
 
 		for err, expected := range data {


### PR DESCRIPTION
Fixes #3786 

The `ShouldRetry()` method now checks the timeout error for compliance with its dial tcp timeout error. If there is an error, the function returns true, since the request should be repeated. A dial error means the TCP connection was never established and the command was never sent to the server, so retry is always safe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, targeted change to retry classification for network dial timeout errors, with added unit coverage. Potential impact is limited to slightly increasing retries on connection-establishment failures.
> 
> **Overview**
> `ShouldRetry` now treats timeout errors that are specifically `net.OpError` with `Op == "dial"` as **always safe to retry**, since no command was sent to Redis.
> 
> Tests were updated to cover `dial` vs non-`dial` `net.OpError` cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e13fd6bf457c48abadcccd30e7bc59f094761150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->