### PR TITLE
feat(multidb, otel): add geofailover OTel recorder methods

### DIFF
--- a/internal/otel/metrics.go
+++ b/internal/otel/metrics.go
@@ -86,6 +86,25 @@ type Recorder interface {
 	// consumerName: name of the consumer
 	RecordStreamLag(ctx context.Context, lag time.Duration, cn *pool.Conn, streamName, consumerGroup, consumerName string)
 
+	// RecordMultiDBFailover records a MultiDB (geo-failover) failover from one
+	// member database to another. fromFQDN/toFQDN are host-only database FQDNs,
+	// reason is "automatic" or "manual", and duration is the wall time of the
+	// failover.
+	RecordMultiDBFailover(ctx context.Context, fromFQDN, toFQDN, reason string, duration time.Duration)
+
+	// RecordMultiDBActiveDatabaseChange records a change of the active MultiDB
+	// member database (failover, fallback, or manual selection). fromFQDN/toFQDN
+	// are host-only database FQDNs.
+	RecordMultiDBActiveDatabaseChange(ctx context.Context, fromFQDN, toFQDN string)
+
+	// RecordMultiDBCircuitStateChange records a MultiDB circuit breaker state
+	// transition for the database identified by dbFQDN.
+	RecordMultiDBCircuitStateChange(ctx context.Context, dbFQDN, fromState, toState string)
+
+	// RecordMultiDBHealthCheck records the result of a MultiDB health-check pass
+	// for the database identified by dbFQDN. duration is the wall time of the check.
+	RecordMultiDBHealthCheck(ctx context.Context, dbFQDN string, success bool, duration time.Duration)
+
 	// RecordConnectionCount records a change in connection count (UpDownCounter)
 	// delta: +1 when connection added, -1 when connection removed
 	// state: connection state (e.g., "idle", "used")
@@ -243,6 +262,26 @@ func RecordStreamLag(ctx context.Context, lag time.Duration, cn *pool.Conn, stre
 	getRecorder().RecordStreamLag(ctx, lag, cn, streamName, consumerGroup, consumerName)
 }
 
+// RecordMultiDBFailover records a MultiDB failover from one database to another.
+func RecordMultiDBFailover(ctx context.Context, fromFQDN, toFQDN, reason string, duration time.Duration) {
+	getRecorder().RecordMultiDBFailover(ctx, fromFQDN, toFQDN, reason, duration)
+}
+
+// RecordMultiDBActiveDatabaseChange records a change of the active MultiDB database.
+func RecordMultiDBActiveDatabaseChange(ctx context.Context, fromFQDN, toFQDN string) {
+	getRecorder().RecordMultiDBActiveDatabaseChange(ctx, fromFQDN, toFQDN)
+}
+
+// RecordMultiDBCircuitStateChange records a MultiDB circuit breaker state transition.
+func RecordMultiDBCircuitStateChange(ctx context.Context, dbFQDN, fromState, toState string) {
+	getRecorder().RecordMultiDBCircuitStateChange(ctx, dbFQDN, fromState, toState)
+}
+
+// RecordMultiDBHealthCheck records the result of a MultiDB health-check pass.
+func RecordMultiDBHealthCheck(ctx context.Context, dbFQDN string, success bool, duration time.Duration) {
+	getRecorder().RecordMultiDBHealthCheck(ctx, dbFQDN, success, duration)
+}
+
 type noopRecorder struct{}
 
 func (noopRecorder) RecordOperationDuration(context.Context, time.Duration, Cmder, int, error, *pool.Conn, int) {
@@ -263,6 +302,12 @@ func (noopRecorder) RecordPubSubMessage(context.Context, *pool.Conn, string, str
 
 func (noopRecorder) RecordStreamLag(context.Context, time.Duration, *pool.Conn, string, string, string) {
 }
+
+func (noopRecorder) RecordMultiDBFailover(context.Context, string, string, string, time.Duration) {}
+func (noopRecorder) RecordMultiDBActiveDatabaseChange(context.Context, string, string)            {}
+func (noopRecorder) RecordMultiDBCircuitStateChange(context.Context, string, string, string)      {}
+func (noopRecorder) RecordMultiDBHealthCheck(context.Context, string, bool, time.Duration)        {}
+
 func (noopRecorder) RecordConnectionCount(context.Context, int, *pool.Conn, string, bool) {}
 func (noopRecorder) RecordPendingRequests(context.Context, int, *pool.Conn, string)       {}
 

--- a/otel.go
+++ b/otel.go
@@ -77,6 +77,25 @@ type OTelRecorder interface {
 	// consumerGroup: name of the consumer group
 	// consumerName: name of the consumer
 	RecordStreamLag(ctx context.Context, lag time.Duration, cn ConnInfo, streamName, consumerGroup, consumerName string)
+
+	// RecordMultiDBFailover records a MultiDB (geo-failover) failover from one
+	// member database to another. fromFQDN/toFQDN are host-only database FQDNs,
+	// reason is "automatic" or "manual", and duration is the wall time of the
+	// failover.
+	RecordMultiDBFailover(ctx context.Context, fromFQDN, toFQDN, reason string, duration time.Duration)
+
+	// RecordMultiDBActiveDatabaseChange records a change of the active MultiDB
+	// member database (failover, fallback, or manual selection). fromFQDN/toFQDN
+	// are host-only database FQDNs.
+	RecordMultiDBActiveDatabaseChange(ctx context.Context, fromFQDN, toFQDN string)
+
+	// RecordMultiDBCircuitStateChange records a MultiDB circuit breaker state
+	// transition for the database identified by dbFQDN.
+	RecordMultiDBCircuitStateChange(ctx context.Context, dbFQDN, fromState, toState string)
+
+	// RecordMultiDBHealthCheck records the result of a MultiDB health-check pass
+	// for the database identified by dbFQDN. duration is the wall time of the check.
+	RecordMultiDBHealthCheck(ctx context.Context, dbFQDN string, success bool, duration time.Duration)
 }
 
 // OTelConnectionCounter is an optional capability interface for recording
@@ -180,6 +199,22 @@ func (a *otelRecorderAdapter) RecordPubSubMessage(ctx context.Context, cn *pool.
 
 func (a *otelRecorderAdapter) RecordStreamLag(ctx context.Context, lag time.Duration, cn *pool.Conn, streamName, consumerGroup, consumerName string) {
 	a.recorder.RecordStreamLag(ctx, lag, toConnInfo(cn), streamName, consumerGroup, consumerName)
+}
+
+func (a *otelRecorderAdapter) RecordMultiDBFailover(ctx context.Context, fromFQDN, toFQDN, reason string, duration time.Duration) {
+	a.recorder.RecordMultiDBFailover(ctx, fromFQDN, toFQDN, reason, duration)
+}
+
+func (a *otelRecorderAdapter) RecordMultiDBActiveDatabaseChange(ctx context.Context, fromFQDN, toFQDN string) {
+	a.recorder.RecordMultiDBActiveDatabaseChange(ctx, fromFQDN, toFQDN)
+}
+
+func (a *otelRecorderAdapter) RecordMultiDBCircuitStateChange(ctx context.Context, dbFQDN, fromState, toState string) {
+	a.recorder.RecordMultiDBCircuitStateChange(ctx, dbFQDN, fromState, toState)
+}
+
+func (a *otelRecorderAdapter) RecordMultiDBHealthCheck(ctx context.Context, dbFQDN string, success bool, duration time.Duration) {
+	a.recorder.RecordMultiDBHealthCheck(ctx, dbFQDN, success, duration)
 }
 
 func (a *otelRecorderAdapter) RecordConnectionCount(ctx context.Context, delta int, cn *pool.Conn, state string, isPubSub bool) {

--- a/otel.go
+++ b/otel.go
@@ -77,25 +77,6 @@ type OTelRecorder interface {
 	// consumerGroup: name of the consumer group
 	// consumerName: name of the consumer
 	RecordStreamLag(ctx context.Context, lag time.Duration, cn ConnInfo, streamName, consumerGroup, consumerName string)
-
-	// RecordMultiDBFailover records a MultiDB (geo-failover) failover from one
-	// member database to another. fromFQDN/toFQDN are host-only database FQDNs,
-	// reason is "automatic" or "manual", and duration is the wall time of the
-	// failover.
-	RecordMultiDBFailover(ctx context.Context, fromFQDN, toFQDN, reason string, duration time.Duration)
-
-	// RecordMultiDBActiveDatabaseChange records a change of the active MultiDB
-	// member database (failover, fallback, or manual selection). fromFQDN/toFQDN
-	// are host-only database FQDNs.
-	RecordMultiDBActiveDatabaseChange(ctx context.Context, fromFQDN, toFQDN string)
-
-	// RecordMultiDBCircuitStateChange records a MultiDB circuit breaker state
-	// transition for the database identified by dbFQDN.
-	RecordMultiDBCircuitStateChange(ctx context.Context, dbFQDN, fromState, toState string)
-
-	// RecordMultiDBHealthCheck records the result of a MultiDB health-check pass
-	// for the database identified by dbFQDN. duration is the wall time of the check.
-	RecordMultiDBHealthCheck(ctx context.Context, dbFQDN string, success bool, duration time.Duration)
 }
 
 // OTelConnectionCounter is an optional capability interface for recording
@@ -115,6 +96,32 @@ type OTelConnectionCounter interface {
 	// delta: +1 when request starts waiting, -1 when request stops waiting
 	// poolName is passed explicitly because we may not have a connection yet when request starts
 	RecordPendingRequests(ctx context.Context, delta int, cn ConnInfo, poolName string)
+}
+
+// OTelMultiDBRecorder is an optional capability interface for recording
+// MultiDB (geo-failover) metrics. Implementations of OTelRecorder can
+// optionally implement this interface to receive MultiDB notifications.
+// This is kept separate from OTelRecorder to avoid breaking existing
+// third-party implementations when new methods are added.
+type OTelMultiDBRecorder interface {
+	// RecordMultiDBFailover records a MultiDB (geo-failover) failover from one
+	// member database to another. fromFQDN/toFQDN are host-only database FQDNs,
+	// reason is "automatic" or "manual", and duration is the wall time of the
+	// failover.
+	RecordMultiDBFailover(ctx context.Context, fromFQDN, toFQDN, reason string, duration time.Duration)
+
+	// RecordMultiDBActiveDatabaseChange records a change of the active MultiDB
+	// member database (failover, fallback, or manual selection). fromFQDN/toFQDN
+	// are host-only database FQDNs.
+	RecordMultiDBActiveDatabaseChange(ctx context.Context, fromFQDN, toFQDN string)
+
+	// RecordMultiDBCircuitStateChange records a MultiDB circuit breaker state
+	// transition for the database identified by dbFQDN.
+	RecordMultiDBCircuitStateChange(ctx context.Context, dbFQDN, fromState, toState string)
+
+	// RecordMultiDBHealthCheck records the result of a MultiDB health-check pass
+	// for the database identified by dbFQDN. duration is the wall time of the check.
+	RecordMultiDBHealthCheck(ctx context.Context, dbFQDN string, success bool, duration time.Duration)
 }
 
 // This is used for async gauge metrics that need to pull stats from pools periodically.
@@ -202,19 +209,27 @@ func (a *otelRecorderAdapter) RecordStreamLag(ctx context.Context, lag time.Dura
 }
 
 func (a *otelRecorderAdapter) RecordMultiDBFailover(ctx context.Context, fromFQDN, toFQDN, reason string, duration time.Duration) {
-	a.recorder.RecordMultiDBFailover(ctx, fromFQDN, toFQDN, reason, duration)
+	if r, ok := a.recorder.(OTelMultiDBRecorder); ok {
+		r.RecordMultiDBFailover(ctx, fromFQDN, toFQDN, reason, duration)
+	}
 }
 
 func (a *otelRecorderAdapter) RecordMultiDBActiveDatabaseChange(ctx context.Context, fromFQDN, toFQDN string) {
-	a.recorder.RecordMultiDBActiveDatabaseChange(ctx, fromFQDN, toFQDN)
+	if r, ok := a.recorder.(OTelMultiDBRecorder); ok {
+		r.RecordMultiDBActiveDatabaseChange(ctx, fromFQDN, toFQDN)
+	}
 }
 
 func (a *otelRecorderAdapter) RecordMultiDBCircuitStateChange(ctx context.Context, dbFQDN, fromState, toState string) {
-	a.recorder.RecordMultiDBCircuitStateChange(ctx, dbFQDN, fromState, toState)
+	if r, ok := a.recorder.(OTelMultiDBRecorder); ok {
+		r.RecordMultiDBCircuitStateChange(ctx, dbFQDN, fromState, toState)
+	}
 }
 
 func (a *otelRecorderAdapter) RecordMultiDBHealthCheck(ctx context.Context, dbFQDN string, success bool, duration time.Duration) {
-	a.recorder.RecordMultiDBHealthCheck(ctx, dbFQDN, success, duration)
+	if r, ok := a.recorder.(OTelMultiDBRecorder); ok {
+		r.RecordMultiDBHealthCheck(ctx, dbFQDN, success, duration)
+	}
 }
 
 func (a *otelRecorderAdapter) RecordConnectionCount(ctx context.Context, delta int, cn *pool.Conn, state string, isPubSub bool) {


### PR DESCRIPTION
Add the MultiDB (geo-failover) recording surface to the OTel plumbing so later PRs can emit failover/observability signals through the existing recorder indirection:

- OTelRecorder (otel.go): four new RecordMultiDB* methods (Failover, ActiveDatabaseChange, CircuitStateChange, HealthCheck) plus the otelRecorderAdapter forwarders.
- internal/otel.Recorder (internal/otel/metrics.go): the same four methods, matching package-level helper funcs, and no-op implementations on noopRecorder.

This is purely additive and no-op safe: with no recorder registered the global noopRecorder handles the calls, so behavior is unchanged until a recorder is wired up (later PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive interfaces and no-op implementations only; no failover or metrics emission is hooked up in this PR.
> 
> **Overview**
> Adds an **optional** OpenTelemetry surface for **MultiDB (geo-failover)** so later work can emit metrics without changing runtime behavior today.
> 
> **Public API (`otel.go`):** New `OTelMultiDBRecorder` with four hooks—failover (from/to FQDN, automatic vs manual, duration), active database changes, circuit breaker state transitions, and health-check outcomes with duration. `otelRecorderAdapter` forwards each call only when the registered `OTelRecorder` also implements `OTelMultiDBRecorder`, matching the existing optional `OTelConnectionCounter` pattern so third-party recorders are not forced to implement new methods.
> 
> **Internal (`internal/otel/metrics.go`):** The same four methods on `Recorder`, package-level helpers, and no-op stubs on `noopRecorder`. Until a real recorder implements them and MultiDB code calls the helpers, everything stays a no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bbd2f5f916f1bc439e7470018bcc9ae0a04ede1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->