### PR TITLE
fix(pubsub): include shard channels in newConn routing list

### DIFF
--- a/internal_test.go
+++ b/internal_test.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -967,3 +968,106 @@ func TestInitConn_EntraidLike_NoLeakAcrossReinits(t *testing.T) {
 		t.Fatalf("listener count after orphaned unsubs = %d, want 0", got)
 	}
 }
+
+// TestPubSubConn_PassesPersistedChannelsToNewConn is a regression test for
+// https://github.com/redis/go-redis/issues/3806.
+//
+// ClusterClient.pubSub() installs a newConn closure that picks the target
+// node by hash slot of channels[0]. Before the fix, PubSub.conn() only
+// passed c.channels (regular SUBSCRIBE) into that closure — sharded
+// SSubscribe channels stored in c.schannels were silently dropped.
+//
+// For an SSubscribe-only PubSub (the common ClusterClient.SSubscribe case)
+// the channel list was empty on reconnect, so the closure fell through to
+// nodes.Random(). The reconnected SSUBSCRIBE went to the wrong shard, the
+// MOVED reply was never read, and the PubSub looked healthy while receiving
+// no messages.
+//
+// This test exercises PubSub.conn() with a stub newConn that records the
+// channel list it receives. The cluster routing layer is not under test
+// here — the regression is whether the channel list reaches the closure.
+func TestPubSubConn_PassesPersistedChannelsToNewConn(t *testing.T) {
+	const (
+		regularCh = "regular-ch"
+		shardCh   = "{shardA}-ch1"
+		freshCh   = "fresh-ch"
+	)
+
+	tests := []struct {
+		name        string
+		channels    map[string]struct{}
+		schannels   map[string]struct{}
+		newChannels []string
+		wantIn      []string // strings that MUST be present in the captured slice
+	}{
+		{
+			name:     "subscribe-only reconnect: existing channels forwarded",
+			channels: map[string]struct{}{regularCh: {}},
+			wantIn:   []string{regularCh},
+		},
+		{
+			// The bug from #3806: SSubscribe-only reconnect dropped
+			// c.schannels and reached newConn with an empty list.
+			name:      "ssubscribe-only reconnect: schannels forwarded (#3806)",
+			schannels: map[string]struct{}{shardCh: {}},
+			wantIn:    []string{shardCh},
+		},
+		{
+			name:        "initial ssubscribe: newChannels forwarded",
+			newChannels: []string{shardCh},
+			wantIn:      []string{shardCh},
+		},
+		{
+			name:      "mixed subscribe + ssubscribe: both kinds forwarded",
+			channels:  map[string]struct{}{regularCh: {}},
+			schannels: map[string]struct{}{shardCh: {}},
+			wantIn:    []string{regularCh, shardCh},
+		},
+		{
+			name:        "newChannels appended after persisted ones",
+			schannels:   map[string]struct{}{shardCh: {}},
+			newChannels: []string{freshCh},
+			wantIn:      []string{shardCh, freshCh},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured []string
+			stubErr := errors.New("stub: newConn does not create a real conn")
+
+			ps := &PubSub{
+				opt:       &Options{Addr: "stub:6379"},
+				channels:  tt.channels,
+				schannels: tt.schannels,
+				newConn: func(_ context.Context, _ string, channels []string) (*pool.Conn, error) {
+					captured = append([]string(nil), channels...)
+					return nil, stubErr
+				},
+				closeConn: func(*pool.Conn) error { return nil },
+			}
+
+			ps.mu.Lock()
+			_, err := ps.conn(context.Background(), tt.newChannels)
+			ps.mu.Unlock()
+			if !errors.Is(err, stubErr) {
+				t.Fatalf("conn err = %v, want stub", err)
+			}
+
+			for _, want := range tt.wantIn {
+				found := false
+				for _, got := range captured {
+					if got == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("missing %q in channels passed to newConn (got %v); see #3806",
+						want, captured)
+				}
+			}
+		})
+	}
+}
+

--- a/pubsub.go
+++ b/pubsub.go
@@ -87,7 +87,16 @@ func (c *PubSub) conn(ctx context.Context, newChannels []string) (*pool.Conn, er
 		c.opt.Addr = internal.RedisNull
 	}
 
+	// Include c.schannels so reconnect-time routing of an SSubscribe-only
+	// PubSub picks the slot owner (channels[0] in ClusterClient.pubSub()'s
+	// newConn closure) instead of a random node.
+	// See https://github.com/redis/go-redis/issues/3806.
+	// c.patterns is intentionally NOT included: patterns are not slot-
+	// addressable, and adding them would force PSubscribe-only PubSubs to
+	// pin to a single node based on pattern-string hash, regressing the
+	// existing random-node behaviour.
 	channels := slices.Collect(maps.Keys(c.channels))
+	channels = append(channels, slices.Collect(maps.Keys(c.schannels))...)
 	channels = append(channels, newChannels...)
 
 	cn, err := c.newConn(ctx, c.opt.Addr, channels)


### PR DESCRIPTION
In ClusterClient.SSubscribe, the per-PubSub newConn closure picks the target node by hash slot of channels[0]. PubSub.conn() was only passing c.channels (regular SUBSCRIBE) into that closure — sharded SSubscribe channels stored in c.schannels were silently dropped.

For an SSubscribe-only PubSub (the common ClusterClient.SSubscribe case) this meant the channel list was empty on reconnect, so the closure fell through to nodes.Random(). The reconnected SSUBSCRIBE went to the wrong shard, the MOVED reply was never read by the write-only resubscribe path, and the PubSub looked healthy (Ping succeeds, Receive returns) while delivering no messages. On an N-shard cluster the failure mode hit (N-1)/N reconnects.

Add c.schannels to the channel list built in PubSub.conn(). c.patterns is intentionally NOT added: patterns are not slot-addressable, and including them would pin PSubscribe-only PubSubs to a single pattern-hash node and lose the existing random-node behaviour.

Adds TestPubSubConn_PassesPersistedChannelsToNewConn covering five cases (subscribe-only reconnect, ssubscribe-only reconnect, initial ssubscribe, mixed, and ordering of newChannels) via a stub newConn that captures the channel list. The cluster routing layer itself is not under test — the regression is whether the channel list reaches the closure intact.

Fixes #3806

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster pub/sub reconnect routing for SSubscribe and mixed subscriptions; scope is small but wrong routing would silently drop messages.
> 
> **Overview**
> **`PubSub.conn()`** now forwards persisted **shard (`SSubscribe`) channel names** to the `newConn` callback together with regular subscribe channels and any `newChannels`, so cluster reconnects can route by slot instead of picking a random node when only sharded subscriptions exist (#3806).
> 
> **`c.patterns` is still omitted** from that routing list so pattern-only pub/sub keeps its prior random-node behavior.
> 
> Adds **`TestPubSubConn_PassesPersistedChannelsToNewConn`** with a stub `newConn` that asserts the combined channel list for subscribe-only, ssubscribe-only, mixed, and ordering cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a53e6ca67925eea9705213dc346b7f62f283b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->