### PR TITLE
fix(push): fix peeking when push name is truncated

### DIFF
--- a/internal/proto/peek_push_notification_test.go
+++ b/internal/proto/peek_push_notification_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -756,5 +758,27 @@ func TestPeekPushNotificationName_EmptyArrayLength(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "empty push notification array length") {
 		t.Fatalf("PeekPushNotificationName: error should mention empty array length, got %v", err)
+	}
+}
+
+// TestPeekPushNotificationName_OverflowingNameLength asserts that a frame
+// advertising a name length near math.MaxInt does not panic. Computing
+// next+nameLen would overflow int and wrap negative, slipping past a naive
+// "end > len(buf)" guard and panicking the backing slice; the parser must
+// instead treat it as incomplete and surface an error without crashing.
+func TestPeekPushNotificationName_OverflowingNameLength(t *testing.T) {
+	data := []byte(">1\r\n$" + strconv.Itoa(math.MaxInt) + "\r\n")
+	rd := NewReader(bytes.NewReader(data))
+
+	if _, err := rd.PeekReplyType(); err != nil {
+		t.Fatalf("PeekReplyType: %v", err)
+	}
+
+	name, err := rd.PeekPushNotificationName()
+	if err == nil {
+		t.Fatalf("PeekPushNotificationName: want error for overflowing name length, got name=%q", name)
+	}
+	if name != "" {
+		t.Fatalf("PeekPushNotificationName: want empty name on error, got %q", name)
 	}
 }

--- a/internal/proto/peek_push_notification_test.go
+++ b/internal/proto/peek_push_notification_test.go
@@ -678,10 +678,13 @@ func TestPeekPushNotificationName_TruncatedHeader(t *testing.T) {
 	for _, tc := range cutpoints {
 		t.Run(tc.name, func(t *testing.T) {
 			data := []byte(frame)
-			// Use a chunked reader whose first chunk equals tc.prefix and
-			// whose second chunk delivers the rest. bufio will fill from the
-			// first chunk only, then block-fill from the second when we
-			// peek past it.
+			// Use a chunked reader that hands out tc.prefix bytes per Read
+			// call (not per fill). bufio's first fill therefore returns only
+			// tc.prefix bytes; satisfying a Peek that wants more forces
+			// additional Reads, each capped at tc.prefix bytes, until the
+			// peek window is full. That sequence reproduces the partial-fill
+			// boundary from issue #3839 where the buffered prefix landed in
+			// the middle of the push frame header.
 			rd := NewReader(&chunkedReader{data: data, chunkSize: tc.prefix})
 
 			if _, err := rd.PeekReplyType(); err != nil {
@@ -728,5 +731,30 @@ func TestPeekPushNotificationName_TruncatedHeaderUnderlyingEOF(t *testing.T) {
 	}
 	if name != "" {
 		t.Fatalf("PeekPushNotificationName: want empty name on error, got %q", name)
+	}
+}
+
+// TestPeekPushNotificationName_EmptyArrayLength asserts that ">\r\n" is
+// reported as a malformed frame rather than an incomplete prefix. RESP
+// requires at least one digit after '>' for the array length; without the
+// empty-length check in parsePushNotificationName the parser would treat
+// ">\r\n" as a valid prefix and PeekPushNotificationName would block
+// waiting for the rest of a frame that is already corrupt.
+func TestPeekPushNotificationName_EmptyArrayLength(t *testing.T) {
+	rd := NewReader(bytes.NewReader([]byte(">\r\n")))
+
+	if _, err := rd.PeekReplyType(); err != nil {
+		t.Fatalf("PeekReplyType: %v", err)
+	}
+
+	name, err := rd.PeekPushNotificationName()
+	if err == nil {
+		t.Fatalf("PeekPushNotificationName: want error for empty array length, got name=%q", name)
+	}
+	if name != "" {
+		t.Fatalf("PeekPushNotificationName: want empty name on error, got %q", name)
+	}
+	if !strings.Contains(err.Error(), "empty push notification array length") {
+		t.Fatalf("PeekPushNotificationName: error should mention empty array length, got %v", err)
 	}
 }

--- a/internal/proto/peek_push_notification_test.go
+++ b/internal/proto/peek_push_notification_test.go
@@ -3,6 +3,7 @@ package proto
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"math/rand"
 	"strings"
 	"testing"
@@ -620,4 +621,112 @@ func TestPeekPushNotificationNameBehavior(t *testing.T) {
 		t.Log("")
 		t.Log("Note: Buffer must be primed with a peek operation first")
 	})
+}
+
+// chunkedReader hands its data out in fixed-size chunks, one per Read. This
+// lets us deterministically reproduce the bufio fill boundary that landed in
+// the middle of a push frame header in issue #3839.
+type chunkedReader struct {
+	data      []byte
+	chunkSize int
+	off       int
+}
+
+func (r *chunkedReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := r.chunkSize
+	if n > len(p) {
+		n = len(p)
+	}
+	if r.off+n > len(r.data) {
+		n = len(r.data) - r.off
+	}
+	copy(p, r.data[r.off:r.off+n])
+	r.off += n
+	return n, nil
+}
+
+// TestPeekPushNotificationName_TruncatedHeader covers issue #3839: when only
+// a prefix of a push frame is buffered, PeekPushNotificationName must NOT
+// return a truncated name. It should block to fetch the rest of the header
+// (so the caller can identify the notification correctly) or, when the
+// underlying read fails, return that error.
+func TestPeekPushNotificationName_TruncatedHeader(t *testing.T) {
+	const frame = ">3\r\n$7\r\nmessage\r\n$7\r\nchannel\r\n$5\r\nhello\r\n"
+
+	// Boundaries that previously caused PeekPushNotificationName to silently
+	// return a truncated name. `prefix` is the number of bytes the chunked
+	// reader hands out per Read call; with the bug, every chunk boundary that
+	// lands inside the frame header is a place where the function returned a
+	// truncated name instead of blocking for the rest.
+	cutpoints := []struct {
+		name   string
+		prefix int
+	}{
+		{"after_push_marker", 1},
+		{"inside_array_len_line", 3},
+		{"after_array_len_line", 4},
+		{"after_dollar", 5},
+		{"inside_bulk_len_line", 6},
+		{"after_bulk_len_line", 8},
+		{"inside_name", 13}, // the exact failure mode from #3839 ("messa")
+		{"before_name_crlf", 15},
+	}
+
+	for _, tc := range cutpoints {
+		t.Run(tc.name, func(t *testing.T) {
+			data := []byte(frame)
+			// Use a chunked reader whose first chunk equals tc.prefix and
+			// whose second chunk delivers the rest. bufio will fill from the
+			// first chunk only, then block-fill from the second when we
+			// peek past it.
+			rd := NewReader(&chunkedReader{data: data, chunkSize: tc.prefix})
+
+			if _, err := rd.PeekReplyType(); err != nil {
+				t.Fatalf("PeekReplyType: %v", err)
+			}
+
+			name, err := rd.PeekPushNotificationName()
+			if err != nil {
+				t.Fatalf("PeekPushNotificationName: unexpected error: %v", err)
+			}
+			if name != "message" {
+				t.Fatalf("PeekPushNotificationName: got %q, want %q", name, "message")
+			}
+
+			// And the full frame must still be readable afterwards.
+			reply, err := rd.ReadReply()
+			if err != nil {
+				t.Fatalf("ReadReply: %v", err)
+			}
+			arr, ok := reply.([]interface{})
+			if !ok || len(arr) != 3 || arr[0] != "message" || arr[1] != "channel" || arr[2] != "hello" {
+				t.Fatalf("ReadReply: got %#v, want [message channel hello]", reply)
+			}
+		})
+	}
+}
+
+// TestPeekPushNotificationName_TruncatedHeaderUnderlyingEOF covers the case
+// where the underlying connection delivers a partial frame and then closes.
+// PeekPushNotificationName must surface the read error rather than returning
+// a truncated name.
+func TestPeekPushNotificationName_TruncatedHeaderUnderlyingEOF(t *testing.T) {
+	// A push frame that ends mid-name.
+	data := []byte(">3\r\n$7\r\nmessa")
+	rd := NewReader(bytes.NewReader(data))
+
+	if _, err := rd.PeekReplyType(); err != nil {
+		t.Fatalf("PeekReplyType: %v", err)
+	}
+
+	name, err := rd.PeekPushNotificationName()
+	if err == nil {
+		t.Fatalf("PeekPushNotificationName: want error, got name=%q", name)
+	}
+	if name != "" {
+		t.Fatalf("PeekPushNotificationName: want empty name on error, got %q", name)
+	}
 }

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -100,9 +100,20 @@ func (r *Reader) PeekReplyType() (byte, error) {
 	return b[0], nil
 }
 
+// PeekPushNotificationName returns the notification name of the next RESP3
+// push frame without consuming it. The caller is expected to have already
+// verified that the next reply is a push notification (e.g. via PeekReplyType
+// returning RespPush).
+//
+// To identify the name the method may block briefly reading more bytes from
+// the underlying connection. That is safe: once the push marker '>' has been
+// observed, the server is committed to sending the rest of the frame, so
+// fetching the next few header bytes does not race with anything the caller
+// could be waiting on. Blocking is preferred to a truncated peek, which would
+// silently misidentify the notification and cause the caller's ReadReply to
+// consume (and drop) the frame; see issue #3839.
 func (r *Reader) PeekPushNotificationName() (string, error) {
-	// "prime" the buffer by peeking at the next byte
-	c, err := r.Peek(1)
+	c, err := r.rd.Peek(1)
 	if err != nil {
 		return "", err
 	}
@@ -110,80 +121,126 @@ func (r *Reader) PeekPushNotificationName() (string, error) {
 		return "", fmt.Errorf("redis: can't peek push notification name, next reply is not a push notification")
 	}
 
-	// peek 36 bytes at most, should be enough to read the push notification name
-	toPeek := 36
-	buffered := r.Buffered()
-	if buffered == 0 {
-		return "", fmt.Errorf("redis: can't peek push notification name, no data available")
+	// Start with a peek window that covers every Redis-defined notification
+	// header (MOVING, MIGRATING, FAILED_OVER, message, pmessage, smessage,
+	// subscribe, unsubscribe, ...). If a longer name is encountered, grow
+	// the window up to maxPushHeaderPeek before giving up.
+	const initialPeek = 36
+	const maxPushHeaderPeek = 4096
+
+	peekSize := initialPeek
+	for {
+		buf, peekErr := r.rd.Peek(peekSize)
+		name, complete, parseErr := parsePushNotificationName(buf)
+		if parseErr != nil {
+			return "", parseErr
+		}
+		if complete {
+			return name, nil
+		}
+		// Parser ran out of bytes. Surface a failed underlying read before
+		// growing further; otherwise grow the peek window and retry.
+		if peekErr != nil {
+			return "", peekErr
+		}
+		if peekSize >= maxPushHeaderPeek {
+			return "", fmt.Errorf("redis: push notification header exceeds %d bytes", maxPushHeaderPeek)
+		}
+		peekSize *= 2
+		if peekSize > maxPushHeaderPeek {
+			peekSize = maxPushHeaderPeek
+		}
 	}
-	if buffered < toPeek {
-		toPeek = buffered
-	}
-	buf, err := r.rd.Peek(toPeek)
-	if err != nil {
-		return "", err
+}
+
+// parsePushNotificationName extracts the notification name from a buffered
+// RESP3 push frame prefix. The three return values are:
+//
+//   - (name, true, nil): the full name is in buf.
+//   - ("", false, nil):  buf is a valid prefix but too short to determine the
+//     name; the caller should fetch more bytes and retry.
+//   - ("", _, err):      buf is malformed.
+//
+// This split lets PeekPushNotificationName tell "incomplete header" apart
+// from "corrupt frame" without ever returning a truncated string.
+func parsePushNotificationName(buf []byte) (string, bool, error) {
+	// Need at least ">N\r" before any meaningful work.
+	if len(buf) < 3 {
+		return "", false, nil
 	}
 	if buf[0] != RespPush {
-		return "", fmt.Errorf("redis: can't parse push notification: %q", buf)
+		return "", false, fmt.Errorf("redis: can't parse push notification: %q", buf)
 	}
 
-	if len(buf) < 3 {
-		return "", fmt.Errorf("redis: can't parse push notification: %q", buf)
+	// Skip the array length line ">N\r\n".
+	pos, ok, err := skipDigitsThenCRLF(buf, 1)
+	if err != nil {
+		return "", false, fmt.Errorf("redis: can't parse push notification: %w", err)
+	}
+	if !ok {
+		return "", false, nil
 	}
 
-	// remove push notification type
-	buf = buf[1:]
-	// remove first line - e.g. >2\r\n
-	for i := 0; i < len(buf)-1; i++ {
-		if buf[i] == '\r' && buf[i+1] == '\n' {
-			buf = buf[i+2:]
-			break
-		} else {
-			if buf[i] < '0' || buf[i] > '9' {
-				return "", fmt.Errorf("redis: can't parse push notification: %q", buf)
-			}
-		}
+	// First element type byte: '$' (bulk) or '+' (simple-string).
+	if pos >= len(buf) {
+		return "", false, nil
 	}
-	if len(buf) < 2 {
-		return "", fmt.Errorf("redis: can't parse push notification: %q", buf)
+	typeOfName := buf[pos]
+	if typeOfName != RespString && typeOfName != RespStatus {
+		return "", false, fmt.Errorf("redis: can't parse push notification name: %q", buf[pos:])
 	}
-	// next line should be $<length><string>\r\n or +<length><string>\r\n
-	// should have the type of the push notification name and it's length
-	if buf[0] != RespString && buf[0] != RespStatus {
-		return "", fmt.Errorf("redis: can't parse push notification name: %q", buf)
-	}
-	typeOfName := buf[0]
-	// remove the type of the push notification name
-	buf = buf[1:]
+	pos++
+
 	if typeOfName == RespString {
-		// remove the length of the string
-		if len(buf) < 2 {
-			return "", fmt.Errorf("redis: can't parse push notification name: %q", buf)
+		// Read "$M\r\n" then the M-byte name.
+		lenStart := pos
+		next, ok, err := skipDigitsThenCRLF(buf, pos)
+		if err != nil {
+			return "", false, fmt.Errorf("redis: can't parse push notification name length: %w", err)
 		}
-		for i := 0; i < len(buf)-1; i++ {
-			if buf[i] == '\r' && buf[i+1] == '\n' {
-				buf = buf[i+2:]
-				break
-			} else {
-				if buf[i] < '0' || buf[i] > '9' {
-					return "", fmt.Errorf("redis: can't parse push notification name: %q", buf)
-				}
-			}
+		if !ok {
+			return "", false, nil
 		}
+		if next-2 == lenStart {
+			return "", false, fmt.Errorf("redis: empty push notification name length")
+		}
+		nameLen, err := util.Atoi(buf[lenStart : next-2])
+		if err != nil {
+			return "", false, fmt.Errorf("redis: invalid push notification name length %q: %w", buf[lenStart:next-2], err)
+		}
+		if nameLen < 0 {
+			return "", false, fmt.Errorf("redis: negative push notification name length: %d", nameLen)
+		}
+		end := next + nameLen
+		if end > len(buf) {
+			return "", false, nil
+		}
+		return util.BytesToString(buf[next:end]), true, nil
 	}
 
-	if len(buf) < 2 {
-		return "", fmt.Errorf("redis: can't parse push notification name: %q", buf)
-	}
-	// keep only the notification name
-	for i := 0; i < len(buf)-1; i++ {
+	// RespStatus: scan for the terminating CRLF.
+	for i := pos; i < len(buf)-1; i++ {
 		if buf[i] == '\r' && buf[i+1] == '\n' {
-			buf = buf[:i]
-			break
+			return util.BytesToString(buf[pos:i]), true, nil
 		}
 	}
+	return "", false, nil
+}
 
-	return util.BytesToString(buf), nil
+// skipDigitsThenCRLF advances past zero-or-more ASCII digits and the
+// terminating "\r\n" starting at offset start in buf. It returns the position
+// after the "\r\n" and true on success; (pos, false, nil) if buf is too
+// short; or an error if a non-digit non-CR byte is encountered before the CRLF.
+func skipDigitsThenCRLF(buf []byte, start int) (int, bool, error) {
+	for pos := start; pos < len(buf)-1; pos++ {
+		if buf[pos] == '\r' && buf[pos+1] == '\n' {
+			return pos + 2, true, nil
+		}
+		if buf[pos] < '0' || buf[pos] > '9' {
+			return pos, false, fmt.Errorf("expected digit or CRLF, got %q", buf[pos])
+		}
+	}
+	return len(buf), false, nil
 }
 
 // ReadLine Return a valid reply, it will check the protocol or redis error,

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -173,12 +173,20 @@ func parsePushNotificationName(buf []byte) (string, bool, error) {
 	}
 
 	// Skip the array length line ">N\r\n".
-	pos, ok, err := skipDigitsThenCRLF(buf, 1)
+	const arrayLenStart = 1 // first byte after the '>' marker
+	pos, ok, err := skipDigitsThenCRLF(buf, arrayLenStart)
 	if err != nil {
 		return "", false, fmt.Errorf("redis: can't parse push notification: %w", err)
 	}
 	if !ok {
 		return "", false, nil
+	}
+	// Reject ">\r\n": RESP requires at least one digit for the array length.
+	// Without this check the empty length looks like a valid prefix and the
+	// caller would block fetching more bytes for a frame that is already
+	// malformed.
+	if pos-2 == arrayLenStart {
+		return "", false, fmt.Errorf("redis: empty push notification array length")
 	}
 
 	// First element type byte: '$' (bulk) or '+' (simple-string).

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -219,11 +219,15 @@ func parsePushNotificationName(buf []byte) (string, bool, error) {
 		if nameLen < 0 {
 			return "", false, fmt.Errorf("redis: negative push notification name length: %d", nameLen)
 		}
-		end := next + nameLen
-		if end > len(buf) {
+		// Compare against the remaining bytes instead of computing
+		// next+nameLen: a hugely advertised length on malformed input could
+		// overflow int, wrap negative, slip past an "end > len(buf)" guard and
+		// panic the slice below. next <= len(buf) here, so the subtraction is
+		// safe.
+		if nameLen > len(buf)-next {
 			return "", false, nil
 		}
-		return util.BytesToString(buf[next:end]), true, nil
+		return util.BytesToString(buf[next : next+nameLen]), true, nil
 	}
 
 	// RespStatus: scan for the terminating CRLF.

--- a/push/processor_unit_test.go
+++ b/push/processor_unit_test.go
@@ -3,7 +3,11 @@ package push
 import (
 	"context"
 	"fmt"
+	"io"
+	"strings"
 	"testing"
+
+	"github.com/redis/go-redis/v9/internal/proto"
 )
 
 // TestProcessorCreation tests processor creation and initialization
@@ -395,4 +399,89 @@ func TestErrorWrapping(t *testing.T) {
 			t.Errorf("IsHandlerNilError should return false for non-matching error")
 		}
 	})
+}
+
+// chunkedReader3839 reproduces the exact bufio fill boundary from issue #3839:
+// the underlying connection delivers chunks of a fixed size, and the chunk
+// boundary lands in the middle of a RESP3 "message" push frame header. Before
+// the fix, PeekPushNotificationName silently returned the truncated name
+// (e.g. "messa") and ProcessPendingNotifications consumed the frame via
+// ReadReply, dropping the message.
+type chunkedReader3839 struct {
+	data      []byte
+	chunkSize int
+	off       int
+}
+
+func (r *chunkedReader3839) Read(p []byte) (int, error) {
+	if r.off >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := r.chunkSize
+	if n > len(p) {
+		n = len(p)
+	}
+	if r.off+n > len(r.data) {
+		n = len(r.data) - r.off
+	}
+	copy(p, r.data[r.off:r.off+n])
+	r.off += n
+	return n, nil
+}
+
+// TestProcessPendingNotifications_RESP3PubSubMessageLossRegression is the
+// reporter's exact reproducer for issue #3839. It drives the same code path
+// PubSub.ReceiveTimeout runs on every Receive:
+//
+//	processor.ProcessPendingNotifications(ctx, handlerCtx, rd) // drain out-of-band pushes
+//	rd.ReadReply()                                              // read the actual message
+//
+// A burst of identical RESP3 "message" push frames is fed through a chunked
+// reader so that at every bufio fill boundary, only the beginning of a frame
+// is buffered. With the bug, fewer messages are delivered than published.
+// With the fix, all messages are delivered.
+func TestProcessPendingNotifications_RESP3PubSubMessageLossRegression(t *testing.T) {
+	const frame = ">3\r\n$7\r\nmessage\r\n$7\r\nchannel\r\n$5\r\nhello\r\n"
+	const frameLen = len(frame)
+	const numFrames = 1000
+
+	stream := strings.Repeat(frame, numFrames)
+
+	// 4072 % 41 = 13, leaving the prefix ">3\r\n$7\r\nmessa" buffered at each
+	// fill boundary - the exact failure mode from #3839.
+	const chunkSize = 4072
+	if rem := chunkSize % frameLen; rem < 9 || rem > 16 {
+		t.Fatalf("test setup error: chunkSize %% frameLen = %d, want 9..16", rem)
+	}
+
+	rd := proto.NewReader(&chunkedReader3839{data: []byte(stream), chunkSize: chunkSize})
+	processor := NewProcessor()
+	ctx := context.Background()
+	handlerCtx := NotificationHandlerContext{IsBlocking: true}
+
+	delivered := 0
+	for {
+		if err := processor.ProcessPendingNotifications(ctx, handlerCtx, rd); err != nil {
+			t.Fatalf("ProcessPendingNotifications after %d delivered: %v", delivered, err)
+		}
+		reply, err := rd.ReadReply()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("ReadReply after %d delivered: %v", delivered, err)
+		}
+		arr, ok := reply.([]interface{})
+		if !ok || len(arr) == 0 || arr[0] != "message" {
+			t.Fatalf("unexpected reply after %d delivered: %#v", delivered, reply)
+		}
+		delivered++
+	}
+
+	if delivered != numFrames {
+		t.Fatalf(
+			"#3839 regressed: published %d messages but only %d delivered (%d dropped)",
+			numFrames, delivered, numFrames-delivered,
+		)
+	}
 }


### PR DESCRIPTION
fixes #3839 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes low-level RESP3 read/peek behavior on live connections (may block briefly) on a path used by pub/sub and push draining; well-covered by regression tests but affects core protocol parsing.
> 
> **Overview**
> Fixes **#3839**, where RESP3 pub/sub could **lose messages** because `PeekPushNotificationName` only inspected already-buffered bytes and could return a **truncated** notification name (e.g. `"messa"`). The push processor then mis-routed the frame and `ReadReply` dropped it.
> 
> **`PeekPushNotificationName`** now grows the peek window (36 → up to 4096) and **reads more from the connection** until the header is complete or the read fails, instead of capping at `Buffered()`. Parsing is refactored into **`parsePushNotificationName`** and **`skipDigitsThenCRLF`**, which separate incomplete prefixes from corrupt frames and avoid returning partial names; malformed cases include empty array length, EOF mid-header, and overflow-safe bulk length handling.
> 
> Tests add chunked-read boundaries, malformed/overflow cases, and a **`ProcessPendingNotifications`** regression that delivers 1000 RESP3 `message` frames through the same drain-then-`ReadReply` path as `PubSub.ReceiveTimeout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1329d105f0dcffaaa3d418faad6a9c68f5db27dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->