### PR TITLE
fix(credentials): Memory leak when connections are not properly closed #3812

### DIFF
--- a/internal/pool/hooks_test.go
+++ b/internal/pool/hooks_test.go
@@ -229,3 +229,39 @@ func TestPoolWithHooks(t *testing.T) {
 		t.Errorf("Expected 1 hook after removing, got %d", manager.GetHookCount())
 	}
 }
+
+// TestCloseConnInvokesOnRemove guards against a regression where (*ConnPool).CloseConn
+// removed a connection from the pool without notifying pool hooks via OnRemove,
+// causing per-connection state (e.g. streaming credentials listeners) to leak
+// for every stale-conn close, idle/lifetime expiry, or health-check failure.
+func TestCloseConnInvokesOnRemove(t *testing.T) {
+	opt := &Options{
+		Dialer: func(ctx context.Context) (net.Conn, error) {
+			return &net.TCPConn{}, nil
+		},
+		PoolSize:           1,
+		MaxConcurrentDials: 1,
+		DialTimeout:        time.Second,
+	}
+
+	p := NewConnPool(opt)
+	defer p.Close()
+
+	hook := &TestHook{ShouldPool: true, ShouldAccept: true}
+	p.AddPoolHook(hook)
+
+	ctx := context.Background()
+	cn, err := p.NewConn(ctx)
+	if err != nil {
+		t.Fatalf("NewConn failed: %v", err)
+	}
+
+	// The underlying net.TCPConn{} is a zero value, so cn.Close() may report
+	// "invalid argument" — we don't care about the close error, only about
+	// whether the OnRemove hook fired before the close.
+	_ = p.CloseConn(ctx, cn, CloseReasonStale, MetricStateIdle)
+
+	if hook.OnRemoveCalled != 1 {
+		t.Errorf("Expected OnRemove to fire once for CloseConn, got %d", hook.OnRemoveCalled)
+	}
+}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1447,6 +1447,10 @@ func (p *ConnPool) removeConnInternal(ctx context.Context, cn *Conn, reason erro
 //   - reason: why the connection is being closed (use CloseReason* constants)
 //   - fromState: the metric state the connection was in (use MetricState* constants)
 func (p *ConnPool) CloseConn(ctx context.Context, cn *Conn, reason string, fromState string) error {
+	if hookManager := p.hookManager.Load(); hookManager != nil {
+		hookManager.ProcessOnRemove(ctx, cn, errors.New(reason))
+	}
+
 	removed := p.removeConnWithLock(cn)
 
 	// Only emit UpDownCounter decrements if we actually removed the connection.


### PR DESCRIPTION
Fixes #3812 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection teardown in `(*ConnPool).CloseConn`, so incorrect ordering or duplicate `OnRemove` invocations could impact hook-managed state and cleanup across concurrent close paths.
> 
> **Overview**
> Fixes a hook-cleanup gap by making `(*ConnPool).CloseConn` always notify pool hooks via `ProcessOnRemove` before removing/closing the connection, aligning it with other removal paths and preventing per-connection state leaks.
> 
> Adds `TestCloseConnInvokesOnRemove` to ensure `CloseConn` triggers `OnRemove` exactly once, guarding against regressions when stale/expired/unhealthy connections are closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d47cb45683eebe195132622d0563d0c723187d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->