### PR TITLE
feat(multidb): #1 internal/circuitbreaker - add unified circuit breaker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master, v9, 'v9.*']
   pull_request:
-    branches: [master, v9, v9.7, v9.8, 'ndyakov/**', 'ofekshenawa/**', 'ce/**']
+    branches: [master, v9, v9.7, v9.8, 'ndyakov/**', 'ofekshenawa/**', 'ce/**', 'feature/**']
 
 permissions:
   contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches: [master, v9, v9.7, v9.8]
   pull_request:
-    branches: [master, v9, v9.7, v9.8]
+    branches: [master, v9, v9.7, v9.8, 'feature/**']
 
 jobs:
   analyze:

--- a/.github/workflows/doctests.yaml
+++ b/.github/workflows/doctests.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master, examples]
   pull_request:
-    branches: [master, examples]
+    branches: [master, examples, 'feature/**']
 
 permissions:
   contents: read

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -3,7 +3,7 @@ name: govulncheck
 
 on:
   pull_request:
-    branches: [master, v9, v9.7, v9.8, "ndyakov/**", "ofekshenawa/**", "ce/**"]
+    branches: [master, v9, v9.7, v9.8, "ndyakov/**", "ofekshenawa/**", "ce/**", "feature/**"]
   push:
     branches: [master, v9, "v9.*"]
   schedule:

--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -211,7 +211,18 @@ func (cb *CircuitBreaker) RecordFailure() {
 		failures := cb.failures.Add(1)
 		if int(failures) >= cb.config.FailureThreshold {
 			if cb.state.CompareAndSwap(int32(StateClosed), int32(StateOpen)) {
+				// Notify callbacks before clearing the half-open counters so
+				// observers see the failure count that triggered the
+				// transition, matching the half-open -> closed/open paths.
 				cb.notifyCallbacks(StateClosed, StateOpen)
+				// successes and requests should already be 0 in Closed (they
+				// are only incremented while half-open, and every half-open
+				// exit zeroes them). Reset defensively so the invariant
+				// "successes/requests are clean on entry to Open" is upheld
+				// consistently across all transitions into Open, even if a
+				// future change starts touching those counters in Closed.
+				cb.successes.Store(0)
+				cb.requests.Store(0)
 			}
 		}
 	case StateHalfOpen:

--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -119,9 +119,11 @@ func (cb *CircuitBreaker) CheckState() State {
 	state := State(cb.state.Load())
 
 	if state == StateOpen {
-		// Check if we should transition to half-open
-		lastFailure := time.Unix(0, cb.lastFailure.Load())
-		if time.Since(lastFailure) >= cb.config.OpenTimeout {
+		// Check if we should transition to half-open.
+		// Guard against a zero timestamp (no failure recorded yet) so we don't
+		// treat the Unix epoch as the last failure and transition immediately.
+		lastFailure := cb.lastFailure.Load()
+		if lastFailure != 0 && time.Now().UnixNano()-lastFailure >= int64(cb.config.OpenTimeout) {
 			if cb.state.CompareAndSwap(int32(StateOpen), int32(StateHalfOpen)) {
 				cb.successes.Store(0)
 				cb.requests.Store(0)
@@ -170,10 +172,12 @@ func (cb *CircuitBreaker) RecordSuccess() {
 		}
 		if int(successes) >= cb.config.SuccessThreshold {
 			if cb.state.CompareAndSwap(int32(StateHalfOpen), int32(StateClosed)) {
+				// Notify callbacks before resetting counters so they observe
+				// the success count that triggered the transition.
+				cb.notifyCallbacks(StateHalfOpen, StateClosed)
 				cb.failures.Store(0)
 				cb.successes.Store(0)
 				cb.requests.Store(0)
-				cb.notifyCallbacks(StateHalfOpen, StateClosed)
 			}
 		}
 	case StateClosed:

--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -1,0 +1,291 @@
+// Package circuitbreaker provides a circuit breaker implementation for fault tolerance.
+package circuitbreaker
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// State represents the state of a circuit breaker.
+type State int32
+
+const (
+	// StateClosed indicates the circuit is closed and requests are allowed.
+	StateClosed State = iota
+	// StateOpen indicates the circuit is open and requests are blocked.
+	StateOpen
+	// StateHalfOpen indicates the circuit is testing if the service has recovered.
+	StateHalfOpen
+)
+
+// String returns the string representation of the circuit state.
+func (s State) String() string {
+	switch s {
+	case StateClosed:
+		return "closed"
+	case StateOpen:
+		return "open"
+	case StateHalfOpen:
+		return "half-open"
+	default:
+		return "unknown"
+	}
+}
+
+// Config holds configuration for a circuit breaker.
+type Config struct {
+	// FailureThreshold is the number of failures before opening the circuit.
+	// Default: 5
+	FailureThreshold int
+
+	// SuccessThreshold is the number of successes in half-open state before closing.
+	// Default: 2
+	SuccessThreshold int
+
+	// MaxHalfOpenRequests is the maximum number of requests allowed in half-open state.
+	// If 0, uses SuccessThreshold as the limit.
+	// Default: 0 (uses SuccessThreshold)
+	MaxHalfOpenRequests int
+
+	// OpenTimeout is how long to wait before transitioning from open to half-open.
+	// This is the circuit "grace period" that gives a failed database time to
+	// self-heal before it is probed again.
+	// Default: 60 seconds
+	OpenTimeout time.Duration
+}
+
+// DefaultConfig returns the default circuit breaker configuration.
+func DefaultConfig() Config {
+	return Config{
+		FailureThreshold:    5,
+		SuccessThreshold:    2,
+		MaxHalfOpenRequests: 0,
+		OpenTimeout:         60 * time.Second,
+	}
+}
+
+// applyDefaults fills in zero values with defaults.
+func (c *Config) applyDefaults() {
+	if c.FailureThreshold <= 0 {
+		c.FailureThreshold = 5
+	}
+	if c.SuccessThreshold <= 0 {
+		c.SuccessThreshold = 2
+	}
+	if c.MaxHalfOpenRequests <= 0 {
+		c.MaxHalfOpenRequests = c.SuccessThreshold
+	}
+	if c.OpenTimeout <= 0 {
+		c.OpenTimeout = 60 * time.Second
+	}
+}
+
+// StateChangeCallback is called when the circuit breaker state changes.
+type StateChangeCallback func(oldState, newState State)
+
+// CircuitBreaker implements the circuit breaker pattern.
+type CircuitBreaker struct {
+	config Config
+
+	state       atomic.Int32
+	failures    atomic.Int32
+	successes   atomic.Int32
+	requests    atomic.Int32 // Request count in half-open state
+	lastFailure atomic.Int64 // Unix nano timestamp
+
+	mu        sync.RWMutex
+	callbacks []StateChangeCallback
+}
+
+// New creates a new circuit breaker with the given configuration.
+func New(config Config) *CircuitBreaker {
+	config.applyDefaults()
+	cb := &CircuitBreaker{
+		config: config,
+	}
+	cb.state.Store(int32(StateClosed))
+	return cb
+}
+
+// State returns the current state without triggering any transitions.
+func (cb *CircuitBreaker) State() State {
+	return State(cb.state.Load())
+}
+
+// CheckState returns the current state and may trigger state transitions.
+// Use this when you need to check if requests should be allowed.
+func (cb *CircuitBreaker) CheckState() State {
+	state := State(cb.state.Load())
+
+	if state == StateOpen {
+		// Check if we should transition to half-open
+		lastFailure := time.Unix(0, cb.lastFailure.Load())
+		if time.Since(lastFailure) >= cb.config.OpenTimeout {
+			if cb.state.CompareAndSwap(int32(StateOpen), int32(StateHalfOpen)) {
+				cb.successes.Store(0)
+				cb.requests.Store(0)
+				cb.notifyCallbacks(StateOpen, StateHalfOpen)
+				return StateHalfOpen
+			}
+		}
+	}
+
+	return State(cb.state.Load())
+}
+
+// IsAllowed returns true if a request should be allowed through.
+// This is a convenience method that combines CheckState with half-open request limiting.
+func (cb *CircuitBreaker) IsAllowed() bool {
+	state := cb.CheckState()
+
+	switch state {
+	case StateClosed:
+		return true
+	case StateOpen:
+		return false
+	case StateHalfOpen:
+		// Limit requests in half-open state
+		requests := cb.requests.Add(1)
+		if int(requests) > cb.config.MaxHalfOpenRequests {
+			cb.requests.Add(-1) // Revert
+			return false
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+// RecordSuccess records a successful operation.
+func (cb *CircuitBreaker) RecordSuccess() {
+	state := State(cb.state.Load())
+
+	switch state {
+	case StateHalfOpen:
+		successes := cb.successes.Add(1)
+		// Re-check state after increment - another goroutine may have changed it
+		if State(cb.state.Load()) != StateHalfOpen {
+			return
+		}
+		if int(successes) >= cb.config.SuccessThreshold {
+			if cb.state.CompareAndSwap(int32(StateHalfOpen), int32(StateClosed)) {
+				cb.failures.Store(0)
+				cb.successes.Store(0)
+				cb.requests.Store(0)
+				cb.notifyCallbacks(StateHalfOpen, StateClosed)
+			}
+		}
+	case StateClosed:
+		// Reset failure count on success
+		cb.failures.Store(0)
+	}
+}
+
+// RecordFailure records a failed operation.
+func (cb *CircuitBreaker) RecordFailure() {
+	cb.lastFailure.Store(time.Now().UnixNano())
+	state := State(cb.state.Load())
+
+	switch state {
+	case StateClosed:
+		failures := cb.failures.Add(1)
+		if int(failures) >= cb.config.FailureThreshold {
+			if cb.state.CompareAndSwap(int32(StateClosed), int32(StateOpen)) {
+				cb.notifyCallbacks(StateClosed, StateOpen)
+			}
+		}
+	case StateHalfOpen:
+		// Any failure in half-open state opens the circuit
+		if cb.state.CompareAndSwap(int32(StateHalfOpen), int32(StateOpen)) {
+			cb.successes.Store(0)
+			cb.requests.Store(0)
+			cb.notifyCallbacks(StateHalfOpen, StateOpen)
+		}
+	}
+}
+
+// OnStateChange registers a callback to be called when the state changes.
+func (cb *CircuitBreaker) OnStateChange(callback StateChangeCallback) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	cb.callbacks = append(cb.callbacks, callback)
+}
+
+// notifyCallbacks notifies all registered callbacks of a state change.
+func (cb *CircuitBreaker) notifyCallbacks(oldState, newState State) {
+	cb.mu.RLock()
+	callbacks := make([]StateChangeCallback, len(cb.callbacks))
+	copy(callbacks, cb.callbacks)
+	cb.mu.RUnlock()
+
+	for _, callback := range callbacks {
+		callback(oldState, newState)
+	}
+}
+
+// Reset resets the circuit breaker to closed state.
+// If the circuit was not already closed, callbacks are notified.
+func (cb *CircuitBreaker) Reset() {
+	oldState := State(cb.state.Swap(int32(StateClosed)))
+	cb.failures.Store(0)
+	cb.successes.Store(0)
+	cb.requests.Store(0)
+	cb.lastFailure.Store(0)
+	if oldState != StateClosed {
+		cb.notifyCallbacks(oldState, StateClosed)
+	}
+}
+
+// Stats returns current statistics for monitoring.
+type Stats struct {
+	State           State
+	Failures        int32
+	Successes       int32
+	Requests        int32
+	LastFailureTime time.Time
+}
+
+// Stats returns current statistics.
+func (cb *CircuitBreaker) Stats() Stats {
+	lastFailure := cb.lastFailure.Load()
+	var lastFailureTime time.Time
+	if lastFailure > 0 {
+		lastFailureTime = time.Unix(0, lastFailure)
+	}
+
+	return Stats{
+		State:           cb.State(),
+		Failures:        cb.failures.Load(),
+		Successes:       cb.successes.Load(),
+		Requests:        cb.requests.Load(),
+		LastFailureTime: lastFailureTime,
+	}
+}
+
+// Execute runs the given function with circuit breaker protection.
+// Returns ErrCircuitOpen if the circuit is open and not ready for testing.
+func (cb *CircuitBreaker) Execute(fn func() error) error {
+	if !cb.IsAllowed() {
+		return ErrCircuitOpen
+	}
+
+	err := fn()
+	if err != nil {
+		cb.RecordFailure()
+		return err
+	}
+
+	cb.RecordSuccess()
+	return nil
+}
+
+// ErrCircuitOpen is returned when the circuit breaker is open.
+var ErrCircuitOpen = &CircuitOpenError{}
+
+// CircuitOpenError indicates the circuit breaker is open.
+type CircuitOpenError struct{}
+
+func (e *CircuitOpenError) Error() string {
+	return "circuit breaker is open"
+}

--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -159,6 +159,21 @@ func (cb *CircuitBreaker) IsAllowed() bool {
 	}
 }
 
+// ReleaseHalfOpen returns a half-open request slot previously reserved by a
+// successful IsAllowed call when the operation produced neither a recordable
+// success nor failure (for example, it was aborted for an unrelated reason).
+// Without this, a reserved-but-never-completed probe could permanently starve
+// half-open recovery once MaxHalfOpenRequests slots are exhausted. It only has
+// an effect while the breaker is half-open.
+func (cb *CircuitBreaker) ReleaseHalfOpen() {
+	if State(cb.state.Load()) != StateHalfOpen {
+		return
+	}
+	if cb.requests.Add(-1) < 0 {
+		cb.requests.Store(0)
+	}
+}
+
 // RecordSuccess records a successful operation.
 func (cb *CircuitBreaker) RecordSuccess() {
 	state := State(cb.state.Load())
@@ -200,11 +215,14 @@ func (cb *CircuitBreaker) RecordFailure() {
 			}
 		}
 	case StateHalfOpen:
-		// Any failure in half-open state opens the circuit
+		// Any failure in half-open state opens the circuit.
 		if cb.state.CompareAndSwap(int32(StateHalfOpen), int32(StateOpen)) {
+			// Notify callbacks before resetting counters so they observe the
+			// counts that triggered the transition, matching the half-open ->
+			// closed path in RecordSuccess.
+			cb.notifyCallbacks(StateHalfOpen, StateOpen)
 			cb.successes.Store(0)
 			cb.requests.Store(0)
-			cb.notifyCallbacks(StateHalfOpen, StateOpen)
 		}
 	}
 }

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -208,6 +208,42 @@ func TestCircuitBreaker_OnStateChange(t *testing.T) {
 	}
 }
 
+func TestCircuitBreaker_CallbackObservesSuccessCountOnClose(t *testing.T) {
+	config := Config{
+		FailureThreshold: 2,
+		SuccessThreshold: 2,
+		OpenTimeout:      50 * time.Millisecond,
+	}
+	cb := New(config)
+
+	var closeSuccesses int32 = -1
+	cb.OnStateChange(func(oldState, newState State) {
+		if oldState == StateHalfOpen && newState == StateClosed {
+			closeSuccesses = cb.Stats().Successes
+		}
+	})
+
+	// Open the circuit, wait for the timeout, then transition to half-open.
+	cb.RecordFailure()
+	cb.RecordFailure()
+	time.Sleep(60 * time.Millisecond)
+	cb.CheckState()
+
+	// Record enough successes to close the circuit.
+	cb.RecordSuccess()
+	cb.RecordSuccess()
+
+	if cb.State() != StateClosed {
+		t.Fatalf("expected state to be Closed, got %v", cb.State())
+	}
+	// The callback must see the success count that triggered the close, not the
+	// post-reset value of 0.
+	if closeSuccesses != int32(config.SuccessThreshold) {
+		t.Errorf("expected callback to observe %d successes, got %d",
+			config.SuccessThreshold, closeSuccesses)
+	}
+}
+
 func TestCircuitBreaker_Reset(t *testing.T) {
 	config := Config{
 		FailureThreshold: 2,

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -164,6 +164,52 @@ func TestCircuitBreaker_MaxHalfOpenRequests(t *testing.T) {
 	}
 }
 
+func TestCircuitBreaker_ReleaseHalfOpen(t *testing.T) {
+	config := Config{
+		FailureThreshold:    2,
+		SuccessThreshold:    3,
+		MaxHalfOpenRequests: 2,
+		OpenTimeout:         50 * time.Millisecond,
+	}
+	cb := New(config)
+
+	// Open the circuit, then wait for the half-open window.
+	cb.RecordFailure()
+	cb.RecordFailure()
+	time.Sleep(60 * time.Millisecond)
+
+	// Reserve both half-open slots.
+	if !cb.IsAllowed() {
+		t.Fatal("first request should be allowed in half-open")
+	}
+	if !cb.IsAllowed() {
+		t.Fatal("second request should be allowed in half-open")
+	}
+	if cb.IsAllowed() {
+		t.Fatal("third request should be rejected before release")
+	}
+
+	// Releasing a reserved slot should let a subsequent probe through.
+	cb.ReleaseHalfOpen()
+	if !cb.IsAllowed() {
+		t.Error("request should be allowed after ReleaseHalfOpen")
+	}
+
+	// Release must not drive the counter negative or admit extra probes.
+	cb.ReleaseHalfOpen()
+	cb.ReleaseHalfOpen()
+	if cb.requests.Load() < 0 {
+		t.Errorf("requests counter must not go negative, got %d", cb.requests.Load())
+	}
+
+	// ReleaseHalfOpen is a no-op outside the half-open state.
+	cb.Reset()
+	cb.ReleaseHalfOpen()
+	if cb.requests.Load() != 0 {
+		t.Errorf("expected requests to remain 0 when closed, got %d", cb.requests.Load())
+	}
+}
+
 func TestCircuitBreaker_OnStateChange(t *testing.T) {
 	config := Config{
 		FailureThreshold: 2,

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -1,0 +1,323 @@
+package circuitbreaker
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCircuitBreaker_InitialState(t *testing.T) {
+	cb := New(DefaultConfig())
+
+	if cb.State() != StateClosed {
+		t.Errorf("expected initial state to be Closed, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreaker_OpenAfterFailures(t *testing.T) {
+	config := Config{
+		FailureThreshold: 3,
+		SuccessThreshold: 2,
+		OpenTimeout:      100 * time.Millisecond,
+	}
+	cb := New(config)
+
+	// Record failures
+	for i := 0; i < 3; i++ {
+		cb.RecordFailure()
+	}
+
+	if cb.State() != StateOpen {
+		t.Errorf("expected state to be Open after %d failures, got %v", 3, cb.State())
+	}
+}
+
+func TestCircuitBreaker_TransitionToHalfOpen(t *testing.T) {
+	config := Config{
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+		OpenTimeout:      50 * time.Millisecond,
+	}
+	cb := New(config)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	if cb.State() != StateOpen {
+		t.Fatalf("expected state to be Open, got %v", cb.State())
+	}
+
+	// Wait for timeout
+	time.Sleep(60 * time.Millisecond)
+
+	// CheckState should transition to half-open
+	state := cb.CheckState()
+	if state != StateHalfOpen {
+		t.Errorf("expected state to be HalfOpen after timeout, got %v", state)
+	}
+}
+
+func TestCircuitBreaker_CloseAfterSuccesses(t *testing.T) {
+	config := Config{
+		FailureThreshold: 2,
+		SuccessThreshold: 2,
+		OpenTimeout:      50 * time.Millisecond,
+	}
+	cb := New(config)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Wait for timeout and transition to half-open
+	time.Sleep(60 * time.Millisecond)
+	cb.CheckState()
+
+	// Record successes
+	cb.RecordSuccess()
+	cb.RecordSuccess()
+
+	if cb.State() != StateClosed {
+		t.Errorf("expected state to be Closed after successes, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreaker_ReopenOnFailureInHalfOpen(t *testing.T) {
+	config := Config{
+		FailureThreshold: 2,
+		SuccessThreshold: 2,
+		OpenTimeout:      50 * time.Millisecond,
+	}
+	cb := New(config)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Wait for timeout and transition to half-open
+	time.Sleep(60 * time.Millisecond)
+	cb.CheckState()
+
+	if cb.State() != StateHalfOpen {
+		t.Fatalf("expected state to be HalfOpen, got %v", cb.State())
+	}
+
+	// Record a failure - should reopen
+	cb.RecordFailure()
+
+	if cb.State() != StateOpen {
+		t.Errorf("expected state to be Open after failure in half-open, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreaker_IsAllowed(t *testing.T) {
+	config := Config{
+		FailureThreshold: 2,
+		SuccessThreshold: 2,
+		OpenTimeout:      50 * time.Millisecond,
+	}
+	cb := New(config)
+
+	// Should be allowed when closed
+	if !cb.IsAllowed() {
+		t.Error("expected IsAllowed to return true when closed")
+	}
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Should not be allowed when open
+	if cb.IsAllowed() {
+		t.Error("expected IsAllowed to return false when open")
+	}
+}
+
+func TestCircuitBreaker_MaxHalfOpenRequests(t *testing.T) {
+	config := Config{
+		FailureThreshold:    2,
+		SuccessThreshold:    3,
+		MaxHalfOpenRequests: 2,
+		OpenTimeout:         50 * time.Millisecond,
+	}
+	cb := New(config)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Wait for timeout
+	time.Sleep(60 * time.Millisecond)
+
+	// First two requests should be allowed
+	if !cb.IsAllowed() {
+		t.Error("first request should be allowed in half-open")
+	}
+	if !cb.IsAllowed() {
+		t.Error("second request should be allowed in half-open")
+	}
+
+	// Third request should be rejected
+	if cb.IsAllowed() {
+		t.Error("third request should be rejected (max half-open requests)")
+	}
+}
+
+func TestCircuitBreaker_OnStateChange(t *testing.T) {
+	config := Config{
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+		OpenTimeout:      50 * time.Millisecond,
+	}
+	cb := New(config)
+
+	var transitions []struct{ old, new State }
+	cb.OnStateChange(func(oldState, newState State) {
+		transitions = append(transitions, struct{ old, new State }{oldState, newState})
+	})
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Wait and transition to half-open
+	time.Sleep(60 * time.Millisecond)
+	cb.CheckState()
+
+	// Close the circuit
+	cb.RecordSuccess()
+
+	if len(transitions) != 3 {
+		t.Fatalf("expected 3 transitions, got %d", len(transitions))
+	}
+
+	// Closed -> Open
+	if transitions[0].old != StateClosed || transitions[0].new != StateOpen {
+		t.Errorf("expected Closed->Open, got %v->%v", transitions[0].old, transitions[0].new)
+	}
+
+	// Open -> HalfOpen
+	if transitions[1].old != StateOpen || transitions[1].new != StateHalfOpen {
+		t.Errorf("expected Open->HalfOpen, got %v->%v", transitions[1].old, transitions[1].new)
+	}
+
+	// HalfOpen -> Closed
+	if transitions[2].old != StateHalfOpen || transitions[2].new != StateClosed {
+		t.Errorf("expected HalfOpen->Closed, got %v->%v", transitions[2].old, transitions[2].new)
+	}
+}
+
+func TestCircuitBreaker_Reset(t *testing.T) {
+	config := Config{
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+		OpenTimeout:      1 * time.Hour, // Long timeout
+	}
+	cb := New(config)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	if cb.State() != StateOpen {
+		t.Fatalf("expected state to be Open, got %v", cb.State())
+	}
+
+	// Reset
+	cb.Reset()
+
+	if cb.State() != StateClosed {
+		t.Errorf("expected state to be Closed after reset, got %v", cb.State())
+	}
+
+	stats := cb.Stats()
+	if stats.Failures != 0 || stats.Successes != 0 {
+		t.Errorf("expected counters to be reset, got failures=%d, successes=%d",
+			stats.Failures, stats.Successes)
+	}
+}
+
+func TestCircuitBreaker_ResetNotifiesCallbacks(t *testing.T) {
+	config := Config{
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+		OpenTimeout:      1 * time.Hour,
+	}
+	cb := New(config)
+
+	var transitions []struct{ old, new State }
+	cb.OnStateChange(func(oldState, newState State) {
+		transitions = append(transitions, struct{ old, new State }{oldState, newState})
+	})
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	if len(transitions) != 1 {
+		t.Fatalf("expected 1 transition (Closed->Open), got %d", len(transitions))
+	}
+
+	// Reset should notify callback
+	cb.Reset()
+
+	if len(transitions) != 2 {
+		t.Fatalf("expected 2 transitions after reset, got %d", len(transitions))
+	}
+
+	// Verify Open -> Closed transition
+	if transitions[1].old != StateOpen || transitions[1].new != StateClosed {
+		t.Errorf("expected Open->Closed, got %v->%v", transitions[1].old, transitions[1].new)
+	}
+
+	// Reset when already closed should NOT notify
+	cb.Reset()
+	if len(transitions) != 2 {
+		t.Errorf("expected no callback when resetting already-closed circuit, got %d transitions", len(transitions))
+	}
+}
+
+func TestCircuitBreaker_ConcurrentAccess(t *testing.T) {
+	config := Config{
+		FailureThreshold: 100,
+		SuccessThreshold: 50,
+		OpenTimeout:      100 * time.Millisecond,
+	}
+	cb := New(config)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			cb.RecordFailure()
+		}()
+		go func() {
+			defer wg.Done()
+			cb.RecordSuccess()
+		}()
+	}
+	wg.Wait()
+
+	// Should not panic and state should be valid
+	state := cb.State()
+	if state != StateClosed && state != StateOpen && state != StateHalfOpen {
+		t.Errorf("invalid state: %v", state)
+	}
+}
+
+func TestCircuitBreaker_Stats(t *testing.T) {
+	cb := New(DefaultConfig())
+
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	stats := cb.Stats()
+	if stats.Failures != 2 {
+		t.Errorf("expected 2 failures, got %d", stats.Failures)
+	}
+	if stats.LastFailureTime.IsZero() {
+		t.Error("expected LastFailureTime to be set")
+	}
+}

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -403,3 +403,64 @@ func TestCircuitBreaker_Stats(t *testing.T) {
 		t.Error("expected LastFailureTime to be set")
 	}
 }
+
+// TestCircuitBreaker_HalfOpenCountersAreCleanOnReentry asserts the invariant
+// that successes and requests start at 0 every time the breaker enters the
+// HalfOpen state, regardless of what activity preceded it. The transitions
+// out of HalfOpen and out of Open each zero those counters; this test guards
+// against a future change that lets them carry over from a previous cycle.
+func TestCircuitBreaker_HalfOpenCountersAreCleanOnReentry(t *testing.T) {
+	config := Config{
+		FailureThreshold: 2,
+		SuccessThreshold: 2,
+		OpenTimeout:      50 * time.Millisecond,
+	}
+	cb := New(config)
+
+	// Cycle 1: drive the breaker through Open -> HalfOpen -> Closed so the
+	// counters have non-trivial values before the next failure burst.
+	cb.RecordFailure()
+	cb.RecordFailure()
+	time.Sleep(60 * time.Millisecond)
+	cb.CheckState() // -> HalfOpen
+	cb.RecordSuccess()
+	cb.RecordSuccess() // -> Closed (zeroes failures, successes, requests)
+
+	if cb.State() != StateClosed {
+		t.Fatalf("setup: expected Closed after first cycle, got %v", cb.State())
+	}
+
+	// Run plenty of successful traffic in Closed; this must not leak into
+	// the successes counter (which is only meaningful in HalfOpen).
+	for i := 0; i < 50; i++ {
+		cb.RecordSuccess()
+	}
+	if s := cb.Stats().Successes; s != 0 {
+		t.Errorf("successes must remain 0 in Closed, got %d", s)
+	}
+
+	// Cycle 2: drive Closed -> Open. After the transition both half-open
+	// counters must be 0 so the next HalfOpen cycle starts clean.
+	cb.RecordFailure()
+	cb.RecordFailure() // -> Open
+	if cb.State() != StateOpen {
+		t.Fatalf("expected Open after threshold, got %v", cb.State())
+	}
+	stats := cb.Stats()
+	if stats.Successes != 0 {
+		t.Errorf("successes must be 0 on entry to Open, got %d", stats.Successes)
+	}
+	if stats.Requests != 0 {
+		t.Errorf("requests must be 0 on entry to Open, got %d", stats.Requests)
+	}
+
+	// And the first success after Open -> HalfOpen must count as 1, not as
+	// "1 + whatever leaked from before".
+	time.Sleep(60 * time.Millisecond)
+	cb.CheckState() // -> HalfOpen
+	cb.RecordSuccess()
+	if s := cb.Stats().Successes; s != 1 {
+		t.Errorf("first success in HalfOpen must be 1, got %d", s)
+	}
+}
+

--- a/internal/multidb/circuit_breaker.go
+++ b/internal/multidb/circuit_breaker.go
@@ -1,0 +1,76 @@
+// Package multidb provides internal components for multi-database support.
+package multidb
+
+import (
+	"time"
+
+	"github.com/redis/go-redis/v9/internal/circuitbreaker"
+)
+
+// CircuitState represents the state of a circuit breaker.
+// This is an alias to the internal circuitbreaker package.
+type CircuitState = circuitbreaker.State
+
+const (
+	// CircuitClosed indicates the circuit is closed and requests are allowed.
+	CircuitClosed = circuitbreaker.StateClosed
+	// CircuitOpen indicates the circuit is open and requests are blocked.
+	CircuitOpen = circuitbreaker.StateOpen
+	// CircuitHalfOpen indicates the circuit is testing if the service has recovered.
+	CircuitHalfOpen = circuitbreaker.StateHalfOpen
+)
+
+// CircuitBreakerConfig holds configuration for a circuit breaker.
+type CircuitBreakerConfig struct {
+	// FailureThreshold is the number of failures before opening the circuit.
+	FailureThreshold int
+	// SuccessThreshold is the number of successes in half-open state before closing.
+	SuccessThreshold int
+	// GracePeriod is how long to wait before transitioning from open to half-open.
+	// This grace period gives a failed database time to self-heal before it is
+	// probed again. Default: 60 seconds.
+	GracePeriod time.Duration
+}
+
+// DefaultCircuitBreakerConfig returns the default circuit breaker configuration.
+func DefaultCircuitBreakerConfig() CircuitBreakerConfig {
+	return CircuitBreakerConfig{
+		FailureThreshold: 5,
+		SuccessThreshold: 2,
+		GracePeriod:      60 * time.Second,
+	}
+}
+
+// CircuitBreakerCallback is called when the circuit breaker state changes.
+type CircuitBreakerCallback func(oldState, newState CircuitState)
+
+// CircuitBreaker wraps the internal circuitbreaker.CircuitBreaker.
+type CircuitBreaker struct {
+	*circuitbreaker.CircuitBreaker
+	config CircuitBreakerConfig
+}
+
+// NewCircuitBreaker creates a new circuit breaker with the given configuration.
+func NewCircuitBreaker(config CircuitBreakerConfig) *CircuitBreaker {
+	return &CircuitBreaker{
+		CircuitBreaker: circuitbreaker.New(circuitbreaker.Config{
+			FailureThreshold:    config.FailureThreshold,
+			SuccessThreshold:    config.SuccessThreshold,
+			MaxHalfOpenRequests: config.SuccessThreshold,
+			OpenTimeout:         config.GracePeriod,
+		}),
+		config: config,
+	}
+}
+
+// OnStateChange registers a callback to be called when the state changes.
+func (cb *CircuitBreaker) OnStateChange(callback CircuitBreakerCallback) {
+	cb.CircuitBreaker.OnStateChange(func(oldState, newState circuitbreaker.State) {
+		callback(oldState, newState)
+	})
+}
+
+// Config returns the circuit breaker configuration.
+func (cb *CircuitBreaker) Config() CircuitBreakerConfig {
+	return cb.config
+}

--- a/internal/multidb/circuit_breaker_test.go
+++ b/internal/multidb/circuit_breaker_test.go
@@ -1,0 +1,217 @@
+package multidb
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestCircuitBreaker_InitialState(t *testing.T) {
+	cb := NewCircuitBreaker(DefaultCircuitBreakerConfig())
+
+	if cb.State() != CircuitClosed {
+		t.Errorf("expected initial state to be Closed, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreaker_OpenAfterFailures(t *testing.T) {
+	config := CircuitBreakerConfig{
+		FailureThreshold: 3,
+		SuccessThreshold: 2,
+		GracePeriod:      100 * time.Millisecond,
+	}
+	cb := NewCircuitBreaker(config)
+
+	// Record failures
+	for i := 0; i < 3; i++ {
+		cb.RecordFailure()
+	}
+
+	if cb.State() != CircuitOpen {
+		t.Errorf("expected state to be Open after %d failures, got %v", 3, cb.State())
+	}
+}
+
+func TestCircuitBreaker_HalfOpenAfterTimeout(t *testing.T) {
+	config := CircuitBreakerConfig{
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+		GracePeriod:      50 * time.Millisecond,
+	}
+	cb := NewCircuitBreaker(config)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	if cb.State() != CircuitOpen {
+		t.Fatalf("expected state to be Open, got %v", cb.State())
+	}
+
+	// Wait for timeout
+	time.Sleep(60 * time.Millisecond)
+
+	// CheckState should transition to HalfOpen
+	state := cb.CheckState()
+	if state != CircuitHalfOpen {
+		t.Errorf("expected state to be HalfOpen after timeout, got %v", state)
+	}
+}
+
+func TestCircuitBreaker_CloseAfterSuccesses(t *testing.T) {
+	config := CircuitBreakerConfig{
+		FailureThreshold: 2,
+		SuccessThreshold: 2,
+		GracePeriod:      10 * time.Millisecond,
+	}
+	cb := NewCircuitBreaker(config)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Wait for timeout and transition to half-open
+	time.Sleep(20 * time.Millisecond)
+	cb.CheckState()
+
+	// Record successes
+	cb.RecordSuccess()
+	cb.RecordSuccess()
+
+	if cb.State() != CircuitClosed {
+		t.Errorf("expected state to be Closed after successes, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreaker_ReopenOnFailureInHalfOpen(t *testing.T) {
+	config := CircuitBreakerConfig{
+		FailureThreshold: 2,
+		SuccessThreshold: 2,
+		GracePeriod:      10 * time.Millisecond,
+	}
+	cb := NewCircuitBreaker(config)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Wait for timeout and transition to half-open
+	time.Sleep(20 * time.Millisecond)
+	cb.CheckState()
+
+	// Record failure in half-open
+	cb.RecordFailure()
+
+	if cb.State() != CircuitOpen {
+		t.Errorf("expected state to be Open after failure in HalfOpen, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreaker_Reset(t *testing.T) {
+	config := CircuitBreakerConfig{
+		FailureThreshold: 2,
+		SuccessThreshold: 2,
+		GracePeriod:      1 * time.Hour,
+	}
+	cb := NewCircuitBreaker(config)
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	if cb.State() != CircuitOpen {
+		t.Fatalf("expected state to be Open, got %v", cb.State())
+	}
+
+	// Reset
+	cb.Reset()
+
+	if cb.State() != CircuitClosed {
+		t.Errorf("expected state to be Closed after reset, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreaker_Callbacks(t *testing.T) {
+	config := CircuitBreakerConfig{
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+		GracePeriod:      10 * time.Millisecond,
+	}
+	cb := NewCircuitBreaker(config)
+
+	var transitions []struct {
+		old, new CircuitState
+	}
+	var mu sync.Mutex
+
+	cb.OnStateChange(func(old, new CircuitState) {
+		mu.Lock()
+		transitions = append(transitions, struct{ old, new CircuitState }{old, new})
+		mu.Unlock()
+	})
+
+	// Open the circuit
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Wait and transition to half-open
+	time.Sleep(20 * time.Millisecond)
+	cb.CheckState()
+
+	// Close the circuit
+	cb.RecordSuccess()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(transitions) != 3 {
+		t.Errorf("expected 3 transitions, got %d", len(transitions))
+	}
+}
+
+func TestCircuitBreaker_Concurrent(t *testing.T) {
+	config := CircuitBreakerConfig{
+		FailureThreshold: 100,
+		SuccessThreshold: 10,
+		GracePeriod:      1 * time.Hour,
+	}
+	cb := NewCircuitBreaker(config)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			cb.RecordSuccess()
+		}()
+		go func() {
+			defer wg.Done()
+			cb.RecordFailure()
+		}()
+	}
+	wg.Wait()
+
+	// Should not panic and state should be valid
+	state := cb.State()
+	if state != CircuitClosed && state != CircuitOpen {
+		t.Errorf("unexpected state: %v", state)
+	}
+}
+
+func TestCircuitState_String(t *testing.T) {
+	tests := []struct {
+		state    CircuitState
+		expected string
+	}{
+		{CircuitClosed, "closed"},
+		{CircuitOpen, "open"},
+		{CircuitHalfOpen, "half-open"},
+		{CircuitState(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.state.String(); got != tt.expected {
+			t.Errorf("CircuitState(%d).String() = %q, want %q", tt.state, got, tt.expected)
+		}
+	}
+}

--- a/maintnotifications/circuit_breaker.go
+++ b/maintnotifications/circuit_breaker.go
@@ -2,6 +2,7 @@ package maintnotifications
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -23,9 +24,13 @@ const (
 	CircuitBreakerHalfOpen = circuitbreaker.StateHalfOpen
 )
 
-// CircuitBreaker wraps the internal circuit breaker with endpoint-specific logging.
+// CircuitBreaker wraps the internal circuit breaker with endpoint-specific
+// logging. The inner breaker is held as an unexported field (rather than
+// embedded) so its exported methods are not promoted onto this type; that keeps
+// callers on the wrapper's API and preserves wrapper invariants such as the
+// lastSuccessTime bookkeeping.
 type CircuitBreaker struct {
-	*circuitbreaker.CircuitBreaker
+	inner           *circuitbreaker.CircuitBreaker
 	endpoint        string
 	lastSuccessTime atomic.Int64 // Unix timestamp of last success
 }
@@ -44,7 +49,7 @@ func newCircuitBreaker(endpoint string, config *Config) *CircuitBreaker {
 	}
 
 	cb := &CircuitBreaker{
-		CircuitBreaker: circuitbreaker.New(circuitbreaker.Config{
+		inner: circuitbreaker.New(circuitbreaker.Config{
 			FailureThreshold:    failureThreshold,
 			SuccessThreshold:    maxRequests, // Use maxRequests as success threshold
 			MaxHalfOpenRequests: maxRequests,
@@ -54,11 +59,11 @@ func newCircuitBreaker(endpoint string, config *Config) *CircuitBreaker {
 	}
 
 	// Register logging callback for state changes
-	cb.CircuitBreaker.OnStateChange(func(oldState, newState circuitbreaker.State) {
+	cb.inner.OnStateChange(func(oldState, newState circuitbreaker.State) {
 		switch {
 		case oldState == circuitbreaker.StateClosed && newState == circuitbreaker.StateOpen:
 			if internal.LogLevel.WarnOrAbove() {
-				stats := cb.CircuitBreaker.Stats()
+				stats := cb.inner.Stats()
 				internal.Logger.Printf(context.Background(), logs.CircuitBreakerOpened(endpoint, int64(stats.Failures)))
 			}
 		case oldState == circuitbreaker.StateOpen && newState == circuitbreaker.StateHalfOpen:
@@ -67,7 +72,7 @@ func newCircuitBreaker(endpoint string, config *Config) *CircuitBreaker {
 			}
 		case oldState == circuitbreaker.StateHalfOpen && newState == circuitbreaker.StateClosed:
 			if internal.LogLevel.InfoOrAbove() {
-				stats := cb.CircuitBreaker.Stats()
+				stats := cb.inner.Stats()
 				internal.Logger.Printf(context.Background(), logs.CircuitBreakerClosed(endpoint, int64(stats.Successes)))
 			}
 		case oldState == circuitbreaker.StateHalfOpen && newState == circuitbreaker.StateOpen:
@@ -83,19 +88,38 @@ func newCircuitBreaker(endpoint string, config *Config) *CircuitBreaker {
 // IsOpen returns true if the circuit breaker is open (rejecting requests).
 // It uses CheckState so the open->half-open transition is honored once
 // OpenTimeout has elapsed, rather than reporting a stale open state.
+//
+// IsOpen does not reserve a half-open request slot; callers that gate work on
+// the breaker should use allowRequest so MaxHalfOpenRequests is respected.
 func (cb *CircuitBreaker) IsOpen() bool {
-	return cb.CircuitBreaker.CheckState() == circuitbreaker.StateOpen
+	return cb.inner.CheckState() == circuitbreaker.StateOpen
+}
+
+// allowRequest reports whether a request should be allowed through, reserving a
+// half-open probe slot when in the half-open state so concurrent callers are
+// bounded by MaxHalfOpenRequests. A reserved slot must be settled with a
+// subsequent recordSuccess/recordFailure, or released via releaseRequest when
+// the operation produced neither outcome.
+func (cb *CircuitBreaker) allowRequest() bool {
+	return cb.inner.IsAllowed()
+}
+
+// releaseRequest returns a half-open slot reserved by allowRequest when the
+// operation completed without a recordable success or failure.
+func (cb *CircuitBreaker) releaseRequest() {
+	cb.inner.ReleaseHalfOpen()
 }
 
 // Execute runs the given function with circuit breaker protection
 func (cb *CircuitBreaker) Execute(fn func() error) error {
-	err := cb.CircuitBreaker.Execute(fn)
+	err := cb.inner.Execute(fn)
 	if err == nil {
 		cb.lastSuccessTime.Store(time.Now().Unix())
 		return nil
 	}
-	// Convert internal circuit open error to our package's error
-	if err == circuitbreaker.ErrCircuitOpen {
+	// Convert internal circuit open error to our package's error. Use errors.Is
+	// so a future wrapped ErrCircuitOpen is still translated to the public error.
+	if errors.Is(err, circuitbreaker.ErrCircuitOpen) {
 		return ErrCircuitBreakerOpen
 	}
 	return err
@@ -103,23 +127,23 @@ func (cb *CircuitBreaker) Execute(fn func() error) error {
 
 // recordFailure records a failure (for external use when not using Execute)
 func (cb *CircuitBreaker) recordFailure() {
-	cb.CircuitBreaker.RecordFailure()
+	cb.inner.RecordFailure()
 }
 
 // recordSuccess records a success (for external use when not using Execute)
 func (cb *CircuitBreaker) recordSuccess() {
 	cb.lastSuccessTime.Store(time.Now().Unix())
-	cb.CircuitBreaker.RecordSuccess()
+	cb.inner.RecordSuccess()
 }
 
 // GetState returns the current state of the circuit breaker
 func (cb *CircuitBreaker) GetState() CircuitBreakerState {
-	return cb.CircuitBreaker.State()
+	return cb.inner.State()
 }
 
 // GetStats returns current statistics for monitoring
 func (cb *CircuitBreaker) GetStats() CircuitBreakerStats {
-	stats := cb.CircuitBreaker.Stats()
+	stats := cb.inner.Stats()
 	return CircuitBreakerStats{
 		Endpoint:        cb.endpoint,
 		State:           stats.State,
@@ -270,7 +294,7 @@ func (cbm *CircuitBreakerManager) Shutdown() {
 func (cbm *CircuitBreakerManager) Reset() {
 	cbm.breakers.Range(func(key, value interface{}) bool {
 		entry := value.(*CircuitBreakerEntry)
-		entry.breaker.CircuitBreaker.Reset()
+		entry.breaker.inner.Reset()
 		entry.breaker.lastSuccessTime.Store(0)
 		return true
 	})

--- a/maintnotifications/circuit_breaker.go
+++ b/maintnotifications/circuit_breaker.go
@@ -7,52 +7,27 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9/internal"
+	"github.com/redis/go-redis/v9/internal/circuitbreaker"
 	"github.com/redis/go-redis/v9/internal/maintnotifications/logs"
 )
 
 // CircuitBreakerState represents the state of a circuit breaker
-type CircuitBreakerState int32
+type CircuitBreakerState = circuitbreaker.State
 
 const (
 	// CircuitBreakerClosed - normal operation, requests allowed
-	CircuitBreakerClosed CircuitBreakerState = iota
+	CircuitBreakerClosed = circuitbreaker.StateClosed
 	// CircuitBreakerOpen - failing fast, requests rejected
-	CircuitBreakerOpen
+	CircuitBreakerOpen = circuitbreaker.StateOpen
 	// CircuitBreakerHalfOpen - testing if service recovered
-	CircuitBreakerHalfOpen
+	CircuitBreakerHalfOpen = circuitbreaker.StateHalfOpen
 )
 
-func (s CircuitBreakerState) String() string {
-	switch s {
-	case CircuitBreakerClosed:
-		return "closed"
-	case CircuitBreakerOpen:
-		return "open"
-	case CircuitBreakerHalfOpen:
-		return "half-open"
-	default:
-		return "unknown"
-	}
-}
-
-// CircuitBreaker implements the circuit breaker pattern for endpoint-specific failure handling
+// CircuitBreaker wraps the internal circuit breaker with endpoint-specific logging.
 type CircuitBreaker struct {
-	// Configuration
-	failureThreshold int           // Number of failures before opening
-	resetTimeout     time.Duration // How long to stay open before testing
-	maxRequests      int           // Max requests allowed in half-open state
-
-	// State tracking (atomic for lock-free access)
-	state           atomic.Int32 // CircuitBreakerState
-	failures        atomic.Int64 // Current failure count
-	successes       atomic.Int64 // Success count in half-open state
-	requests        atomic.Int64 // Request count in half-open state
-	lastFailureTime atomic.Int64 // Unix timestamp of last failure
+	*circuitbreaker.CircuitBreaker
+	endpoint        string
 	lastSuccessTime atomic.Int64 // Unix timestamp of last success
-
-	// Endpoint identification
-	endpoint string
-	config   *Config
 }
 
 // newCircuitBreaker creates a new circuit breaker for an endpoint
@@ -68,136 +43,88 @@ func newCircuitBreaker(endpoint string, config *Config) *CircuitBreaker {
 		maxRequests = config.CircuitBreakerMaxRequests
 	}
 
-	return &CircuitBreaker{
-		failureThreshold: failureThreshold,
-		resetTimeout:     resetTimeout,
-		maxRequests:      maxRequests,
-		endpoint:         endpoint,
-		config:           config,
-		state:            atomic.Int32{}, // Defaults to CircuitBreakerClosed (0)
+	cb := &CircuitBreaker{
+		CircuitBreaker: circuitbreaker.New(circuitbreaker.Config{
+			FailureThreshold:    failureThreshold,
+			SuccessThreshold:    maxRequests, // Use maxRequests as success threshold
+			MaxHalfOpenRequests: maxRequests,
+			OpenTimeout:         resetTimeout,
+		}),
+		endpoint: endpoint,
 	}
+
+	// Register logging callback for state changes
+	cb.CircuitBreaker.OnStateChange(func(oldState, newState circuitbreaker.State) {
+		switch {
+		case oldState == circuitbreaker.StateClosed && newState == circuitbreaker.StateOpen:
+			if internal.LogLevel.WarnOrAbove() {
+				stats := cb.CircuitBreaker.Stats()
+				internal.Logger.Printf(context.Background(), logs.CircuitBreakerOpened(endpoint, int64(stats.Failures)))
+			}
+		case oldState == circuitbreaker.StateOpen && newState == circuitbreaker.StateHalfOpen:
+			if internal.LogLevel.InfoOrAbove() {
+				internal.Logger.Printf(context.Background(), logs.CircuitBreakerTransitioningToHalfOpen(endpoint))
+			}
+		case oldState == circuitbreaker.StateHalfOpen && newState == circuitbreaker.StateClosed:
+			if internal.LogLevel.InfoOrAbove() {
+				stats := cb.CircuitBreaker.Stats()
+				internal.Logger.Printf(context.Background(), logs.CircuitBreakerClosed(endpoint, int64(stats.Successes)))
+			}
+		case oldState == circuitbreaker.StateHalfOpen && newState == circuitbreaker.StateOpen:
+			if internal.LogLevel.WarnOrAbove() {
+				internal.Logger.Printf(context.Background(), logs.CircuitBreakerReopened(endpoint))
+			}
+		}
+	})
+
+	return cb
 }
 
 // IsOpen returns true if the circuit breaker is open (rejecting requests)
 func (cb *CircuitBreaker) IsOpen() bool {
-	state := CircuitBreakerState(cb.state.Load())
-	return state == CircuitBreakerOpen
-}
-
-// shouldAttemptReset checks if enough time has passed to attempt reset
-func (cb *CircuitBreaker) shouldAttemptReset() bool {
-	lastFailure := time.Unix(cb.lastFailureTime.Load(), 0)
-	return time.Since(lastFailure) >= cb.resetTimeout
+	return cb.CircuitBreaker.State() == circuitbreaker.StateOpen
 }
 
 // Execute runs the given function with circuit breaker protection
 func (cb *CircuitBreaker) Execute(fn func() error) error {
-	// Single atomic state load for consistency
-	state := CircuitBreakerState(cb.state.Load())
-
-	switch state {
-	case CircuitBreakerOpen:
-		if cb.shouldAttemptReset() {
-			// Attempt transition to half-open
-			if cb.state.CompareAndSwap(int32(CircuitBreakerOpen), int32(CircuitBreakerHalfOpen)) {
-				cb.requests.Store(0)
-				cb.successes.Store(0)
-				if internal.LogLevel.InfoOrAbove() {
-					internal.Logger.Printf(context.Background(), logs.CircuitBreakerTransitioningToHalfOpen(cb.endpoint))
-				}
-				// Fall through to half-open logic
-			} else {
-				return ErrCircuitBreakerOpen
-			}
-		} else {
-			return ErrCircuitBreakerOpen
-		}
-		fallthrough
-	case CircuitBreakerHalfOpen:
-		requests := cb.requests.Add(1)
-		if requests > int64(cb.maxRequests) {
-			cb.requests.Add(-1) // Revert the increment
-			return ErrCircuitBreakerOpen
-		}
+	err := cb.CircuitBreaker.Execute(fn)
+	if err == nil {
+		cb.lastSuccessTime.Store(time.Now().Unix())
+		return nil
 	}
-
-	// Execute the function with consistent state
-	err := fn()
-
-	if err != nil {
-		cb.recordFailure()
-		return err
+	// Convert internal circuit open error to our package's error
+	if err == circuitbreaker.ErrCircuitOpen {
+		return ErrCircuitBreakerOpen
 	}
-
-	cb.recordSuccess()
-	return nil
+	return err
 }
 
-// recordFailure records a failure and potentially opens the circuit
+// recordFailure records a failure (for external use when not using Execute)
 func (cb *CircuitBreaker) recordFailure() {
-	cb.lastFailureTime.Store(time.Now().Unix())
-	failures := cb.failures.Add(1)
-
-	state := CircuitBreakerState(cb.state.Load())
-
-	switch state {
-	case CircuitBreakerClosed:
-		if failures >= int64(cb.failureThreshold) {
-			if cb.state.CompareAndSwap(int32(CircuitBreakerClosed), int32(CircuitBreakerOpen)) {
-				if internal.LogLevel.WarnOrAbove() {
-					internal.Logger.Printf(context.Background(), logs.CircuitBreakerOpened(cb.endpoint, failures))
-				}
-			}
-		}
-	case CircuitBreakerHalfOpen:
-		// Any failure in half-open state immediately opens the circuit
-		if cb.state.CompareAndSwap(int32(CircuitBreakerHalfOpen), int32(CircuitBreakerOpen)) {
-			if internal.LogLevel.WarnOrAbove() {
-				internal.Logger.Printf(context.Background(), logs.CircuitBreakerReopened(cb.endpoint))
-			}
-		}
-	}
+	cb.CircuitBreaker.RecordFailure()
 }
 
-// recordSuccess records a success and potentially closes the circuit
+// recordSuccess records a success (for external use when not using Execute)
 func (cb *CircuitBreaker) recordSuccess() {
 	cb.lastSuccessTime.Store(time.Now().Unix())
-
-	state := CircuitBreakerState(cb.state.Load())
-
-	switch state {
-	case CircuitBreakerClosed:
-		// Reset failure count on success in closed state
-		cb.failures.Store(0)
-	case CircuitBreakerHalfOpen:
-		successes := cb.successes.Add(1)
-
-		// If we've had enough successful requests, close the circuit
-		if successes >= int64(cb.maxRequests) {
-			if cb.state.CompareAndSwap(int32(CircuitBreakerHalfOpen), int32(CircuitBreakerClosed)) {
-				cb.failures.Store(0)
-				if internal.LogLevel.InfoOrAbove() {
-					internal.Logger.Printf(context.Background(), logs.CircuitBreakerClosed(cb.endpoint, successes))
-				}
-			}
-		}
-	}
+	cb.CircuitBreaker.RecordSuccess()
 }
 
 // GetState returns the current state of the circuit breaker
 func (cb *CircuitBreaker) GetState() CircuitBreakerState {
-	return CircuitBreakerState(cb.state.Load())
+	return cb.CircuitBreaker.State()
 }
 
 // GetStats returns current statistics for monitoring
 func (cb *CircuitBreaker) GetStats() CircuitBreakerStats {
+	stats := cb.CircuitBreaker.Stats()
 	return CircuitBreakerStats{
 		Endpoint:        cb.endpoint,
-		State:           cb.GetState(),
-		Failures:        cb.failures.Load(),
-		Successes:       cb.successes.Load(),
-		Requests:        cb.requests.Load(),
-		LastFailureTime: time.Unix(cb.lastFailureTime.Load(), 0),
+		State:           stats.State,
+		Failures:        int64(stats.Failures),
+		Successes:       int64(stats.Successes),
+		Requests:        int64(stats.Requests),
+		LastFailureTime: stats.LastFailureTime,
 		LastSuccessTime: time.Unix(cb.lastSuccessTime.Load(), 0),
 	}
 }
@@ -341,13 +268,8 @@ func (cbm *CircuitBreakerManager) Shutdown() {
 func (cbm *CircuitBreakerManager) Reset() {
 	cbm.breakers.Range(func(key, value interface{}) bool {
 		entry := value.(*CircuitBreakerEntry)
-		breaker := entry.breaker
-		breaker.state.Store(int32(CircuitBreakerClosed))
-		breaker.failures.Store(0)
-		breaker.successes.Store(0)
-		breaker.requests.Store(0)
-		breaker.lastFailureTime.Store(0)
-		breaker.lastSuccessTime.Store(0)
+		entry.breaker.CircuitBreaker.Reset()
+		entry.breaker.lastSuccessTime.Store(0)
 		return true
 	})
 }

--- a/maintnotifications/circuit_breaker.go
+++ b/maintnotifications/circuit_breaker.go
@@ -80,9 +80,11 @@ func newCircuitBreaker(endpoint string, config *Config) *CircuitBreaker {
 	return cb
 }
 
-// IsOpen returns true if the circuit breaker is open (rejecting requests)
+// IsOpen returns true if the circuit breaker is open (rejecting requests).
+// It uses CheckState so the open->half-open transition is honored once
+// OpenTimeout has elapsed, rather than reporting a stale open state.
 func (cb *CircuitBreaker) IsOpen() bool {
-	return cb.CircuitBreaker.State() == circuitbreaker.StateOpen
+	return cb.CircuitBreaker.CheckState() == circuitbreaker.StateOpen
 }
 
 // Execute runs the given function with circuit breaker protection

--- a/maintnotifications/circuit_breaker_test.go
+++ b/maintnotifications/circuit_breaker_test.go
@@ -298,8 +298,10 @@ func TestCircuitBreakerManager(t *testing.T) {
 			t.Error("Circuit should be closed after reset")
 		}
 
-		if cb.failures.Load() != 0 {
-			t.Error("Failure count should be reset to 0")
+		// Verify reset worked by checking state (can't access internal counters)
+		stats := cb.GetStats()
+		if stats.State != CircuitBreakerClosed {
+			t.Error("Circuit state should be closed after reset")
 		}
 	})
 
@@ -312,16 +314,8 @@ func TestCircuitBreakerManager(t *testing.T) {
 
 		cb := newCircuitBreaker("test-endpoint:6379", config)
 
-		// Test that configuration values are used
-		if cb.failureThreshold != 10 {
-			t.Errorf("Expected failureThreshold=10, got %d", cb.failureThreshold)
-		}
-		if cb.resetTimeout != 30*time.Second {
-			t.Errorf("Expected resetTimeout=30s, got %v", cb.resetTimeout)
-		}
-		if cb.maxRequests != 5 {
-			t.Errorf("Expected maxRequests=5, got %d", cb.maxRequests)
-		}
+		// Test that configuration values are used by verifying behavior
+		// (can't access internal fields directly)
 
 		// Test that circuit opens after configured threshold
 		testError := errors.New("test error")

--- a/maintnotifications/handoff_worker.go
+++ b/maintnotifications/handoff_worker.go
@@ -367,8 +367,11 @@ func (hwm *handoffWorkerManager) performConnectionHandoff(ctx context.Context, c
 	// Use circuit breaker to protect against failing endpoints
 	circuitBreaker := hwm.circuitBreakerManager.GetCircuitBreaker(newEndpoint)
 
-	// Check if circuit breaker is open before attempting handoff
-	if circuitBreaker.IsOpen() {
+	// Gate the handoff on the circuit breaker. allowRequest reserves a half-open
+	// probe slot so that, once OpenTimeout elapses, concurrent handoffs to a
+	// recovering endpoint stay bounded by MaxHalfOpenRequests instead of all
+	// being admitted at once.
+	if !circuitBreaker.allowRequest() {
 		internal.Logger.Printf(ctx, logs.CircuitBreakerOpen(connID, newEndpoint))
 		return false, ErrCircuitBreakerOpen // Don't retry when circuit breaker is open
 	}
@@ -378,9 +381,14 @@ func (hwm *handoffWorkerManager) performConnectionHandoff(ctx context.Context, c
 
 	// Update circuit breaker based on result
 	if err != nil {
-		// Only track dial/network errors in circuit breaker, not initialization errors
+		// Only track dial/network errors in circuit breaker, not initialization errors.
 		if shouldRetry {
 			circuitBreaker.recordFailure()
+		} else {
+			// Initialization error: not a dial/network failure, so it neither
+			// opens nor closes the breaker. Release the reserved half-open slot
+			// so it does not starve future recovery probes.
+			circuitBreaker.releaseRequest()
 		}
 		return shouldRetry, err
 	}


### PR DESCRIPTION
Add a unified circuit breaker implementation in internal/circuitbreaker, create a wrapper in internal/multidb with multidb CircuitState types, and refactor maintnotifications to embed the internal circuit breaker.

- State machine (Closed -> Open -> HalfOpen -> Closed)
- Lock-free atomic operations
- Configurable thresholds and timeouts
- State change callbacks with Reset() notification
- Execute() method for wrapping function calls
- MaxHalfOpenRequests for limiting half-open test requests

maintnotifications.CircuitBreaker now embeds *circuitbreaker.CircuitBreaker and wires endpoint-specific logging via OnStateChange, preserving its existing public API (type alias + constants).

Part of the MultiDBClient geo-failover feature (PR 1 of n - probably around 10-11 prs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fault-tolerance behavior on maintenance handoffs (half-open gating and slot release); well-covered by tests but affects retry/fail-fast paths for failing endpoints.
> 
> **Overview**
> Introduces a shared **`internal/circuitbreaker`** implementation (closed → open → half-open lifecycle, configurable thresholds/timeouts, half-open probe limits, `ReleaseHalfOpen`, state-change callbacks, and `Execute`) with tests, plus an **`internal/multidb`** wrapper for upcoming MultiDB/geo-failover work.
> 
> **`maintnotifications`** drops its bespoke breaker logic in favor of the shared package while keeping the same public types/constants; endpoint logging is wired through `OnStateChange`, and handoffs now use **`allowRequest` / `releaseRequest`** so half-open probes are capped and non-network failures do not consume probe slots. CI workflows gain **`feature/**`** on pull requests so feature-branch PRs run the usual checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2693ea62fbc7381218f7d18f3b3321c48b14d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->