### PR TITLE
fix: avoid retrying ClusterClient Watch callback errors

### DIFF
--- a/osscluster.go
+++ b/osscluster.go
@@ -2110,6 +2110,7 @@ func (c *ClusterClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 			}
 		}
 
+		// Track callback errors separately to avoid retrying user failures through cluster retry classification.
 		var fnErr error
 		err = node.Client.Watch(ctx, func(tx *Tx) error {
 			fnErr = fn(tx)

--- a/osscluster.go
+++ b/osscluster.go
@@ -2110,9 +2110,16 @@ func (c *ClusterClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 			}
 		}
 
-		err = node.Client.Watch(ctx, fn, keys...)
+		var fnErr error
+		err = node.Client.Watch(ctx, func(tx *Tx) error {
+			fnErr = fn(tx)
+			return fnErr
+		}, keys...)
 		if err == nil {
 			break
+		}
+		if fnErr != nil {
+			return fnErr
 		}
 
 		moved, ask, addr := isMovedError(err)

--- a/osscluster_test.go
+++ b/osscluster_test.go
@@ -1355,6 +1355,27 @@ var _ = Describe("ClusterClient", func() {
 			Expect(info.Val()).Should(ContainSubstring("tcp_port:16601"))
 		})
 
+		It("should not retry Watch callback errors wrapping net.ErrClosed", func() {
+			opt := redisClusterOptions()
+			opt.MaxRedirects = 1
+			opt.MinRetryBackoff = -1
+			opt.MaxRetryBackoff = -1
+
+			client := cluster.newClusterClient(ctx, opt)
+			defer func() {
+				Expect(client.Close()).NotTo(HaveOccurred())
+			}()
+
+			calls := 0
+			err := client.Watch(ctx, func(tx *redis.Tx) error {
+				calls++
+				return fmt.Errorf("external call failed: %w", net.ErrClosed)
+			}, "watch-callback-net-error")
+
+			Expect(errors.Is(err, net.ErrClosed)).To(BeTrue())
+			Expect(calls).To(Equal(1))
+		})
+
 		assertClusterClient()
 	})
 

--- a/osscluster_test.go
+++ b/osscluster_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"slices"
 	"strconv"
@@ -1355,7 +1356,7 @@ var _ = Describe("ClusterClient", func() {
 			Expect(info.Val()).Should(ContainSubstring("tcp_port:16601"))
 		})
 
-		It("should not retry Watch callback errors wrapping net.ErrClosed", func() {
+		It("should not retry Watch callback errors wrapping io.EOF", func() {
 			opt := redisClusterOptions()
 			opt.MaxRedirects = 1
 			opt.MinRetryBackoff = -1
@@ -1369,10 +1370,10 @@ var _ = Describe("ClusterClient", func() {
 			calls := 0
 			err := client.Watch(ctx, func(tx *redis.Tx) error {
 				calls++
-				return fmt.Errorf("external call failed: %w", net.ErrClosed)
+				return fmt.Errorf("external call failed: %w", io.EOF)
 			}, "watch-callback-net-error")
 
-			Expect(errors.Is(err, net.ErrClosed)).To(BeTrue())
+			Expect(errors.Is(err, io.EOF)).To(BeTrue())
 			Expect(calls).To(Equal(1))
 		})
 


### PR DESCRIPTION
## Summary

Fixes ClusterClient.Watch retrying user callback errors that wrap retryable network errors.

## Changes

- Track errors returned from the Watch callback.
- Return callback errors directly instead of passing them through the cluster retry classifier.
- Add a regression test for a callback error wrapping net.ErrClosed.

## Testing

- gofmt -w osscluster.go osscluster_test.go
- git diff --check
- go test ./... -run '^$'

Note: focused ClusterClient specs require a local Redis cluster at 127.0.0.1:6390, so they were not executed locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster transaction retry/error-handling logic; behavior changes could affect apps that implicitly relied on retries when callbacks returned wrapped network errors.
> 
> **Overview**
> `ClusterClient.Watch` now captures errors returned by the user callback and returns them directly, instead of feeding them through the cluster retry/redirect classification (which could previously trigger extra retries).
> 
> Adds a regression test ensuring a callback error wrapping `io.EOF` is surfaced to the caller and the callback is invoked only once even when `MaxRedirects` allows retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 858c9084c33431151ee42662a63e75324553369e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->