### PR TITLE
Support COUNT aggregate for sorted set union/intersection

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -6760,6 +6760,111 @@ var _ = Describe("Commands", func() {
 			}}))
 		})
 
+		It("should support COUNT aggregate for ZUnion and ZInter", Label("NonRedisEnterprise"), func() {
+			SkipBeforeRedisVersion(8.8, "COUNT aggregate requires Redis 8.8+")
+
+			err := client.ZAddArgs(ctx, "zset1", redis.ZAddArgs{
+				Members: []redis.Z{
+					{Score: 100, Member: "foo"},
+					{Score: 100, Member: "bar"},
+				},
+			}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = client.ZAddArgs(ctx, "zset2", redis.ZAddArgs{
+				Members: []redis.Z{
+					{Score: 200, Member: "foo"},
+					{Score: 200, Member: "bar"},
+				},
+			}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = client.ZAddArgs(ctx, "zset3", redis.ZAddArgs{
+				Members: []redis.Z{
+					{Score: 300, Member: "foo"},
+				},
+			}).Err()
+			Expect(err).NotTo(HaveOccurred())
+
+			keys := []string{"zset1", "zset2", "zset3"}
+
+			union, err := client.ZUnion(ctx, redis.ZStore{
+				Keys:      keys,
+				Aggregate: "COUNT",
+			}).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(union).To(Equal([]string{"bar", "foo"}))
+
+			unionScores, err := client.ZUnionWithScores(ctx, redis.ZStore{
+				Keys:      keys,
+				Aggregate: "COUNT",
+			}).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(unionScores).To(Equal([]redis.Z{
+				{Score: 2, Member: "bar"},
+				{Score: 3, Member: "foo"},
+			}))
+
+			n, err := client.ZUnionStore(ctx, "out", &redis.ZStore{
+				Keys:      keys,
+				Aggregate: "COUNT",
+			}).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(2)))
+
+			storedUnion, err := client.ZRangeWithScores(ctx, "out", 0, -1).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(storedUnion).To(Equal([]redis.Z{
+				{Score: 2, Member: "bar"},
+				{Score: 3, Member: "foo"},
+			}))
+
+			n, err = client.ZUnionStore(ctx, "weighted_out", &redis.ZStore{
+				Keys:      keys,
+				Weights:   []float64{10, 5, 3},
+				Aggregate: "COUNT",
+			}).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(2)))
+
+			weightedUnion, err := client.ZRangeWithScores(ctx, "weighted_out", 0, -1).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(weightedUnion).To(Equal([]redis.Z{
+				{Score: 15, Member: "bar"},
+				{Score: 18, Member: "foo"},
+			}))
+
+			inter, err := client.ZInter(ctx, &redis.ZStore{
+				Keys:      keys,
+				Aggregate: "COUNT",
+			}).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(inter).To(Equal([]string{"foo"}))
+
+			interScores, err := client.ZInterWithScores(ctx, &redis.ZStore{
+				Keys:      keys,
+				Aggregate: "COUNT",
+			}).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(interScores).To(Equal([]redis.Z{
+				{Score: 3, Member: "foo"},
+			}))
+
+			n, err = client.ZInterStore(ctx, "inter_out", &redis.ZStore{
+				Keys:      keys,
+				Weights:   []float64{10, 5, 3},
+				Aggregate: "COUNT",
+			}).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(1)))
+
+			storedInter, err := client.ZRangeWithScores(ctx, "inter_out", 0, -1).Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(storedInter).To(Equal([]redis.Z{
+				{Score: 18, Member: "foo"},
+			}))
+		})
+
 		It("should ZRandMember", func() {
 			err := client.ZAdd(ctx, "zset", redis.Z{Score: 1, Member: "one"}).Err()
 			Expect(err).NotTo(HaveOccurred())

--- a/sortedset_commands.go
+++ b/sortedset_commands.go
@@ -781,7 +781,7 @@ type ZWithKey struct {
 type ZStore struct {
 	Keys    []string
 	Weights []float64
-	// Can be SUM, MIN or MAX.
+	// Can be SUM, MIN, MAX or COUNT.
 	Aggregate string
 }
 


### PR DESCRIPTION
Adds Redis 8.8 COUNT aggregate support for ZINTER/ZINTERSTORE/ZUNION/ZUNIONSTORE via ZStore.Aggregate.
Covers unweighted count semantics and weighted membership-sum semantics with integration tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds integration tests and a doc comment update; runtime behavior is unchanged except for allowing a new `Aggregate` value to be passed through to Redis.
> 
> **Overview**
> Adds Redis 8.8+ integration coverage for using `ZStore.Aggregate = "COUNT"` with `ZUnion`/`ZUnionWithScores`/`ZUnionStore` and `ZInter`/`ZInterWithScores`/`ZInterStore`, including weighted vs unweighted COUNT semantics.
> 
> Updates the `ZStore.Aggregate` doc comment to document `COUNT` as a supported option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b104fc609d7256d55badebea14b35d79ab2444eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->