### PR TITLE
fix(cluster): fall back to origin port when CLUSTER SLOTS reports port 0

### DIFF
--- a/internal_test.go
+++ b/internal_test.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"fmt"
+	"net"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -345,6 +346,119 @@ func TestNodeAddress(t *testing.T) {
 	})
 }
 
+// TestNewClusterState_PortZero verifies that nodes reported by CLUSTER SLOTS
+// with a port of 0 — the topology produced by TLS-only Redis clusters started
+// with `--port 0 --tls-port 6379` — get their dial address normalized so they
+// do not surface to the dial path as ":0".
+//
+// Regression test for https://github.com/redis/go-redis/issues/3726
+// PubSub in v9.18.0 fails in TLS-only clusters because newClusterState stores
+// the verbatim ":0" port into clusterNode.Client.opt.Addr and the PubSub path
+// dials that address directly with no MOVED/seed fallback, producing
+// `dial tcp <ip>:0: connection refused`.
+//
+// The fix is expected to use the origin endpoint's port as a fallback whenever
+// CLUSTER SLOTS reports port 0 — the origin is by definition reachable, since
+// that is the address we used to obtain the slot map in the first place.
+func TestNewClusterState_PortZero(t *testing.T) {
+	t.Run("non-loopback origin replaces :0 port with origin port", func(t *testing.T) {
+		opt := &ClusterOptions{}
+		opt.init()
+		nodes := newClusterNodes(opt)
+		defer nodes.Close()
+
+		// Simulates a TLS-only cluster: CLUSTER SLOTS reports port 0 because
+		// the server is configured with `--port 0 --tls-port 6379`.
+		slots := []ClusterSlot{{
+			Start: 0,
+			End:   5460,
+			Nodes: []ClusterNode{{Addr: "172.30.0.10:0"}},
+		}, {
+			Start: 5461,
+			End:   10922,
+			Nodes: []ClusterNode{{Addr: "172.30.0.11:0"}},
+		}}
+
+		// Origin is the TLS configuration endpoint that returned this slot map.
+		state, err := newClusterState(nodes, slots, "172.30.0.10:6379")
+		if err != nil {
+			t.Fatalf("newClusterState failed: %v", err)
+		}
+
+		for i, want := range []string{"172.30.0.10:6379", "172.30.0.11:6379"} {
+			got := state.slots[i].nodes[0].Client.Options().Addr
+			if _, port, _ := net.SplitHostPort(got); port == "0" {
+				t.Fatalf("slot %d Addr = %q: port 0 reached the dial path "+
+					"(see #3726: PubSub dials this verbatim and fails with "+
+					"`connection refused`)", i, got)
+			}
+			if got != want {
+				t.Errorf("slot %d Addr = %q, want %q (origin port should be "+
+					"used as fallback for :0 nodes)", i, got, want)
+			}
+
+			// NodeAddress documents the raw server-reported endpoint
+			// (see options.go: "the exact endpoint string returned by
+			// CLUSTER SLOTS before any resolution or transformation").
+			// The port-0 fix is a transformation, so NodeAddress keeps
+			// the original ":0" value used by maintenance-notification
+			// matching. If the design changes this, update this assertion.
+			wantNodeAddr := []string{"172.30.0.10:0", "172.30.0.11:0"}[i]
+			if got := state.slots[i].nodes[0].Client.NodeAddress(); got != wantNodeAddr {
+				t.Errorf("slot %d NodeAddress = %q, want %q (raw server value)",
+					i, got, wantNodeAddr)
+			}
+		}
+	})
+
+	t.Run("non-zero ports are unchanged", func(t *testing.T) {
+		// Guards against the fix over-rewriting ports for normal clusters.
+		opt := &ClusterOptions{}
+		opt.init()
+		nodes := newClusterNodes(opt)
+		defer nodes.Close()
+
+		slots := []ClusterSlot{{
+			Nodes: []ClusterNode{{Addr: "172.30.0.10:6380"}},
+		}}
+
+		state, err := newClusterState(nodes, slots, "172.30.0.10:6379")
+		if err != nil {
+			t.Fatalf("newClusterState failed: %v", err)
+		}
+
+		if got := state.slots[0].nodes[0].Client.Options().Addr; got != "172.30.0.10:6380" {
+			t.Errorf("Addr = %q, want %q (non-zero ports must be preserved)",
+				got, "172.30.0.10:6380")
+		}
+	})
+
+	t.Run("loopback :0 follows loopback substitution and uses origin port", func(t *testing.T) {
+		// Combines the two transformations newClusterState already does
+		// (loopback substitution + the new port-0 fallback) and asserts
+		// the order is sane: replace the loopback host with the origin
+		// host, then replace the :0 port with the origin port.
+		opt := &ClusterOptions{}
+		opt.init()
+		nodes := newClusterNodes(opt)
+		defer nodes.Close()
+
+		slots := []ClusterSlot{{
+			Nodes: []ClusterNode{{Addr: "127.0.0.1:0"}},
+		}}
+
+		state, err := newClusterState(nodes, slots, "172.30.0.10:6379")
+		if err != nil {
+			t.Fatalf("newClusterState failed: %v", err)
+		}
+
+		if got := state.slots[0].nodes[0].Client.Options().Addr; got != "172.30.0.10:6379" {
+			t.Errorf("Addr = %q, want %q (loopback host + :0 port should both "+
+				"be replaced from the origin)", got, "172.30.0.10:6379")
+		}
+	})
+}
+
 type fixedHash string
 
 func (h fixedHash) Get(string) string {
@@ -657,7 +771,8 @@ var _ = Describe("ClusterClient", func() {
 })
 
 var _ = Describe("isLoopback", func() {
-	DescribeTable("should correctly identify loopback addresses",
+	DescribeTable(
+		"should correctly identify loopback addresses",
 		func(host string, expected bool) {
 			result := isLoopback(host)
 			Expect(result).To(Equal(expected))
@@ -690,7 +805,6 @@ var _ = Describe("isLoopback", func() {
 		Entry("partial docker internal", "docker.internal", false),
 	)
 })
-
 
 // TestOnCloseHooks_RunInRegistrationOrder verifies that hooks registered under
 // distinct ids are all invoked on run() in the order they were registered.
@@ -787,7 +901,6 @@ func TestOnCloseHooks_Unregister(t *testing.T) {
 	}
 }
 
-
 // TestOnCloseHooks_AllRunOnError confirms every hook is invoked even if an
 // earlier one returns an error, and that the first error is returned.
 func TestOnCloseHooks_AllRunOnError(t *testing.T) {
@@ -848,7 +961,6 @@ func TestOnCloseHooks_ConcurrentRegisterSameID(t *testing.T) {
 	}
 }
 
-
 // entraidLikeProvider mimics the exact semantics of
 // github.com/redis/go-redis-entraid's StreamingCredentialsProvider relevant
 // to issue #3772: it deduplicates subscriptions by listener pointer
@@ -858,10 +970,10 @@ func TestOnCloseHooks_ConcurrentRegisterSameID(t *testing.T) {
 // equivalent: the first one called removes the entry, any subsequent call
 // is a safe no-op.
 type entraidLikeProvider struct {
-	mu          sync.Mutex
-	listeners   []auth.CredentialsListener
-	subscribeN  int32
-	unsubCalls  int32
+	mu         sync.Mutex
+	listeners  []auth.CredentialsListener
+	subscribeN int32
+	unsubCalls int32
 }
 
 func (p *entraidLikeProvider) Subscribe(listener auth.CredentialsListener) (auth.Credentials, auth.UnsubscribeFunc, error) {

--- a/osscluster.go
+++ b/osscluster.go
@@ -534,7 +534,7 @@ func (n *clusterNode) updateLatency() {
 	if successes == 0 {
 		// If none of the pings worked, set latency to some arbitrarily high value so this node gets
 		// least priority.
-		latency = float64((maximumNodeLatency) / time.Microsecond)
+		latency = float64(maximumNodeLatency / time.Microsecond)
 	} else {
 		latency = float64(dur) / float64(successes)
 	}
@@ -820,7 +820,7 @@ func newClusterState(
 		createdAt:  time.Now(),
 	}
 
-	originHost, _, _ := net.SplitHostPort(origin)
+	originHost, originPort, _ := net.SplitHostPort(origin)
 	isLoopbackOrigin := isLoopback(originHost)
 
 	for _, slot := range slots {
@@ -832,6 +832,11 @@ func newClusterState(
 			if !isLoopbackOrigin {
 				addr = replaceLoopbackHost(addr, originHost)
 			}
+			// TLS-only clusters (`--port 0 --tls-port 6379`) report port 0
+			// in CLUSTER SLOTS. Fall back to the origin port — by definition
+			// reachable, since it is the port that returned this slot map.
+			// See https://github.com/redis/go-redis/issues/3726.
+			addr = replaceZeroPort(addr, originPort)
 
 			node, err := c.nodes.GetOrCreateWithNodeAddress(addr, nodeAddress)
 			if err != nil {
@@ -883,6 +888,21 @@ func replaceLoopbackHost(nodeAddr, originHost string) string {
 
 	// Use origin host which is not loopback and node port.
 	return net.JoinHostPort(originHost, nodePort)
+}
+
+// replaceZeroPort substitutes originPort for a node port of "0", which is
+// what CLUSTER SLOTS reports for TLS-only clusters started with
+// `--port 0 --tls-port <port>`. Non-zero ports and addresses without a
+// recoverable origin port are returned unchanged.
+func replaceZeroPort(nodeAddr, originPort string) string {
+	if originPort == "" || originPort == "0" {
+		return nodeAddr
+	}
+	nodeHost, nodePort, err := net.SplitHostPort(nodeAddr)
+	if err != nil || nodePort != "0" {
+		return nodeAddr
+	}
+	return net.JoinHostPort(nodeHost, originPort)
 }
 
 // isLoopback returns true if the host is a loopback address.
@@ -948,7 +968,7 @@ func (c *clusterState) slotClosestNode(slot int) (*clusterNode, error) {
 		return c.nodes.Random()
 	}
 
-	var allNodesFailing = true
+	allNodesFailing := true
 	var (
 		closestNonFailingNode *clusterNode
 		closestNode           *clusterNode


### PR DESCRIPTION
In TLS-only clusters started with `--port 0 --tls-port <port>`, CLUSTER SLOTS reports the regular port as 0. newClusterState used to pass that value verbatim into clusterNode.Client.opt.Addr, which the PubSub path dials directly with no MOVED/seed fallback, producing `dial tcp <ip>:0: connection refused`.

Add a replaceZeroPort helper symmetric to replaceLoopbackHost: when a slot node's port is "0", substitute the origin endpoint's port — by definition reachable, since it is the port we used to fetch the slot map. NodeAddress is left untouched so maintenance-notification matching continues to see the server-reported value.

Adds TestNewClusterState_PortZero covering the bug scenario plus the non-zero passthrough and the loopback+:0 composition.

Fixes #3726

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster address normalization used by all node dials including PubSub; behavior is narrow (port 0 only) but incorrect fallback could mis-route in exotic topologies.
> 
> **Overview**
> **Cluster topology** now normalizes dial addresses when `CLUSTER SLOTS` reports port **0** (TLS-only setups with `--port 0 --tls-port <n>`). In `newClusterState`, after existing loopback host substitution, **`replaceZeroPort`** rewrites `:0` endpoints to use the **origin** endpoint’s port—the same address used to fetch the slot map—so clients (including **PubSub**, which dials `Client.opt.Addr` directly) no longer hit `dial tcp <ip>:0`.
> 
> **`NodeAddress`** stays the raw server-reported value (`…:0`) for maintenance-notification matching; only the transformed **`Addr`** used for connections changes. Regression coverage is in **`TestNewClusterState_PortZero`** (TLS `:0` case, non-zero ports unchanged, loopback + `:0` composition).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f527f945e167dc8c42c690675fe71fa9fa9fbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->