### PR TITLE
chore: remove unused queue channel from ConnPool

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -388,7 +388,6 @@ type ConnPool struct {
 	dialErrorsNum uint32 // atomic
 	lastDialError atomic.Value
 
-	queue           chan struct{}
 	dialsInProgress chan struct{}
 	dialsQueue      *wantConnQueue
 	// Fast semaphore for connection limiting with eventual fairness
@@ -420,7 +419,6 @@ func NewConnPool(opt *Options) *ConnPool {
 	p := &ConnPool{
 		cfg:             opt,
 		semaphore:       internal.NewFastSemaphore(opt.PoolSize),
-		queue:           make(chan struct{}, opt.PoolSize),
 		conns:           make(map[uint64]*Conn),
 		dialsInProgress: make(chan struct{}, opt.MaxConcurrentDials),
 		dialsQueue:      newWantConnQueue(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> No references to `queue` remain; connection limiting still uses the existing semaphore path only.
> 
> **Overview**
> Removes the unused `queue` buffered channel from `ConnPool` and stops allocating it in `NewConnPool`. Pool concurrency is already enforced via `FastSemaphore` (`waitTurn` / `freeTurn`), so this field was dead weight with no behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 215dda917c630917236027a3f4d871e9eaf11b58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->