### PR TITLE
Add standalone hash subkey notification test

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -47,7 +47,7 @@ runs:
         elif [[ -n "$REDIS_VERSION" ]]; then
           # Mapping of redis version to redis testing containers
           declare -A redis_version_mapping=(
-            ["8.8.x"]="8.8-m02"
+            ["8.8.x"]="8.8-m03"
             ["8.6.x"]="8.6.1"
             ["8.4.x"]="8.4.0"
             ["8.2.x"]="8.2.1-pre"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           
           # Mapping of redis version to redis testing containers
           declare -A redis_version_mapping=(
-            ["8.8.x"]="8.8-m02"
+            ["8.8.x"]="8.8-m03"
             ["8.6.x"]="8.6.1"
             ["8.4.x"]="8.4.0"
             ["8.2.x"]="8.2.1-pre"

--- a/.github/workflows/doctests.yaml
+++ b/.github/workflows/doctests.yaml
@@ -16,7 +16,7 @@ jobs:
 
     services:
       redis-stack:
-        image: redislabs/client-libs-test:8.8-m02
+        image: redislabs/client-libs-test:8.8-m03
         env:
           TLS_ENABLED: no
           REDIS_CLUSTER: no

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GO_MOD_DIRS := $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort)
 REDIS_VERSION ?= 8.8
 RE_CLUSTER ?= false
 RCE_DOCKER ?= true
-CLIENT_LIBS_TEST_IMAGE ?= redislabs/client-libs-test:8.8-m02
+CLIENT_LIBS_TEST_IMAGE ?= redislabs/client-libs-test:8.8-m03
 
 docker.start:
 	export RE_CLUSTER=$(RE_CLUSTER) && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 ---
 
-x-default-image: &default-image ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.8-m02}
+x-default-image: &default-image ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.8-m03}
 
 services:
   redis:

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -81,6 +81,72 @@ var _ = Describe("PubSub", func() {
 		Expect(stats.Misses).To(Equal(uint32(1)))
 	})
 
+	It("should receive hash field subkey notifications", Label("hash-expiration", "NonRedisEnterprise"), func() {
+		SkipBeforeRedisVersion(8.8, "subkeyspace notifications require Redis 8.8")
+
+		config, err := client.ConfigGet(ctx, "notify-keyspace-events").Result()
+		Expect(err).NotTo(HaveOccurred())
+		previousNotifyConfig := config["notify-keyspace-events"]
+		Expect(client.ConfigSet(ctx, "notify-keyspace-events", "STh").Err()).NotTo(HaveOccurred())
+		defer client.ConfigSet(ctx, "notify-keyspace-events", previousNotifyConfig)
+
+		const (
+			hashKey         = "skn:hash"
+			field           = "field-alpha"
+			hexpireChannel  = "__subkeyevent@0__:hexpire"
+			expiredChannel  = "__subkeyevent@0__:hexpired"
+			expectedPayload = "8:skn:hash|11:field-alpha"
+		)
+		Expect(client.Del(ctx, hashKey).Err()).NotTo(HaveOccurred())
+
+		pubsub := client.Subscribe(ctx, hexpireChannel, expiredChannel)
+		defer pubsub.Close()
+
+		for _, expected := range []redis.Subscription{
+			{Kind: "subscribe", Channel: hexpireChannel, Count: 1},
+			{Kind: "subscribe", Channel: expiredChannel, Count: 2},
+		} {
+			msgi, err := pubsub.ReceiveTimeout(ctx, time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(msgi).To(Equal(&expected))
+		}
+
+		Expect(client.HSet(ctx, hashKey, field, "value").Err()).NotTo(HaveOccurred())
+		res, err := client.HPExpire(ctx, hashKey, 50*time.Millisecond, field).Result()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal([]int64{1}))
+
+		seen := make(map[string]string)
+		deadline := time.Now().Add(10 * time.Second)
+
+		for time.Now().Before(deadline) &&
+			(seen[hexpireChannel] == "" || seen[expiredChannel] == "") {
+			msgi, err := pubsub.ReceiveTimeout(ctx, 500*time.Millisecond)
+			if err != nil {
+				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+					continue
+				}
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			msg, ok := msgi.(*redis.Message)
+			if !ok {
+				continue
+			}
+			if msg.Channel != hexpireChannel && msg.Channel != expiredChannel {
+				continue
+			}
+
+			Expect(msg.Pattern).To(BeEmpty())
+			Expect(msg.Payload).To(Equal(expectedPayload))
+			Expect(msg.PayloadSlice).To(BeEmpty())
+			seen[msg.Channel] = msg.Payload
+		}
+
+		Expect(seen).To(HaveKeyWithValue(hexpireChannel, expectedPayload))
+		Expect(seen).To(HaveKeyWithValue(expiredChannel, expectedPayload))
+	})
+
 	It("should pub/sub channels", func() {
 		channels, err := client.PubSubChannels(ctx, "mychannel*").Result()
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Adds a standalone PubSub functional test for Redis 8.8 hash subkey notifications.
Verifies HFE `hexpire` and `hexpired` events include the affected hash field name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly test/CI changes, but the new timing-based PubSub assertion and Redis test image bump could introduce CI flakiness or environment-specific failures.
> 
> **Overview**
> Adds a new PubSub integration test that enables `notify-keyspace-events`, performs `HPExpire` on a hash field, and asserts Redis 8.8 `__subkeyevent@0__` `hexpire`/`hexpired` messages include the expected key+field payload.
> 
> Updates local Docker/Makefile defaults and GitHub Actions workflows to use `redislabs/client-libs-test:8.8-m03` (from `8.8-m02`) for Redis 8.8 testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 685773f06d89edd95c50896fc3122622f852b099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->