### PR TITLE
fix(test): fix race condition in sentinel failover metric test

### DIFF
--- a/sentinel_test.go
+++ b/sentinel_test.go
@@ -818,8 +818,10 @@ var _ = Describe("Sentinel Failover with Conns", Serial, Ordered, func() {
 				time.Sleep(500 * time.Millisecond)
 			}
 
-			Expect(failoverCloseCount.Load()).To(Equal(int32(1)),
-				"Expected exactly 1 CloseReasonFailover metric, got %d", failoverCloseCount.Load())
+			Eventually(func() int32 {
+				return failoverCloseCount.Load()
+			}, "5s", "100ms").Should(Equal(int32(1)),
+				"Expected exactly 1 CloseReasonFailover metric")
 
 			multi, err := client.Do(ctx, "MULTI").Result()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Fixs a flaky test: https://github.com/redis/go-redis/actions/runs/26288981438/job/77383812191

Root cause: a race condition between two independent goroutines that detect failover completion:

1. The test's polling loop queries sentinel.Master() directly, which returns as soon as the sentinel server reports the new master.

2. The ConnectionClosed metric callback is triggered asynchronously via the pubsub "+switch-master" message. The pubsub listener runs in a separate goroutine closes stale connections and emits the CloseReasonFailover metric.

When the test's polling loop breaks before the pubsub listener has processed the "+switch-master" message, the metric callback does fire eventually, but after the assertion has already failed.

Fix: replace the direct Expect assertion with Eventually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that replaces a racy immediate assertion with a bounded `Eventually` wait to accommodate asynchronous failover metric emission.
> 
> **Overview**
> Makes the `Sentinel Failover with Conns` test less flaky by replacing the immediate `Expect` on the `CloseReasonFailover` close-metric count with a bounded `Eventually` assertion (5s/100ms), so the test waits for the async metric callback to fire after failover is reported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf44e6f03f52c0f98911fa257fa25d17ebfd36c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->