### PR TITLE
(feat) Add support for xautoclaim to return list of deleted messages ids from PEL

### DIFF
--- a/command.go
+++ b/command.go
@@ -159,8 +159,9 @@ const (
 
 type (
 	CmdTypeXAutoClaimValue struct {
-		messages []XMessage
-		start    string
+		messages   []XMessage
+		start      string
+		deletedIDs []string
 	}
 
 	CmdTypeXAutoClaimJustIDValue struct {
@@ -2610,8 +2611,9 @@ func (cmd *XPendingExtCmd) Clone() Cmder {
 type XAutoClaimCmd struct {
 	baseCmd
 
-	start string
-	val   []XMessage
+	start      string
+	val        []XMessage
+	deletedIDs []string
 }
 
 var _ Cmder = (*XAutoClaimCmd)(nil)
@@ -2626,17 +2628,18 @@ func NewXAutoClaimCmd(ctx context.Context, args ...interface{}) *XAutoClaimCmd {
 	}
 }
 
-func (cmd *XAutoClaimCmd) SetVal(val []XMessage, start string) {
+func (cmd *XAutoClaimCmd) SetVal(val []XMessage, start string, deletedIDs []string) {
 	cmd.val = val
 	cmd.start = start
+	cmd.deletedIDs = deletedIDs
 }
 
-func (cmd *XAutoClaimCmd) Val() (messages []XMessage, start string) {
-	return cmd.val, cmd.start
+func (cmd *XAutoClaimCmd) Val() (messages []XMessage, start string, deletedIDs []string) {
+	return cmd.val, cmd.start, cmd.deletedIDs
 }
 
-func (cmd *XAutoClaimCmd) Result() (messages []XMessage, start string, err error) {
-	return cmd.val, cmd.start, cmd.err
+func (cmd *XAutoClaimCmd) Result() (messages []XMessage, start string, deletedIDs []string, err error) {
+	return cmd.val, cmd.start, cmd.deletedIDs, cmd.err
 }
 
 func (cmd *XAutoClaimCmd) String() string {
@@ -2667,8 +2670,19 @@ func (cmd *XAutoClaimCmd) readReply(rd *proto.Reader) error {
 		return err
 	}
 
-	if n >= 3 {
-		if err := rd.DiscardNext(); err != nil {
+	if n < 3 {
+		return nil
+	}
+
+	nn, err := rd.ReadArrayLen()
+	if err != nil {
+		return err
+	}
+
+	cmd.deletedIDs = make([]string, nn)
+	for i := 0; i < nn; i++ {
+		cmd.deletedIDs[i], err = rd.ReadString()
+		if err != nil {
 			return err
 		}
 	}
@@ -8020,11 +8034,11 @@ func ExtractCommandValue(cmd interface{}) (interface{}, error) {
 			}
 		case CmdTypeXAutoClaim:
 			if xAutoClaimCmd, ok := cmd.(interface {
-				Val() ([]XMessage, string)
+				Val() ([]XMessage, string, []string)
 				Err() error
 			}); ok {
-				messages, start := xAutoClaimCmd.Val()
-				return CmdTypeXAutoClaimValue{messages: messages, start: start}, xAutoClaimCmd.Err()
+				messages, start, deletedIDs := xAutoClaimCmd.Val()
+				return CmdTypeXAutoClaimValue{messages: messages, start: start, deletedIDs: deletedIDs}, xAutoClaimCmd.Err()
 			}
 		case CmdTypeXAutoClaimJustID:
 			if xAutoClaimJustIDCmd, ok := cmd.(interface {

--- a/command.go
+++ b/command.go
@@ -109,6 +109,7 @@ const (
 	CmdTypeXPending
 	CmdTypeXPendingExt
 	CmdTypeXAutoClaim
+	CmdTypeXAutoClaimWithDeleted
 	CmdTypeXAutoClaimJustID
 	CmdTypeXInfoConsumers
 	CmdTypeXInfoGroups
@@ -159,6 +160,11 @@ const (
 
 type (
 	CmdTypeXAutoClaimValue struct {
+		messages []XMessage
+		start    string
+	}
+
+	CmdTypeXAutoClaimWithDeletedValue struct {
 		messages   []XMessage
 		start      string
 		deletedIDs []string
@@ -2611,9 +2617,8 @@ func (cmd *XPendingExtCmd) Clone() Cmder {
 type XAutoClaimCmd struct {
 	baseCmd
 
-	start      string
-	val        []XMessage
-	deletedIDs []string
+	start string
+	val   []XMessage
 }
 
 var _ Cmder = (*XAutoClaimCmd)(nil)
@@ -2628,18 +2633,17 @@ func NewXAutoClaimCmd(ctx context.Context, args ...interface{}) *XAutoClaimCmd {
 	}
 }
 
-func (cmd *XAutoClaimCmd) SetVal(val []XMessage, start string, deletedIDs []string) {
+func (cmd *XAutoClaimCmd) SetVal(val []XMessage, start string) {
 	cmd.val = val
 	cmd.start = start
-	cmd.deletedIDs = deletedIDs
 }
 
-func (cmd *XAutoClaimCmd) Val() (messages []XMessage, start string, deletedIDs []string) {
-	return cmd.val, cmd.start, cmd.deletedIDs
+func (cmd *XAutoClaimCmd) Val() (messages []XMessage, start string) {
+	return cmd.val, cmd.start
 }
 
-func (cmd *XAutoClaimCmd) Result() (messages []XMessage, start string, deletedIDs []string, err error) {
-	return cmd.val, cmd.start, cmd.deletedIDs, cmd.err
+func (cmd *XAutoClaimCmd) Result() (messages []XMessage, start string, err error) {
+	return cmd.val, cmd.start, cmd.err
 }
 
 func (cmd *XAutoClaimCmd) String() string {
@@ -2647,6 +2651,100 @@ func (cmd *XAutoClaimCmd) String() string {
 }
 
 func (cmd *XAutoClaimCmd) readReply(rd *proto.Reader) error {
+	n, err := rd.ReadArrayLen()
+	if err != nil {
+		return err
+	}
+
+	switch n {
+	case 2, // Redis 6
+		3: // Redis 7:
+		// ok
+	default:
+		return fmt.Errorf("redis: got %d elements in XAutoClaim reply, wanted 2/3", n)
+	}
+
+	cmd.start, err = rd.ReadString()
+	if err != nil {
+		return err
+	}
+
+	cmd.val, err = readXMessageSlice(rd)
+	if err != nil {
+		return err
+	}
+
+	if n >= 3 {
+		return rd.DiscardNext()
+	}
+
+	return nil
+}
+
+func (cmd *XAutoClaimCmd) Clone() Cmder {
+	var val []XMessage
+	if cmd.val != nil {
+		val = make([]XMessage, len(cmd.val))
+		for i, msg := range cmd.val {
+			val[i] = XMessage{
+				ID: msg.ID,
+			}
+			if msg.Values != nil {
+				val[i].Values = make(map[string]interface{}, len(msg.Values))
+				for k, v := range msg.Values {
+					val[i].Values[k] = v
+				}
+			}
+		}
+	}
+	return &XAutoClaimCmd{
+		baseCmd: cmd.cloneBaseCmd(),
+		start:   cmd.start,
+		val:     val,
+	}
+}
+
+//------------------------------------------------------------------------------
+
+type XAutoClaimWithDeletedCmd struct {
+	baseCmd
+
+	start      string
+	val        []XMessage
+	deletedIDs []string
+}
+
+var _ Cmder = (*XAutoClaimWithDeletedCmd)(nil)
+
+func NewXAutoClaimWithDeletedCmd(ctx context.Context, args ...interface{}) *XAutoClaimWithDeletedCmd {
+	return &XAutoClaimWithDeletedCmd{
+		baseCmd: baseCmd{
+			ctx:     ctx,
+			args:    args,
+			cmdType: CmdTypeXAutoClaimWithDeleted,
+		},
+	}
+}
+
+func (cmd *XAutoClaimWithDeletedCmd) SetVal(val []XMessage, start string, deletedIDs []string) {
+	cmd.val = val
+	cmd.start = start
+	cmd.deletedIDs = deletedIDs
+}
+
+func (cmd *XAutoClaimWithDeletedCmd) Val() (messages []XMessage, start string, deletedIDs []string) {
+	return cmd.val, cmd.start, cmd.deletedIDs
+}
+
+func (cmd *XAutoClaimWithDeletedCmd) Result() (messages []XMessage, start string, deletedIDs []string, err error) {
+	return cmd.val, cmd.start, cmd.deletedIDs, cmd.err
+}
+
+func (cmd *XAutoClaimWithDeletedCmd) String() string {
+	return cmdString(cmd, cmd.val)
+}
+
+func (cmd *XAutoClaimWithDeletedCmd) readReply(rd *proto.Reader) error {
 	n, err := rd.ReadArrayLen()
 	if err != nil {
 		return err
@@ -2690,7 +2788,7 @@ func (cmd *XAutoClaimCmd) readReply(rd *proto.Reader) error {
 	return nil
 }
 
-func (cmd *XAutoClaimCmd) Clone() Cmder {
+func (cmd *XAutoClaimWithDeletedCmd) Clone() Cmder {
 	var val []XMessage
 	if cmd.val != nil {
 		val = make([]XMessage, len(cmd.val))
@@ -2711,7 +2809,7 @@ func (cmd *XAutoClaimCmd) Clone() Cmder {
 		deletedIDs = make([]string, len(cmd.deletedIDs))
 		copy(deletedIDs, cmd.deletedIDs)
 	}
-	return &XAutoClaimCmd{
+	return &XAutoClaimWithDeletedCmd{
 		baseCmd:    cmd.cloneBaseCmd(),
 		start:      cmd.start,
 		val:        val,
@@ -8040,11 +8138,19 @@ func ExtractCommandValue(cmd interface{}) (interface{}, error) {
 			}
 		case CmdTypeXAutoClaim:
 			if xAutoClaimCmd, ok := cmd.(interface {
+				Val() ([]XMessage, string)
+				Err() error
+			}); ok {
+				messages, start := xAutoClaimCmd.Val()
+				return CmdTypeXAutoClaimValue{messages: messages, start: start}, xAutoClaimCmd.Err()
+			}
+		case CmdTypeXAutoClaimWithDeleted:
+			if xAutoClaimWithDeletedCmd, ok := cmd.(interface {
 				Val() ([]XMessage, string, []string)
 				Err() error
 			}); ok {
-				messages, start, deletedIDs := xAutoClaimCmd.Val()
-				return CmdTypeXAutoClaimValue{messages: messages, start: start, deletedIDs: deletedIDs}, xAutoClaimCmd.Err()
+				messages, start, deletedIDs := xAutoClaimWithDeletedCmd.Val()
+				return CmdTypeXAutoClaimWithDeletedValue{messages: messages, start: start, deletedIDs: deletedIDs}, xAutoClaimWithDeletedCmd.Err()
 			}
 		case CmdTypeXAutoClaimJustID:
 			if xAutoClaimJustIDCmd, ok := cmd.(interface {

--- a/command.go
+++ b/command.go
@@ -2706,10 +2706,16 @@ func (cmd *XAutoClaimCmd) Clone() Cmder {
 			}
 		}
 	}
+	var deletedIDs []string
+	if cmd.deletedIDs != nil {
+		deletedIDs = make([]string, len(cmd.deletedIDs))
+		copy(deletedIDs, cmd.deletedIDs)
+	}
 	return &XAutoClaimCmd{
-		baseCmd: cmd.cloneBaseCmd(),
-		start:   cmd.start,
-		val:     val,
+		baseCmd:    cmd.cloneBaseCmd(),
+		start:      cmd.start,
+		val:        val,
+		deletedIDs: deletedIDs,
 	}
 }
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -7564,7 +7564,7 @@ var _ = Describe("Commands", func() {
 					Start:    "-",
 					Count:    2,
 				}
-				msgs, start, ids, err := client.XAutoClaim(ctx, xca).Result()
+				msgs, start, err := client.XAutoClaim(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(start).To(Equal("3-0"))
 				Expect(msgs).To(Equal([]redis.XMessage{{
@@ -7574,19 +7574,17 @@ var _ = Describe("Commands", func() {
 					ID:     "2-0",
 					Values: map[string]interface{}{"dos": "deux"},
 				}}))
-				Expect(ids).To(Equal([]string{}))
 
 				xca.Start = start
-				msgs, start, ids, err = client.XAutoClaim(ctx, xca).Result()
+				msgs, start, err = client.XAutoClaim(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(start).To(Equal("0-0"))
 				Expect(msgs).To(Equal([]redis.XMessage{{
 					ID:     "3-0",
 					Values: map[string]interface{}{"tres": "troix"},
 				}}))
-				Expect(ids).To(Equal([]string{}))
 
-				ids, start, err = client.XAutoClaimJustID(ctx, xca).Result()
+				ids, start, err := client.XAutoClaimJustID(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(start).To(Equal("0-0"))
 				Expect(ids).To(Equal([]string{"3-0"}))
@@ -7603,7 +7601,7 @@ var _ = Describe("Commands", func() {
 				err := client.XDel(ctx, "stream", "2-0").Err()
 				Expect(err).NotTo(HaveOccurred())
 
-				msgs, start, ids, err := client.XAutoClaim(ctx, xca).Result()
+				msgs, start, ids, err := client.XAutoClaimWithDelete(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(start).To(Equal("0-0"))
 				Expect(msgs).To(Equal([]redis.XMessage{{

--- a/commands_test.go
+++ b/commands_test.go
@@ -7592,6 +7592,31 @@ var _ = Describe("Commands", func() {
 				Expect(ids).To(Equal([]string{"3-0"}))
 			})
 
+			It("should XAutoClaim return deletedIDs", func() {
+				xca := &redis.XAutoClaimArgs{
+					Stream:   "stream",
+					Group:    "group",
+					Consumer: "consumer",
+					Start:    "-",
+					Count:    3,
+				}
+				err := client.XDel(ctx, "stream", "2-0").Err()
+				Expect(err).NotTo(HaveOccurred())
+
+				msgs, start, ids, err := client.XAutoClaim(ctx, xca).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(start).To(Equal("0-0"))
+				Expect(msgs).To(Equal([]redis.XMessage{{
+					ID:     "1-0",
+					Values: map[string]interface{}{"uno": "un"},
+				}, {
+					ID:     "3-0",
+					Values: map[string]interface{}{"tres": "troix"},
+				}}))
+				Expect(ids).To(Equal([]string{"2-0"}))
+
+			})
+
 			It("should XClaim", func() {
 				msgs, err := client.XClaim(ctx, &redis.XClaimArgs{
 					Stream:   "stream",

--- a/commands_test.go
+++ b/commands_test.go
@@ -7564,7 +7564,7 @@ var _ = Describe("Commands", func() {
 					Start:    "-",
 					Count:    2,
 				}
-				msgs, start, err := client.XAutoClaim(ctx, xca).Result()
+				msgs, start, ids, err := client.XAutoClaim(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(start).To(Equal("3-0"))
 				Expect(msgs).To(Equal([]redis.XMessage{{
@@ -7574,17 +7574,19 @@ var _ = Describe("Commands", func() {
 					ID:     "2-0",
 					Values: map[string]interface{}{"dos": "deux"},
 				}}))
+				Expect(ids).To(Equal([]string{}))
 
 				xca.Start = start
-				msgs, start, err = client.XAutoClaim(ctx, xca).Result()
+				msgs, start, ids, err = client.XAutoClaim(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(start).To(Equal("0-0"))
 				Expect(msgs).To(Equal([]redis.XMessage{{
 					ID:     "3-0",
 					Values: map[string]interface{}{"tres": "troix"},
 				}}))
+				Expect(ids).To(Equal([]string{}))
 
-				ids, start, err := client.XAutoClaimJustID(ctx, xca).Result()
+				ids, start, err = client.XAutoClaimJustID(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(start).To(Equal("0-0"))
 				Expect(ids).To(Equal([]string{"3-0"}))

--- a/commands_test.go
+++ b/commands_test.go
@@ -7601,7 +7601,7 @@ var _ = Describe("Commands", func() {
 				err := client.XDel(ctx, "stream", "2-0").Err()
 				Expect(err).NotTo(HaveOccurred())
 
-				msgs, start, ids, err := client.XAutoClaimWithDelete(ctx, xca).Result()
+				msgs, start, ids, err := client.XAutoClaimWithDeleted(ctx, xca).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(start).To(Equal("0-0"))
 				Expect(msgs).To(Equal([]redis.XMessage{{

--- a/doctests/stream_tutorial_test.go
+++ b/doctests/stream_tutorial_test.go
@@ -856,7 +856,7 @@ func ExampleClient_raceitaly() {
 	// STEP_END
 
 	// STEP_START xautoclaim
-	res30, res30a, err := rdb.XAutoClaim(ctx, &redis.XAutoClaimArgs{
+	res30, res30a, res30b, err := rdb.XAutoClaim(ctx, &redis.XAutoClaimArgs{
 		Stream:   "race:italy",
 		Group:    "italy_riders",
 		Consumer: "Alice",
@@ -870,10 +870,11 @@ func ExampleClient_raceitaly() {
 
 	fmt.Println(res30)  // >>> [{1692632647899-0 map[rider:Royce] 0 0}]
 	fmt.Println(res30a) // >>> 1692632662819-0
+	fmt.Println(res30b) // >>> []
 	// STEP_END
 
 	// STEP_START xautoclaim_cursor
-	res31, res31a, err := rdb.XAutoClaim(ctx, &redis.XAutoClaimArgs{
+	res31, res31a, res31b, err := rdb.XAutoClaim(ctx, &redis.XAutoClaimArgs{
 		Stream:   "race:italy",
 		Group:    "italy_riders",
 		Consumer: "Lora",
@@ -887,6 +888,7 @@ func ExampleClient_raceitaly() {
 
 	fmt.Println(res31)  // >>> []
 	fmt.Println(res31a) // >>> 0-0
+	fmt.Println(res31b) // >>> []
 	// STEP_END
 
 	// STEP_START xinfo

--- a/doctests/stream_tutorial_test.go
+++ b/doctests/stream_tutorial_test.go
@@ -1013,7 +1013,9 @@ func ExampleClient_raceitaly() {
 	// [{1692632647899-0 map[rider:Royce] 0 0}]
 	// 1692632662819-0
 	// []
+	// []
 	// 0-0
+	// []
 	// 5
 	// {1692632639151-0 map[rider:Castilla] 0 0}
 	// [{italy_riders 3 2 1692632662819-0 3 2}]

--- a/doctests/stream_tutorial_test.go
+++ b/doctests/stream_tutorial_test.go
@@ -1011,7 +1011,6 @@ func ExampleClient_raceitaly() {
 	// [{1692632647899-0 map[rider:Royce] 0 0}]
 	// 1692632662819-0
 	// []
-	// []
 	// 0-0
 	// 5
 	// {1692632639151-0 map[rider:Castilla] 0 0}

--- a/doctests/stream_tutorial_test.go
+++ b/doctests/stream_tutorial_test.go
@@ -856,7 +856,7 @@ func ExampleClient_raceitaly() {
 	// STEP_END
 
 	// STEP_START xautoclaim
-	res30, res30a, res30b, err := rdb.XAutoClaim(ctx, &redis.XAutoClaimArgs{
+	res30, res30a, err := rdb.XAutoClaim(ctx, &redis.XAutoClaimArgs{
 		Stream:   "race:italy",
 		Group:    "italy_riders",
 		Consumer: "Alice",
@@ -870,11 +870,10 @@ func ExampleClient_raceitaly() {
 
 	fmt.Println(res30)  // >>> [{1692632647899-0 map[rider:Royce] 0 0}]
 	fmt.Println(res30a) // >>> 1692632662819-0
-	fmt.Println(res30b) // >>> []
 	// STEP_END
 
 	// STEP_START xautoclaim_cursor
-	res31, res31a, res31b, err := rdb.XAutoClaim(ctx, &redis.XAutoClaimArgs{
+	res31, res31a, err := rdb.XAutoClaim(ctx, &redis.XAutoClaimArgs{
 		Stream:   "race:italy",
 		Group:    "italy_riders",
 		Consumer: "Lora",
@@ -888,7 +887,6 @@ func ExampleClient_raceitaly() {
 
 	fmt.Println(res31)  // >>> []
 	fmt.Println(res31a) // >>> 0-0
-	fmt.Println(res31b) // >>> []
 	// STEP_END
 
 	// STEP_START xinfo
@@ -1015,7 +1013,6 @@ func ExampleClient_raceitaly() {
 	// []
 	// []
 	// 0-0
-	// []
 	// 5
 	// {1692632639151-0 map[rider:Castilla] 0 0}
 	// [{italy_riders 3 2 1692632662819-0 3 2}]

--- a/osscluster_router.go
+++ b/osscluster_router.go
@@ -241,6 +241,8 @@ func createCommandByType(ctx context.Context, cmdType CmdType, args ...interface
 		return NewXPendingExtCmd(ctx, args...)
 	case CmdTypeXAutoClaim:
 		return NewXAutoClaimCmd(ctx, args...)
+	case CmdTypeXAutoClaimWithDeleted:
+		return NewXAutoClaimWithDeletedCmd(ctx, args...)
 	case CmdTypeXAutoClaimJustID:
 		return NewXAutoClaimJustIDCmd(ctx, args...)
 	case CmdTypeXInfoStreamFull:
@@ -665,6 +667,12 @@ func (c *ClusterClient) setCommandValue(cmd Cmder, value interface{}) error {
 	case CmdTypeXAutoClaim:
 		if c, ok := cmd.(*XAutoClaimCmd); ok {
 			if v, ok := value.(CmdTypeXAutoClaimValue); ok {
+				c.SetVal(v.messages, v.start)
+			}
+		}
+	case CmdTypeXAutoClaimWithDeleted:
+		if c, ok := cmd.(*XAutoClaimWithDeletedCmd); ok {
+			if v, ok := value.(CmdTypeXAutoClaimWithDeletedValue); ok {
 				c.SetVal(v.messages, v.start, v.deletedIDs)
 			}
 		}

--- a/osscluster_router.go
+++ b/osscluster_router.go
@@ -665,7 +665,7 @@ func (c *ClusterClient) setCommandValue(cmd Cmder, value interface{}) error {
 	case CmdTypeXAutoClaim:
 		if c, ok := cmd.(*XAutoClaimCmd); ok {
 			if v, ok := value.(CmdTypeXAutoClaimValue); ok {
-				c.SetVal(v.messages, v.start)
+				c.SetVal(v.messages, v.start, v.deletedIDs)
 			}
 		}
 	case CmdTypeXAutoClaimJustID:

--- a/stream_commands.go
+++ b/stream_commands.go
@@ -34,7 +34,7 @@ type StreamCmdable interface {
 	XClaim(ctx context.Context, a *XClaimArgs) *XMessageSliceCmd
 	XClaimJustID(ctx context.Context, a *XClaimArgs) *StringSliceCmd
 	XAutoClaim(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimCmd
-	XAutoClaimWithDelete(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimWithDeletedCmd
+	XAutoClaimWithDeleted(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimWithDeletedCmd
 	XAutoClaimJustID(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimJustIDCmd
 	XTrimMaxLen(ctx context.Context, key string, maxLen int64) *IntCmd
 	XTrimMaxLenApprox(ctx context.Context, key string, maxLen, limit int64) *IntCmd
@@ -407,7 +407,7 @@ func (c cmdable) XAutoClaim(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimC
 	return cmd
 }
 
-func (c cmdable) XAutoClaimWithDelete(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimWithDeletedCmd {
+func (c cmdable) XAutoClaimWithDeleted(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimWithDeletedCmd {
 	args := xAutoClaimArgs(ctx, a)
 	cmd := NewXAutoClaimWithDeletedCmd(ctx, args...)
 	_ = c(ctx, cmd)

--- a/stream_commands.go
+++ b/stream_commands.go
@@ -34,6 +34,7 @@ type StreamCmdable interface {
 	XClaim(ctx context.Context, a *XClaimArgs) *XMessageSliceCmd
 	XClaimJustID(ctx context.Context, a *XClaimArgs) *StringSliceCmd
 	XAutoClaim(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimCmd
+	XAutoClaimWithDelete(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimWithDeletedCmd
 	XAutoClaimJustID(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimJustIDCmd
 	XTrimMaxLen(ctx context.Context, key string, maxLen int64) *IntCmd
 	XTrimMaxLenApprox(ctx context.Context, key string, maxLen, limit int64) *IntCmd

--- a/stream_commands.go
+++ b/stream_commands.go
@@ -406,6 +406,13 @@ func (c cmdable) XAutoClaim(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimC
 	return cmd
 }
 
+func (c cmdable) XAutoClaimWithDelete(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimWithDeletedCmd {
+	args := xAutoClaimArgs(ctx, a)
+	cmd := NewXAutoClaimWithDeletedCmd(ctx, args...)
+	_ = c(ctx, cmd)
+	return cmd
+}
+
 func (c cmdable) XAutoClaimJustID(ctx context.Context, a *XAutoClaimArgs) *XAutoClaimJustIDCmd {
 	args := xAutoClaimArgs(ctx, a)
 	args = append(args, "justid")


### PR DESCRIPTION
Since Redis 7.0, `XAUTOCLAIM` now returns a list of deleted message IDs as the 3rd part of the reply. Previously that part was discarded when received. This adds the ability to read those deleted message IDs and return them.

See: https://redis.io/docs/latest/commands/xautoclaim/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public stream command and command type to parse Redis 7+ `XAUTOCLAIM` replies, touching reply parsing and cluster aggregation paths; mistakes could cause incorrect stream consumption behavior or aggregation failures.
> 
> **Overview**
> Adds Redis 7+ support for `XAUTOCLAIM`’s third reply element (deleted PEL entry IDs) by introducing `XAutoClaimWithDeleted` / `XAutoClaimWithDeletedCmd`, which parses and returns `deletedIDs` instead of discarding them.
> 
> Updates command-type plumbing (`CmdTypeXAutoClaimWithDeleted`, value extraction, and OSS cluster router command creation/value setting) and adds a regression test asserting deleted IDs are surfaced after an `XDEL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 260293c0ff543dd8ab8efd6feb4b55239a51ba43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->