### PR TITLE
Bump redis image version to 8.8-rc1 in CI

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -47,7 +47,7 @@ runs:
         elif [[ -n "$REDIS_VERSION" ]]; then
           # Mapping of redis version to redis testing containers
           declare -A redis_version_mapping=(
-            ["8.8.x"]="8.8-m03"
+            ["8.8.x"]="8.8-rc1"
             ["8.6.x"]="8.6.1"
             ["8.4.x"]="8.4.0"
             ["8.2.x"]="8.2.1-pre"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
           
           # Mapping of redis version to redis testing containers
           declare -A redis_version_mapping=(
-            ["8.8.x"]="8.8-m03"
+            ["8.8.x"]="8.8-rc1"
             ["8.6.x"]="8.6.1"
             ["8.4.x"]="8.4.0"
             ["8.2.x"]="8.2.1-pre"

--- a/.github/workflows/doctests.yaml
+++ b/.github/workflows/doctests.yaml
@@ -16,7 +16,7 @@ jobs:
 
     services:
       redis-stack:
-        image: redislabs/client-libs-test:8.8-m03
+        image: redislabs/client-libs-test:8.8-rc1
         env:
           TLS_ENABLED: no
           REDIS_CLUSTER: no

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GO_MOD_DIRS := $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort)
 REDIS_VERSION ?= 8.8
 RE_CLUSTER ?= false
 RCE_DOCKER ?= true
-CLIENT_LIBS_TEST_IMAGE ?= redislabs/client-libs-test:8.8-m03
+CLIENT_LIBS_TEST_IMAGE ?= redislabs/client-libs-test:8.8-rc1
 
 docker.start:
 	export RE_CLUSTER=$(RE_CLUSTER) && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 ---
 
-x-default-image: &default-image ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.8-m03}
+x-default-image: &default-image ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.8-rc1}
 
 services:
   redis:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only updates CI/dev test container image tags; failures would be limited to test environment compatibility with Redis 8.8-rc1.
> 
> **Overview**
> Updates the Redis `client-libs-test` container used for local `docker compose` and GitHub Actions to **8.8-rc1** (from `8.8-m03`).
> 
> This bumps the `8.8.x` image mapping in the composite `run-tests` action and `build.yml`, updates the doctests service image, and changes the default `CLIENT_LIBS_TEST_IMAGE` in the `Makefile`/`docker-compose.yml` fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17da548fd5bb5fb4df47e4da30231c6061b05a9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->