### PR TITLE
fix(pubsub): prevent double reconnect in releaseConn

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -173,6 +173,7 @@ func (c *PubSub) releaseConn(ctx context.Context, cn *pool.Conn, err error, allo
 
 	if !cn.IsUsable() || cn.ShouldHandoff() {
 		c.reconnect(ctx, fmt.Errorf("pubsub: connection is not usable"))
+		return
 	}
 
 	if isBadConn(err, allowTimeout, c.opt.Addr) {


### PR DESCRIPTION
When a connection is both not usable and has a bad conn error, releaseConn would call reconnect twice — first establishing a new connection, then immediately closing it to create another. Add early return after the first reconnect to avoid the wasted connection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single control-flow guard in pub/sub connection release; no API or security surface changes.
> 
> **Overview**
> Fixes a bug in **`PubSub.releaseConn`** where an unusable or handoff connection could trigger **`reconnect` twice** in one call—once for `!IsUsable()` / `ShouldHandoff()`, and again if `isBadConn(err, …)` was also true.
> 
> Adds an **early `return`** after the first reconnect so a bad-connection error on the same release path does not immediately tear down and reopen the connection again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02ebca1ef7ad30e8df7f36da2565dbe11619a29f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->