### PR TITLE
feat(multidb): #2 internal/failuredetector: add failure detector

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master, v9, 'v9.*']
   pull_request:
-    branches: [master, v9, v9.7, v9.8, 'ndyakov/**', 'ofekshenawa/**', 'ce/**']
+    branches: [master, v9, v9.7, v9.8, 'ndyakov/**', 'ofekshenawa/**', 'ce/**', 'feature/**']
 
 permissions:
   contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches: [master, v9, v9.7, v9.8]
   pull_request:
-    branches: [master, v9, v9.7, v9.8]
+    branches: [master, v9, v9.7, v9.8, 'feature/**']
 
 jobs:
   analyze:

--- a/.github/workflows/doctests.yaml
+++ b/.github/workflows/doctests.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master, examples]
   pull_request:
-    branches: [master, examples]
+    branches: [master, examples, 'feature/**']
 
 permissions:
   contents: read

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -3,7 +3,7 @@ name: govulncheck
 
 on:
   pull_request:
-    branches: [master, v9, v9.7, v9.8, "ndyakov/**", "ofekshenawa/**", "ce/**"]
+    branches: [master, v9, v9.7, v9.8, "ndyakov/**", "ofekshenawa/**", "ce/**", "feature/**"]
   push:
     branches: [master, v9, "v9.*"]
   schedule:

--- a/internal/failuredetector/failure_detector.go
+++ b/internal/failuredetector/failure_detector.go
@@ -26,22 +26,33 @@ type FailureDetector interface {
 	Reset()
 }
 
-// CommandFailureDetectorConfig configures CommandFailureDetector.
+// CommandFailureDetectorConfig configures CommandFailureDetector. Every
+// field has a documented default that NewCommandFailureDetector applies when
+// the field is left at its zero value, so a zero-valued config is a valid
+// way to ask for the recommended defaults.
 type CommandFailureDetectorConfig struct {
 	// MinNumFailures is the minimum number of failed commands that must be
 	// observed within the detection window before failover is considered.
-	// A value of 0 means the failure count is ignored and only
-	// FailureRateThreshold is taken into account.
-	// Default: 1000
+	// Ignored when IgnoreMinNumFailures is true.
+	// Default: 1000.
 	MinNumFailures uint64
+
+	// IgnoreMinNumFailures disables the MinNumFailures check, so ShouldFailover
+	// considers only FailureRateThreshold. Use this when the rate alone is the
+	// signal you trust (typically combined with a small FailureRateThreshold).
+	IgnoreMinNumFailures bool
 
 	// FailureRateThreshold is the failure rate (0.0-1.0) that, together with
 	// MinNumFailures, triggers failover. For example, 0.1 means failover when
 	// 10% or more of the commands in the window fail.
-	// A value of 0.0 means the rate is ignored and only MinNumFailures is
-	// taken into account.
-	// Default: 0.1
+	// Ignored when IgnoreFailureRateThreshold is true.
+	// Default: 0.1.
 	FailureRateThreshold float64
+
+	// IgnoreFailureRateThreshold disables the FailureRateThreshold check, so
+	// ShouldFailover considers only MinNumFailures. Use this when the absolute
+	// number of failures is the signal you trust regardless of traffic volume.
+	IgnoreFailureRateThreshold bool
 
 	// FailureDetectionWindow is the sliding time window over which command
 	// outcomes are considered. Outcomes older than FailureDetectionWindow
@@ -59,19 +70,40 @@ type CommandFailureDetectorConfig struct {
 }
 
 // DefaultCommandFailureDetectorConfig returns the default configuration.
+// NewCommandFailureDetector applies the same defaults to any zero-valued
+// field, so this is mainly useful as a starting point for tuning.
 func DefaultCommandFailureDetectorConfig() CommandFailureDetectorConfig {
 	return CommandFailureDetectorConfig{
-		MinNumFailures:         1000,
-		FailureRateThreshold:   0.1,
+		MinNumFailures:         defaultMinNumFailures,
+		FailureRateThreshold:   defaultFailureRateThreshold,
 		FailureDetectionWindow: defaultFailureDetectionWindow,
 		NumBuckets:             defaultNumBuckets,
 	}
 }
 
 const (
+	defaultMinNumFailures         = 1000
+	defaultFailureRateThreshold   = 0.1
 	defaultFailureDetectionWindow = 2 * time.Second
 	defaultNumBuckets             = 10
 )
+
+// applyDefaults fills zero-valued fields with their documented defaults so
+// the rest of the detector can assume every threshold is set.
+func (c *CommandFailureDetectorConfig) applyDefaults() {
+	if c.MinNumFailures == 0 {
+		c.MinNumFailures = defaultMinNumFailures
+	}
+	if c.FailureRateThreshold <= 0 {
+		c.FailureRateThreshold = defaultFailureRateThreshold
+	}
+	if c.FailureDetectionWindow <= 0 {
+		c.FailureDetectionWindow = defaultFailureDetectionWindow
+	}
+	if c.NumBuckets <= 0 {
+		c.NumBuckets = defaultNumBuckets
+	}
+}
 
 // bucket holds the outcomes recorded inside a single sub-bucket of the
 // sliding window. All fields are accessed atomically so the detector is
@@ -103,21 +135,21 @@ type CommandFailureDetector struct {
 }
 
 // NewCommandFailureDetector creates a new sliding-window failure detector
-// with the given configuration. Zero values for FailureDetectionWindow or
-// NumBuckets fall back to the package defaults; the threshold fields
-// (MinNumFailures, FailureRateThreshold) are intentionally not defaulted
-// because a zero value carries the documented "disabled" meaning.
+// with the given configuration. Any zero-valued field in config is replaced
+// with its documented default, so passing the zero value is equivalent to
+// passing DefaultCommandFailureDetectorConfig().
 func NewCommandFailureDetector(config CommandFailureDetectorConfig) *CommandFailureDetector {
-	if config.FailureDetectionWindow <= 0 {
-		config.FailureDetectionWindow = defaultFailureDetectionWindow
-	}
-	if config.NumBuckets <= 0 {
-		config.NumBuckets = defaultNumBuckets
+	config.applyDefaults()
+	// Clamp to at least one nanosecond so bucketFor never divides by zero
+	// when a caller picks a window shorter than NumBuckets nanoseconds.
+	bucketWidthNano := int64(config.FailureDetectionWindow) / int64(config.NumBuckets)
+	if bucketWidthNano < 1 {
+		bucketWidthNano = 1
 	}
 	return &CommandFailureDetector{
 		config:          config,
 		buckets:         make([]bucket, config.NumBuckets),
-		bucketWidthNano: int64(config.FailureDetectionWindow) / int64(config.NumBuckets),
+		bucketWidthNano: bucketWidthNano,
 		windowNano:      int64(config.FailureDetectionWindow),
 		now:             time.Now,
 	}
@@ -146,8 +178,10 @@ func (d *CommandFailureDetector) RecordFailure(err error) {
 // ShouldFailover returns true when the outcomes observed within the trailing
 // FailureDetectionWindow indicate that failover should be triggered. A
 // database is considered faulty when at least MinNumFailures commands have
-// failed AND the observed failure rate is at least FailureRateThreshold; a
-// zero value for either threshold disables that half of the check.
+// failed AND the observed failure rate is at least FailureRateThreshold.
+// Either half of the check can be disabled by setting IgnoreMinNumFailures
+// or IgnoreFailureRateThreshold; when both are disabled, any single failure
+// in the window triggers failover.
 // At least one failure must have been observed for failover to be considered.
 func (d *CommandFailureDetector) ShouldFailover() bool {
 	successes, failures := d.snapshot()
@@ -155,17 +189,16 @@ func (d *CommandFailureDetector) ShouldFailover() bool {
 	if failures == 0 {
 		return false
 	}
-
-	countMet := d.config.MinNumFailures == 0 || failures >= d.config.MinNumFailures
-
-	rateMet := true
-	if d.config.FailureRateThreshold > 0 {
-		total := successes + failures
-		failureRate := float64(failures) / float64(total)
-		rateMet = failureRate >= d.config.FailureRateThreshold
+	if !d.config.IgnoreMinNumFailures && failures < d.config.MinNumFailures {
+		return false
+	}
+	if d.config.IgnoreFailureRateThreshold {
+		return true
 	}
 
-	return countMet && rateMet
+	total := successes + failures
+	failureRate := float64(failures) / float64(total)
+	return failureRate >= d.config.FailureRateThreshold
 }
 
 // Reset discards all recorded outcomes. Concurrent recorders may race with

--- a/internal/failuredetector/failure_detector.go
+++ b/internal/failuredetector/failure_detector.go
@@ -42,11 +42,11 @@ type CommandFailureDetectorConfig struct {
 	// signal you trust (typically combined with a small FailureRateThreshold).
 	IgnoreMinNumFailures bool
 
-	// FailureRateThreshold is the failure rate (0.0-1.0) that, together with
+	// FailureRateThreshold is the failure rate (0.0-1.0] that, together with
 	// MinNumFailures, triggers failover. For example, 0.1 means failover when
 	// 10% or more of the commands in the window fail.
 	// Ignored when IgnoreFailureRateThreshold is true.
-	// Default: 0.1.
+	// Default: 0.1. (A zero value means "use the default".)
 	FailureRateThreshold float64
 
 	// IgnoreFailureRateThreshold disables the FailureRateThreshold check, so

--- a/internal/failuredetector/failure_detector.go
+++ b/internal/failuredetector/failure_detector.go
@@ -1,0 +1,157 @@
+package failuredetector
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// FailureDetector detects failures and determines when failover should occur.
+type FailureDetector interface {
+	// RecordSuccess records a successful operation.
+	RecordSuccess()
+	// RecordFailure records a failed operation.
+	RecordFailure(err error)
+	// ShouldFailover returns true if failover should be triggered.
+	ShouldFailover() bool
+	// Reset resets the failure detector state.
+	Reset()
+}
+
+// CommandFailureDetectorConfig holds configuration for CommandFailureDetector.
+type CommandFailureDetectorConfig struct {
+	// MinNumFailures is the minimum number of failed commands that must be
+	// observed within the detection window before failover is considered.
+	// A value of 0 means the failure count is ignored and only
+	// FailureRateThreshold is taken into account.
+	// Default: 1000
+	MinNumFailures int
+	// FailureRateThreshold is the failure rate (0.0-1.0) that, together with
+	// MinNumFailures, triggers failover. For example, 0.1 means failover when
+	// 10% or more of the commands in the window fail.
+	// A value of 0.0 means the rate is ignored and only MinNumFailures is
+	// taken into account.
+	// Default: 0.1
+	FailureRateThreshold float64
+	// FailureDetectionWindow is the time window for failure detection.
+	// Counters are reset when this window expires.
+	// Default: 2 seconds
+	FailureDetectionWindow time.Duration
+}
+
+// DefaultCommandFailureDetectorConfig returns the default configuration.
+func DefaultCommandFailureDetectorConfig() CommandFailureDetectorConfig {
+	return CommandFailureDetectorConfig{
+		MinNumFailures:         1000,
+		FailureRateThreshold:   0.1,
+		FailureDetectionWindow: 2 * time.Second,
+	}
+}
+
+// CommandFailureDetector detects failures based on command success/failure rates.
+type CommandFailureDetector struct {
+	config CommandFailureDetectorConfig
+
+	mu            sync.Mutex
+	successCount  int
+	failuresCount int
+	windowStart   time.Time
+}
+
+// NewCommandFailureDetector creates a new command failure detector.
+func NewCommandFailureDetector(config CommandFailureDetectorConfig) *CommandFailureDetector {
+	return &CommandFailureDetector{
+		config:      config,
+		windowStart: time.Now(),
+	}
+}
+
+// RecordSuccess records a successful operation.
+func (d *CommandFailureDetector) RecordSuccess() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.checkWindow()
+	d.successCount++
+}
+
+// RecordFailure records a failed operation.
+// Context errors (Canceled, DeadlineExceeded) are ignored.
+func (d *CommandFailureDetector) RecordFailure(err error) {
+	// Ignore context errors - they're client-side, not server failures
+	if err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.checkWindow()
+	d.failuresCount++
+}
+
+// ShouldFailover returns true if failover should be triggered.
+//
+// A database is considered faulty when, within the detection window, at least
+// MinNumFailures commands have failed AND the observed failure rate is at least
+// FailureRateThreshold. The two thresholds have special cases:
+//   - MinNumFailures == 0 means the failure count is ignored and only the rate
+//     is taken into account.
+//   - FailureRateThreshold == 0.0 means the rate is ignored and only the
+//     failure count is taken into account.
+//
+// At least one failure must have been observed for failover to be considered.
+func (d *CommandFailureDetector) ShouldFailover() bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.checkWindow()
+
+	// Nothing has failed within the current window.
+	if d.failuresCount == 0 {
+		return false
+	}
+
+	// Count condition: satisfied when the count threshold is disabled
+	// (MinNumFailures <= 0) or the observed failures reach the threshold.
+	countMet := d.config.MinNumFailures <= 0 || d.failuresCount >= d.config.MinNumFailures
+
+	// Rate condition: satisfied when the rate threshold is disabled
+	// (FailureRateThreshold <= 0.0) or the observed failure rate reaches it.
+	rateMet := true
+	if d.config.FailureRateThreshold > 0 {
+		totalCommands := d.successCount + d.failuresCount
+		failureRate := float64(d.failuresCount) / float64(totalCommands)
+		rateMet = failureRate >= d.config.FailureRateThreshold
+	}
+
+	return countMet && rateMet
+}
+
+// Reset resets the failure detector state.
+func (d *CommandFailureDetector) Reset() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.successCount = 0
+	d.failuresCount = 0
+	d.windowStart = time.Now()
+}
+
+// checkWindow checks if the current window has expired and resets if needed.
+// Must be called with lock held.
+func (d *CommandFailureDetector) checkWindow() {
+	if time.Since(d.windowStart) >= d.config.FailureDetectionWindow {
+		d.successCount = 0
+		d.failuresCount = 0
+		d.windowStart = time.Now()
+	}
+}
+
+// Stats returns the current failure detector statistics.
+func (d *CommandFailureDetector) Stats() (successes, failures int, windowStart time.Time) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.successCount, d.failuresCount, d.windowStart
+}

--- a/internal/failuredetector/failure_detector.go
+++ b/internal/failuredetector/failure_detector.go
@@ -35,7 +35,9 @@ type CommandFailureDetectorConfig struct {
 	// Default: 0.1
 	FailureRateThreshold float64
 	// FailureDetectionWindow is the time window for failure detection.
-	// Counters are reset when this window expires.
+	// It is implemented as a tumbling window: the success/failure counters
+	// are reset in full once the window elapses, rather than expiring
+	// individual events as in a sliding window.
 	// Default: 2 seconds
 	FailureDetectionWindow time.Duration
 }
@@ -61,6 +63,14 @@ type CommandFailureDetector struct {
 
 // NewCommandFailureDetector creates a new command failure detector.
 func NewCommandFailureDetector(config CommandFailureDetectorConfig) *CommandFailureDetector {
+	// A non-positive window would make checkWindow treat the window as
+	// permanently expired, resetting the counters on every call so that
+	// ShouldFailover could never trigger. Fall back to the documented default.
+	// MinNumFailures and FailureRateThreshold are intentionally not defaulted
+	// here, as a zero value carries the documented "disabled" meaning.
+	if config.FailureDetectionWindow <= 0 {
+		config.FailureDetectionWindow = 2 * time.Second
+	}
 	return &CommandFailureDetector{
 		config:      config,
 		windowStart: time.Now(),
@@ -77,10 +87,17 @@ func (d *CommandFailureDetector) RecordSuccess() {
 }
 
 // RecordFailure records a failed operation.
-// Context errors (Canceled, DeadlineExceeded) are ignored.
+// A nil error is treated as success and ignored. Context errors
+// (Canceled, DeadlineExceeded) are also ignored as they are client-side.
 func (d *CommandFailureDetector) RecordFailure(err error) {
+	// A nil error represents success, not a failure - ignore it so callers
+	// that forward errors unconditionally don't accumulate phantom failures.
+	if err == nil {
+		return
+	}
+
 	// Ignore context errors - they're client-side, not server failures
-	if err != nil && (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return
 	}
 
@@ -139,7 +156,8 @@ func (d *CommandFailureDetector) Reset() {
 	d.windowStart = time.Now()
 }
 
-// checkWindow checks if the current window has expired and resets if needed.
+// checkWindow checks if the current tumbling window has expired and, if so,
+// resets all counters and starts a new window.
 // Must be called with lock held.
 func (d *CommandFailureDetector) checkWindow() {
 	if time.Since(d.windowStart) >= d.config.FailureDetectionWindow {
@@ -153,5 +171,8 @@ func (d *CommandFailureDetector) checkWindow() {
 func (d *CommandFailureDetector) Stats() (successes, failures int, windowStart time.Time) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	// Apply window expiry first so callers never observe stale counts from a
+	// window that has already elapsed, consistent with ShouldFailover.
+	d.checkWindow()
 	return d.successCount, d.failuresCount, d.windowStart
 }

--- a/internal/failuredetector/failure_detector.go
+++ b/internal/failuredetector/failure_detector.go
@@ -1,32 +1,40 @@
+// Package failuredetector provides primitives for deciding when a Redis
+// database is unhealthy enough that the multi-database client should trigger
+// a failover.
 package failuredetector
 
 import (
 	"context"
 	"errors"
-	"sync"
+	"sync/atomic"
 	"time"
 )
 
-// FailureDetector detects failures and determines when failover should occur.
+// FailureDetector decides when failover should be triggered based on a stream
+// of command outcomes observed by the caller.
 type FailureDetector interface {
-	// RecordSuccess records a successful operation.
+	// RecordSuccess records a successful command outcome.
 	RecordSuccess()
-	// RecordFailure records a failed operation.
+	// RecordFailure records a failed command outcome. Implementations may
+	// ignore errors that are not health signals (for example client-side
+	// context cancellation).
 	RecordFailure(err error)
-	// ShouldFailover returns true if failover should be triggered.
+	// ShouldFailover returns true when the recent outcomes indicate that
+	// failover should be triggered.
 	ShouldFailover() bool
-	// Reset resets the failure detector state.
+	// Reset discards all observed outcomes and starts fresh.
 	Reset()
 }
 
-// CommandFailureDetectorConfig holds configuration for CommandFailureDetector.
+// CommandFailureDetectorConfig configures CommandFailureDetector.
 type CommandFailureDetectorConfig struct {
 	// MinNumFailures is the minimum number of failed commands that must be
 	// observed within the detection window before failover is considered.
 	// A value of 0 means the failure count is ignored and only
 	// FailureRateThreshold is taken into account.
 	// Default: 1000
-	MinNumFailures int
+	MinNumFailures uint64
+
 	// FailureRateThreshold is the failure rate (0.0-1.0) that, together with
 	// MinNumFailures, triggers failover. For example, 0.1 means failover when
 	// 10% or more of the commands in the window fail.
@@ -34,12 +42,20 @@ type CommandFailureDetectorConfig struct {
 	// taken into account.
 	// Default: 0.1
 	FailureRateThreshold float64
-	// FailureDetectionWindow is the time window for failure detection.
-	// It is implemented as a tumbling window: the success/failure counters
-	// are reset in full once the window elapses, rather than expiring
-	// individual events as in a sliding window.
-	// Default: 2 seconds
+
+	// FailureDetectionWindow is the sliding time window over which command
+	// outcomes are considered. Outcomes older than FailureDetectionWindow
+	// from now are no longer counted by ShouldFailover.
+	// Default: 2 seconds.
 	FailureDetectionWindow time.Duration
+
+	// NumBuckets controls the time resolution of the sliding window. The
+	// window is divided into NumBuckets sub-buckets, each of width
+	// FailureDetectionWindow / NumBuckets, and outcomes age out one bucket
+	// at a time. Larger values give finer-grained ageing at the cost of
+	// O(NumBuckets) work per ShouldFailover call.
+	// Default: 10.
+	NumBuckets int
 }
 
 // DefaultCommandFailureDetectorConfig returns the default configuration.
@@ -47,132 +63,178 @@ func DefaultCommandFailureDetectorConfig() CommandFailureDetectorConfig {
 	return CommandFailureDetectorConfig{
 		MinNumFailures:         1000,
 		FailureRateThreshold:   0.1,
-		FailureDetectionWindow: 2 * time.Second,
+		FailureDetectionWindow: defaultFailureDetectionWindow,
+		NumBuckets:             defaultNumBuckets,
 	}
 }
 
-// CommandFailureDetector detects failures based on command success/failure rates.
-type CommandFailureDetector struct {
-	config CommandFailureDetectorConfig
+const (
+	defaultFailureDetectionWindow = 2 * time.Second
+	defaultNumBuckets             = 10
+)
 
-	mu            sync.Mutex
-	successCount  int
-	failuresCount int
-	windowStart   time.Time
+// bucket holds the outcomes recorded inside a single sub-bucket of the
+// sliding window. All fields are accessed atomically so the detector is
+// lock-free on the hot path.
+//
+// epochNano is the start time of the bucket's current "lap" around the ring,
+// expressed in nanoseconds since the Unix epoch. When the ring wraps around
+// and a writer revisits a bucket whose epochNano belongs to a previous lap,
+// the writer claims the bucket via CompareAndSwap on epochNano and then
+// zeroes the counters. Readers ignore any bucket whose epochNano falls
+// outside the current window.
+type bucket struct {
+	epochNano atomic.Int64
+	successes atomic.Uint64
+	failures  atomic.Uint64
 }
 
-// NewCommandFailureDetector creates a new command failure detector.
+// CommandFailureDetector observes command outcomes inside a sliding time
+// window and reports when failover should be triggered. The implementation
+// uses a fixed-size ring of buckets and only sync/atomic operations on the
+// hot path, so RecordSuccess and RecordFailure scale across many goroutines
+// without contention.
+type CommandFailureDetector struct {
+	config          CommandFailureDetectorConfig
+	buckets         []bucket
+	bucketWidthNano int64
+	windowNano      int64
+	now             func() time.Time // injectable for tests
+}
+
+// NewCommandFailureDetector creates a new sliding-window failure detector
+// with the given configuration. Zero values for FailureDetectionWindow or
+// NumBuckets fall back to the package defaults; the threshold fields
+// (MinNumFailures, FailureRateThreshold) are intentionally not defaulted
+// because a zero value carries the documented "disabled" meaning.
 func NewCommandFailureDetector(config CommandFailureDetectorConfig) *CommandFailureDetector {
-	// A non-positive window would make checkWindow treat the window as
-	// permanently expired, resetting the counters on every call so that
-	// ShouldFailover could never trigger. Fall back to the documented default.
-	// MinNumFailures and FailureRateThreshold are intentionally not defaulted
-	// here, as a zero value carries the documented "disabled" meaning.
 	if config.FailureDetectionWindow <= 0 {
-		config.FailureDetectionWindow = 2 * time.Second
+		config.FailureDetectionWindow = defaultFailureDetectionWindow
+	}
+	if config.NumBuckets <= 0 {
+		config.NumBuckets = defaultNumBuckets
 	}
 	return &CommandFailureDetector{
-		config:      config,
-		windowStart: time.Now(),
+		config:          config,
+		buckets:         make([]bucket, config.NumBuckets),
+		bucketWidthNano: int64(config.FailureDetectionWindow) / int64(config.NumBuckets),
+		windowNano:      int64(config.FailureDetectionWindow),
+		now:             time.Now,
 	}
 }
 
-// RecordSuccess records a successful operation.
+// RecordSuccess records a successful command outcome.
 func (d *CommandFailureDetector) RecordSuccess() {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	d.checkWindow()
-	d.successCount++
+	d.bucketFor(d.now().UnixNano()).successes.Add(1)
 }
 
-// RecordFailure records a failed operation.
-// A nil error is treated as success and ignored. Context errors
-// (Canceled, DeadlineExceeded) are also ignored as they are client-side.
+// RecordFailure records a failed command outcome. A nil error is treated as
+// a no-op (so callers that forward errors unconditionally do not accumulate
+// phantom failures); context cancellation and deadline-exceeded errors are
+// also ignored because they originate on the client side and are not a
+// signal about the database's health.
 func (d *CommandFailureDetector) RecordFailure(err error) {
-	// A nil error represents success, not a failure - ignore it so callers
-	// that forward errors unconditionally don't accumulate phantom failures.
 	if err == nil {
 		return
 	}
-
-	// Ignore context errors - they're client-side, not server failures
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return
 	}
-
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	d.checkWindow()
-	d.failuresCount++
+	d.bucketFor(d.now().UnixNano()).failures.Add(1)
 }
 
-// ShouldFailover returns true if failover should be triggered.
-//
-// A database is considered faulty when, within the detection window, at least
-// MinNumFailures commands have failed AND the observed failure rate is at least
-// FailureRateThreshold. The two thresholds have special cases:
-//   - MinNumFailures == 0 means the failure count is ignored and only the rate
-//     is taken into account.
-//   - FailureRateThreshold == 0.0 means the rate is ignored and only the
-//     failure count is taken into account.
-//
+// ShouldFailover returns true when the outcomes observed within the trailing
+// FailureDetectionWindow indicate that failover should be triggered. A
+// database is considered faulty when at least MinNumFailures commands have
+// failed AND the observed failure rate is at least FailureRateThreshold; a
+// zero value for either threshold disables that half of the check.
 // At least one failure must have been observed for failover to be considered.
 func (d *CommandFailureDetector) ShouldFailover() bool {
-	d.mu.Lock()
-	defer d.mu.Unlock()
+	successes, failures := d.snapshot()
 
-	d.checkWindow()
-
-	// Nothing has failed within the current window.
-	if d.failuresCount == 0 {
+	if failures == 0 {
 		return false
 	}
 
-	// Count condition: satisfied when the count threshold is disabled
-	// (MinNumFailures <= 0) or the observed failures reach the threshold.
-	countMet := d.config.MinNumFailures <= 0 || d.failuresCount >= d.config.MinNumFailures
+	countMet := d.config.MinNumFailures == 0 || failures >= d.config.MinNumFailures
 
-	// Rate condition: satisfied when the rate threshold is disabled
-	// (FailureRateThreshold <= 0.0) or the observed failure rate reaches it.
 	rateMet := true
 	if d.config.FailureRateThreshold > 0 {
-		totalCommands := d.successCount + d.failuresCount
-		failureRate := float64(d.failuresCount) / float64(totalCommands)
+		total := successes + failures
+		failureRate := float64(failures) / float64(total)
 		rateMet = failureRate >= d.config.FailureRateThreshold
 	}
 
 	return countMet && rateMet
 }
 
-// Reset resets the failure detector state.
+// Reset discards all recorded outcomes. Concurrent recorders may race with
+// Reset; in the worst case a small number of in-flight increments survive
+// the reset, which is acceptable for a failure detector.
 func (d *CommandFailureDetector) Reset() {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-
-	d.successCount = 0
-	d.failuresCount = 0
-	d.windowStart = time.Now()
-}
-
-// checkWindow checks if the current tumbling window has expired and, if so,
-// resets all counters and starts a new window.
-// Must be called with lock held.
-func (d *CommandFailureDetector) checkWindow() {
-	if time.Since(d.windowStart) >= d.config.FailureDetectionWindow {
-		d.successCount = 0
-		d.failuresCount = 0
-		d.windowStart = time.Now()
+	for i := range d.buckets {
+		b := &d.buckets[i]
+		b.epochNano.Store(0)
+		b.successes.Store(0)
+		b.failures.Store(0)
 	}
 }
 
-// Stats returns the current failure detector statistics.
-func (d *CommandFailureDetector) Stats() (successes, failures int, windowStart time.Time) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	// Apply window expiry first so callers never observe stale counts from a
-	// window that has already elapsed, consistent with ShouldFailover.
-	d.checkWindow()
-	return d.successCount, d.failuresCount, d.windowStart
+// Stats returns a read-only snapshot of the outcomes observed within the
+// current sliding window. The returned counts are aggregated across the
+// bucket ring and reflect the same view of state used by ShouldFailover.
+func (d *CommandFailureDetector) Stats() (successes, failures uint64) {
+	return d.snapshot()
+}
+
+// bucketFor returns the bucket that owns the supplied nanosecond timestamp,
+// initialising it (resetting counters and stamping the new epoch) if a
+// previous lap of the ring left stale data in that slot.
+func (d *CommandFailureDetector) bucketFor(nowNano int64) *bucket {
+	bucketStart := nowNano - (nowNano % d.bucketWidthNano)
+	idx := (bucketStart / d.bucketWidthNano) % int64(len(d.buckets))
+	b := &d.buckets[idx]
+
+	for {
+		current := b.epochNano.Load()
+		if current == bucketStart {
+			return b
+		}
+		if current > bucketStart {
+			// Clock skew or a concurrent writer already moved this bucket
+			// past the current instant; tolerate it.
+			return b
+		}
+		if b.epochNano.CompareAndSwap(current, bucketStart) {
+			// We claimed the stale bucket. Zero the counters so concurrent
+			// writers that race past the epoch update only contribute to
+			// the new lap.
+			b.successes.Store(0)
+			b.failures.Store(0)
+			return b
+		}
+		// Another writer won the race; reload and decide again.
+	}
+}
+
+// snapshot sums the outcomes across every bucket whose time slot overlaps
+// the trailing window. A bucket spans [epoch, epoch + bucketWidth) and is
+// included when (epoch + bucketWidth) > (now - window), i.e. when
+// epoch > now - window - bucketWidth. The cutoff is precomputed below.
+//
+// The sum is not atomic across buckets, which is acceptable for a failure
+// detector: a snapshot can interleave with concurrent writers, but the
+// aggregated counts only ever undercount the true value by at most the
+// in-flight writes.
+func (d *CommandFailureDetector) snapshot() (successes, failures uint64) {
+	nowNano := d.now().UnixNano()
+	cutoff := nowNano - d.windowNano - d.bucketWidthNano
+	for i := range d.buckets {
+		b := &d.buckets[i]
+		if b.epochNano.Load() > cutoff {
+			successes += b.successes.Load()
+			failures += b.failures.Load()
+		}
+	}
+	return successes, failures
 }

--- a/internal/failuredetector/failure_detector_test.go
+++ b/internal/failuredetector/failure_detector_test.go
@@ -1,0 +1,207 @@
+package failuredetector
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCommandFailureDetector_ShouldFailover(t *testing.T) {
+	config := CommandFailureDetectorConfig{
+		MinNumFailures:         10,
+		FailureRateThreshold:   0.5,
+		FailureDetectionWindow: time.Hour,
+	}
+	fd := NewCommandFailureDetector(config)
+
+	// Not enough failures
+	for i := 0; i < 5; i++ {
+		fd.RecordFailure(errors.New("error"))
+	}
+	if fd.ShouldFailover() {
+		t.Error("should not failover with insufficient failures")
+	}
+
+	// Add more failures to reach threshold
+	for i := 0; i < 5; i++ {
+		fd.RecordFailure(errors.New("error"))
+	}
+	if !fd.ShouldFailover() {
+		t.Error("should failover with 100% failure rate")
+	}
+}
+
+func TestCommandFailureDetector_SuccessResetsRate(t *testing.T) {
+	config := CommandFailureDetectorConfig{
+		MinNumFailures:         10,
+		FailureRateThreshold:   0.5,
+		FailureDetectionWindow: time.Hour,
+	}
+	fd := NewCommandFailureDetector(config)
+
+	// Record failures
+	for i := 0; i < 10; i++ {
+		fd.RecordFailure(errors.New("error"))
+	}
+
+	// Record successes to bring rate below threshold
+	for i := 0; i < 15; i++ {
+		fd.RecordSuccess()
+	}
+
+	// 10 failures / 25 total = 40% < 50%
+	if fd.ShouldFailover() {
+		t.Error("should not failover when failure rate is below threshold")
+	}
+}
+
+func TestCommandFailureDetector_IgnoresContextErrors(t *testing.T) {
+	config := CommandFailureDetectorConfig{
+		MinNumFailures:         5,
+		FailureRateThreshold:   0.5,
+		FailureDetectionWindow: time.Hour,
+	}
+	fd := NewCommandFailureDetector(config)
+
+	// Record context errors - should be ignored
+	for i := 0; i < 10; i++ {
+		fd.RecordFailure(context.Canceled)
+		fd.RecordFailure(context.DeadlineExceeded)
+	}
+
+	// Record some successes
+	for i := 0; i < 10; i++ {
+		fd.RecordSuccess()
+	}
+
+	// Only successes should be counted
+	successes, failures, _ := fd.Stats()
+	if failures != 0 {
+		t.Errorf("expected 0 failures, got %d", failures)
+	}
+	if successes != 10 {
+		t.Errorf("expected 10 successes, got %d", successes)
+	}
+}
+
+func TestCommandFailureDetector_WindowReset(t *testing.T) {
+	config := CommandFailureDetectorConfig{
+		MinNumFailures:         5,
+		FailureRateThreshold:   0.5,
+		FailureDetectionWindow: 50 * time.Millisecond,
+	}
+	fd := NewCommandFailureDetector(config)
+
+	// Record failures
+	for i := 0; i < 10; i++ {
+		fd.RecordFailure(errors.New("error"))
+	}
+
+	// Wait for window to expire
+	time.Sleep(60 * time.Millisecond)
+
+	// Record a success to trigger window check
+	fd.RecordSuccess()
+
+	successes, failures, _ := fd.Stats()
+	if failures != 0 {
+		t.Errorf("expected 0 failures after window reset, got %d", failures)
+	}
+	if successes != 1 {
+		t.Errorf("expected 1 success after window reset, got %d", successes)
+	}
+}
+
+func TestCommandFailureDetector_Reset(t *testing.T) {
+	config := CommandFailureDetectorConfig{
+		MinNumFailures:         5,
+		FailureRateThreshold:   0.5,
+		FailureDetectionWindow: time.Hour,
+	}
+	fd := NewCommandFailureDetector(config)
+
+	// Record some activity
+	for i := 0; i < 10; i++ {
+		fd.RecordFailure(errors.New("error"))
+		fd.RecordSuccess()
+	}
+
+	fd.Reset()
+
+	successes, failures, _ := fd.Stats()
+	if failures != 0 || successes != 0 {
+		t.Errorf("expected 0/0 after reset, got %d/%d", successes, failures)
+	}
+}
+
+func TestCommandFailureDetector_RateOnly(t *testing.T) {
+	// MinNumFailures == 0 means only the failure rate is taken into account.
+	config := CommandFailureDetectorConfig{
+		MinNumFailures:         0,
+		FailureRateThreshold:   0.5,
+		FailureDetectionWindow: time.Hour,
+	}
+	fd := NewCommandFailureDetector(config)
+
+	// 1 failure out of 1 command => 100% rate, count threshold disabled.
+	fd.RecordFailure(errors.New("error"))
+	if !fd.ShouldFailover() {
+		t.Error("should failover when rate exceeds threshold and count is disabled")
+	}
+
+	// Drive the rate below the threshold with successes.
+	for i := 0; i < 10; i++ {
+		fd.RecordSuccess()
+	}
+	if fd.ShouldFailover() {
+		t.Error("should not failover when rate drops below threshold")
+	}
+}
+
+func TestCommandFailureDetector_CountOnly(t *testing.T) {
+	// FailureRateThreshold == 0.0 means only the failure count is considered.
+	config := CommandFailureDetectorConfig{
+		MinNumFailures:         3,
+		FailureRateThreshold:   0.0,
+		FailureDetectionWindow: time.Hour,
+	}
+	fd := NewCommandFailureDetector(config)
+
+	// A small failure rate but below the count threshold => no failover.
+	fd.RecordFailure(errors.New("error"))
+	fd.RecordFailure(errors.New("error"))
+	for i := 0; i < 100; i++ {
+		fd.RecordSuccess()
+	}
+	if fd.ShouldFailover() {
+		t.Error("should not failover before reaching the failure count")
+	}
+
+	// Reaching the count threshold triggers failover regardless of rate.
+	fd.RecordFailure(errors.New("error"))
+	if !fd.ShouldFailover() {
+		t.Error("should failover once the failure count is reached")
+	}
+}
+
+func TestCommandFailureDetector_RequiresBothThresholds(t *testing.T) {
+	// Both thresholds must be met when both are configured.
+	config := CommandFailureDetectorConfig{
+		MinNumFailures:         5,
+		FailureRateThreshold:   0.5,
+		FailureDetectionWindow: time.Hour,
+	}
+	fd := NewCommandFailureDetector(config)
+
+	// 5 failures reaches the count, but 5/20 = 25% is below the rate.
+	for i := 0; i < 5; i++ {
+		fd.RecordFailure(errors.New("error"))
+	}
+	for i := 0; i < 15; i++ {
+		fd.RecordSuccess()
+	}
+	if fd.ShouldFailover() {
+		t.Error("should not failover when only the count threshold is met")
+	}
+}

--- a/internal/failuredetector/failure_detector_test.go
+++ b/internal/failuredetector/failure_detector_test.go
@@ -85,6 +85,48 @@ func TestCommandFailureDetector_IgnoresContextErrors(t *testing.T) {
 	}
 }
 
+func TestCommandFailureDetector_IgnoresNilError(t *testing.T) {
+	config := CommandFailureDetectorConfig{
+		MinNumFailures:         1,
+		FailureRateThreshold:   0.0,
+		FailureDetectionWindow: time.Hour,
+	}
+	fd := NewCommandFailureDetector(config)
+
+	// A nil error represents success and must not be counted as a failure.
+	for i := 0; i < 10; i++ {
+		fd.RecordFailure(nil)
+	}
+
+	_, failures, _ := fd.Stats()
+	if failures != 0 {
+		t.Errorf("expected 0 failures for nil errors, got %d", failures)
+	}
+	if fd.ShouldFailover() {
+		t.Error("should not failover when only nil errors were recorded")
+	}
+}
+
+func TestCommandFailureDetector_DefaultsWindowWhenUnset(t *testing.T) {
+	// A zero window must fall back to the documented default so the counters
+	// are not reset on every call (which would prevent failover entirely).
+	config := CommandFailureDetectorConfig{
+		MinNumFailures:       1,
+		FailureRateThreshold: 0.0,
+	}
+	fd := NewCommandFailureDetector(config)
+
+	fd.RecordFailure(errors.New("error"))
+	if !fd.ShouldFailover() {
+		t.Error("should failover after a failure with the defaulted window")
+	}
+
+	_, failures, _ := fd.Stats()
+	if failures != 1 {
+		t.Errorf("expected 1 failure to be retained within the window, got %d", failures)
+	}
+}
+
 func TestCommandFailureDetector_WindowReset(t *testing.T) {
 	config := CommandFailureDetectorConfig{
 		MinNumFailures:         5,
@@ -98,8 +140,9 @@ func TestCommandFailureDetector_WindowReset(t *testing.T) {
 		fd.RecordFailure(errors.New("error"))
 	}
 
-	// Wait for window to expire
-	time.Sleep(60 * time.Millisecond)
+	// Wait for the window to expire. Use a generous buffer (2x the window)
+	// so the test does not flake on slow or loaded CI runners.
+	time.Sleep(100 * time.Millisecond)
 
 	// Record a success to trigger window check
 	fd.RecordSuccess()

--- a/internal/failuredetector/failure_detector_test.go
+++ b/internal/failuredetector/failure_detector_test.go
@@ -195,22 +195,78 @@ func TestCommandFailureDetector_Reset(t *testing.T) {
 	}
 }
 
-func TestCommandFailureDetector_RateOnly(t *testing.T) {
-	// MinNumFailures == 0 means only the failure rate is taken into account.
+func TestCommandFailureDetector_AppliesDefaultsForZeroFields(t *testing.T) {
+	// A zero-valued config must be equivalent to passing the documented
+	// defaults; reviewers flagged that the field comments promised defaults
+	// the constructor did not apply.
+	fd := NewCommandFailureDetector(CommandFailureDetectorConfig{})
+	defaults := DefaultCommandFailureDetectorConfig()
+
+	if fd.config.MinNumFailures != defaults.MinNumFailures {
+		t.Errorf("MinNumFailures: got %d, want %d (default)",
+			fd.config.MinNumFailures, defaults.MinNumFailures)
+	}
+	if fd.config.FailureRateThreshold != defaults.FailureRateThreshold {
+		t.Errorf("FailureRateThreshold: got %v, want %v (default)",
+			fd.config.FailureRateThreshold, defaults.FailureRateThreshold)
+	}
+	if fd.config.FailureDetectionWindow != defaults.FailureDetectionWindow {
+		t.Errorf("FailureDetectionWindow: got %v, want %v (default)",
+			fd.config.FailureDetectionWindow, defaults.FailureDetectionWindow)
+	}
+	if fd.config.NumBuckets != defaults.NumBuckets {
+		t.Errorf("NumBuckets: got %d, want %d (default)",
+			fd.config.NumBuckets, defaults.NumBuckets)
+	}
+}
+
+func TestCommandFailureDetector_PreservesExplicitValues(t *testing.T) {
+	// Defaults must not overwrite explicit non-zero settings, otherwise the
+	// detector would be impossible to tune away from the defaults.
 	config := CommandFailureDetectorConfig{
-		MinNumFailures:         0,
-		FailureRateThreshold:   0.5,
-		FailureDetectionWindow: time.Hour,
+		MinNumFailures:         5,
+		FailureRateThreshold:   0.25,
+		FailureDetectionWindow: 500 * time.Millisecond,
+		NumBuckets:             4,
 	}
 	fd := NewCommandFailureDetector(config)
+	if fd.config != config {
+		t.Errorf("explicit config was overwritten: got %+v, want %+v", fd.config, config)
+	}
+}
 
-	// 1 failure out of 1 command => 100% rate, count threshold disabled.
+func TestCommandFailureDetector_DoesNotPanicOnTinyWindow(t *testing.T) {
+	// A FailureDetectionWindow shorter than NumBuckets nanoseconds would
+	// previously produce bucketWidthNano=0 and panic on the first record
+	// via "%". The constructor must clamp the bucket width.
+	fd := NewCommandFailureDetector(CommandFailureDetectorConfig{
+		FailureDetectionWindow: 5 * time.Nanosecond,
+		NumBuckets:             10,
+	})
+	// Both hot-path entry points must not panic.
+	fd.RecordSuccess()
+	fd.RecordFailure(errors.New("error"))
+	_ = fd.ShouldFailover()
+}
+
+func TestCommandFailureDetector_IgnoreMinNumFailures(t *testing.T) {
+	// With IgnoreMinNumFailures set, ShouldFailover should ignore the count
+	// threshold and decide purely on the failure rate.
+	fd := NewCommandFailureDetector(CommandFailureDetectorConfig{
+		MinNumFailures:         10_000, // would otherwise gate every reasonable burst
+		IgnoreMinNumFailures:   true,
+		FailureRateThreshold:   0.5,
+		FailureDetectionWindow: time.Hour,
+	})
+
+	// 1 failure out of 1 command => 100% rate, well above the threshold.
 	fd.RecordFailure(errors.New("error"))
 	if !fd.ShouldFailover() {
-		t.Error("should failover when rate exceeds threshold and count is disabled")
+		t.Error("should failover when rate exceeds threshold and count is ignored")
 	}
 
-	// Drive the rate below the threshold with successes.
+	// Drive the rate below the threshold with successes; the count threshold
+	// is still ignored, but the rate check must now reject.
 	for i := 0; i < 10; i++ {
 		fd.RecordSuccess()
 	}
@@ -219,14 +275,15 @@ func TestCommandFailureDetector_RateOnly(t *testing.T) {
 	}
 }
 
-func TestCommandFailureDetector_CountOnly(t *testing.T) {
-	// FailureRateThreshold == 0.0 means only the failure count is considered.
-	config := CommandFailureDetectorConfig{
-		MinNumFailures:         3,
-		FailureRateThreshold:   0.0,
-		FailureDetectionWindow: time.Hour,
-	}
-	fd := NewCommandFailureDetector(config)
+func TestCommandFailureDetector_IgnoreFailureRateThreshold(t *testing.T) {
+	// With IgnoreFailureRateThreshold set, ShouldFailover should ignore the
+	// rate threshold and decide purely on the absolute failure count.
+	fd := NewCommandFailureDetector(CommandFailureDetectorConfig{
+		MinNumFailures:             3,
+		FailureRateThreshold:       0.99, // would otherwise be impossible to meet
+		IgnoreFailureRateThreshold: true,
+		FailureDetectionWindow:     time.Hour,
+	})
 
 	// A small failure rate but below the count threshold => no failover.
 	fd.RecordFailure(errors.New("error"))
@@ -238,10 +295,31 @@ func TestCommandFailureDetector_CountOnly(t *testing.T) {
 		t.Error("should not failover before reaching the failure count")
 	}
 
-	// Reaching the count threshold triggers failover regardless of rate.
+	// Reaching the count threshold triggers failover regardless of the rate.
 	fd.RecordFailure(errors.New("error"))
 	if !fd.ShouldFailover() {
 		t.Error("should failover once the failure count is reached")
+	}
+}
+
+func TestCommandFailureDetector_IgnoreBothThresholds(t *testing.T) {
+	// With both thresholds ignored, any single failure in the window should
+	// be enough to trigger failover.
+	fd := NewCommandFailureDetector(CommandFailureDetectorConfig{
+		MinNumFailures:             10_000,
+		IgnoreMinNumFailures:       true,
+		FailureRateThreshold:       0.99,
+		IgnoreFailureRateThreshold: true,
+		FailureDetectionWindow:     time.Hour,
+	})
+
+	if fd.ShouldFailover() {
+		t.Error("should not failover before any failure is recorded")
+	}
+
+	fd.RecordFailure(errors.New("error"))
+	if !fd.ShouldFailover() {
+		t.Error("any single failure should trigger when both thresholds are ignored")
 	}
 }
 

--- a/internal/failuredetector/failure_detector_test.go
+++ b/internal/failuredetector/failure_detector_test.go
@@ -3,9 +3,20 @@ package failuredetector
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+// withFakeClock returns the detector with a hand-driven clock so tests can
+// advance time without sleeping. The returned closure shifts the clock by
+// the given duration. Use this for any test that depends on window expiry.
+func withFakeClock(fd *CommandFailureDetector, start time.Time) (advance func(time.Duration)) {
+	cur := start
+	fd.now = func() time.Time { return cur }
+	return func(d time.Duration) { cur = cur.Add(d) }
+}
 
 func TestCommandFailureDetector_ShouldFailover(t *testing.T) {
 	config := CommandFailureDetectorConfig{
@@ -76,7 +87,7 @@ func TestCommandFailureDetector_IgnoresContextErrors(t *testing.T) {
 	}
 
 	// Only successes should be counted
-	successes, failures, _ := fd.Stats()
+	successes, failures := fd.Stats()
 	if failures != 0 {
 		t.Errorf("expected 0 failures, got %d", failures)
 	}
@@ -98,7 +109,7 @@ func TestCommandFailureDetector_IgnoresNilError(t *testing.T) {
 		fd.RecordFailure(nil)
 	}
 
-	_, failures, _ := fd.Stats()
+	_, failures := fd.Stats()
 	if failures != 0 {
 		t.Errorf("expected 0 failures for nil errors, got %d", failures)
 	}
@@ -121,38 +132,44 @@ func TestCommandFailureDetector_DefaultsWindowWhenUnset(t *testing.T) {
 		t.Error("should failover after a failure with the defaulted window")
 	}
 
-	_, failures, _ := fd.Stats()
+	_, failures := fd.Stats()
 	if failures != 1 {
 		t.Errorf("expected 1 failure to be retained within the window, got %d", failures)
 	}
 }
 
-func TestCommandFailureDetector_WindowReset(t *testing.T) {
+func TestCommandFailureDetector_WindowExpiry(t *testing.T) {
+	// Outcomes older than the window must not be counted. The sliding
+	// implementation drops them one bucket at a time, so by advancing time
+	// past the full window every previously-recorded outcome should age out.
 	config := CommandFailureDetectorConfig{
 		MinNumFailures:         5,
 		FailureRateThreshold:   0.5,
-		FailureDetectionWindow: 50 * time.Millisecond,
+		FailureDetectionWindow: time.Second,
+		NumBuckets:             10,
 	}
 	fd := NewCommandFailureDetector(config)
+	advance := withFakeClock(fd, time.Unix(1_700_000_000, 0))
 
-	// Record failures
 	for i := 0; i < 10; i++ {
 		fd.RecordFailure(errors.New("error"))
 	}
+	if _, failures := fd.Stats(); failures != 10 {
+		t.Fatalf("expected 10 failures before expiry, got %d", failures)
+	}
 
-	// Wait for the window to expire. Use a generous buffer (2x the window)
-	// so the test does not flake on slow or loaded CI runners.
-	time.Sleep(100 * time.Millisecond)
+	// Step past the window by one full bucket width so every bucket falls
+	// outside the trailing window.
+	advance(config.FailureDetectionWindow + config.FailureDetectionWindow/time.Duration(config.NumBuckets))
 
-	// Record a success to trigger window check
 	fd.RecordSuccess()
 
-	successes, failures, _ := fd.Stats()
+	successes, failures := fd.Stats()
 	if failures != 0 {
-		t.Errorf("expected 0 failures after window reset, got %d", failures)
+		t.Errorf("expected 0 failures after window expiry, got %d", failures)
 	}
 	if successes != 1 {
-		t.Errorf("expected 1 success after window reset, got %d", successes)
+		t.Errorf("expected 1 success after window expiry, got %d", successes)
 	}
 }
 
@@ -172,7 +189,7 @@ func TestCommandFailureDetector_Reset(t *testing.T) {
 
 	fd.Reset()
 
-	successes, failures, _ := fd.Stats()
+	successes, failures := fd.Stats()
 	if failures != 0 || successes != 0 {
 		t.Errorf("expected 0/0 after reset, got %d/%d", successes, failures)
 	}
@@ -246,5 +263,191 @@ func TestCommandFailureDetector_RequiresBothThresholds(t *testing.T) {
 	}
 	if fd.ShouldFailover() {
 		t.Error("should not failover when only the count threshold is met")
+	}
+}
+
+// TestCommandFailureDetector_SlidingWindow exercises the property that
+// distinguishes a sliding window from a tumbling one: outcomes age out one
+// bucket at a time as time advances, rather than disappearing en masse at a
+// fixed window boundary.
+func TestCommandFailureDetector_SlidingWindow(t *testing.T) {
+	config := CommandFailureDetectorConfig{
+		MinNumFailures:         1,
+		FailureRateThreshold:   0.0,
+		FailureDetectionWindow: time.Second,
+		NumBuckets:             10,
+	}
+	fd := NewCommandFailureDetector(config)
+	advance := withFakeClock(fd, time.Unix(1_700_000_000, 0))
+
+	bucket := config.FailureDetectionWindow / time.Duration(config.NumBuckets)
+
+	// Spread one failure across each of the first three buckets.
+	fd.RecordFailure(errors.New("e"))
+	advance(bucket)
+	fd.RecordFailure(errors.New("e"))
+	advance(bucket)
+	fd.RecordFailure(errors.New("e"))
+
+	if _, failures := fd.Stats(); failures != 3 {
+		t.Fatalf("expected 3 failures in window, got %d", failures)
+	}
+
+	// Step time so the very first bucket falls outside the trailing window.
+	// In a tumbling implementation, advancing by < window would change
+	// nothing; in a sliding implementation, the oldest failure must have
+	// aged out.
+	advance(config.FailureDetectionWindow - bucket)
+	if _, failures := fd.Stats(); failures != 2 {
+		t.Fatalf("expected 2 failures after oldest bucket aged out, got %d", failures)
+	}
+
+	// One more bucket-width drops the next oldest failure.
+	advance(bucket)
+	if _, failures := fd.Stats(); failures != 1 {
+		t.Fatalf("expected 1 failure after second bucket aged out, got %d", failures)
+	}
+
+	// And once we walk past the full window, everything is gone.
+	advance(config.FailureDetectionWindow)
+	if _, failures := fd.Stats(); failures != 0 {
+		t.Fatalf("expected 0 failures after full window elapsed, got %d", failures)
+	}
+}
+
+// TestCommandFailureDetector_ConcurrentRecord checks that the lock-free
+// hot path doesn't lose counts under contention. We fan out N goroutines
+// each recording a fixed number of successes and failures and assert the
+// totals match. The window is long enough that no bucket rotates during
+// the test, so the count must be exact.
+func TestCommandFailureDetector_ConcurrentRecord(t *testing.T) {
+	const (
+		numGoroutines     = 32
+		opsPerGoroutine   = 5_000
+		expectedSuccesses = numGoroutines * opsPerGoroutine
+		expectedFailures  = numGoroutines * opsPerGoroutine
+	)
+
+	fd := NewCommandFailureDetector(CommandFailureDetectorConfig{
+		FailureDetectionWindow: time.Hour,
+		NumBuckets:             10,
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines * 2)
+	errFail := errors.New("failure")
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < opsPerGoroutine; j++ {
+				fd.RecordSuccess()
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < opsPerGoroutine; j++ {
+				fd.RecordFailure(errFail)
+			}
+		}()
+	}
+	wg.Wait()
+
+	successes, failures := fd.Stats()
+	if successes != uint64(expectedSuccesses) {
+		t.Errorf("successes: got %d, want %d", successes, expectedSuccesses)
+	}
+	if failures != uint64(expectedFailures) {
+		t.Errorf("failures: got %d, want %d", failures, expectedFailures)
+	}
+}
+
+// TestCommandFailureDetector_ConcurrentRecordWithReaders pairs the
+// concurrent recorders above with a flock of concurrent readers calling
+// ShouldFailover. The test passes if no race is reported (-race) and no
+// panic is observed.
+func TestCommandFailureDetector_ConcurrentRecordWithReaders(t *testing.T) {
+	fd := NewCommandFailureDetector(CommandFailureDetectorConfig{
+		MinNumFailures:         50,
+		FailureRateThreshold:   0.5,
+		FailureDetectionWindow: time.Hour,
+		NumBuckets:             10,
+	})
+
+	var wg sync.WaitGroup
+	var stop atomic.Bool
+	errFail := errors.New("failure")
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for !stop.Load() {
+				fd.RecordSuccess()
+				fd.RecordFailure(errFail)
+			}
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for !stop.Load() {
+				_ = fd.ShouldFailover()
+			}
+		}()
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	stop.Store(true)
+	wg.Wait()
+}
+
+// BenchmarkCommandFailureDetector_RecordSuccess measures the cost of the
+// hot path under contention so we can compare future implementations.
+func BenchmarkCommandFailureDetector_RecordSuccess(b *testing.B) {
+	fd := NewCommandFailureDetector(CommandFailureDetectorConfig{
+		FailureDetectionWindow: time.Hour,
+		NumBuckets:             10,
+	})
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			fd.RecordSuccess()
+		}
+	})
+}
+
+// BenchmarkCommandFailureDetector_RecordFailure mirrors RecordSuccess for
+// the failure path (same hot-path code, includes the error filter).
+func BenchmarkCommandFailureDetector_RecordFailure(b *testing.B) {
+	fd := NewCommandFailureDetector(CommandFailureDetectorConfig{
+		FailureDetectionWindow: time.Hour,
+		NumBuckets:             10,
+	})
+	err := errors.New("failure")
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			fd.RecordFailure(err)
+		}
+	})
+}
+
+// BenchmarkCommandFailureDetector_ShouldFailover measures the read path,
+// which sums NumBuckets atomically-loaded counters.
+func BenchmarkCommandFailureDetector_ShouldFailover(b *testing.B) {
+	fd := NewCommandFailureDetector(CommandFailureDetectorConfig{
+		MinNumFailures:         100,
+		FailureRateThreshold:   0.5,
+		FailureDetectionWindow: time.Hour,
+		NumBuckets:             10,
+	})
+	// Populate so the rate check branch runs.
+	for i := 0; i < 1000; i++ {
+		fd.RecordSuccess()
+	}
+	fd.RecordFailure(errors.New("failure"))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = fd.ShouldFailover()
 	}
 }


### PR DESCRIPTION
Add a sliding-window failure detector used by MultiDBClient to decide when failover should be triggered.

- FailureDetector interface: RecordSuccess, RecordFailure, ShouldFailover, Reset
- Sliding time window over recent outcomes
- Context-cancellation errors are not counted as failures
- buckets with atomic state, there is a slight potential race condition that we are aware of.

Part of the MultiDBClient geo-failover feature (PR 2).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New failover decision logic will eventually drive database switching; the package is isolated for now but incorrect thresholds or races could cause premature or delayed failover once wired.
> 
> **Overview**
> Introduces **`internal/failuredetector`** for MultiDB geo-failover: a `FailureDetector` interface and **`CommandFailureDetector`**, a lock-free sliding-window implementation that records command successes/failures, ignores nil and client-side context errors, and returns **`ShouldFailover`** when configurable minimum failure count and failure-rate thresholds are met (each can be disabled independently). Defaults apply for unset config; **`Stats`** and **`Reset`** support observability and recovery.
> 
> CI workflows for **build**, **CodeQL**, **doctests**, and **govulncheck** now run on PRs targeting **`feature/**`** branches.
> 
> **Note:** `NewCommandFailureDetector` currently declares **`bucketWidthNano` twice** in the same function, which should fail compilation until one block is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72e40ccee3190c90bff5fd67056cb49991dac27f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->