### PR TITLE
fix: make wrapped dial tcp error redirectable (#3799)

### DIFF
--- a/error.go
+++ b/error.go
@@ -91,6 +91,14 @@ func shouldRetry(err error, retryTimeout bool) bool {
 		return true
 	}
 
+	// Dial errors mean TCP connection was never established — safe to retry even
+	// when wrapped inside context.DeadlineExceeded (from DialTimeout context).
+	// Must be checked before the context error check below.
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr.Op == "dial" {
+		return true
+	}
+
 	// Check for context errors (works with wrapped errors)
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return false
@@ -105,12 +113,6 @@ func shouldRetry(err error, retryTimeout bool) bool {
 	// Check for timeout errors (works with wrapped errors)
 	if isTimeout, hasTimeoutFlag := isTimeoutError(err); isTimeout {
 		if hasTimeoutFlag {
-			// A dial error means the TCP connection was never established and the
-			// command was never sent to the server, so retry is always safe
-			var opErr *net.OpError
-			if errors.As(err, &opErr) && opErr.Op == "dial" {
-				return true
-			}
 			return retryTimeout
 		}
 		return true

--- a/error_wrapping_test.go
+++ b/error_wrapping_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 	"testing"
 
@@ -634,6 +635,59 @@ func TestContextErrorWrapping(t *testing.T) {
 		}
 		if redis.ShouldRetry(doubleWrappedErr, true) {
 			t.Errorf("Should not retry wrapped context.DeadlineExceeded even with retryTimeout=true")
+		}
+	})
+}
+
+// TestDialTimeoutShouldRetry tests that dial errors wrapped in context.DeadlineExceeded
+// (as produced by pool.go's context.WithTimeout(ctx, DialTimeout)) are retried.
+func TestDialTimeoutShouldRetry(t *testing.T) {
+	makeDialOpError := func(inner error) *net.OpError {
+		return &net.OpError{Op: "dial", Net: "tcp", Err: inner}
+	}
+
+	t.Run("bare dial OpError retries", func(t *testing.T) {
+		err := makeDialOpError(&net.AddrError{Err: "connection refused", Addr: "127.0.0.1:6379"})
+		if !redis.ShouldRetry(err, false) {
+			t.Errorf("bare dial OpError should retry")
+		}
+	})
+
+	t.Run("dial OpError wrapped in context.DeadlineExceeded retries", func(t *testing.T) {
+		// Simulates pool.go wraps net.OpError as DeadlineExceeded.
+		dialErr := makeDialOpError(context.DeadlineExceeded)
+		wrappedErr := fmt.Errorf("dial tcp: %w", dialErr)
+		if !redis.ShouldRetry(wrappedErr, false) {
+			t.Errorf("dial OpError wrapped in DeadlineExceeded should retry, got false")
+		}
+		if !redis.ShouldRetry(wrappedErr, true) {
+			t.Errorf("dial OpError wrapped in DeadlineExceeded should retry, got false")
+		}
+	})
+
+	t.Run("plain context.DeadlineExceeded does not retry", func(t *testing.T) {
+		err := fmt.Errorf("op failed: %w", context.DeadlineExceeded)
+		if redis.ShouldRetry(err, false) {
+			t.Errorf("plain DeadlineExceeded should not retry")
+		}
+		if redis.ShouldRetry(err, true) {
+			t.Errorf("plain DeadlineExceeded should not retry even with retryTimeout=true")
+		}
+	})
+
+	t.Run("plain context.Canceled does not retry", func(t *testing.T) {
+		err := fmt.Errorf("op failed: %w", context.Canceled)
+		if redis.ShouldRetry(err, false) {
+			t.Errorf("plain context.Canceled should not retry")
+		}
+	})
+
+	t.Run("non-dial OpError does not bypass DeadlineExceeded check", func(t *testing.T) {
+		// Op="read" wrapped in DeadlineExceeded should NOT retry (user context expired)
+		readErr := &net.OpError{Op: "read", Net: "tcp", Err: context.DeadlineExceeded}
+		wrappedErr := fmt.Errorf("read: %w", readErr)
+		if redis.ShouldRetry(wrappedErr, false) {
+			t.Errorf("non-dial OpError with DeadlineExceeded should not retry")
 		}
 	})
 }


### PR DESCRIPTION
fixes #3799

Now check if it was an OpError before we check for context errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `shouldRetry` behavior for connection failures by retrying `net.OpError` dial errors even when wrapped with `context.DeadlineExceeded`, which could alter retry frequency under timeout conditions.
> 
> **Overview**
> Fixes retry classification so TCP *dial* failures are retried even when they appear wrapped as `context.DeadlineExceeded` (e.g., from dial timeouts), by checking for `net.OpError{Op:"dial"}` **before** context cancellation/deadline handling.
> 
> Adds `TestDialTimeoutShouldRetry` coverage to ensure dial errors (including those wrapped in deadline errors) retry, while non-dial `net.OpError` and plain context errors still do not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd5266f1d1371788606adcfc76ffbd6bf3aea523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->