### PR TITLE
Accumulate connection pool wait statistics across all nodes

### DIFF
--- a/osscluster.go
+++ b/osscluster.go
@@ -1450,6 +1450,8 @@ func (c *ClusterClient) PoolStats() *PoolStats {
 		acc.Hits += s.Hits
 		acc.Misses += s.Misses
 		acc.Timeouts += s.Timeouts
+		acc.WaitCount += s.WaitCount
+		acc.WaitDurationNs += s.WaitDurationNs
 
 		acc.TotalConns += s.TotalConns
 		acc.IdleConns += s.IdleConns
@@ -1461,6 +1463,8 @@ func (c *ClusterClient) PoolStats() *PoolStats {
 		acc.Hits += s.Hits
 		acc.Misses += s.Misses
 		acc.Timeouts += s.Timeouts
+		acc.WaitCount += s.WaitCount
+		acc.WaitDurationNs += s.WaitDurationNs
 
 		acc.TotalConns += s.TotalConns
 		acc.IdleConns += s.IdleConns

--- a/osscluster_test.go
+++ b/osscluster_test.go
@@ -730,6 +730,57 @@ var _ = Describe("ClusterClient", func() {
 			Expect(stats).To(BeAssignableToTypeOf(&redis.PoolStats{}))
 		})
 
+		It("should sum pool wait statistics across all nodes", func() {
+			// Set a unity pool size to force a wait on any concurrently dispatched requests.
+			opt := redisClusterOptions()
+			opt.PoolSize = 1
+			opt.MinIdleConns = 0
+			opt.PoolTimeout = 5 * time.Second
+			client := cluster.newClusterClient(ctx, opt)
+
+			state, err := client.LoadState(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state.Masters).NotTo(BeEmpty())
+
+			// Deliberately contend connection acquisition on all per-node connection pools.
+			for _, master := range state.Masters {
+				nodePool := master.Client.Pool()
+				cn, err := nodePool.Get(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				time.AfterFunc(100*time.Millisecond, func() {
+					nodePool.Put(ctx, cn)
+				})
+
+				// Get will block until a connection is available; this synchronizes on the Put
+				// of the connection obtained from the initial acquisition
+				cn2, err := nodePool.Get(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				nodePool.Put(ctx, cn2)
+			}
+
+			var expectedWaits uint32
+			var expectedWaitDuration int64
+
+			for _, master := range state.Masters {
+				s := master.Client.Pool().Stats()
+				expectedWaits += s.WaitCount
+				expectedWaitDuration += s.WaitDurationNs
+			}
+
+			for _, slave := range state.Slaves {
+				s := slave.Client.Pool().Stats()
+				expectedWaits += s.WaitCount
+				expectedWaitDuration += s.WaitDurationNs
+			}
+
+			Expect(expectedWaits).To(BeNumerically(">=", uint32(len(state.Masters))))
+			Expect(expectedWaitDuration).To(BeNumerically(">", int64(0)))
+
+			stats := client.PoolStats()
+			Expect(stats.WaitCount).To(Equal(expectedWaits))
+			Expect(stats.WaitDurationNs).To(Equal(expectedWaitDuration))
+		})
+
 		It("should return an error when there are no attempts left", func() {
 			opt := redisClusterOptions()
 			opt.MaxRedirects = -1


### PR DESCRIPTION
`PoolStats()` on the cluster client currently correctly sum-accumulates gauge statistics for connection pool hits, misses, timeouts, and connection volume (total, idle, stale), but does not accumulate acquisition waits and cumulative wait duration.

Both are gauges and can be sum-aggregated like the other statistics. This fixes an observation that these values are always reported as 0 for a cluster client, even if the underlying per-node connection pools experience saturation.

Motivation: This is a high-signal metric for detecting insufficient connection pool capacity, but currently only works for a standalone client.

I added a unit test to verify the proposed behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: extends `ClusterClient.PoolStats()` to sum two additional counters and adds a targeted test; no routing, protocol, or data-path behavior changes beyond metrics reporting.
> 
> **Overview**
> `ClusterClient.PoolStats()` now **also aggregates connection-pool acquisition wait metrics** (`WaitCount` and `WaitDurationNs`) across all master and replica node pools, instead of always reporting zeros.
> 
> Adds a unit test that forces per-node pool contention (`PoolSize=1`) and asserts the cluster-level `PoolStats()` wait metrics equal the sum of the underlying node pool stats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80399a4040b7f5afc30f383bc6a52700ff24a5b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->