### PR TITLE
fix: ignore unknown fields in CLUSTER SHARDS response

### DIFF
--- a/command.go
+++ b/command.go
@@ -7125,7 +7125,9 @@ func (cmd *ClusterShardsCmd) readReply(rd *proto.Reader) error {
 						case "health":
 							cmd.val[i].Nodes[k].Health, err = rd.ReadString()
 						default:
-							return fmt.Errorf("redis: unexpected key %q in CLUSTER SHARDS node reply", nodeKey)
+							if err = rd.DiscardNext(); err != nil {
+								return err
+							}
 						}
 
 						if err != nil {
@@ -7134,7 +7136,9 @@ func (cmd *ClusterShardsCmd) readReply(rd *proto.Reader) error {
 					}
 				}
 			default:
-				return fmt.Errorf("redis: unexpected key %q in CLUSTER SHARDS reply", key)
+				if err = rd.DiscardNext(); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/command_cluster_shards_test.go
+++ b/command_cluster_shards_test.go
@@ -1,0 +1,103 @@
+package redis
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/redis/go-redis/v9/internal/proto"
+)
+
+func TestClusterShardsCmdIgnoresUnknownFields(t *testing.T) {
+	// Simulate a CLUSTER SHARDS response containing unknown fields at both the
+	// shard level and node level. The 'nodes' field contains a list of all nodes
+	// within the shard. Each individual node is a map of attributes that describe
+	// the node. Some attributes are optional and more attributes may be added in
+	// the future. The client must tolerate unknown attributes gracefully.
+	//
+	// This response contains:
+	// - 1 shard with an unknown top-level field "new-shard-field"
+	// - 1 slot range [0, 5460]
+	// - 1 node with an unknown field "new-node-field"
+	reply := "*1\r\n" + // array of 1 shard
+		"%4\r\n" + // shard map with 4 entries (slots, nodes, new-shard-field, another-future-field)
+		// slots
+		"$5\r\nslots\r\n" +
+		"*2\r\n:0\r\n:5460\r\n" +
+		// nodes
+		"$5\r\nnodes\r\n" +
+		"*1\r\n" + // 1 node
+		"%5\r\n" + // node map with 5 entries (id, port, role, health + 1 unknown)
+		"$2\r\nid\r\n$40\r\ne7d1eec13a26e40c197e55aaa34ab68efa3d5db5\r\n" +
+		"$4\r\nport\r\n:6379\r\n" +
+		"$4\r\nrole\r\n$6\r\nmaster\r\n" +
+		"$6\r\nhealth\r\n$6\r\nonline\r\n" +
+		"$14\r\nnew-node-field\r\n$11\r\nsome-value1\r\n" +
+		// unknown shard-level field (string value)
+		"$15\r\nnew-shard-field\r\n$11\r\nsome-value2\r\n" +
+		// unknown shard-level field (integer value)
+		"$20\r\nanother-future-field\r\n:42\r\n"
+
+	cmd := NewClusterShardsCmd(context.Background())
+	rd := proto.NewReader(strings.NewReader(reply))
+
+	if err := cmd.readReply(rd); err != nil {
+		t.Fatalf("readReply() returned unexpected error: %v", err)
+	}
+
+	if len(cmd.val) != 1 {
+		t.Fatalf("expected 1 shard, got %d", len(cmd.val))
+	}
+
+	shard := cmd.val[0]
+
+	if len(shard.Slots) != 1 || shard.Slots[0].Start != 0 || shard.Slots[0].End != 5460 {
+		t.Fatalf("unexpected slots: %+v", shard.Slots)
+	}
+
+	if len(shard.Nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(shard.Nodes))
+	}
+
+	node := shard.Nodes[0]
+	if node.ID != "e7d1eec13a26e40c197e55aaa34ab68efa3d5db5" {
+		t.Errorf("node ID = %q, want e7d1eec13a26e40c197e55aaa34ab68efa3d5db5", node.ID)
+	}
+	if node.Port != 6379 {
+		t.Errorf("node Port = %d, want 6379", node.Port)
+	}
+	if node.Role != "master" {
+		t.Errorf("node Role = %q, want master", node.Role)
+	}
+	if node.Health != "online" {
+		t.Errorf("node Health = %q, want online", node.Health)
+	}
+}
+
+func TestClusterShardsCmdUnknownNodeFieldWithArrayValue(t *testing.T) {
+	// Verify that unknown node fields with complex values (arrays) are skipped.
+	reply := "*1\r\n" + // 1 shard
+		"%2\r\n" + // shard map: slots + nodes
+		"$5\r\nslots\r\n*2\r\n:0\r\n:16383\r\n" +
+		"$5\r\nnodes\r\n" +
+		"*1\r\n" + // 1 node
+		"%3\r\n" + // node map: id, role, unknown-array-field
+		"$2\r\nid\r\n$40\r\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\r\n" +
+		"$4\r\nrole\r\n$7\r\nreplica\r\n" +
+		"$13\r\nfuture-extras\r\n*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n"
+
+	cmd := NewClusterShardsCmd(context.Background())
+	rd := proto.NewReader(strings.NewReader(reply))
+
+	if err := cmd.readReply(rd); err != nil {
+		t.Fatalf("readReply() returned unexpected error: %v", err)
+	}
+
+	node := cmd.val[0].Nodes[0]
+	if node.ID != "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+		t.Errorf("node ID = %q, want aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", node.ID)
+	}
+	if node.Role != "replica" {
+		t.Errorf("node Role = %q, want replica", node.Role)
+	}
+}


### PR DESCRIPTION
## Summary

The `CLUSTER SHARDS` response parser errors on any unrecognized field, breaking clients whenever the server introduces new node or shard attributes.

The [`nodes` field](https://redis.io/docs/latest/commands/cluster-shards/) contains a list of all nodes within the shard. Each individual node is a map of attributes that describe the node. Some attributes are optional and more attributes may be added in the future. The current list of attributes:

> id, endpoint, ip, hostname, port, tls-port, role, replication-offset, health

The parser should be forward-compatible. Unknown fields are now discarded via `rd.DiscardNext()`, the same pattern used elsewhere in this codebase (e.g., `FunctionListCmd`, `ModuleLoadexConfig` parsing).

Changes:
- Replace `fmt.Errorf` on unknown node-level fields with `rd.DiscardNext()`
- Replace `fmt.Errorf` on unknown shard-level fields with `rd.DiscardNext()`
- Add unit tests verifying unknown fields (string, integer, array values) are silently skipped

## Test plan

- [x] Unit tests cover unknown fields at both shard and node levels
- [x] Tests exercise string, integer, and array-typed unknown values
- [x] CI passes (no Go installed locally to verify)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster topology parsing used for routing; incorrect discard logic could break cluster clients, but behavior aligns with existing DiscardNext patterns and is covered by new unit tests.
> 
> **Overview**
> The **`CLUSTER SHARDS`** reply parser no longer fails when Redis returns **unknown shard- or node-level attributes**. Unrecognized keys are **skipped** with `rd.DiscardNext()` instead of returning `fmt.Errorf`, matching forward-compatibility used elsewhere (e.g. `XInfo*` parsers).
> 
> **Tests** assert that known `slots` / `nodes` data still parses when extra fields are present (string, integer, and array-valued unknown node fields).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f4fdaf8d5a3d2986bb6222b024d8b85b177732e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->