### PR TITLE
feat(multidb): #3 add health check implementations

### DIFF
--- a/multidb/healthcheck.go
+++ b/multidb/healthcheck.go
@@ -93,6 +93,57 @@ type ConfigurableHealthCheck interface {
 	Config() HealthCheckConfig
 }
 
+// probeFunc runs one probe of a health check and reports whether it passed
+// along with any error that caused a failure.
+type probeFunc func(context.Context, redis.MultiDBHealthCheck) (bool, error)
+
+// checkRunner interprets the probes of a single health check (all / majority /
+// any) and reports whether that check is healthy.
+type checkRunner func(ctx context.Context, hc redis.MultiDBHealthCheck, probe probeFunc) bool
+
+// runChecks executes every health check concurrently, each with its own
+// timeout, and returns true only if all of them pass (AND across checks). The
+// per-check probe interpretation is delegated to runner. It is the single
+// implementation shared by every policy; the policies differ only in which
+// runner they pass in.
+func runChecks(ctx context.Context, checks []redis.MultiDBHealthCheck, probe probeFunc, runner checkRunner) bool {
+	if len(checks) == 0 {
+		return true
+	}
+	// Buffered to the number of checks so a worker never blocks on send even
+	// when we return early, preventing goroutine leaks.
+	results := make(chan bool, len(checks))
+	var wg sync.WaitGroup
+	for _, hc := range checks {
+		wg.Add(1)
+		go func(check redis.MultiDBHealthCheck) {
+			defer wg.Done()
+			results <- runner(ctx, check, probe)
+		}(hc)
+	}
+	go func() { wg.Wait(); close(results) }()
+
+	// Every health check must pass (AND across checks).
+	for result := range results {
+		if !result {
+			return false
+		}
+	}
+	return true
+}
+
+func standaloneProbe(client *redis.Client) probeFunc {
+	return func(ctx context.Context, hc redis.MultiDBHealthCheck) (bool, error) {
+		return hc.CheckHealth(ctx, client)
+	}
+}
+
+func clusterProbe(client *redis.ClusterClient) probeFunc {
+	return func(ctx context.Context, hc redis.MultiDBHealthCheck) (bool, error) {
+		return hc.CheckClusterHealth(ctx, client)
+	}
+}
+
 // HealthyAllPolicy returns true if ALL probes succeed for each health check.
 // For each health check, it runs the configured number of probes with delays.
 // ALL probes must succeed for the health check to be considered healthy.
@@ -106,40 +157,11 @@ type HealthyAllPolicy struct{}
 func NewHealthyAllPolicy() *HealthyAllPolicy { return &HealthyAllPolicy{} }
 
 func (p *HealthyAllPolicy) Execute(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.Client) bool {
-	return p.execute(ctx, checks, func(ctx context.Context, hc redis.MultiDBHealthCheck) bool {
-		return hc.CheckHealth(ctx, client)
-	})
+	return runChecks(ctx, checks, standaloneProbe(client), runProbesAllMustPass)
 }
 
 func (p *HealthyAllPolicy) ExecuteCluster(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.ClusterClient) bool {
-	return p.execute(ctx, checks, func(ctx context.Context, hc redis.MultiDBHealthCheck) bool {
-		return hc.CheckClusterHealth(ctx, client)
-	})
-}
-
-func (p *HealthyAllPolicy) execute(ctx context.Context, checks []redis.MultiDBHealthCheck, probeFn func(context.Context, redis.MultiDBHealthCheck) bool) bool {
-	if len(checks) == 0 {
-		return true
-	}
-	// Run all health checks concurrently, each with its own timeout
-	results := make(chan bool, len(checks))
-	var wg sync.WaitGroup
-	for _, hc := range checks {
-		wg.Add(1)
-		go func(check redis.MultiDBHealthCheck) {
-			defer wg.Done()
-			results <- runProbesAllMustPass(ctx, check, probeFn)
-		}(hc)
-	}
-	go func() { wg.Wait(); close(results) }()
-
-	// All health checks must pass
-	for result := range results {
-		if !result {
-			return false
-		}
-	}
-	return true
+	return runChecks(ctx, checks, clusterProbe(client), runProbesAllMustPass)
 }
 
 // HealthyMajorityPolicy returns true if a MAJORITY of probes succeed.
@@ -154,40 +176,11 @@ type HealthyMajorityPolicy struct{}
 func NewHealthyMajorityPolicy() *HealthyMajorityPolicy { return &HealthyMajorityPolicy{} }
 
 func (p *HealthyMajorityPolicy) Execute(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.Client) bool {
-	return p.execute(ctx, checks, func(ctx context.Context, hc redis.MultiDBHealthCheck) bool {
-		return hc.CheckHealth(ctx, client)
-	})
+	return runChecks(ctx, checks, standaloneProbe(client), runProbesMajority)
 }
 
 func (p *HealthyMajorityPolicy) ExecuteCluster(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.ClusterClient) bool {
-	return p.execute(ctx, checks, func(ctx context.Context, hc redis.MultiDBHealthCheck) bool {
-		return hc.CheckClusterHealth(ctx, client)
-	})
-}
-
-func (p *HealthyMajorityPolicy) execute(ctx context.Context, checks []redis.MultiDBHealthCheck, probeFn func(context.Context, redis.MultiDBHealthCheck) bool) bool {
-	if len(checks) == 0 {
-		return true
-	}
-	// Run all health checks concurrently
-	results := make(chan bool, len(checks))
-	var wg sync.WaitGroup
-	for _, hc := range checks {
-		wg.Add(1)
-		go func(check redis.MultiDBHealthCheck) {
-			defer wg.Done()
-			results <- runProbesMajority(ctx, check, probeFn)
-		}(hc)
-	}
-	go func() { wg.Wait(); close(results) }()
-
-	// All health checks must pass (each uses majority internally)
-	for result := range results {
-		if !result {
-			return false
-		}
-	}
-	return true
+	return runChecks(ctx, checks, clusterProbe(client), runProbesMajority)
 }
 
 // HealthyAnyPolicy returns true if AT LEAST ONE probe succeeds.
@@ -201,58 +194,43 @@ type HealthyAnyPolicy struct{}
 func NewHealthyAnyPolicy() *HealthyAnyPolicy { return &HealthyAnyPolicy{} }
 
 func (p *HealthyAnyPolicy) Execute(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.Client) bool {
-	return p.execute(ctx, checks, func(ctx context.Context, hc redis.MultiDBHealthCheck) bool {
-		return hc.CheckHealth(ctx, client)
-	})
+	return runChecks(ctx, checks, standaloneProbe(client), runProbesAny)
 }
 
 func (p *HealthyAnyPolicy) ExecuteCluster(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.ClusterClient) bool {
-	return p.execute(ctx, checks, func(ctx context.Context, hc redis.MultiDBHealthCheck) bool {
-		return hc.CheckClusterHealth(ctx, client)
-	})
+	return runChecks(ctx, checks, clusterProbe(client), runProbesAny)
 }
 
-func (p *HealthyAnyPolicy) execute(ctx context.Context, checks []redis.MultiDBHealthCheck, probeFn func(context.Context, redis.MultiDBHealthCheck) bool) bool {
-	if len(checks) == 0 {
-		return true
-	}
-	// Run all health checks concurrently
-	results := make(chan bool, len(checks))
-	var wg sync.WaitGroup
-	for _, hc := range checks {
-		wg.Add(1)
-		go func(check redis.MultiDBHealthCheck) {
-			defer wg.Done()
-			results <- runProbesAny(ctx, check, probeFn)
-		}(hc)
-	}
-	go func() { wg.Wait(); close(results) }()
-
-	// All health checks must pass (each uses any internally)
-	for result := range results {
-		if !result {
-			return false
-		}
-	}
-	return true
-}
-
-// getConfig returns the health check config, using defaults if not configurable.
+// getConfig returns the health check config, using defaults if not
+// configurable. Invalid values from a configurable check are clamped to their
+// defaults so the probe runners stay robust: a non-positive Probes would
+// otherwise make a check trivially pass (zero iterations), and a non-positive
+// Timeout would expire the context immediately.
 func getConfig(hc redis.MultiDBHealthCheck) HealthCheckConfig {
+	cfg := DefaultHealthCheckConfig()
 	if chc, ok := hc.(ConfigurableHealthCheck); ok {
-		return chc.Config()
+		cfg = chc.Config()
 	}
-	return DefaultHealthCheckConfig()
+	if cfg.Probes <= 0 {
+		cfg.Probes = DefaultHealthCheckProbes
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = DefaultHealthCheckTimeout
+	}
+	if cfg.Delay < 0 {
+		cfg.Delay = DefaultHealthCheckDelay
+	}
+	return cfg
 }
 
 // runProbesAllMustPass runs probes where ALL must succeed.
-func runProbesAllMustPass(ctx context.Context, hc redis.MultiDBHealthCheck, probeFn func(context.Context, redis.MultiDBHealthCheck) bool) bool {
+func runProbesAllMustPass(ctx context.Context, hc redis.MultiDBHealthCheck, probe probeFunc) bool {
 	cfg := getConfig(hc)
 	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
 
 	for i := 0; i < cfg.Probes; i++ {
-		if !probeFn(ctx, hc) {
+		if ok, _ := probe(ctx, hc); !ok {
 			return false
 		}
 		if i < cfg.Probes-1 && cfg.Delay > 0 {
@@ -267,7 +245,7 @@ func runProbesAllMustPass(ctx context.Context, hc redis.MultiDBHealthCheck, prob
 }
 
 // runProbesMajority runs probes where MAJORITY must succeed.
-func runProbesMajority(ctx context.Context, hc redis.MultiDBHealthCheck, probeFn func(context.Context, redis.MultiDBHealthCheck) bool) bool {
+func runProbesMajority(ctx context.Context, hc redis.MultiDBHealthCheck, probe probeFunc) bool {
 	cfg := getConfig(hc)
 	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
@@ -282,7 +260,7 @@ func runProbesMajority(ctx context.Context, hc redis.MultiDBHealthCheck, probeFn
 	successes := 0
 
 	for i := 0; i < cfg.Probes; i++ {
-		if probeFn(ctx, hc) {
+		if ok, _ := probe(ctx, hc); ok {
 			successes++
 			if successes >= requiredSuccesses {
 				return true
@@ -305,13 +283,13 @@ func runProbesMajority(ctx context.Context, hc redis.MultiDBHealthCheck, probeFn
 }
 
 // runProbesAny runs probes where ANY success is enough.
-func runProbesAny(ctx context.Context, hc redis.MultiDBHealthCheck, probeFn func(context.Context, redis.MultiDBHealthCheck) bool) bool {
+func runProbesAny(ctx context.Context, hc redis.MultiDBHealthCheck, probe probeFunc) bool {
 	cfg := getConfig(hc)
 	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
 
 	for i := 0; i < cfg.Probes; i++ {
-		if probeFn(ctx, hc) {
+		if ok, _ := probe(ctx, hc); ok {
 			return true
 		}
 		if i < cfg.Probes-1 && cfg.Delay > 0 {

--- a/multidb/healthcheck.go
+++ b/multidb/healthcheck.go
@@ -12,10 +12,9 @@ import (
 
 // Default values for health check configuration
 const (
-	DefaultHealthCheckProbes   = 3
-	DefaultHealthCheckDelay    = 500 * time.Millisecond
-	DefaultHealthCheckTimeout  = 3 * time.Second
-	DefaultHealthCheckInterval = 5 * time.Second
+	DefaultHealthCheckProbes  = 3
+	DefaultHealthCheckDelay   = 500 * time.Millisecond
+	DefaultHealthCheckTimeout = 3 * time.Second
 )
 
 // HealthCheckConfig holds configuration for health checks.

--- a/multidb/healthcheck.go
+++ b/multidb/healthcheck.go
@@ -1,0 +1,317 @@
+// Package multidb provides health check and failover strategy implementations
+// for use with redis.MultiDBClient.
+package multidb
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Default values for health check configuration
+const (
+	DefaultHealthCheckProbes   = 3
+	DefaultHealthCheckDelay    = 500 * time.Millisecond
+	DefaultHealthCheckTimeout  = 3 * time.Second
+	DefaultHealthCheckInterval = 5 * time.Second
+)
+
+// HealthCheckConfig holds configuration for health checks.
+type HealthCheckConfig struct {
+	Probes  int
+	Delay   time.Duration
+	Timeout time.Duration
+}
+
+// DefaultHealthCheckConfig returns the default health check configuration.
+func DefaultHealthCheckConfig() HealthCheckConfig {
+	return HealthCheckConfig{
+		Probes:  DefaultHealthCheckProbes,
+		Delay:   DefaultHealthCheckDelay,
+		Timeout: DefaultHealthCheckTimeout,
+	}
+}
+
+// HealthCheckOption is a functional option for configuring health checks.
+type HealthCheckOption func(*HealthCheckConfig)
+
+// WithProbes sets the number of probes.
+func WithProbes(probes int) HealthCheckOption {
+	return func(c *HealthCheckConfig) {
+		if probes > 0 {
+			c.Probes = probes
+		}
+	}
+}
+
+// WithDelay sets the delay between probes.
+func WithDelay(delay time.Duration) HealthCheckOption {
+	return func(c *HealthCheckConfig) {
+		if delay >= 0 {
+			c.Delay = delay
+		}
+	}
+}
+
+// WithTimeout sets the timeout for the health check.
+func WithTimeout(timeout time.Duration) HealthCheckOption {
+	return func(c *HealthCheckConfig) {
+		if timeout > 0 {
+			c.Timeout = timeout
+		}
+	}
+}
+
+func applyOptions(opts []HealthCheckOption) HealthCheckConfig {
+	cfg := DefaultHealthCheckConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}
+
+// HealthCheckPolicy defines how health check probes are evaluated.
+type HealthCheckPolicy interface {
+	Execute(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.Client) bool
+	ExecuteCluster(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.ClusterClient) bool
+}
+
+// Compile-time interface compliance checks
+var (
+	_ redis.MultiDBHealthCheck = (*PingHealthCheck)(nil)
+	_ redis.MultiDBHealthCheck = (*LagAwareHealthCheck)(nil)
+	_ HealthCheckPolicy        = (*HealthyAllPolicy)(nil)
+	_ HealthCheckPolicy        = (*HealthyMajorityPolicy)(nil)
+	_ HealthCheckPolicy        = (*HealthyAnyPolicy)(nil)
+)
+
+// ConfigurableHealthCheck is an interface for health checks that have configuration.
+type ConfigurableHealthCheck interface {
+	redis.MultiDBHealthCheck
+	Config() HealthCheckConfig
+}
+
+// HealthyAllPolicy returns true if ALL probes succeed for each health check.
+// For each health check, it runs the configured number of probes with delays.
+// ALL probes must succeed for the health check to be considered healthy.
+//
+// Note: The policy applies to probes within each individual health check.
+// When multiple health checks are provided (e.g. Ping + LagAware), ALL
+// health checks must pass — the policy does not control the relationship
+// between different health checks, only between probes of the same check.
+type HealthyAllPolicy struct{}
+
+func NewHealthyAllPolicy() *HealthyAllPolicy { return &HealthyAllPolicy{} }
+
+func (p *HealthyAllPolicy) Execute(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.Client) bool {
+	return p.execute(ctx, checks, func(ctx context.Context, hc redis.MultiDBHealthCheck) bool {
+		return hc.CheckHealth(ctx, client)
+	})
+}
+
+func (p *HealthyAllPolicy) ExecuteCluster(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.ClusterClient) bool {
+	return p.execute(ctx, checks, func(ctx context.Context, hc redis.MultiDBHealthCheck) bool {
+		return hc.CheckClusterHealth(ctx, client)
+	})
+}
+
+func (p *HealthyAllPolicy) execute(ctx context.Context, checks []redis.MultiDBHealthCheck, probeFn func(context.Context, redis.MultiDBHealthCheck) bool) bool {
+	if len(checks) == 0 {
+		return true
+	}
+	// Run all health checks concurrently, each with its own timeout
+	results := make(chan bool, len(checks))
+	var wg sync.WaitGroup
+	for _, hc := range checks {
+		wg.Add(1)
+		go func(check redis.MultiDBHealthCheck) {
+			defer wg.Done()
+			results <- runProbesAllMustPass(ctx, check, probeFn)
+		}(hc)
+	}
+	go func() { wg.Wait(); close(results) }()
+
+	// All health checks must pass
+	for result := range results {
+		if !result {
+			return false
+		}
+	}
+	return true
+}
+
+// HealthyMajorityPolicy returns true if a MAJORITY of probes succeed.
+// For each health check, it runs the configured number of probes with delays.
+// More than half of the probes must succeed.
+//
+// Note: The policy applies to probes within each individual health check.
+// When multiple health checks are provided, ALL health checks must pass
+// (each needing a majority of its probes to succeed).
+type HealthyMajorityPolicy struct{}
+
+func NewHealthyMajorityPolicy() *HealthyMajorityPolicy { return &HealthyMajorityPolicy{} }
+
+func (p *HealthyMajorityPolicy) Execute(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.Client) bool {
+	return p.execute(ctx, checks, func(ctx context.Context, hc redis.MultiDBHealthCheck) bool {
+		return hc.CheckHealth(ctx, client)
+	})
+}
+
+func (p *HealthyMajorityPolicy) ExecuteCluster(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.ClusterClient) bool {
+	return p.execute(ctx, checks, func(ctx context.Context, hc redis.MultiDBHealthCheck) bool {
+		return hc.CheckClusterHealth(ctx, client)
+	})
+}
+
+func (p *HealthyMajorityPolicy) execute(ctx context.Context, checks []redis.MultiDBHealthCheck, probeFn func(context.Context, redis.MultiDBHealthCheck) bool) bool {
+	if len(checks) == 0 {
+		return true
+	}
+	// Run all health checks concurrently
+	results := make(chan bool, len(checks))
+	var wg sync.WaitGroup
+	for _, hc := range checks {
+		wg.Add(1)
+		go func(check redis.MultiDBHealthCheck) {
+			defer wg.Done()
+			results <- runProbesMajority(ctx, check, probeFn)
+		}(hc)
+	}
+	go func() { wg.Wait(); close(results) }()
+
+	// All health checks must pass (each uses majority internally)
+	for result := range results {
+		if !result {
+			return false
+		}
+	}
+	return true
+}
+
+// HealthyAnyPolicy returns true if AT LEAST ONE probe succeeds.
+// For each health check, it runs probes until one succeeds or all fail.
+//
+// Note: The policy applies to probes within each individual health check.
+// When multiple health checks are provided, ALL health checks must pass
+// (each needing at least one successful probe).
+type HealthyAnyPolicy struct{}
+
+func NewHealthyAnyPolicy() *HealthyAnyPolicy { return &HealthyAnyPolicy{} }
+
+func (p *HealthyAnyPolicy) Execute(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.Client) bool {
+	return p.execute(ctx, checks, func(ctx context.Context, hc redis.MultiDBHealthCheck) bool {
+		return hc.CheckHealth(ctx, client)
+	})
+}
+
+func (p *HealthyAnyPolicy) ExecuteCluster(ctx context.Context, checks []redis.MultiDBHealthCheck, client *redis.ClusterClient) bool {
+	return p.execute(ctx, checks, func(ctx context.Context, hc redis.MultiDBHealthCheck) bool {
+		return hc.CheckClusterHealth(ctx, client)
+	})
+}
+
+func (p *HealthyAnyPolicy) execute(ctx context.Context, checks []redis.MultiDBHealthCheck, probeFn func(context.Context, redis.MultiDBHealthCheck) bool) bool {
+	if len(checks) == 0 {
+		return true
+	}
+	// Run all health checks concurrently
+	results := make(chan bool, len(checks))
+	var wg sync.WaitGroup
+	for _, hc := range checks {
+		wg.Add(1)
+		go func(check redis.MultiDBHealthCheck) {
+			defer wg.Done()
+			results <- runProbesAny(ctx, check, probeFn)
+		}(hc)
+	}
+	go func() { wg.Wait(); close(results) }()
+
+	// All health checks must pass (each uses any internally)
+	for result := range results {
+		if !result {
+			return false
+		}
+	}
+	return true
+}
+
+// getConfig returns the health check config, using defaults if not configurable.
+func getConfig(hc redis.MultiDBHealthCheck) HealthCheckConfig {
+	if chc, ok := hc.(ConfigurableHealthCheck); ok {
+		return chc.Config()
+	}
+	return DefaultHealthCheckConfig()
+}
+
+// runProbesAllMustPass runs probes where ALL must succeed.
+func runProbesAllMustPass(ctx context.Context, hc redis.MultiDBHealthCheck, probeFn func(context.Context, redis.MultiDBHealthCheck) bool) bool {
+	cfg := getConfig(hc)
+	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+
+	for i := 0; i < cfg.Probes; i++ {
+		if !probeFn(ctx, hc) {
+			return false
+		}
+		if i < cfg.Probes-1 && cfg.Delay > 0 {
+			select {
+			case <-ctx.Done():
+				return false
+			case <-time.After(cfg.Delay):
+			}
+		}
+	}
+	return true
+}
+
+// runProbesMajority runs probes where MAJORITY must succeed.
+func runProbesMajority(ctx context.Context, hc redis.MultiDBHealthCheck, probeFn func(context.Context, redis.MultiDBHealthCheck) bool) bool {
+	cfg := getConfig(hc)
+	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+
+	// Strict majority: more than half must pass
+	// (probes - 1) // 2 gives the max allowed failures
+	allowedFailures := (cfg.Probes - 1) / 2
+	failures := 0
+
+	for i := 0; i < cfg.Probes; i++ {
+		if !probeFn(ctx, hc) {
+			failures++
+			if failures > allowedFailures {
+				return false
+			}
+		}
+		if i < cfg.Probes-1 && cfg.Delay > 0 {
+			select {
+			case <-ctx.Done():
+				return false
+			case <-time.After(cfg.Delay):
+			}
+		}
+	}
+	return true
+}
+
+// runProbesAny runs probes where ANY success is enough.
+func runProbesAny(ctx context.Context, hc redis.MultiDBHealthCheck, probeFn func(context.Context, redis.MultiDBHealthCheck) bool) bool {
+	cfg := getConfig(hc)
+	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+
+	for i := 0; i < cfg.Probes; i++ {
+		if probeFn(ctx, hc) {
+			return true
+		}
+		if i < cfg.Probes-1 && cfg.Delay > 0 {
+			select {
+			case <-ctx.Done():
+				return false
+			case <-time.After(cfg.Delay):
+			}
+		}
+	}
+	return false
+}

--- a/multidb/healthcheck.go
+++ b/multidb/healthcheck.go
@@ -118,7 +118,7 @@ func runChecks(ctx context.Context, checks []redis.MultiDBHealthCheck, probe pro
 		wg.Add(1)
 		go func(check redis.MultiDBHealthCheck) {
 			defer wg.Done()
-			results <- runner(ctx, check, probe)
+			results <- safeRunner(ctx, check, probe, runner)
 		}(hc)
 	}
 	go func() { wg.Wait(); close(results) }()
@@ -130,6 +130,19 @@ func runChecks(ctx context.Context, checks []redis.MultiDBHealthCheck, probe pro
 		}
 	}
 	return true
+}
+
+// safeRunner invokes runner and recovers from any panic, reporting the check
+// as unhealthy in that case. This guarantees every worker in runChecks sends
+// exactly one result: a panicking runner must not be silently dropped, which
+// would let the consumer return true after fewer than len(checks) results.
+func safeRunner(ctx context.Context, hc redis.MultiDBHealthCheck, probe probeFunc, runner checkRunner) (ok bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			ok = false
+		}
+	}()
+	return runner(ctx, hc, probe)
 }
 
 func standaloneProbe(client *redis.Client) probeFunc {

--- a/multidb/healthcheck.go
+++ b/multidb/healthcheck.go
@@ -275,10 +275,19 @@ func runProbesMajority(ctx context.Context, hc redis.MultiDBHealthCheck, probeFn
 	// Strict majority: more than half must pass
 	// (probes - 1) // 2 gives the max allowed failures
 	allowedFailures := (cfg.Probes - 1) / 2
+	// requiredSuccesses is the number of successful probes that guarantees a
+	// strict majority, allowing an early exit once it is reached.
+	requiredSuccesses := cfg.Probes - allowedFailures
 	failures := 0
+	successes := 0
 
 	for i := 0; i < cfg.Probes; i++ {
-		if !probeFn(ctx, hc) {
+		if probeFn(ctx, hc) {
+			successes++
+			if successes >= requiredSuccesses {
+				return true
+			}
+		} else {
 			failures++
 			if failures > allowedFailures {
 				return false

--- a/multidb/healthcheck_lag_aware.go
+++ b/multidb/healthcheck_lag_aware.go
@@ -323,7 +323,7 @@ func (h *LagAwareHealthCheck) getBDBs(ctx context.Context, url string) ([]bdbInf
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("REST API returned status %d", resp.StatusCode)
+		return nil, fmt.Errorf("multidb: REST API returned status %d", resp.StatusCode)
 	}
 	var bdbs []bdbInfo
 	if err := json.NewDecoder(resp.Body).Decode(&bdbs); err != nil {

--- a/multidb/healthcheck_lag_aware.go
+++ b/multidb/healthcheck_lag_aware.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -224,42 +225,47 @@ func hostFromAddr(addr string) (string, bool) {
 	return addr, true
 }
 
-// CheckHealth performs a single REST API health check probe.
-func (h *LagAwareHealthCheck) CheckHealth(ctx context.Context, client *redis.Client) bool {
+// CheckHealth performs a single REST API health check probe. It returns
+// (false, err) with the error that made the database unhealthy (config error,
+// an unusable address, or a REST API failure) so callers can record it.
+func (h *LagAwareHealthCheck) CheckHealth(ctx context.Context, client *redis.Client) (bool, error) {
 	if h.configErr != nil {
-		return false
+		return false, h.configErr
 	}
 	host, ok := hostFromAddr(client.Options().Addr)
 	if !ok {
-		return false
+		return false, fmt.Errorf("multidb: cannot derive REST API host from address %q", client.Options().Addr)
 	}
 	return h.checkLagHealth(ctx, host)
 }
 
 // CheckClusterHealth performs a single REST API health check probe.
-func (h *LagAwareHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) bool {
+func (h *LagAwareHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) (bool, error) {
 	if h.configErr != nil {
-		return false
+		return false, h.configErr
 	}
 	opts := client.Options()
 	if len(opts.Addrs) == 0 {
-		return false
+		return false, fmt.Errorf("multidb: cluster client has no addresses")
 	}
 	host, ok := hostFromAddr(opts.Addrs[0])
 	if !ok {
-		return false
+		return false, fmt.Errorf("multidb: cannot derive REST API host from address %q", opts.Addrs[0])
 	}
 	return h.checkLagHealth(ctx, host)
 }
 
-func (h *LagAwareHealthCheck) checkLagHealth(ctx context.Context, dbHost string) bool {
+func (h *LagAwareHealthCheck) checkLagHealth(ctx context.Context, dbHost string) (bool, error) {
 	baseURL := strings.TrimRight(h.baseURL, "/")
 	if baseURL == "" {
-		baseURL = fmt.Sprintf("https://%s:%d", dbHost, h.restAPIPort)
+		// net.JoinHostPort brackets IPv6 literals so the URL is valid
+		// (e.g. https://[::1]:9443 rather than https://::1:9443).
+		hostPort := net.JoinHostPort(dbHost, strconv.Itoa(h.restAPIPort))
+		baseURL = fmt.Sprintf("https://%s", hostPort)
 	}
 	bdbs, err := h.getBDBs(ctx, fmt.Sprintf("%s/v1/bdbs", baseURL))
 	if err != nil {
-		return false
+		return false, err
 	}
 	var uid int
 	found := false
@@ -271,23 +277,26 @@ func (h *LagAwareHealthCheck) checkLagHealth(ctx context.Context, dbHost string)
 		}
 	}
 	if !found {
-		return false
+		return false, fmt.Errorf("multidb: no matching bdb found for host %q", dbHost)
 	}
 	url := fmt.Sprintf("%s/v1/bdbs/%d/availability?extend_check=lag&availability_lag_tolerance_ms=%d",
 		baseURL, uid, h.lagTolerance)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return false
+		return false, err
 	}
 	if h.username != "" && h.password != "" {
 		req.SetBasicAuth(h.username, h.password)
 	}
 	resp, err := h.httpClient.Do(req)
 	if err != nil {
-		return false
+		return false, err
 	}
 	defer resp.Body.Close()
-	return resp.StatusCode >= 200 && resp.StatusCode < 300
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return false, fmt.Errorf("multidb: availability check returned status %d", resp.StatusCode)
+	}
+	return true, nil
 }
 
 type bdbInfo struct {

--- a/multidb/healthcheck_lag_aware.go
+++ b/multidb/healthcheck_lag_aware.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -32,6 +33,10 @@ type LagAwareHealthCheck struct {
 	username     string
 	password     string
 	tlsConfig    *tls.Config
+	// configErr records the first error encountered while applying options
+	// (e.g. an invalid PEM or unreadable cert file). When set, health checks
+	// fail fast rather than silently running with an incomplete TLS config.
+	configErr error
 }
 
 // HTTPClient is an interface for making HTTP requests.
@@ -41,6 +46,16 @@ type HTTPClient interface {
 
 // LagAwareHealthCheckOption is a functional option for LagAwareHealthCheck.
 type LagAwareHealthCheckOption func(*LagAwareHealthCheck)
+
+// WithLagAwareHealthCheckConfig applies generic HealthCheckOption values
+// (e.g. WithProbes, WithDelay, WithTimeout) to a LagAwareHealthCheck.
+func WithLagAwareHealthCheckConfig(opts ...HealthCheckOption) LagAwareHealthCheckOption {
+	return func(h *LagAwareHealthCheck) {
+		for _, opt := range opts {
+			opt(&h.config)
+		}
+	}
+}
 
 // WithLagAwareBaseURL sets the base URL for the REST API.
 func WithLagAwareBaseURL(baseURL string) LagAwareHealthCheckOption {
@@ -83,6 +98,8 @@ func WithLagAwareInsecureSkipVerify() LagAwareHealthCheckOption {
 }
 
 // WithLagAwareRootCAs sets the root CA certificates for TLS verification.
+// If the PEM data cannot be parsed, the error is recorded and subsequent
+// health checks fail rather than silently running without the CAs.
 func WithLagAwareRootCAs(certPEM []byte) LagAwareHealthCheckOption {
 	return func(h *LagAwareHealthCheck) {
 		if h.tlsConfig == nil {
@@ -91,15 +108,20 @@ func WithLagAwareRootCAs(certPEM []byte) LagAwareHealthCheckOption {
 		if h.tlsConfig.RootCAs == nil {
 			h.tlsConfig.RootCAs = x509.NewCertPool()
 		}
-		h.tlsConfig.RootCAs.AppendCertsFromPEM(certPEM)
+		if !h.tlsConfig.RootCAs.AppendCertsFromPEM(certPEM) {
+			h.setConfigErr(fmt.Errorf("multidb: failed to parse root CA PEM"))
+		}
 	}
 }
 
 // WithLagAwareRootCAsFromFile loads root CA certificates from a PEM file.
+// If the file cannot be read or parsed, the error is recorded and subsequent
+// health checks fail rather than silently running without the CAs.
 func WithLagAwareRootCAsFromFile(caFile string) LagAwareHealthCheckOption {
 	return func(h *LagAwareHealthCheck) {
 		certPEM, err := os.ReadFile(caFile)
 		if err != nil {
+			h.setConfigErr(fmt.Errorf("multidb: failed to read root CA file %q: %w", caFile, err))
 			return
 		}
 		if h.tlsConfig == nil {
@@ -108,15 +130,20 @@ func WithLagAwareRootCAsFromFile(caFile string) LagAwareHealthCheckOption {
 		if h.tlsConfig.RootCAs == nil {
 			h.tlsConfig.RootCAs = x509.NewCertPool()
 		}
-		h.tlsConfig.RootCAs.AppendCertsFromPEM(certPEM)
+		if !h.tlsConfig.RootCAs.AppendCertsFromPEM(certPEM) {
+			h.setConfigErr(fmt.Errorf("multidb: failed to parse root CA PEM from file %q", caFile))
+		}
 	}
 }
 
 // WithLagAwareClientCert sets the client certificate for mutual TLS (mTLS).
+// If the key pair cannot be loaded, the error is recorded and subsequent
+// health checks fail rather than silently disabling mTLS.
 func WithLagAwareClientCert(certPEM, keyPEM []byte) LagAwareHealthCheckOption {
 	return func(h *LagAwareHealthCheck) {
 		cert, err := tls.X509KeyPair(certPEM, keyPEM)
 		if err != nil {
+			h.setConfigErr(fmt.Errorf("multidb: failed to load client certificate: %w", err))
 			return
 		}
 		if h.tlsConfig == nil {
@@ -127,10 +154,13 @@ func WithLagAwareClientCert(certPEM, keyPEM []byte) LagAwareHealthCheckOption {
 }
 
 // WithLagAwareClientCertFromFiles loads client cert and key from files.
+// If the key pair cannot be loaded, the error is recorded and subsequent
+// health checks fail rather than silently disabling mTLS.
 func WithLagAwareClientCertFromFiles(certFile, keyFile string) LagAwareHealthCheckOption {
 	return func(h *LagAwareHealthCheck) {
 		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 		if err != nil {
+			h.setConfigErr(fmt.Errorf("multidb: failed to load client certificate from files: %w", err))
 			return
 		}
 		if h.tlsConfig == nil {
@@ -140,23 +170,33 @@ func WithLagAwareClientCertFromFiles(certFile, keyFile string) LagAwareHealthChe
 	}
 }
 
+// setConfigErr records the first configuration error encountered.
+func (h *LagAwareHealthCheck) setConfigErr(err error) {
+	if h.configErr == nil {
+		h.configErr = err
+	}
+}
+
 // NewLagAwareHealthCheck creates a new LagAwareHealthCheck.
-func NewLagAwareHealthCheck(opts ...interface{}) *LagAwareHealthCheck {
+//
+// Generic health check settings (probes, delay, timeout) can be supplied via
+// WithLagAwareHealthCheckConfig.
+func NewLagAwareHealthCheck(opts ...LagAwareHealthCheckOption) *LagAwareHealthCheck {
 	h := &LagAwareHealthCheck{
 		config:       DefaultHealthCheckConfig(),
 		restAPIPort:  DefaultRESTAPIPort,
 		lagTolerance: DefaultLagTolerance,
 	}
 	for _, opt := range opts {
-		switch o := opt.(type) {
-		case LagAwareHealthCheckOption:
-			o(h)
-		case HealthCheckOption:
-			o(&h.config)
-		}
+		opt(h)
 	}
 	if h.httpClient == nil {
-		transport := &http.Transport{}
+		transport, ok := http.DefaultTransport.(*http.Transport)
+		if ok {
+			transport = transport.Clone()
+		} else {
+			transport = &http.Transport{}
+		}
 		if h.tlsConfig != nil {
 			transport.TLSClientConfig = h.tlsConfig
 		}
@@ -167,30 +207,53 @@ func NewLagAwareHealthCheck(opts ...interface{}) *LagAwareHealthCheck {
 
 func (h *LagAwareHealthCheck) Config() HealthCheckConfig { return h.config }
 
+// hostFromAddr extracts the host from a Redis address, stripping the port and
+// any IPv6 brackets. It reports false for unix-socket addresses, which cannot
+// be used to derive an HTTPS REST API base URL.
+func hostFromAddr(addr string) (string, bool) {
+	if addr == "" {
+		return "", false
+	}
+	if strings.HasPrefix(addr, "/") || strings.HasPrefix(addr, "unix://") {
+		return "", false
+	}
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host, true
+	}
+	// No port present; treat the whole value as the host.
+	return addr, true
+}
+
 // CheckHealth performs a single REST API health check probe.
 func (h *LagAwareHealthCheck) CheckHealth(ctx context.Context, client *redis.Client) bool {
-	host := client.Options().Addr
-	if idx := strings.LastIndex(host, ":"); idx > 0 {
-		host = host[:idx]
+	if h.configErr != nil {
+		return false
+	}
+	host, ok := hostFromAddr(client.Options().Addr)
+	if !ok {
+		return false
 	}
 	return h.checkLagHealth(ctx, host)
 }
 
 // CheckClusterHealth performs a single REST API health check probe.
 func (h *LagAwareHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) bool {
+	if h.configErr != nil {
+		return false
+	}
 	opts := client.Options()
 	if len(opts.Addrs) == 0 {
 		return false
 	}
-	host := opts.Addrs[0]
-	if idx := strings.LastIndex(host, ":"); idx > 0 {
-		host = host[:idx]
+	host, ok := hostFromAddr(opts.Addrs[0])
+	if !ok {
+		return false
 	}
 	return h.checkLagHealth(ctx, host)
 }
 
 func (h *LagAwareHealthCheck) checkLagHealth(ctx context.Context, dbHost string) bool {
-	baseURL := h.baseURL
+	baseURL := strings.TrimRight(h.baseURL, "/")
 	if baseURL == "" {
 		baseURL = fmt.Sprintf("https://%s:%d", dbHost, h.restAPIPort)
 	}

--- a/multidb/healthcheck_lag_aware.go
+++ b/multidb/healthcheck_lag_aware.go
@@ -199,9 +199,18 @@ func NewLagAwareHealthCheck(opts ...LagAwareHealthCheckOption) *LagAwareHealthCh
 			transport = &http.Transport{}
 		}
 		if h.tlsConfig != nil {
-			transport.TLSClientConfig = h.tlsConfig
+			// Clone so a caller-supplied tls.Config that is shared or later
+			// mutated cannot race with the transport's use of it.
+			transport.TLSClientConfig = h.tlsConfig.Clone()
 		}
-		h.httpClient = &http.Client{Timeout: DefaultHTTPTimeout, Transport: transport}
+		// Honor a configured probe timeout larger than the default so REST
+		// calls are not capped below the probe budget; the request context
+		// still bounds each individual call.
+		httpTimeout := DefaultHTTPTimeout
+		if h.config.Timeout > httpTimeout {
+			httpTimeout = h.config.Timeout
+		}
+		h.httpClient = &http.Client{Timeout: httpTimeout, Transport: transport}
 	}
 	return h
 }

--- a/multidb/healthcheck_lag_aware.go
+++ b/multidb/healthcheck_lag_aware.go
@@ -231,7 +231,12 @@ func hostFromAddr(addr string) (string, bool) {
 	if host, _, err := net.SplitHostPort(addr); err == nil {
 		return host, true
 	}
-	// No port present; treat the whole value as the host.
+	// No port present; treat the whole value as the host. Strip any surrounding
+	// IPv6 brackets (e.g. "[::1]") so callers can re-bracket the host via
+	// net.JoinHostPort without producing a doubly-bracketed "[[::1]]:9443".
+	if strings.HasPrefix(addr, "[") && strings.HasSuffix(addr, "]") {
+		addr = addr[1 : len(addr)-1]
+	}
 	return addr, true
 }
 

--- a/multidb/healthcheck_lag_aware.go
+++ b/multidb/healthcheck_lag_aware.go
@@ -314,7 +314,7 @@ func (h *LagAwareHealthCheck) getBDBs(ctx context.Context, url string) ([]bdbInf
 	if err != nil {
 		return nil, err
 	}
-	if h.username != "" && h.password != "" {
+	if h.username != "" {
 		req.SetBasicAuth(h.username, h.password)
 	}
 	resp, err := h.httpClient.Do(req)

--- a/multidb/healthcheck_lag_aware.go
+++ b/multidb/healthcheck_lag_aware.go
@@ -285,7 +285,7 @@ func (h *LagAwareHealthCheck) checkLagHealth(ctx context.Context, dbHost string)
 	if err != nil {
 		return false, err
 	}
-	if h.username != "" && h.password != "" {
+	if h.username != "" {
 		req.SetBasicAuth(h.username, h.password)
 	}
 	resp, err := h.httpClient.Do(req)

--- a/multidb/healthcheck_lag_aware.go
+++ b/multidb/healthcheck_lag_aware.go
@@ -1,0 +1,275 @@
+package multidb
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Default values for LagAwareHealthCheck
+const (
+	DefaultRESTAPIPort  = 9443
+	DefaultLagTolerance = 5000 // milliseconds
+	DefaultHTTPTimeout  = 10 * time.Second
+)
+
+// LagAwareHealthCheck checks database health via Redis Enterprise REST API.
+// It verifies that the database is healthy based on replication lag tolerance.
+type LagAwareHealthCheck struct {
+	config       HealthCheckConfig
+	baseURL      string
+	restAPIPort  int
+	lagTolerance int
+	httpClient   HTTPClient
+	username     string
+	password     string
+	tlsConfig    *tls.Config
+}
+
+// HTTPClient is an interface for making HTTP requests.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// LagAwareHealthCheckOption is a functional option for LagAwareHealthCheck.
+type LagAwareHealthCheckOption func(*LagAwareHealthCheck)
+
+// WithLagAwareBaseURL sets the base URL for the REST API.
+func WithLagAwareBaseURL(baseURL string) LagAwareHealthCheckOption {
+	return func(h *LagAwareHealthCheck) { h.baseURL = baseURL }
+}
+
+// WithLagAwareRESTAPIPort sets the REST API port (default: 9443).
+func WithLagAwareRESTAPIPort(port int) LagAwareHealthCheckOption {
+	return func(h *LagAwareHealthCheck) { h.restAPIPort = port }
+}
+
+// WithLagAwareTolerance sets the lag tolerance in milliseconds (default: 5000).
+func WithLagAwareTolerance(toleranceMS int) LagAwareHealthCheckOption {
+	return func(h *LagAwareHealthCheck) { h.lagTolerance = toleranceMS }
+}
+
+// WithLagAwareHTTPClient sets a custom HTTP client.
+func WithLagAwareHTTPClient(client HTTPClient) LagAwareHealthCheckOption {
+	return func(h *LagAwareHealthCheck) { h.httpClient = client }
+}
+
+// WithLagAwareBasicAuth sets basic authentication credentials.
+func WithLagAwareBasicAuth(username, password string) LagAwareHealthCheckOption {
+	return func(h *LagAwareHealthCheck) { h.username = username; h.password = password }
+}
+
+// WithLagAwareTLSConfig sets a custom TLS configuration.
+func WithLagAwareTLSConfig(cfg *tls.Config) LagAwareHealthCheckOption {
+	return func(h *LagAwareHealthCheck) { h.tlsConfig = cfg }
+}
+
+// WithLagAwareInsecureSkipVerify disables TLS certificate verification.
+func WithLagAwareInsecureSkipVerify() LagAwareHealthCheckOption {
+	return func(h *LagAwareHealthCheck) {
+		if h.tlsConfig == nil {
+			h.tlsConfig = &tls.Config{}
+		}
+		h.tlsConfig.InsecureSkipVerify = true
+	}
+}
+
+// WithLagAwareRootCAs sets the root CA certificates for TLS verification.
+func WithLagAwareRootCAs(certPEM []byte) LagAwareHealthCheckOption {
+	return func(h *LagAwareHealthCheck) {
+		if h.tlsConfig == nil {
+			h.tlsConfig = &tls.Config{}
+		}
+		if h.tlsConfig.RootCAs == nil {
+			h.tlsConfig.RootCAs = x509.NewCertPool()
+		}
+		h.tlsConfig.RootCAs.AppendCertsFromPEM(certPEM)
+	}
+}
+
+// WithLagAwareRootCAsFromFile loads root CA certificates from a PEM file.
+func WithLagAwareRootCAsFromFile(caFile string) LagAwareHealthCheckOption {
+	return func(h *LagAwareHealthCheck) {
+		certPEM, err := os.ReadFile(caFile)
+		if err != nil {
+			return
+		}
+		if h.tlsConfig == nil {
+			h.tlsConfig = &tls.Config{}
+		}
+		if h.tlsConfig.RootCAs == nil {
+			h.tlsConfig.RootCAs = x509.NewCertPool()
+		}
+		h.tlsConfig.RootCAs.AppendCertsFromPEM(certPEM)
+	}
+}
+
+// WithLagAwareClientCert sets the client certificate for mutual TLS (mTLS).
+func WithLagAwareClientCert(certPEM, keyPEM []byte) LagAwareHealthCheckOption {
+	return func(h *LagAwareHealthCheck) {
+		cert, err := tls.X509KeyPair(certPEM, keyPEM)
+		if err != nil {
+			return
+		}
+		if h.tlsConfig == nil {
+			h.tlsConfig = &tls.Config{}
+		}
+		h.tlsConfig.Certificates = append(h.tlsConfig.Certificates, cert)
+	}
+}
+
+// WithLagAwareClientCertFromFiles loads client cert and key from files.
+func WithLagAwareClientCertFromFiles(certFile, keyFile string) LagAwareHealthCheckOption {
+	return func(h *LagAwareHealthCheck) {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return
+		}
+		if h.tlsConfig == nil {
+			h.tlsConfig = &tls.Config{}
+		}
+		h.tlsConfig.Certificates = append(h.tlsConfig.Certificates, cert)
+	}
+}
+
+// NewLagAwareHealthCheck creates a new LagAwareHealthCheck.
+func NewLagAwareHealthCheck(opts ...interface{}) *LagAwareHealthCheck {
+	h := &LagAwareHealthCheck{
+		config:       DefaultHealthCheckConfig(),
+		restAPIPort:  DefaultRESTAPIPort,
+		lagTolerance: DefaultLagTolerance,
+	}
+	for _, opt := range opts {
+		switch o := opt.(type) {
+		case LagAwareHealthCheckOption:
+			o(h)
+		case HealthCheckOption:
+			o(&h.config)
+		}
+	}
+	if h.httpClient == nil {
+		transport := &http.Transport{}
+		if h.tlsConfig != nil {
+			transport.TLSClientConfig = h.tlsConfig
+		}
+		h.httpClient = &http.Client{Timeout: DefaultHTTPTimeout, Transport: transport}
+	}
+	return h
+}
+
+func (h *LagAwareHealthCheck) Config() HealthCheckConfig { return h.config }
+
+// CheckHealth performs a single REST API health check probe.
+func (h *LagAwareHealthCheck) CheckHealth(ctx context.Context, client *redis.Client) bool {
+	host := client.Options().Addr
+	if idx := strings.LastIndex(host, ":"); idx > 0 {
+		host = host[:idx]
+	}
+	return h.checkLagHealth(ctx, host)
+}
+
+// CheckClusterHealth performs a single REST API health check probe.
+func (h *LagAwareHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) bool {
+	opts := client.Options()
+	if len(opts.Addrs) == 0 {
+		return false
+	}
+	host := opts.Addrs[0]
+	if idx := strings.LastIndex(host, ":"); idx > 0 {
+		host = host[:idx]
+	}
+	return h.checkLagHealth(ctx, host)
+}
+
+func (h *LagAwareHealthCheck) checkLagHealth(ctx context.Context, dbHost string) bool {
+	baseURL := h.baseURL
+	if baseURL == "" {
+		baseURL = fmt.Sprintf("https://%s:%d", dbHost, h.restAPIPort)
+	}
+	bdbs, err := h.getBDBs(ctx, fmt.Sprintf("%s/v1/bdbs", baseURL))
+	if err != nil {
+		return false
+	}
+	var uid int
+	found := false
+	for _, bdb := range bdbs {
+		if h.bdbMatchesHost(bdb, dbHost) {
+			uid = bdb.UID
+			found = true
+			break
+		}
+	}
+	if !found {
+		return false
+	}
+	url := fmt.Sprintf("%s/v1/bdbs/%d/availability?extend_check=lag&availability_lag_tolerance_ms=%d",
+		baseURL, uid, h.lagTolerance)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false
+	}
+	if h.username != "" && h.password != "" {
+		req.SetBasicAuth(h.username, h.password)
+	}
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 300
+}
+
+type bdbInfo struct {
+	UID       int           `json:"uid"`
+	Endpoints []bdbEndpoint `json:"endpoints"`
+}
+
+type bdbEndpoint struct {
+	DNSName string   `json:"dns_name"`
+	Addr    []string `json:"addr"`
+}
+
+func (h *LagAwareHealthCheck) getBDBs(ctx context.Context, url string) ([]bdbInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if h.username != "" && h.password != "" {
+		req.SetBasicAuth(h.username, h.password)
+	}
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("REST API returned status %d", resp.StatusCode)
+	}
+	var bdbs []bdbInfo
+	if err := json.NewDecoder(resp.Body).Decode(&bdbs); err != nil {
+		return nil, err
+	}
+	return bdbs, nil
+}
+
+func (h *LagAwareHealthCheck) bdbMatchesHost(bdb bdbInfo, host string) bool {
+	for _, ep := range bdb.Endpoints {
+		if ep.DNSName == host {
+			return true
+		}
+		for _, addr := range ep.Addr {
+			if addr == host {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/multidb/healthcheck_lag_aware.go
+++ b/multidb/healthcheck_lag_aware.go
@@ -83,9 +83,10 @@ func WithLagAwareBasicAuth(username, password string) LagAwareHealthCheckOption 
 	return func(h *LagAwareHealthCheck) { h.username = username; h.password = password }
 }
 
-// WithLagAwareTLSConfig sets a custom TLS configuration.
+// WithLagAwareTLSConfig sets a custom TLS configuration. The config is cloned so
+// later options (and the health check itself) never mutate the caller's value.
 func WithLagAwareTLSConfig(cfg *tls.Config) LagAwareHealthCheckOption {
-	return func(h *LagAwareHealthCheck) { h.tlsConfig = cfg }
+	return func(h *LagAwareHealthCheck) { h.tlsConfig = cfg.Clone() }
 }
 
 // WithLagAwareInsecureSkipVerify disables TLS certificate verification.

--- a/multidb/healthcheck_ping.go
+++ b/multidb/healthcheck_ping.go
@@ -36,15 +36,25 @@ func (h *PingHealthCheck) Config() HealthCheckConfig {
 	return h.config
 }
 
-// CheckHealth performs a single PING probe against the client.
-func (h *PingHealthCheck) CheckHealth(ctx context.Context, client *redis.Client) bool {
-	return client.Ping(ctx).Err() == nil
+// CheckHealth performs a single PING probe against the client. It returns
+// (false, err) with the PING error when the probe fails so callers can record
+// why the check was unhealthy.
+func (h *PingHealthCheck) CheckHealth(ctx context.Context, client *redis.Client) (bool, error) {
+	if err := client.Ping(ctx).Err(); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
-// CheckClusterHealth performs a single PING probe against ALL nodes in the cluster.
-func (h *PingHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) bool {
+// CheckClusterHealth performs a single PING probe against ALL nodes in the
+// cluster. It returns (false, err) with the first shard's PING error when the
+// probe fails.
+func (h *PingHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) (bool, error) {
 	err := client.ForEachShard(ctx, func(ctx context.Context, shard *redis.Client) error {
 		return shard.Ping(ctx).Err()
 	})
-	return err == nil
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/multidb/healthcheck_ping.go
+++ b/multidb/healthcheck_ping.go
@@ -2,6 +2,8 @@ package multidb
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -48,13 +50,20 @@ func (h *PingHealthCheck) CheckHealth(ctx context.Context, client *redis.Client)
 
 // CheckClusterHealth performs a single PING probe against ALL nodes in the
 // cluster. It returns (false, err) with the first shard's PING error when the
-// probe fails.
+// probe fails. An empty topology (no shards pinged) is reported as unhealthy
+// rather than trivially healthy, matching LagAwareHealthCheck which fails when
+// the cluster has no addresses.
 func (h *PingHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) (bool, error) {
+	var pinged int64
 	err := client.ForEachShard(ctx, func(ctx context.Context, shard *redis.Client) error {
+		atomic.AddInt64(&pinged, 1)
 		return shard.Ping(ctx).Err()
 	})
 	if err != nil {
 		return false, err
+	}
+	if atomic.LoadInt64(&pinged) == 0 {
+		return false, fmt.Errorf("multidb: cluster has no shards to ping")
 	}
 	return true, nil
 }

--- a/multidb/healthcheck_ping.go
+++ b/multidb/healthcheck_ping.go
@@ -1,0 +1,50 @@
+package multidb
+
+import (
+	"context"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// PingHealthCheck checks health using the PING command.
+// Each call to CheckHealth/CheckClusterHealth performs a SINGLE ping probe.
+// The number of probes and how they're interpreted is controlled by the
+// HealthCheckPolicy and the config (Probes, Delay, Timeout).
+type PingHealthCheck struct {
+	config HealthCheckConfig
+}
+
+// NewPingHealthCheck creates a new PingHealthCheck with optional configuration.
+//
+// Example:
+//
+//	hc := multidb.NewPingHealthCheck()
+//
+//	hc := multidb.NewPingHealthCheck(
+//	    multidb.WithProbes(5),
+//	    multidb.WithDelay(100*time.Millisecond),
+//	    multidb.WithTimeout(5*time.Second),
+//	)
+func NewPingHealthCheck(opts ...HealthCheckOption) *PingHealthCheck {
+	return &PingHealthCheck{
+		config: applyOptions(opts),
+	}
+}
+
+// Config returns the health check configuration.
+func (h *PingHealthCheck) Config() HealthCheckConfig {
+	return h.config
+}
+
+// CheckHealth performs a single PING probe against the client.
+func (h *PingHealthCheck) CheckHealth(ctx context.Context, client *redis.Client) bool {
+	return client.Ping(ctx).Err() == nil
+}
+
+// CheckClusterHealth performs a single PING probe against ALL nodes in the cluster.
+func (h *PingHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) bool {
+	err := client.ForEachShard(ctx, func(ctx context.Context, shard *redis.Client) error {
+		return shard.Ping(ctx).Err()
+	})
+	return err == nil
+}

--- a/multidb/healthcheck_test.go
+++ b/multidb/healthcheck_test.go
@@ -228,7 +228,7 @@ func TestLagAwareConfigErrorFailsHealthCheck(t *testing.T) {
 	}
 }
 
-func TestLagAwareTLSConfigIsCloned(t *testing.T) {
+func TestLagAwareTLSConfigOptionIsCloned(t *testing.T) {
 	caller := &tls.Config{}
 	hc := NewLagAwareHealthCheck(
 		WithLagAwareTLSConfig(caller),

--- a/multidb/healthcheck_test.go
+++ b/multidb/healthcheck_test.go
@@ -2,6 +2,7 @@ package multidb
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 	"net/url"
 	"testing"
@@ -547,4 +548,78 @@ func TestHealthCheckConfig(t *testing.T) {
 			t.Errorf("expected Timeout=5s, got %v", hc.Config().Timeout)
 		}
 	})
+}
+
+// panicHealthCheck panics on every probe, simulating a buggy check.
+type panicHealthCheck struct{}
+
+func (panicHealthCheck) CheckHealth(context.Context, *redis.Client) (bool, error) {
+	panic("panicHealthCheck: boom")
+}
+func (panicHealthCheck) CheckClusterHealth(context.Context, *redis.ClusterClient) (bool, error) {
+	panic("panicHealthCheck: boom")
+}
+
+func TestRunChecksRecoversFromPanic(t *testing.T) {
+	// A panicking check must be treated as unhealthy rather than dropping its
+	// result: otherwise the consumer could return true after fewer than
+	// len(checks) results.
+	client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	defer client.Close()
+
+	checks := []redis.MultiDBHealthCheck{
+		newSequenceHealthCheck([]bool{true, true, true}),
+		panicHealthCheck{},
+	}
+	if NewHealthyAllPolicy().Execute(context.Background(), checks, client) {
+		t.Error("expected a panicking health check to make the policy report unhealthy")
+	}
+}
+
+func TestLagAwareHTTPClientTimeout(t *testing.T) {
+	t.Run("defaults to DefaultHTTPTimeout", func(t *testing.T) {
+		hc := NewLagAwareHealthCheck()
+		client, ok := hc.httpClient.(*http.Client)
+		if !ok {
+			t.Fatalf("expected default *http.Client, got %T", hc.httpClient)
+		}
+		if client.Timeout != DefaultHTTPTimeout {
+			t.Errorf("http client timeout = %v, want %v", client.Timeout, DefaultHTTPTimeout)
+		}
+	})
+
+	t.Run("honors a larger probe timeout", func(t *testing.T) {
+		hc := NewLagAwareHealthCheck(
+			WithLagAwareHealthCheckConfig(WithTimeout(30 * time.Second)),
+		)
+		client, ok := hc.httpClient.(*http.Client)
+		if !ok {
+			t.Fatalf("expected default *http.Client, got %T", hc.httpClient)
+		}
+		if client.Timeout < 30*time.Second {
+			t.Errorf("http client timeout = %v, want >= 30s", client.Timeout)
+		}
+	})
+}
+
+func TestLagAwareTLSConfigIsCloned(t *testing.T) {
+	// The transport must use a clone of the supplied tls.Config so a later
+	// mutation by the caller cannot race the transport's use of it.
+	cfg := &tls.Config{InsecureSkipVerify: true}
+	hc := NewLagAwareHealthCheck(WithLagAwareTLSConfig(cfg))
+
+	client, ok := hc.httpClient.(*http.Client)
+	if !ok {
+		t.Fatalf("expected default *http.Client, got %T", hc.httpClient)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+	if transport.TLSClientConfig == cfg {
+		t.Error("expected transport TLS config to be a clone, not the same pointer")
+	}
+	if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Error("expected cloned TLS config to preserve InsecureSkipVerify")
+	}
 }

--- a/multidb/healthcheck_test.go
+++ b/multidb/healthcheck_test.go
@@ -197,6 +197,8 @@ func TestLagAwareHostFromAddr(t *testing.T) {
 		{"[::1]:6379", "::1", true},
 		{"[2001:db8::1]:6379", "2001:db8::1", true},
 		{"localhost", "localhost", true},
+		{"[::1]", "::1", true},
+		{"[2001:db8::1]", "2001:db8::1", true},
 		{"", "", false},
 		{"/tmp/redis.sock", "", false},
 		{"unix:///tmp/redis.sock", "", false},

--- a/multidb/healthcheck_test.go
+++ b/multidb/healthcheck_test.go
@@ -1,0 +1,351 @@
+package multidb
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+func TestPingHealthCheck(t *testing.T) {
+	t.Run("CheckHealth returns true for healthy client", func(t *testing.T) {
+		client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+		defer client.Close()
+
+		hc := NewPingHealthCheck()
+		ctx := context.Background()
+
+		// This test requires a running Redis server
+		// If no server, we just verify the check doesn't panic
+		_ = hc.CheckHealth(ctx, client)
+	})
+
+	t.Run("CheckHealth returns false for unreachable client", func(t *testing.T) {
+		client := redis.NewClient(&redis.Options{
+			Addr:        "localhost:59999", // unlikely to be running
+			DialTimeout: 100 * time.Millisecond,
+		})
+		defer client.Close()
+
+		hc := NewPingHealthCheck()
+		ctx := context.Background()
+
+		if hc.CheckHealth(ctx, client) {
+			t.Error("expected CheckHealth to return false for unreachable client")
+		}
+	})
+}
+
+// mockHealthCheck is a test helper that returns a configurable result
+type mockHealthCheck struct {
+	healthy bool
+}
+
+func (m *mockHealthCheck) CheckHealth(ctx context.Context, client *redis.Client) bool {
+	return m.healthy
+}
+
+func (m *mockHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) bool {
+	return m.healthy
+}
+
+// --- LagAwareHealthCheck Tests ---
+
+func TestLagAwareHealthCheck(t *testing.T) {
+	t.Run("NewLagAwareHealthCheck with defaults", func(t *testing.T) {
+		hc := NewLagAwareHealthCheck()
+
+		if hc.restAPIPort != DefaultRESTAPIPort {
+			t.Errorf("expected restAPIPort=%d, got %d", DefaultRESTAPIPort, hc.restAPIPort)
+		}
+		if hc.lagTolerance != DefaultLagTolerance {
+			t.Errorf("expected lagTolerance=%d, got %d", DefaultLagTolerance, hc.lagTolerance)
+		}
+		if hc.httpClient == nil {
+			t.Error("expected httpClient to be set")
+		}
+	})
+
+	t.Run("NewLagAwareHealthCheck with options", func(t *testing.T) {
+		hc := NewLagAwareHealthCheck(
+			WithLagAwareBaseURL("https://example.com"),
+			WithLagAwareRESTAPIPort(8443),
+			WithLagAwareTolerance(1000),
+			WithLagAwareBasicAuth("user", "pass"),
+		)
+
+		if hc.baseURL != "https://example.com" {
+			t.Errorf("expected baseURL=https://example.com, got %s", hc.baseURL)
+		}
+		if hc.restAPIPort != 8443 {
+			t.Errorf("expected restAPIPort=8443, got %d", hc.restAPIPort)
+		}
+		if hc.lagTolerance != 1000 {
+			t.Errorf("expected lagTolerance=1000, got %d", hc.lagTolerance)
+		}
+		if hc.username != "user" || hc.password != "pass" {
+			t.Error("expected basic auth to be set")
+		}
+	})
+
+	t.Run("CheckHealth returns false when REST API is unreachable", func(t *testing.T) {
+		client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+		defer client.Close()
+
+		// Use a mock HTTP client that always fails
+		hc := NewLagAwareHealthCheck(
+			WithLagAwareHTTPClient(&mockHTTPClient{err: context.DeadlineExceeded}),
+		)
+
+		ctx := context.Background()
+		if hc.CheckHealth(ctx, client) {
+			t.Error("expected CheckHealth to return false when REST API is unreachable")
+		}
+	})
+
+	t.Run("bdbMatchesHost matches DNS name", func(t *testing.T) {
+		hc := NewLagAwareHealthCheck()
+		bdb := bdbInfo{
+			UID: 1,
+			Endpoints: []bdbEndpoint{
+				{DNSName: "redis.example.com", Addr: []string{"10.0.0.1"}},
+			},
+		}
+
+		if !hc.bdbMatchesHost(bdb, "redis.example.com") {
+			t.Error("expected bdbMatchesHost to match DNS name")
+		}
+		if !hc.bdbMatchesHost(bdb, "10.0.0.1") {
+			t.Error("expected bdbMatchesHost to match address")
+		}
+		if hc.bdbMatchesHost(bdb, "other.example.com") {
+			t.Error("expected bdbMatchesHost to not match different host")
+		}
+	})
+
+	t.Run("TLS options are applied", func(t *testing.T) {
+		// Test InsecureSkipVerify
+		hc := NewLagAwareHealthCheck(
+			WithLagAwareInsecureSkipVerify(),
+		)
+		if hc.tlsConfig == nil {
+			t.Fatal("expected tlsConfig to be set")
+		}
+		if !hc.tlsConfig.InsecureSkipVerify {
+			t.Error("expected InsecureSkipVerify to be true")
+		}
+
+		// Test RootCAs with PEM data
+		caPEM := []byte(`-----BEGIN CERTIFICATE-----
+MIIBkTCB+wIJAKHBfpegAzYCMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnVu
+dXNlZDAeFw0yMzAxMDEwMDAwMDBaFw0yNDAxMDEwMDAwMDBaMBExDzANBgNVBAMM
+BnVudXNlZDBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC7o96WoVCH9xgnLRkMz8pN
+2FteamOrPwGMKfkMqF+EAlyH3/wMP0luxSK8BOxdBz0SSlmj2PJwqFcF2rXmVykv
+AgMBAAGjUzBRMB0GA1UdDgQWBBQK7ULMHX4ELihB4Bsg+caBRgLsVzAfBgNVHSME
+GDAWgBQK7ULMHX4ELihB4Bsg+caBRgLsVzAPBgNVHRMBAf8EBTADAQH/MA0GCSqG
+SIb3DQEBCwUAA0EA0FH0N5LT0Y6P6iKv9eDLqE8n6kWUKFq3V6sNqJBUzBuV5IpM
+H8PD6BY8JK7P5K8K0K8K0K8K0K8K0K8K0K8K0A==
+-----END CERTIFICATE-----`)
+		hc2 := NewLagAwareHealthCheck(
+			WithLagAwareRootCAs(caPEM),
+		)
+		if hc2.tlsConfig == nil {
+			t.Fatal("expected tlsConfig to be set")
+		}
+		if hc2.tlsConfig.RootCAs == nil {
+			t.Error("expected RootCAs to be set")
+		}
+	})
+}
+
+// mockHTTPClient is a mock HTTP client for testing.
+type mockHTTPClient struct {
+	response *http.Response
+	err      error
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.response, nil
+}
+
+// --- Health Check Policy Tests ---
+
+// sequenceHealthCheck returns different results for each probe call
+type sequenceHealthCheck struct {
+	results []bool
+	index   int
+	config  HealthCheckConfig
+}
+
+func newSequenceHealthCheck(results []bool) *sequenceHealthCheck {
+	return &sequenceHealthCheck{
+		results: results,
+		config: HealthCheckConfig{
+			Probes:  len(results),
+			Delay:   0,
+			Timeout: 3 * time.Second,
+		},
+	}
+}
+
+func (s *sequenceHealthCheck) Config() HealthCheckConfig {
+	return s.config
+}
+
+func (s *sequenceHealthCheck) CheckHealth(ctx context.Context, client *redis.Client) bool {
+	if s.index >= len(s.results) {
+		return false
+	}
+	result := s.results[s.index]
+	s.index++
+	return result
+}
+
+func (s *sequenceHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) bool {
+	return s.CheckHealth(ctx, nil)
+}
+
+func TestHealthCheckPolicies(t *testing.T) {
+	t.Run("HealthyAllPolicy requires all probes to pass", func(t *testing.T) {
+		policy := NewHealthyAllPolicy()
+		client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+		defer client.Close()
+
+		// All probes pass
+		hc := newSequenceHealthCheck([]bool{true, true, true})
+		checks := []redis.MultiDBHealthCheck{hc}
+		if !policy.Execute(context.Background(), checks, client) {
+			t.Error("expected all passing probes to return true")
+		}
+
+		// One probe fails
+		hc = newSequenceHealthCheck([]bool{true, false, true})
+		checks = []redis.MultiDBHealthCheck{hc}
+		if policy.Execute(context.Background(), checks, client) {
+			t.Error("expected one failing probe to return false")
+		}
+	})
+
+	t.Run("HealthyMajorityPolicy requires majority of probes to pass", func(t *testing.T) {
+		policy := NewHealthyMajorityPolicy()
+		client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+		defer client.Close()
+
+		// 3 probes: 2 pass, 1 fails - should succeed (majority)
+		hc := newSequenceHealthCheck([]bool{true, false, true})
+		checks := []redis.MultiDBHealthCheck{hc}
+		if !policy.Execute(context.Background(), checks, client) {
+			t.Error("expected 2/3 passing probes to return true")
+		}
+
+		// 3 probes: 1 passes, 2 fail - should fail
+		hc = newSequenceHealthCheck([]bool{true, false, false})
+		checks = []redis.MultiDBHealthCheck{hc}
+		if policy.Execute(context.Background(), checks, client) {
+			t.Error("expected 1/3 passing probes to return false")
+		}
+	})
+
+	t.Run("HealthyAnyPolicy requires at least one probe to pass", func(t *testing.T) {
+		policy := NewHealthyAnyPolicy()
+		client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+		defer client.Close()
+
+		// First probe fails, second passes - should succeed
+		hc := newSequenceHealthCheck([]bool{false, true, false})
+		checks := []redis.MultiDBHealthCheck{hc}
+		if !policy.Execute(context.Background(), checks, client) {
+			t.Error("expected one passing probe to return true")
+		}
+
+		// All probes fail - should fail
+		hc = newSequenceHealthCheck([]bool{false, false, false})
+		checks = []redis.MultiDBHealthCheck{hc}
+		if policy.Execute(context.Background(), checks, client) {
+			t.Error("expected no passing probes to return false")
+		}
+	})
+
+	t.Run("Empty checks return true for all policies", func(t *testing.T) {
+		client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+		defer client.Close()
+		ctx := context.Background()
+
+		var checks []redis.MultiDBHealthCheck
+
+		if !NewHealthyAllPolicy().Execute(ctx, checks, client) {
+			t.Error("HealthyAllPolicy should return true for empty checks")
+		}
+		if !NewHealthyMajorityPolicy().Execute(ctx, checks, client) {
+			t.Error("HealthyMajorityPolicy should return true for empty checks")
+		}
+		if !NewHealthyAnyPolicy().Execute(ctx, checks, client) {
+			t.Error("HealthyAnyPolicy should return true for empty checks")
+		}
+	})
+
+	t.Run("Multiple health checks all must pass", func(t *testing.T) {
+		policy := NewHealthyAllPolicy()
+		client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+		defer client.Close()
+
+		// Two health checks, both pass
+		checks := []redis.MultiDBHealthCheck{
+			newSequenceHealthCheck([]bool{true, true, true}),
+			newSequenceHealthCheck([]bool{true, true, true}),
+		}
+		if !policy.Execute(context.Background(), checks, client) {
+			t.Error("expected both health checks to pass")
+		}
+
+		// Two health checks, one fails
+		checks = []redis.MultiDBHealthCheck{
+			newSequenceHealthCheck([]bool{true, true, true}),
+			newSequenceHealthCheck([]bool{true, false, true}), // fails with AllPolicy
+		}
+		if policy.Execute(context.Background(), checks, client) {
+			t.Error("expected one failing health check to return false")
+		}
+	})
+}
+
+func TestHealthCheckConfig(t *testing.T) {
+	t.Run("DefaultHealthCheckConfig has correct values", func(t *testing.T) {
+		cfg := DefaultHealthCheckConfig()
+		if cfg.Probes != DefaultHealthCheckProbes {
+			t.Errorf("expected Probes=%d, got %d", DefaultHealthCheckProbes, cfg.Probes)
+		}
+		if cfg.Delay != DefaultHealthCheckDelay {
+			t.Errorf("expected Delay=%v, got %v", DefaultHealthCheckDelay, cfg.Delay)
+		}
+		if cfg.Timeout != DefaultHealthCheckTimeout {
+			t.Errorf("expected Timeout=%v, got %v", DefaultHealthCheckTimeout, cfg.Timeout)
+		}
+	})
+
+	t.Run("WithProbes sets probes", func(t *testing.T) {
+		hc := NewPingHealthCheck(WithProbes(5))
+		if hc.Config().Probes != 5 {
+			t.Errorf("expected Probes=5, got %d", hc.Config().Probes)
+		}
+	})
+
+	t.Run("WithDelay sets delay", func(t *testing.T) {
+		hc := NewPingHealthCheck(WithDelay(100 * time.Millisecond))
+		if hc.Config().Delay != 100*time.Millisecond {
+			t.Errorf("expected Delay=100ms, got %v", hc.Config().Delay)
+		}
+	})
+
+	t.Run("WithTimeout sets timeout", func(t *testing.T) {
+		hc := NewPingHealthCheck(WithTimeout(5 * time.Second))
+		if hc.Config().Timeout != 5*time.Second {
+			t.Errorf("expected Timeout=5s, got %v", hc.Config().Timeout)
+		}
+	})
+}

--- a/multidb/healthcheck_test.go
+++ b/multidb/healthcheck_test.go
@@ -3,6 +3,7 @@ package multidb
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -20,8 +21,8 @@ func TestPingHealthCheck(t *testing.T) {
 		}
 
 		hc := NewPingHealthCheck()
-		if !hc.CheckHealth(ctx, client) {
-			t.Error("expected CheckHealth to return true for healthy client")
+		if ok, err := hc.CheckHealth(ctx, client); !ok {
+			t.Errorf("expected CheckHealth to return true for healthy client, err=%v", err)
 		}
 	})
 
@@ -35,8 +36,10 @@ func TestPingHealthCheck(t *testing.T) {
 		hc := NewPingHealthCheck()
 		ctx := context.Background()
 
-		if hc.CheckHealth(ctx, client) {
+		if ok, err := hc.CheckHealth(ctx, client); ok {
 			t.Error("expected CheckHealth to return false for unreachable client")
+		} else if err == nil {
+			t.Error("expected CheckHealth to return a non-nil error for unreachable client")
 		}
 	})
 }
@@ -46,12 +49,12 @@ type mockHealthCheck struct {
 	healthy bool
 }
 
-func (m *mockHealthCheck) CheckHealth(ctx context.Context, client *redis.Client) bool {
-	return m.healthy
+func (m *mockHealthCheck) CheckHealth(ctx context.Context, client *redis.Client) (bool, error) {
+	return m.healthy, nil
 }
 
-func (m *mockHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) bool {
-	return m.healthy
+func (m *mockHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) (bool, error) {
+	return m.healthy, nil
 }
 
 // --- LagAwareHealthCheck Tests ---
@@ -103,7 +106,7 @@ func TestLagAwareHealthCheck(t *testing.T) {
 		)
 
 		ctx := context.Background()
-		if hc.CheckHealth(ctx, client) {
+		if ok, _ := hc.CheckHealth(ctx, client); ok {
 			t.Error("expected CheckHealth to return false when REST API is unreachable")
 		}
 	})
@@ -199,8 +202,10 @@ func TestLagAwareConfigErrorFailsHealthCheck(t *testing.T) {
 	if hc.configErr == nil {
 		t.Fatal("expected configErr to be set for invalid root CA PEM")
 	}
-	if hc.CheckHealth(context.Background(), client) {
+	if ok, err := hc.CheckHealth(context.Background(), client); ok {
 		t.Error("expected CheckHealth to return false when config error is set")
+	} else if err == nil {
+		t.Error("expected CheckHealth to surface the config error")
 	}
 }
 
@@ -215,6 +220,138 @@ func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 		return nil, m.err
 	}
 	return m.response, nil
+}
+
+// urlCapturingHTTPClient records the URLs it is asked to fetch and always
+// fails the request, so the caller's CheckHealth returns early. It is used to
+// assert how the base URL is constructed without needing a live REST API.
+type urlCapturingHTTPClient struct {
+	urls []string
+}
+
+func (c *urlCapturingHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.urls = append(c.urls, req.URL.String())
+	return nil, context.DeadlineExceeded
+}
+
+func TestLagAwareIPv6BaseURL(t *testing.T) {
+	// An IPv6 Redis address must produce a bracketed, parseable HTTPS base URL
+	// (https://[::1]:9443/...), not the malformed https://::1:9443/...
+	capture := &urlCapturingHTTPClient{}
+	hc := NewLagAwareHealthCheck(WithLagAwareHTTPClient(capture))
+
+	client := redis.NewClient(&redis.Options{Addr: "[::1]:6379"})
+	defer client.Close()
+
+	if ok, _ := hc.CheckHealth(context.Background(), client); ok {
+		t.Fatal("expected CheckHealth to fail with the capturing client")
+	}
+	if len(capture.urls) == 0 {
+		t.Fatal("expected at least one REST API request")
+	}
+	got := capture.urls[0]
+	wantPrefix := "https://[::1]:9443/v1/bdbs"
+	if got != wantPrefix {
+		t.Errorf("IPv6 base URL = %q, want %q", got, wantPrefix)
+	}
+	// The URL must be parseable and round-trip the IPv6 host with brackets.
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("constructed URL %q is not parseable: %v", got, err)
+	}
+	if u.Hostname() != "::1" {
+		t.Errorf("parsed hostname = %q, want ::1", u.Hostname())
+	}
+}
+
+func TestLagAwareCheckHealthReturnsError(t *testing.T) {
+	// CheckHealth must surface the underlying failure (here: the HTTP error)
+	// so health-check metrics can record why the check was unhealthy.
+	hc := NewLagAwareHealthCheck(
+		WithLagAwareHTTPClient(&mockHTTPClient{err: context.DeadlineExceeded}),
+	)
+	client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	defer client.Close()
+
+	ok, err := hc.CheckHealth(context.Background(), client)
+	if ok {
+		t.Error("expected CheckHealth to return false")
+	}
+	if err == nil {
+		t.Error("expected CheckHealth to return a non-nil error")
+	}
+}
+
+func TestLagAwareUnusableAddrReturnsError(t *testing.T) {
+	// A unix-socket address cannot yield a REST API host; CheckHealth must
+	// report this as an error rather than a silent false.
+	hc := NewLagAwareHealthCheck()
+	client := redis.NewClient(&redis.Options{Network: "unix", Addr: "/tmp/redis.sock"})
+	defer client.Close()
+
+	ok, err := hc.CheckHealth(context.Background(), client)
+	if ok {
+		t.Error("expected CheckHealth to return false for unix-socket address")
+	}
+	if err == nil {
+		t.Error("expected CheckHealth to return an error for unix-socket address")
+	}
+}
+
+func TestGetConfigClampsInvalidValues(t *testing.T) {
+	// A configurable check returning non-positive Probes/Timeout (or negative
+	// Delay) must be clamped to defaults so probe runners stay robust.
+	hc := &configReturningCheck{cfg: HealthCheckConfig{Probes: 0, Timeout: 0, Delay: -1}}
+	got := getConfig(hc)
+	if got.Probes != DefaultHealthCheckProbes {
+		t.Errorf("Probes = %d, want clamped to %d", got.Probes, DefaultHealthCheckProbes)
+	}
+	if got.Timeout != DefaultHealthCheckTimeout {
+		t.Errorf("Timeout = %v, want clamped to %v", got.Timeout, DefaultHealthCheckTimeout)
+	}
+	if got.Delay != DefaultHealthCheckDelay {
+		t.Errorf("Delay = %v, want clamped to %v", got.Delay, DefaultHealthCheckDelay)
+	}
+
+	// A check with Probes=0 must not be treated as trivially healthy.
+	policy := NewHealthyAllPolicy()
+	client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	defer client.Close()
+	bad := &countingCheck{}
+	bad.cfg = HealthCheckConfig{Probes: 0, Timeout: time.Second}
+	policy.Execute(context.Background(), []redis.MultiDBHealthCheck{bad}, client)
+	if bad.calls == 0 {
+		t.Error("expected at least one probe call after clamping Probes=0 to default")
+	}
+}
+
+// configReturningCheck is a ConfigurableHealthCheck that returns a fixed config.
+type configReturningCheck struct {
+	cfg HealthCheckConfig
+}
+
+func (c *configReturningCheck) Config() HealthCheckConfig { return c.cfg }
+func (c *configReturningCheck) CheckHealth(context.Context, *redis.Client) (bool, error) {
+	return true, nil
+}
+func (c *configReturningCheck) CheckClusterHealth(context.Context, *redis.ClusterClient) (bool, error) {
+	return true, nil
+}
+
+// countingCheck records how many probe calls it received.
+type countingCheck struct {
+	cfg   HealthCheckConfig
+	calls int
+}
+
+func (c *countingCheck) Config() HealthCheckConfig { return c.cfg }
+func (c *countingCheck) CheckHealth(context.Context, *redis.Client) (bool, error) {
+	c.calls++
+	return true, nil
+}
+func (c *countingCheck) CheckClusterHealth(context.Context, *redis.ClusterClient) (bool, error) {
+	c.calls++
+	return true, nil
 }
 
 // --- Health Check Policy Tests ---
@@ -241,16 +378,16 @@ func (s *sequenceHealthCheck) Config() HealthCheckConfig {
 	return s.config
 }
 
-func (s *sequenceHealthCheck) CheckHealth(ctx context.Context, client *redis.Client) bool {
+func (s *sequenceHealthCheck) CheckHealth(ctx context.Context, client *redis.Client) (bool, error) {
 	if s.index >= len(s.results) {
-		return false
+		return false, nil
 	}
 	result := s.results[s.index]
 	s.index++
-	return result
+	return result, nil
 }
 
-func (s *sequenceHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) bool {
+func (s *sequenceHealthCheck) CheckClusterHealth(ctx context.Context, client *redis.ClusterClient) (bool, error) {
 	return s.CheckHealth(ctx, nil)
 }
 

--- a/multidb/healthcheck_test.go
+++ b/multidb/healthcheck_test.go
@@ -14,12 +14,15 @@ func TestPingHealthCheck(t *testing.T) {
 		client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
 		defer client.Close()
 
-		hc := NewPingHealthCheck()
 		ctx := context.Background()
+		if err := client.Ping(ctx).Err(); err != nil {
+			t.Skipf("Redis not available: %v", err)
+		}
 
-		// This test requires a running Redis server
-		// If no server, we just verify the check doesn't panic
-		_ = hc.CheckHealth(ctx, client)
+		hc := NewPingHealthCheck()
+		if !hc.CheckHealth(ctx, client) {
+			t.Error("expected CheckHealth to return true for healthy client")
+		}
 	})
 
 	t.Run("CheckHealth returns false for unreachable client", func(t *testing.T) {
@@ -158,6 +161,47 @@ H8PD6BY8JK7P5K8K0K8K0K8K0K8K0K8K0K8K0A==
 			t.Error("expected RootCAs to be set")
 		}
 	})
+}
+
+func TestLagAwareHostFromAddr(t *testing.T) {
+	tests := []struct {
+		addr     string
+		wantHost string
+		wantOK   bool
+	}{
+		{"localhost:6379", "localhost", true},
+		{"10.0.0.1:6379", "10.0.0.1", true},
+		{"redis.example.com:9443", "redis.example.com", true},
+		{"[::1]:6379", "::1", true},
+		{"[2001:db8::1]:6379", "2001:db8::1", true},
+		{"localhost", "localhost", true},
+		{"", "", false},
+		{"/tmp/redis.sock", "", false},
+		{"unix:///tmp/redis.sock", "", false},
+	}
+	for _, tc := range tests {
+		host, ok := hostFromAddr(tc.addr)
+		if ok != tc.wantOK || host != tc.wantHost {
+			t.Errorf("hostFromAddr(%q) = (%q, %v), want (%q, %v)",
+				tc.addr, host, ok, tc.wantHost, tc.wantOK)
+		}
+	}
+}
+
+func TestLagAwareConfigErrorFailsHealthCheck(t *testing.T) {
+	client := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	defer client.Close()
+
+	// An invalid PEM records a config error, which must fail health checks.
+	hc := NewLagAwareHealthCheck(
+		WithLagAwareRootCAs([]byte("not a valid pem")),
+	)
+	if hc.configErr == nil {
+		t.Fatal("expected configErr to be set for invalid root CA PEM")
+	}
+	if hc.CheckHealth(context.Background(), client) {
+		t.Error("expected CheckHealth to return false when config error is set")
+	}
 }
 
 // mockHTTPClient is a mock HTTP client for testing.

--- a/multidb/healthcheck_test.go
+++ b/multidb/healthcheck_test.go
@@ -228,6 +228,23 @@ func TestLagAwareConfigErrorFailsHealthCheck(t *testing.T) {
 	}
 }
 
+func TestLagAwareTLSConfigIsCloned(t *testing.T) {
+	caller := &tls.Config{}
+	hc := NewLagAwareHealthCheck(
+		WithLagAwareTLSConfig(caller),
+		WithLagAwareInsecureSkipVerify(),
+	)
+	if !hc.tlsConfig.InsecureSkipVerify {
+		t.Error("expected health check TLS config to have InsecureSkipVerify set")
+	}
+	if caller.InsecureSkipVerify {
+		t.Error("expected caller TLS config to be left unmodified")
+	}
+	if hc.tlsConfig == caller {
+		t.Error("expected health check to hold a clone, not the caller's TLS config")
+	}
+}
+
 // mockHTTPClient is a mock HTTP client for testing.
 type mockHTTPClient struct {
 	response *http.Response

--- a/multidb/healthcheck_test.go
+++ b/multidb/healthcheck_test.go
@@ -42,6 +42,24 @@ func TestPingHealthCheck(t *testing.T) {
 			t.Error("expected CheckHealth to return a non-nil error for unreachable client")
 		}
 	})
+
+	t.Run("CheckClusterHealth returns false+error for unreachable/empty cluster", func(t *testing.T) {
+		// A cluster with no reachable shards must not be reported as trivially
+		// healthy: CheckClusterHealth must return (false, err) rather than
+		// (true, nil) when no shard was actually pinged.
+		client := redis.NewClusterClient(&redis.ClusterOptions{
+			Addrs:       []string{"localhost:59999"},
+			DialTimeout: 100 * time.Millisecond,
+		})
+		defer client.Close()
+
+		hc := NewPingHealthCheck()
+		if ok, err := hc.CheckClusterHealth(context.Background(), client); ok {
+			t.Error("expected CheckClusterHealth to return false for an empty/unreachable cluster")
+		} else if err == nil {
+			t.Error("expected CheckClusterHealth to return a non-nil error for an empty/unreachable cluster")
+		}
+	})
 }
 
 // mockHealthCheck is a test helper that returns a configurable result

--- a/multidb_healthcheck.go
+++ b/multidb_healthcheck.go
@@ -3,10 +3,16 @@ package redis
 import "context"
 
 // MultiDBHealthCheck is the interface for health checking databases.
+//
+// Each method reports whether the database is healthy together with the error
+// that made it unhealthy (if any). A healthy result is (true, nil). An
+// unhealthy result is (false, err) where err explains the failure so callers
+// (e.g. health-check metrics) can record why a check failed; err may be nil
+// when the check completed and simply determined the database is not healthy.
 type MultiDBHealthCheck interface {
 	// CheckHealth checks if a standalone client is healthy.
-	CheckHealth(ctx context.Context, client *Client) bool
+	CheckHealth(ctx context.Context, client *Client) (bool, error)
 
 	// CheckClusterHealth checks if a cluster client is healthy.
-	CheckClusterHealth(ctx context.Context, client *ClusterClient) bool
+	CheckClusterHealth(ctx context.Context, client *ClusterClient) (bool, error)
 }

--- a/multidb_healthcheck.go
+++ b/multidb_healthcheck.go
@@ -1,0 +1,12 @@
+package redis
+
+import "context"
+
+// MultiDBHealthCheck is the interface for health checking databases.
+type MultiDBHealthCheck interface {
+	// CheckHealth checks if a standalone client is healthy.
+	CheckHealth(ctx context.Context, client *Client) bool
+
+	// CheckClusterHealth checks if a cluster client is healthy.
+	CheckClusterHealth(ctx context.Context, client *ClusterClient) bool
+}


### PR DESCRIPTION
Add health check implementations for MultiDBClient:
- PingHealthCheck: single PING probe with configurable probes/delay/timeout
- LagAwareHealthCheck: gates on replication lag via the Redis Enterprise REST API
- Policies (HealthyAllPolicy, HealthyMajorityPolicy, HealthyAnyPolicy) that govern how probes WITHIN each health check are interpreted; across multiple checks the relationship is always AND (every check must pass regardless of policy)

The policy runners execute checks concurrently with a per-check timeout and a buffered results channel sized to the number of checks, so a hung check cannot wedge the policy and worker goroutines never leak on early return.

Also add the MultiDBHealthCheck interface to the root redis package (the minimal contract these checks implement: CheckHealth / CheckClusterHealth). The remaining MultiDBClient options and interfaces follow in a later PR.

Part of the MultiDBClient geo-failover feature (PR 3).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New failover-related health logic (including TLS/HTTP to Redis Enterprise) will drive routing when integrated; currently additive with broad tests and no MultiDBClient wiring in this PR.
> 
> **Overview**
> Introduces **`multidb`** health checks and policies for upcoming **`MultiDBClient`** geo-failover, plus the root **`MultiDBHealthCheck`** contract (`CheckHealth` / `CheckClusterHealth` returning `(bool, error)`).
> 
> **`PingHealthCheck`** runs one PING per probe (all cluster shards on cluster clients; empty topology is unhealthy). **`LagAwareHealthCheck`** probes Redis Enterprise via HTTPS (BDB lookup + lag-aware availability), with TLS/mTLS options, config-error fail-fast, and IPv6-safe REST URLs.
> 
> **`HealthyAllPolicy`**, **`HealthyMajorityPolicy`**, and **`HealthyAnyPolicy`** only decide how probes within each check are scored; multiple checks are always ANDed. Shared **`runChecks`** runs checks concurrently with per-check timeouts, buffered results (no goroutine leaks on early exit), invalid config clamping, and panic recovery.
> 
> Large **`healthcheck_test.go`** coverage accompanies the new code; **`MultiDBClient` wiring** is deferred to a later PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 061665957767b14fa2df7747c39e8af14582159b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->