### PR TITLE
chore: improve go-redis maintenance path

### DIFF
--- a/tls_test.go
+++ b/tls_test.go
@@ -21,7 +21,9 @@ func loadTLSConfig(certDir string) (*tls.Config, error) {
 	}
 
 	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return nil, os.ErrInvalid
+	}
 
 	// Load client cert and key
 	cert, err := tls.LoadX509KeyPair(


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in tx_test.go, tls_test.go related to CI, Docker, Kubernetes, build tooling, release automation; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to a helper; no production TLS or client behavior is modified.
> 
> **Overview**
> The TLS test helper `loadTLSConfig` now **checks the boolean result** of `AppendCertsFromPEM` when loading the CA certificate. If the PEM cannot be parsed into the pool, it **returns `os.ErrInvalid`** instead of continuing with a config that might lack trusted CAs.
> 
> This tightens failure behavior for bad or empty CA material in the Docker TLS fixture path used by the TLS integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4048d4ce5c5e19df8c5301476f8412ad64df4ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->