### PR TITLE
fix(hello): do not send maintnotifications handshake when hello fails

### DIFF
--- a/internal_maint_notif_test.go
+++ b/internal_maint_notif_test.go
@@ -3,12 +3,17 @@ package redis
 import (
 	"bufio"
 	"context"
+	"fmt"
+	"io"
 	"net"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/redis/go-redis/v9/internal/pool"
+	"github.com/redis/go-redis/v9/maintnotifications"
 )
 
 // TestInitConnNilMaintNotificationsConfig is a regression test for
@@ -93,4 +98,209 @@ func TestInitConnNilMaintNotificationsConfig(t *testing.T) {
 	}()
 
 	_ = c.initConn(context.Background(), cn)
+}
+
+
+// mockRESP2Server is a minimal RESP server used to exercise the HELLO
+// fallback path in initConn. It replies with a Redis protocol error to
+// HELLO (simulating a server that only speaks RESP2) and with +OK to every
+// other command. It records every command received so tests can assert
+// which commands were (or were not) sent on the wire.
+type mockRESP2Server struct {
+	ln       net.Listener
+	mu       sync.Mutex
+	commands []string
+}
+
+func (s *mockRESP2Server) Addr() string { return s.ln.Addr().String() }
+func (s *mockRESP2Server) Close()       { _ = s.ln.Close() }
+
+func (s *mockRESP2Server) Commands() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.commands))
+	copy(out, s.commands)
+	return out
+}
+
+// readRESPCommand reads a single RESP array command from r and returns its
+// arguments as strings.
+func readRESPCommand(r *bufio.Reader) ([]string, error) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return nil, err
+	}
+	line = strings.TrimRight(line, "\r\n")
+	if !strings.HasPrefix(line, "*") {
+		return nil, fmt.Errorf("expected array header, got %q", line)
+	}
+	n, err := strconv.Atoi(line[1:])
+	if err != nil {
+		return nil, err
+	}
+	args := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		hdr, err := r.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		hdr = strings.TrimRight(hdr, "\r\n")
+		if !strings.HasPrefix(hdr, "$") {
+			return nil, fmt.Errorf("expected bulk header, got %q", hdr)
+		}
+		length, err := strconv.Atoi(hdr[1:])
+		if err != nil {
+			return nil, err
+		}
+		buf := make([]byte, length)
+		if _, err := io.ReadFull(r, buf); err != nil {
+			return nil, err
+		}
+		if _, err := r.Discard(2); err != nil {
+			return nil, err
+		}
+		args = append(args, string(buf))
+	}
+	return args, nil
+}
+
+func (s *mockRESP2Server) handle(c net.Conn) {
+	defer c.Close()
+	r := bufio.NewReader(c)
+	for {
+		args, err := readRESPCommand(r)
+		if err != nil {
+			return
+		}
+		if len(args) == 0 {
+			continue
+		}
+		name := strings.ToUpper(args[0])
+		full := name
+		if len(args) > 1 {
+			full = name + " " + strings.ToUpper(args[1])
+		}
+		s.mu.Lock()
+		s.commands = append(s.commands, full)
+		s.mu.Unlock()
+
+		if name == "HELLO" {
+			_, _ = c.Write([]byte("-ERR unknown command 'hello'\r\n"))
+			continue
+		}
+		_, _ = c.Write([]byte("+OK\r\n"))
+	}
+}
+
+func startMockRESP2Server(t *testing.T) *mockRESP2Server {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	s := &mockRESP2Server{ln: ln}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go s.handle(conn)
+		}
+	}()
+	return s
+}
+
+
+// assertNoMaintNotifications fails the test if a CLIENT MAINT_NOTIFICATIONS
+// command was observed by srv.
+func assertNoMaintNotifications(t *testing.T, srv *mockRESP2Server) {
+	t.Helper()
+	for _, cmd := range srv.Commands() {
+		if cmd == "CLIENT MAINT_NOTIFICATIONS" {
+			t.Fatalf("CLIENT MAINT_NOTIFICATIONS must not be sent when HELLO falls back to RESP2; commands observed: %v", srv.Commands())
+		}
+	}
+}
+
+// initConnOnMockServer dials srv, puts the connection into INITIALIZING and
+// runs c.initConn against it. It returns the error from initConn (if any).
+func initConnOnMockServer(t *testing.T, c *baseClient, srv *mockRESP2Server) error {
+	t.Helper()
+	netConn, err := net.DialTimeout("tcp", srv.Addr(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("failed to dial mock server: %v", err)
+	}
+	t.Cleanup(func() { _ = netConn.Close() })
+	cn := pool.NewConn(netConn)
+	cn.GetStateMachine().Transition(pool.StateInitializing)
+	return c.initConn(context.Background(), cn)
+}
+
+// newTestBaseClient builds a baseClient wired up with hooks for use in
+// tests that exercise initConn directly.
+func newTestBaseClient(opt *Options) *baseClient {
+	c := &baseClient{opt: opt}
+	c.initHooks(hooks{
+		dial:       c.dial,
+		process:    c.process,
+		pipeline:   c.processPipeline,
+		txPipeline: c.processTxPipeline,
+	})
+	return c
+}
+
+// TestInitConn_HelloFallback_ModeEnabled verifies that when the server
+// rejects HELLO (so the connection falls back to RESP2) and the user has
+// explicitly requested ModeEnabled with Protocol: 3, initConn fails with a
+// clear RESP3-related error instead of silently sending a meaningless
+// CLIENT MAINT_NOTIFICATIONS command on a RESP2 connection.
+func TestInitConn_HelloFallback_ModeEnabled(t *testing.T) {
+	srv := startMockRESP2Server(t)
+	defer srv.Close()
+
+	opt := &Options{
+		Addr:     srv.Addr(),
+		Protocol: 3,
+		MaintNotificationsConfig: &maintnotifications.Config{
+			Mode: maintnotifications.ModeEnabled,
+		},
+	}
+	opt.init()
+
+	c := newTestBaseClient(opt)
+	err := initConnOnMockServer(t, c, srv)
+	if err == nil {
+		t.Fatalf("expected initConn to fail when HELLO falls back to RESP2 with ModeEnabled, got nil")
+	}
+	if !strings.Contains(err.Error(), "RESP3") {
+		t.Fatalf("expected error to mention RESP3, got %v", err)
+	}
+	assertNoMaintNotifications(t, srv)
+}
+
+// TestInitConn_HelloFallback_ModeAuto verifies that when HELLO is rejected
+// and ModeAuto is configured, initConn succeeds without sending CLIENT
+// MAINT_NOTIFICATIONS and the feature is silently disabled on the client.
+func TestInitConn_HelloFallback_ModeAuto(t *testing.T) {
+	srv := startMockRESP2Server(t)
+	defer srv.Close()
+
+	opt := &Options{
+		Addr:     srv.Addr(),
+		Protocol: 3,
+		MaintNotificationsConfig: &maintnotifications.Config{
+			Mode: maintnotifications.ModeAuto,
+		},
+	}
+	opt.init()
+
+	c := newTestBaseClient(opt)
+	if err := initConnOnMockServer(t, c, srv); err != nil {
+		t.Fatalf("initConn returned error in ModeAuto (expected silent disable and success): %v", err)
+	}
+	assertNoMaintNotifications(t, srv)
+	if opt.MaintNotificationsConfig.Mode != maintnotifications.ModeDisabled {
+		t.Fatalf("expected mode to be silently set to Disabled after RESP2 fallback, got %q", opt.MaintNotificationsConfig.Mode)
+	}
 }

--- a/redis.go
+++ b/redis.go
@@ -604,8 +604,13 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 
 	// for redis-server versions that do not support the HELLO command,
 	// RESP2 will continue to be used.
+	// helloOK tracks whether HELLO succeeded. If it did not, the connection
+	// falls back to RESP2 regardless of c.opt.Protocol, and features that
+	// require RESP3 (e.g. maintenance notifications) must be skipped.
+	helloOK := false
 	if initErr = conn.Hello(ctx, c.opt.Protocol, username, password, c.opt.ClientName).Err(); initErr == nil {
 		// Authentication successful with HELLO command
+		helloOK = true
 	} else if !isRedisError(initErr) {
 		// When the server responds with the RESP protocol and the result is not a normal
 		// execution result of the HELLO command, we consider it to be an indication that
@@ -654,10 +659,38 @@ func (c *baseClient) initConn(ctx context.Context, cn *pool.Conn) error {
 	maintNotifEnabled := c.opt.MaintNotificationsConfig != nil && c.opt.MaintNotificationsConfig.Mode != maintnotifications.ModeDisabled
 	protocol := c.opt.Protocol
 	var endpointType maintnotifications.EndpointType
+	var maintNotifMode maintnotifications.Mode
 	if maintNotifEnabled {
 		endpointType = c.opt.MaintNotificationsConfig.EndpointType
+		maintNotifMode = c.opt.MaintNotificationsConfig.Mode
 	}
 	c.optLock.RUnlock()
+
+	// Maintenance notifications require RESP3 push frames. If HELLO failed
+	// and the connection fell back to RESP2, there is no point in sending
+	// CLIENT MAINT_NOTIFICATIONS: the server either rejects it (making the
+	// error misleading) or accepts it silently, leaving the client unable
+	// to receive any notifications. Decide based on the actual negotiated
+	// protocol rather than the requested one.
+	if maintNotifEnabled && protocol == 3 && !helloOK {
+		if maintNotifMode == maintnotifications.ModeEnabled {
+			// Explicitly requested - fail fast with a clear reason.
+			cn.GetStateMachine().Transition(pool.StateClosed)
+			if errorCallback := pool.GetMetricErrorCallback(); errorCallback != nil {
+				errorCallback(ctx, "HANDSHAKE_FAILED", cn, "HANDSHAKE_FAILED", true, 0)
+			}
+			return fmt.Errorf("failed to enable maintnotifications: server does not support RESP3 (HELLO command failed)")
+		}
+		// auto/other modes: silently disable maintnotifications for this client.
+		c.optLock.Lock()
+		c.opt.MaintNotificationsConfig.Mode = maintnotifications.ModeDisabled
+		c.optLock.Unlock()
+		if err := c.disableMaintNotificationsUpgrades(); err != nil {
+			internal.Logger.Printf(ctx, "failed to disable maintnotifications in auto mode: %v", err)
+		}
+		maintNotifEnabled = false
+	}
+
 	var maintNotifHandshakeErr error
 	if maintNotifEnabled && protocol == 3 {
 		maintNotifHandshakeErr = conn.ClientMaintNotifications(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes connection initialization behavior around protocol negotiation and maintenance-notification setup; could affect clients that request RESP3 but connect to servers/proxies without `HELLO` support.
> 
> **Overview**
> Prevents `initConn` from attempting the `CLIENT MAINT_NOTIFICATIONS` handshake when `HELLO` fails and the connection effectively falls back to RESP2, even if `Options.Protocol` requested RESP3.
> 
> If maintnotifications were *explicitly* enabled (`ModeEnabled`) with `Protocol: 3`, `initConn` now fails fast with a clear RESP3/`HELLO`-related error; for auto modes it silently disables maintnotifications (updates `MaintNotificationsConfig.Mode` to `ModeDisabled` and tears down related upgrades) and continues.
> 
> Adds a mock RESP2 server and new regression tests to assert no `CLIENT MAINT_NOTIFICATIONS` command is sent on `HELLO` fallback, and to validate the differing `ModeEnabled` vs `ModeAuto` outcomes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7782866c4da4d51083d1882c4058c92d38d5304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->