### PR TITLE
Redisotel: tracing Filter with ctx

### DIFF
--- a/extra/redisotel/config.go
+++ b/extra/redisotel/config.go
@@ -1,6 +1,7 @@
 package redisotel
 
 import (
+	"context"
 	"strings"
 
 	"github.com/redis/go-redis/v9"
@@ -24,9 +25,9 @@ type config struct {
 
 	dbStmtEnabled         bool
 	callerEnabled         bool
-	filterDial            bool
-	filterProcessPipeline func(cmds []redis.Cmder) bool
-	filterProcess         func(cmd redis.Cmder) bool
+	filterDial            func(ctx context.Context, network, addr string) bool
+	filterProcessPipeline func(ctx context.Context, cmds []redis.Cmder) bool
+	filterProcess         func(ctx context.Context, cmd redis.Cmder) bool
 
 	// Metrics options.
 
@@ -67,8 +68,10 @@ func newConfig(opts ...baseOption) *config {
 		mp:            otel.GetMeterProvider(),
 		dbStmtEnabled: true,
 		callerEnabled: true,
-		filterProcess: DefaultCommandFilter,
-		filterProcessPipeline: func(cmds []redis.Cmder) bool {
+		filterProcess: func(ctx context.Context, cmd redis.Cmder) bool {
+			return DefaultCommandFilter(cmd)
+		},
+		filterProcessPipeline: func(ctx context.Context, cmds []redis.Cmder) bool {
 			for _, cmd := range cmds {
 				if DefaultCommandFilter(cmd) {
 					return true
@@ -147,29 +150,57 @@ func WithCallerEnabled(on bool) TracingOption {
 
 // WithCommandFilter allows filtering of commands when tracing to omit commands that may have sensitive details like
 // passwords.
+// Deprecated: use WithCommandFilterCtx instead to have access to the context in the filter.
+// TODO: Deprecation timeline?
 func WithCommandFilter(filter func(cmd redis.Cmder) bool) TracingOption {
-	return tracingOption(func(conf *config) {
-		conf.filterProcess = filter
+	return WithCommandFilterCtx(func(ctx context.Context, cmd redis.Cmder) bool {
+		return filter(cmd)
 	})
 }
 
 // WithCommandsFilter allows filtering of pipeline commands
 // when tracing to omit commands that may have sensitive details like
 // passwords in a pipeline.
+// Deprecated: use WithCommandsFilterCtx instead to have access to the context in the filter.
+// TODO: Deprecation timeline?
 func WithCommandsFilter(filter func(cmds []redis.Cmder) bool) TracingOption {
+	return WithCommandsFilterCtx(func(ctx context.Context, cmds []redis.Cmder) bool {
+		return filter(cmds)
+	})
+}
+
+// WithDialFilter enables or disables filtering of dial commands.
+// Deprecated: use WithDialFilterCtx instead to have access to the context in the filter.
+// TODO: Deprecation timeline?
+func WithDialFilter(on bool) TracingOption {
+	return WithDialFilterCtx(func(ctx context.Context, network, addr string) bool {
+		return on
+	})
+}
+
+// WithDialFilterCtx enables or disables filtering of dial commands with access to context, network and address.
+func WithDialFilterCtx(filter func(ctx context.Context, network, addr string) bool) TracingOption {
+	return tracingOption(func(conf *config) {
+		conf.filterDial = filter
+	})
+}
+
+// WithCommandFilterCtx allows filtering of commands with access to the context and cmd.
+func WithCommandFilterCtx(filter func(ctx context.Context, cmd redis.Cmder) bool) TracingOption {
+	return tracingOption(func(conf *config) {
+		conf.filterProcess = filter
+	})
+}
+
+// WithCommandsFilterCtx allows filtering of pipeline commands with access to the context and cmds.
+func WithCommandsFilterCtx(filter func(ctx context.Context, cmds []redis.Cmder) bool) TracingOption {
 	return tracingOption(func(conf *config) {
 		conf.filterProcessPipeline = filter
 	})
 }
 
-// WithDialFilter enables or disables filtering of dial commands.
-func WithDialFilter(on bool) TracingOption {
-	return tracingOption(func(conf *config) {
-		conf.filterDial = on
-	})
-}
-
 // DefaultCommandFilter filters out AUTH commands from tracing.
+// Intentionally skipped context as context is not needed for this default filter.
 func DefaultCommandFilter(cmd redis.Cmder) bool {
 	if strings.ToLower(cmd.Name()) == "auth" {
 		return true
@@ -195,6 +226,7 @@ func DefaultCommandFilter(cmd redis.Cmder) bool {
 
 // BasicCommandFilter filters out AUTH commands from tracing.
 // Deprecated: use DefaultCommandFilter instead.
+// TODO: Deprecation timeline?
 func BasicCommandFilter(cmd redis.Cmder) bool {
 	return DefaultCommandFilter(cmd)
 }

--- a/extra/redisotel/tracing.go
+++ b/extra/redisotel/tracing.go
@@ -88,7 +88,7 @@ func newTracingHook(connString string, opts ...TracingOption) *tracingHook {
 func (th *tracingHook) DialHook(hook redis.DialHook) redis.DialHook {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 
-		if th.conf.filterDial {
+		if th.conf.filterDial != nil && th.conf.filterDial(ctx, network, addr) {
 			return hook(ctx, network, addr)
 		}
 
@@ -108,7 +108,7 @@ func (th *tracingHook) ProcessHook(hook redis.ProcessHook) redis.ProcessHook {
 	return func(ctx context.Context, cmd redis.Cmder) error {
 
 		// Check if the command should be filtered out
-		if th.conf.filterProcess != nil && th.conf.filterProcess(cmd) {
+		if th.conf.filterProcess != nil && th.conf.filterProcess(ctx, cmd) {
 			// If so, just call the next hook
 			return hook(ctx, cmd)
 		}
@@ -147,7 +147,7 @@ func (th *tracingHook) ProcessPipelineHook(
 ) redis.ProcessPipelineHook {
 	return func(ctx context.Context, cmds []redis.Cmder) error {
 
-		if th.conf.filterProcessPipeline != nil && th.conf.filterProcessPipeline(cmds) {
+		if th.conf.filterProcessPipeline != nil && th.conf.filterProcessPipeline(ctx, cmds) {
 			return hook(ctx, cmds)
 		}
 

--- a/extra/redisotel/tracing_test.go
+++ b/extra/redisotel/tracing_test.go
@@ -231,6 +231,36 @@ func TestWithCommandFilterCtx(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+
+	t.Run("filter out command with custom context value", func(t *testing.T) {
+		provider := sdktrace.NewTracerProvider()
+		hook := newTracingHook(
+			"",
+			WithTracerProvider(provider),
+			WithCommandFilterCtx(func(ctx context.Context, cmd redis.Cmder) bool {
+				ctxValue := ctx.Value("filter")
+				t.Log("filter context value:", ctxValue)
+				return ctxValue == "true"
+			}),
+		)
+		ctx, span := provider.Tracer("redis-test").Start(context.TODO(), "redis-test")
+		ctx = context.WithValue(ctx, "filter", "true")
+		cmd := redis.NewCmd(ctx, "ping")
+		defer span.End()
+
+		processHook := hook.ProcessHook(func(ctx context.Context, cmd redis.Cmder) error {
+			innerSpan := trace.SpanFromContext(ctx).(sdktrace.ReadOnlySpan)
+			if innerSpan.Name() != "redis-test" || innerSpan.Name() == "ping" {
+				t.Fatalf("ping command should not be traced")
+			}
+
+			return nil
+		})
+		err := processHook(ctx, cmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestWithCommandsFilterCtx(t *testing.T) {
@@ -298,6 +328,40 @@ func TestWithCommandsFilterCtx(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+
+	t.Run("filter out commands with custom context value", func(t *testing.T) {
+		provider := sdktrace.NewTracerProvider()
+		hook := newTracingHook(
+			"",
+			WithTracerProvider(provider),
+			WithCommandsFilterCtx(func(ctx context.Context, cmds []redis.Cmder) bool {
+				ctxValue := ctx.Value("filter")
+				t.Log("filter context value:", ctxValue)
+				return ctxValue == "true"
+			}),
+		)
+		ctx, span := provider.Tracer("redis-test").Start(context.TODO(), "redis-test")
+
+		ctx = context.WithValue(ctx, "filter", "true")
+
+		cmds := []redis.Cmder{
+			redis.NewCmd(ctx, "ping"),
+			redis.NewCmd(ctx, "info"),
+		}
+		defer span.End()
+
+		processPipelineHook := hook.ProcessPipelineHook(func(ctx context.Context, cmds []redis.Cmder) error {
+			innerSpan := trace.SpanFromContext(ctx).(sdktrace.ReadOnlySpan)
+			if innerSpan.Name() != "redis-test" || innerSpan.Name() == "redis.pipeline ping\ninfo" {
+				t.Fatalf("ping and info commands should not be traced")
+			}
+			return nil
+		})
+		err := processPipelineHook(ctx, cmds)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestWithDialFilterCtx(t *testing.T) {
@@ -344,6 +408,34 @@ func TestWithDialFilterCtx(t *testing.T) {
 			}
 			return nil, nil
 		})
+		_, err := dialHook(ctx, "tcp", "localhost:6379")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("filter out dial with custom context value", func(t *testing.T) {
+		provider := sdktrace.NewTracerProvider()
+		hook := newTracingHook(
+			"",
+			WithTracerProvider(provider),
+			WithDialFilterCtx(func(ctx context.Context, _, _ string) bool {
+				ctxValue := ctx.Value("filter")
+				return ctxValue == "true"
+			}),
+		)
+		ctx := context.TODO()
+		ctx = context.WithValue(ctx, "filter", "true")
+		ctx, span := provider.Tracer("redis-test").Start(ctx, "redis-test")
+		defer span.End()
+		dialHook := hook.DialHook(func(ctx context.Context, network, addr string) (conn net.Conn, err error) {
+			innerSpan := trace.SpanFromContext(ctx).(sdktrace.ReadOnlySpan)
+			if innerSpan.Name() == "redis.dial" {
+				t.Fatalf("dial should not be traced")
+			}
+			return nil, nil
+		})
+
 		_, err := dialHook(ctx, "tcp", "localhost:6379")
 		if err != nil {
 			t.Fatal(err)

--- a/extra/redisotel/tracing_test.go
+++ b/extra/redisotel/tracing_test.go
@@ -95,14 +95,14 @@ func TestWithoutCaller(t *testing.T) {
 	}
 }
 
-func TestWithCommandFilter(t *testing.T) {
+func TestWithCommandFilterCtx(t *testing.T) {
 
 	t.Run("filter out ping command", func(t *testing.T) {
 		provider := sdktrace.NewTracerProvider()
 		hook := newTracingHook(
 			"",
 			WithTracerProvider(provider),
-			WithCommandFilter(func(cmd redis.Cmder) bool {
+			WithCommandFilterCtx(func(_ context.Context, cmd redis.Cmder) bool {
 				return cmd.Name() == "ping"
 			}),
 		)
@@ -129,7 +129,7 @@ func TestWithCommandFilter(t *testing.T) {
 		hook := newTracingHook(
 			"",
 			WithTracerProvider(provider),
-			WithCommandFilter(func(cmd redis.Cmder) bool {
+			WithCommandFilterCtx(func(_ context.Context, cmd redis.Cmder) bool {
 				return false // never filter
 			}),
 		)
@@ -156,7 +156,9 @@ func TestWithCommandFilter(t *testing.T) {
 		hook := newTracingHook(
 			"",
 			WithTracerProvider(provider),
-			WithCommandFilter(DefaultCommandFilter),
+			WithCommandFilterCtx(func(_ context.Context, cmd redis.Cmder) bool {
+				return DefaultCommandFilter(cmd)
+			}),
 		)
 		ctx, span := provider.Tracer("redis-test").Start(context.TODO(), "redis-test")
 		cmd := redis.NewCmd(ctx, "auth", "test-password")
@@ -181,7 +183,9 @@ func TestWithCommandFilter(t *testing.T) {
 		hook := newTracingHook(
 			"",
 			WithTracerProvider(provider),
-			WithCommandFilter(DefaultCommandFilter),
+			WithCommandFilterCtx(func(_ context.Context, cmd redis.Cmder) bool {
+				return DefaultCommandFilter(cmd)
+			}),
 		)
 		ctx, span := provider.Tracer("redis-test").Start(context.TODO(), "redis-test")
 		cmd := redis.NewCmd(ctx, "hello", 3, "AUTH", "test-user", "test-password")
@@ -206,7 +210,9 @@ func TestWithCommandFilter(t *testing.T) {
 		hook := newTracingHook(
 			"",
 			WithTracerProvider(provider),
-			WithCommandFilter(DefaultCommandFilter),
+			WithCommandFilterCtx(func(_ context.Context, cmd redis.Cmder) bool {
+				return DefaultCommandFilter(cmd)
+			}),
 		)
 		ctx, span := provider.Tracer("redis-test").Start(context.TODO(), "redis-test")
 		cmd := redis.NewCmd(ctx, "hello", 3)
@@ -227,13 +233,13 @@ func TestWithCommandFilter(t *testing.T) {
 	})
 }
 
-func TestWithCommandsFilter(t *testing.T) {
+func TestWithCommandsFilterCtx(t *testing.T) {
 	t.Run("filter out ping and info commands", func(t *testing.T) {
 		provider := sdktrace.NewTracerProvider()
 		hook := newTracingHook(
 			"",
 			WithTracerProvider(provider),
-			WithCommandsFilter(func(cmds []redis.Cmder) bool {
+			WithCommandsFilterCtx(func(_ context.Context, cmds []redis.Cmder) bool {
 				for _, cmd := range cmds {
 					if cmd.Name() == "ping" || cmd.Name() == "info" {
 						return true
@@ -268,7 +274,7 @@ func TestWithCommandsFilter(t *testing.T) {
 		hook := newTracingHook(
 			"",
 			WithTracerProvider(provider),
-			WithCommandsFilter(func(cmds []redis.Cmder) bool {
+			WithCommandsFilterCtx(func(_ context.Context, cmds []redis.Cmder) bool {
 				return false // never filter
 			}),
 		)
@@ -294,13 +300,15 @@ func TestWithCommandsFilter(t *testing.T) {
 	})
 }
 
-func TestWithDialFilter(t *testing.T) {
+func TestWithDialFilterCtx(t *testing.T) {
 	t.Run("filter out dial", func(t *testing.T) {
 		provider := sdktrace.NewTracerProvider()
 		hook := newTracingHook(
 			"",
 			WithTracerProvider(provider),
-			WithDialFilter(true),
+			WithDialFilterCtx(func(_ context.Context, network, addr string) bool {
+				return true
+			}),
 		)
 		ctx, span := provider.Tracer("redis-test").Start(context.TODO(), "redis-test")
 		defer span.End()
@@ -323,7 +331,9 @@ func TestWithDialFilter(t *testing.T) {
 		hook := newTracingHook(
 			"",
 			WithTracerProvider(provider),
-			WithDialFilter(false),
+			WithDialFilterCtx(func(_ context.Context, network, addr string) bool {
+				return false // never filter
+			}),
 		)
 		ctx, span := provider.Tracer("redis-test").Start(context.TODO(), "redis-test")
 		defer span.End()


### PR DESCRIPTION
This PR has one of the approach mentioned in #3760. With ability to propagate all the params we got in Dial, Process, Pipeline hook. 

Making it fully flexible for filtering the trace. 


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are localized to redis OpenTelemetry hook filtering and are backward-compatible via deprecated wrapper options, with updated/expanded tests covering the new behavior.
> 
> **Overview**
> Adds **context-aware filtering** to redis OpenTelemetry tracing by changing `filterDial`, `filterProcess`, and `filterProcessPipeline` to accept `context.Context`, and wiring that context through `DialHook`, `ProcessHook`, and `ProcessPipelineHook`.
> 
> Introduces new options `WithDialFilterCtx`, `WithCommandFilterCtx`, and `WithCommandsFilterCtx`, while deprecating the old `WithDialFilter`, `WithCommandFilter`, and `WithCommandsFilter` via wrappers; tests are renamed/updated and new cases verify filtering decisions based on values stored in `context`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36adcfea3d61cc9f774b5ef14559f4a1473e8818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->