### PR TITLE
fix: close non-winning sentinel clients in MasterAddr concurrent probe

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -954,6 +954,7 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 				errCh <- err
 				return
 			}
+
 			once.Do(func() {
 				masterAddr = net.JoinHostPort(addrVal[0], addrVal[1])
 				// Push working sentinel to the top
@@ -962,6 +963,10 @@ func (c *sentinelFailover) MasterAddr(ctx context.Context) (string, error) {
 				internal.Logger.Printf(ctx, "sentinel: selected addr=%s masterAddr=%s", addr, masterAddr)
 				cancel()
 			})
+
+			if sentinelCli != c.sentinel {
+				_ = sentinelCli.Close()
+			}
 		}(i, sentinelAddr)
 	}
 
@@ -1045,9 +1050,9 @@ func (c *sentinelFailover) replicaAddrs(ctx context.Context, useDisconnected boo
 	}
 
 	if sentinelReachable {
-		return []string{}, nil
+		return nil, nil
 	}
-	return []string{}, errors.New("redis: all sentinels specified in configuration are unreachable")
+	return nil, errors.New("redis: all sentinels specified in configuration are unreachable")
 }
 
 func (c *sentinelFailover) getMasterAddr(ctx context.Context, sentinel *SentinelClient) (string, error) {


### PR DESCRIPTION
Problem:
In MasterAddr, multiple goroutines probe sentinels concurrently. The first
to succeed enters sync.Once and saves its SentinelClient via setSentinel.
Other goroutines that also succeeded but lost the once.Do race doesn't
closed its SentinelClient — a resource leak.

fix:
After once.Do returns, close the sentinelCli if it's not the winner.
sync.Once guarantees all goroutines see c.sentinel written by the winner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted resource cleanup and nil-vs-empty-slice return normalization in sentinel failover; no auth or API contract changes for typical callers.
> 
> **Overview**
> Fixes a **connection leak** in the concurrent `MasterAddr` sentinel probe: goroutines that successfully call `GetMasterAddrByName` but lose the race no longer leave extra `SentinelClient` instances open—they close the client unless it is the one stored on `sentinelFailover`.
> 
> `replicaAddrs` now returns **`nil` instead of an empty slice** when sentinels are reachable but no replica addresses are found (errors still return `nil` with the error). Callers that only check `len` behave the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f614c676444d5a209d88c9e7358d854b0ca74826. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->