### PR TITLE
fix: include sharded channels in PubSub.conn() so cluster reconnect routes to the slot owner

### DIFF
--- a/osscluster_test.go
+++ b/osscluster_test.go
@@ -668,6 +668,67 @@ var _ = Describe("ClusterClient", func() {
 			}, 30*time.Second).ShouldNot(HaveOccurred())
 		})
 
+		It("should re-subscribe sharded PubSub to the slot owner after reconnect", func() {
+			const channel = "shard-reconnect-chan"
+
+			pubsub := client.SSubscribe(ctx, channel)
+			defer pubsub.Close()
+
+			expectDelivery := func() error {
+				n, err := client.SPublish(ctx, channel, "hello").Result()
+				if err != nil {
+					return err
+				}
+				if n == 0 {
+					// Nobody is subscribed on the slot owner — the
+					// PubSub reconnected to the wrong node.
+					return fmt.Errorf("SPUBLISH reached 0 subscribers")
+				}
+				msg, err := pubsub.ReceiveTimeout(ctx, time.Second)
+				if err != nil {
+					return err
+				}
+				if _, ok := msg.(*redis.Message); !ok {
+					return fmt.Errorf("got %T, wanted *redis.Message", msg)
+				}
+				return nil
+			}
+
+			// Sanity-check the initial subscription before disrupting it.
+			Eventually(expectDelivery, 30*time.Second).ShouldNot(HaveOccurred())
+
+			// Repeatedly tear down the server side of the PubSub connection
+			// and verify the client re-subscribes to the correct shard.
+			// Each cycle has a 5/6 chance of exposing a wrong-node
+			// reconnect on a 3+3 node test cluster, so 8 iterations make a
+			// false pass vanishingly unlikely.
+			for i := 0; i < 8; i++ {
+				// Kill the PubSub connection on every node so we don't have
+				// to hunt for the slot owner. CLIENT KILL TYPE pubsub only
+				// touches connections in subscribe mode, so the regular
+				// cluster connections used by `client` are unaffected.
+				for _, master := range cluster.masters() {
+					_, _ = master.ClientKillByFilter(ctx, "TYPE", "pubsub").Result()
+				}
+				for _, slave := range cluster.slaves() {
+					_, _ = slave.ClientKillByFilter(ctx, "TYPE", "pubsub").Result()
+				}
+
+				// Drive the PubSub to notice the dead socket and reconnect.
+				Eventually(func() error {
+					return pubsub.Ping(ctx)
+				}, 10*time.Second).ShouldNot(HaveOccurred())
+
+				// Without the fix the new conn went to nodes.Random(); the
+				// SSUBSCRIBE in resubscribe() landed on the wrong shard
+				// (and the resulting -MOVED reply is never read, so the
+				// failure is silent). SPUBLISH on the slot owner therefore
+				// reaches no subscribers.
+				Eventually(expectDelivery, 5*time.Second).ShouldNot(HaveOccurred(),
+					"sharded PubSub did not survive reconnect cycle %d", i)
+			}
+		})
+
 		It("should support PubSub.Ping without channels", func() {
 			pubsub := client.Subscribe(ctx)
 			defer pubsub.Close()

--- a/pubsub.go
+++ b/pubsub.go
@@ -88,6 +88,10 @@ func (c *PubSub) conn(ctx context.Context, newChannels []string) (*pool.Conn, er
 	}
 
 	channels := slices.Collect(maps.Keys(c.channels))
+	// Include sharded subscriptions so cluster newConn can resolve the
+	// correct slot owner; ClusterClient.pubSub falls back to a random node
+	// when channels is empty, which silently drops SSUBSCRIBE on reconnect.
+	channels = append(channels, slices.Collect(maps.Keys(c.schannels))...)
 	channels = append(channels, newChannels...)
 
 	cn, err := c.newConn(ctx, c.opt.Addr, channels)


### PR DESCRIPTION
Fixes #3806.

### Problem

`PubSub.conn()` builds the channel list passed to `newConn` from
`c.channels` only. For a `PubSub` with only sharded subscriptions (the
normal `ClusterClient.SSubscribe` case), that list is empty on reconnect.
`ClusterClient.pubSub`'s `newConn` closure falls back to `nodes.Random()`
when `len(channels) == 0`, so the reconnect lands on a random node. The
`SSUBSCRIBE` written by `resubscribe()` to the wrong node fails silently
(`_subscribe` is write-only and `isBadConn` ignores `MOVED` to a different
address), leaving a `PubSub` that looks healthy — `Ping` succeeds,
`Receive` keeps running — but never receives another message until the
process restarts.

### Fix

Append `c.schannels` to the list, after `c.channels`. The `channels`
argument is only used for slot resolution in the cluster client; the
single-node, ring, and sentinel clients ignore it for routing, so the
change is scoped to cluster behavior. Ordering schannels after channels
keeps behavior identical for `PubSub`s that have any regular
subscriptions.

### Confidence

- Added a regression test in `osscluster_test.go` that `SSubscribe`s,
  kills the PubSub conn on every cluster node (`CLIENT KILL TYPE pubsub`),
  triggers reconnect, and asserts message delivery — repeated 8 times so a
  lucky random-node hit can't mask the bug. Without the fix the chance of
  a false pass on the 3+3 node test cluster is `(1/6)^8 ≈ 6e-7`.
- Reproduced the bug in production on a 25-shard cluster behind a managed
  Redis Cluster; the PubSub silently dropped to ~10% of expected message
  delivery after a transient connection blip and stayed degraded until a
  process restart. Confirmed the fix restores delivery after `CLIENT KILL`.
- `go build`, `go vet`, `gofmt` clean on the patched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster PubSub reconnect/routing behavior; a bug here can silently drop messages after reconnects, though the change is small and covered by a targeted regression test.
> 
> **Overview**
> Fixes a Redis Cluster sharded PubSub reconnect bug where `PubSub.conn()` could reconnect to a random node when only `SSUBSCRIBE` channels were in use, causing resubscribe to land on the wrong shard and silently stop message delivery.
> 
> `PubSub.conn()` now includes sharded channels (`c.schannels`) when building the channel list passed to `newConn` so slot-owner resolution works on reconnect. Adds a regression test that repeatedly kills pubsub connections across all cluster nodes and verifies `SPUBLISH` continues to reach subscribers after each reconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7271dec6e8a48523d9059fea65693f5c5cc87090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->