### PR TITLE
fix(pool): Fix Close. Do healthchecks only on idle conns

### DIFF
--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -82,8 +82,10 @@ type Conn struct {
 	bw *bufio.Writer
 	wr *proto.Writer
 
-	// Lightweight mutex to protect reader operations during handoff
-	// Only used for the brief period during SetNetConn and HasBufferedData/PeekReplyTypeSafe
+	// Lightweight mutex to protect reader operations during handoff and health checks
+	// Used during:
+	// - SetNetConn (write lock for resetting reader state)
+	// - HasBufferedData/PeekReplyTypeSafe (read lock for safe concurrent peek operations)
 	readerMu sync.RWMutex
 
 	// State machine for connection state management

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1616,9 +1616,19 @@ func (p *ConnPool) Close() error {
 		// Check health before closing, since closeConn invalidates the
 		// underlying fd and would make connCheck (inside isHealthyConn)
 		// always fail with EBADF.
-		healthy := p.isHealthyConn(cn, nowNs)
+		// Only check health for idle connections to avoid data races when
+		// peeking at the socket/reader while another goroutine is reading from it.
+		// Non-idle connections are either in use or in transitional states and
+		// shouldn't be health-checked during shutdown.
+		_, isIdle := idleSet[cn.GetID()]
+		var healthy bool
+		if isIdle {
+			healthy = p.isHealthyConn(cn, nowNs)
+		} else {
+			healthy = true
+		}
 		if cb != nil {
-			if _, isIdle := idleSet[cn.GetID()]; isIdle {
+			if isIdle {
 				cb(ctx, -1, cn, "idle", false)
 			} else {
 				cb(ctx, -1, cn, "used", false)


### PR DESCRIPTION
In a rare corner case (actually observed in the CI), if the pool is closed while a connection is in use there will be a data race, since the connection that the pool.Close is trying to execute a healthcheck on (which peeks the socket) is currently being used. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shutdown behavior in the connection pool by skipping socket/reader peeks for non-idle connections, which reduces race risk but could mask close errors for in-use connections during `Close()`.
> 
> **Overview**
> Fixes a shutdown-time data race by changing `ConnPool.Close()` to run `isHealthyConn` only for connections that are currently *idle*, and to treat non-idle connections as healthy for the purpose of deciding whether to surface close errors.
> 
> Also updates `Conn.readerMu` documentation to reflect that the reader lock is used for both handoff and health-check-related peek operations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91a40cfd809c54379972cb28bfdcc7225eaf2680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->