### PR TITLE
fix(ft.hybrid): Always generate vector param names if they are not provided by the user

### DIFF
--- a/search_commands.go
+++ b/search_commands.go
@@ -3904,7 +3904,6 @@ func (c cmdable) FTHybridWithArgs(ctx context.Context, index string, options *FT
 				// the query and clauses using "$<name>".
 				args = append(args, key, value)
 			}
-			}
 		}
 
 		// Add EXPLAINSCORE

--- a/search_commands.go
+++ b/search_commands.go
@@ -408,11 +408,12 @@ const (
 type FTHybridVectorExpression struct {
 	VectorField string
 	VectorData  Vector
-	// VectorParamName specifies the parameter name for passing vector data via PARAMS mechanism.
-	// REQUIRED for Redis 8.6+ (inline vector blobs are not supported in 8.6+).
-	// Optional for Redis 8.4-8.5 (both inline and PARAMS are supported).
-	// When set, the vector blob will be passed as: VSIM @field $VectorParamName PARAMS ... VectorParamName <blob>
-	// When empty, the vector blob will be inlined: VSIM @field <blob> (fails on Redis 8.6+)
+	// VectorParamName optionally specifies the parameter name used to pass the
+	// vector data via the PARAMS mechanism.
+	// Vector data is always passed via PARAMS because inline vector blobs are no
+	// longer supported by Redis. When left empty, the library generates a unique
+	// parameter name automatically.
+	// The vector blob is passed as: VSIM @field $VectorParamName ... PARAMS ... VectorParamName <blob>
 	VectorParamName string
 	Method          FTHybridVectorMethod
 	MethodParams    []interface{}
@@ -3700,6 +3701,19 @@ func hybridVectorBytes(blob []byte) ([]byte, error) {
 	return blob, nil
 }
 
+// generateVectorParamName returns a parameter name that is not already present
+// in params. It is used to pass vector data via the PARAMS mechanism when the
+// caller does not provide a VectorParamName, since inline vector blobs are no
+// longer supported by Redis.
+func generateVectorParamName(params map[string]interface{}) string {
+	for i := 0; ; i++ {
+		name := fmt.Sprintf("__vector_param_%d", i)
+		if _, ok := params[name]; !ok {
+			return name
+		}
+	}
+}
+
 // FTHybridWithArgs - Executes a hybrid search with advanced options
 // FTHybridWithArgs is still experimental, the command behaviour and signature may change
 func (c cmdable) FTHybridWithArgs(ctx context.Context, index string, options *FTHybridOptions) *FTHybridCmd {
@@ -3733,19 +3747,18 @@ func (c cmdable) FTHybridWithArgs(ctx context.Context, index string, options *FT
 				return cmd
 			}
 
-			// If VectorParamName is provided, use PARAMS mechanism (required for Redis 8.6+)
-			// If not provided, inline the vector blob (works on Redis 8.4/8.5, fails on 8.6+)
-			if vectorExpr.VectorParamName != "" {
-				// Use PARAMS mechanism
-				args = append(args, "$"+vectorExpr.VectorParamName)
-				if options.Params == nil {
-					options.Params = make(map[string]interface{})
-				}
-				options.Params[vectorExpr.VectorParamName] = vectorBlob
-			} else {
-				// Inline the vector blob (deprecated in Redis 8.6+)
-				args = append(args, vectorBlob)
+			// Vector data is always passed via the PARAMS mechanism. Inline vector
+			// blobs are no longer supported by Redis, so when VectorParamName is not
+			// provided we generate a unique parameter name and use it.
+			paramName := vectorExpr.VectorParamName
+			if paramName == "" {
+				paramName = generateVectorParamName(options.Params)
 			}
+			args = append(args, "$"+paramName)
+			if options.Params == nil {
+				options.Params = make(map[string]interface{})
+			}
+			options.Params[paramName] = vectorBlob
 
 			if vectorExpr.Method != "" {
 				args = append(args, vectorExpr.Method)

--- a/search_commands.go
+++ b/search_commands.go
@@ -412,13 +412,9 @@ type FTHybridVectorExpression struct {
 	// vector data via the PARAMS mechanism.
 	// Vector data is always passed via PARAMS because inline vector blobs are no
 	// longer supported by Redis. When left empty, the library generates a unique
-	// parameter name automatically (e.g. "__vector_param_0").
+	// parameter name automatically (e.g. "__vector_param_0") without mutating
+	// FTHybridOptions.Params and without colliding with any explicit names.
 	// The vector blob is passed as: VSIM @field $VectorParamName ... PARAMS ... VectorParamName <blob>
-	//
-	// Setting VectorParamName explicitly is recommended. The auto-generated names
-	// come with a couple of known limitations (see FTHybridWithArgs for details):
-	// generated names are written back into FTHybridOptions.Params, and they may
-	// collide with explicit names that follow the "__vector_param_N" pattern.
 	VectorParamName string
 	Method          FTHybridVectorMethod
 	MethodParams    []interface{}
@@ -3725,19 +3721,13 @@ func generateVectorParamName(params map[string]interface{}) string {
 // Vector data is always sent through the PARAMS mechanism, because inline vector
 // blobs are no longer supported by Redis. For every vector expression whose
 // VectorParamName is empty, a unique name is generated (e.g. "__vector_param_0")
-// and the corresponding blob is added to options.Params.
+// and the corresponding blob is passed via PARAMS.
 //
-// Known limitations of the auto-generated names (set VectorParamName explicitly to
-// avoid them):
-//   - options.Params is mutated: generated entries are written into the provided
-//     options. Reusing the same *FTHybridOptions across multiple calls will keep
-//     accumulating "__vector_param_N" entries, so prefer a fresh options value per
-//     call (or set VectorParamName explicitly) when reusing options.
-//   - name collisions: if some expressions set VectorParamName explicitly to a value
-//     matching the generated "__vector_param_N" pattern while others rely on
-//     generation, a generated name may overwrite an explicit one and a VSIM clause
-//     could reference the wrong blob. Setting VectorParamName on all expressions
-//     avoids this.
+// options.Params is never mutated: the command is built from a local copy that
+// combines the caller-provided params with any generated vector parameters. This
+// makes it safe to reuse the same *FTHybridOptions across multiple calls. Generated
+// names are also reserved against all explicit VectorParamName values, so they never
+// collide with explicit names (even those following the "__vector_param_N" pattern).
 func (c cmdable) FTHybridWithArgs(ctx context.Context, index string, options *FTHybridOptions) *FTHybridCmd {
 	args := []interface{}{"FT.HYBRID", index}
 
@@ -3758,6 +3748,20 @@ func (c cmdable) FTHybridWithArgs(ctx context.Context, index string, options *FT
 			}
 		}
 
+		// Vector data is always passed via the PARAMS mechanism (inline vector blobs
+		// are no longer supported by Redis). Build a local copy of the caller-provided
+		// params so options.Params is never mutated, and pre-reserve any explicit
+		// VectorParamName values so generated names never collide with them.
+		params := make(map[string]interface{}, len(options.Params)+len(options.VectorExpressions))
+		for k, v := range options.Params {
+			params[k] = v
+		}
+		for _, vectorExpr := range options.VectorExpressions {
+			if vectorExpr.VectorParamName != "" {
+				params[vectorExpr.VectorParamName] = nil
+			}
+		}
+
 		// Add vector expressions
 		for _, vectorExpr := range options.VectorExpressions {
 			args = append(args, "VSIM", "@"+vectorExpr.VectorField)
@@ -3769,18 +3773,15 @@ func (c cmdable) FTHybridWithArgs(ctx context.Context, index string, options *FT
 				return cmd
 			}
 
-			// Vector data is always passed via the PARAMS mechanism. Inline vector
-			// blobs are no longer supported by Redis, so when VectorParamName is not
-			// provided we generate a unique parameter name and use it.
+			// When VectorParamName is not provided, generate a unique name. Generated
+			// names are tracked only in the local params map, never written back to
+			// options.Params.
 			paramName := vectorExpr.VectorParamName
 			if paramName == "" {
-				paramName = generateVectorParamName(options.Params)
+				paramName = generateVectorParamName(params)
 			}
 			args = append(args, "$"+paramName)
-			if options.Params == nil {
-				options.Params = make(map[string]interface{})
-			}
-			options.Params[paramName] = vectorBlob
+			params[paramName] = vectorBlob
 
 			if vectorExpr.Method != "" {
 				args = append(args, vectorExpr.Method)
@@ -3891,9 +3892,11 @@ func (c cmdable) FTHybridWithArgs(ctx context.Context, index string, options *FT
 		}
 
 		// Add PARAMS
-		if len(options.Params) > 0 {
-			args = append(args, "PARAMS", len(options.Params)*2)
-			for key, value := range options.Params {
+		// Emit from the local params map, which contains the caller-provided params
+		// plus any generated vector parameter names. options.Params is left untouched.
+		if len(params) > 0 {
+			args = append(args, "PARAMS", len(params)*2)
+			for key, value := range params {
 				// Parameter keys should already have '$' prefix from the user
 				// Don't add it again if it's already there
 				args = append(args, key, value)

--- a/search_commands.go
+++ b/search_commands.go
@@ -3900,9 +3900,10 @@ func (c cmdable) FTHybridWithArgs(ctx context.Context, index string, options *FT
 		if len(params) > 0 {
 			args = append(args, "PARAMS", len(params)*2)
 			for key, value := range params {
-				// Parameter keys should already have '$' prefix from the user
-				// Don't add it again if it's already there
+				// PARAMS entries are passed without a '$' prefix; they are referenced in
+				// the query and clauses using "$<name>".
 				args = append(args, key, value)
+			}
 			}
 		}
 

--- a/search_commands.go
+++ b/search_commands.go
@@ -3749,19 +3749,22 @@ func (c cmdable) FTHybridWithArgs(ctx context.Context, index string, options *FT
 		}
 
 		// Vector data is always passed via the PARAMS mechanism (inline vector blobs
-		// are no longer supported by Redis). Build a local copy of the caller-provided
-		// params so options.Params is never mutated, and pre-reserve any explicit
-		// VectorParamName values so generated names never collide with them.
-		params := make(map[string]interface{}, len(options.Params)+len(options.VectorExpressions))
-		for k, v := range options.Params {
-			params[k] = v
-		}
-		for _, vectorExpr := range options.VectorExpressions {
-			if vectorExpr.VectorParamName != "" {
-				params[vectorExpr.VectorParamName] = nil
+		// are no longer supported by Redis). When vectors are present, build a local
+		// copy of the caller-provided params so options.Params is never mutated, and
+		// pre-reserve any explicit VectorParamName values so generated names never
+		// collide with them.
+		params := options.Params
+		if len(options.VectorExpressions) > 0 {
+			params = make(map[string]interface{}, len(options.Params)+len(options.VectorExpressions))
+			for k, v := range options.Params {
+				params[k] = v
+			}
+			for _, vectorExpr := range options.VectorExpressions {
+				if vectorExpr.VectorParamName != "" {
+					params[vectorExpr.VectorParamName] = nil
+				}
 			}
 		}
-
 		// Add vector expressions
 		for _, vectorExpr := range options.VectorExpressions {
 			args = append(args, "VSIM", "@"+vectorExpr.VectorField)

--- a/search_commands.go
+++ b/search_commands.go
@@ -412,8 +412,13 @@ type FTHybridVectorExpression struct {
 	// vector data via the PARAMS mechanism.
 	// Vector data is always passed via PARAMS because inline vector blobs are no
 	// longer supported by Redis. When left empty, the library generates a unique
-	// parameter name automatically.
+	// parameter name automatically (e.g. "__vector_param_0").
 	// The vector blob is passed as: VSIM @field $VectorParamName ... PARAMS ... VectorParamName <blob>
+	//
+	// Setting VectorParamName explicitly is recommended. The auto-generated names
+	// come with a couple of known limitations (see FTHybridWithArgs for details):
+	// generated names are written back into FTHybridOptions.Params, and they may
+	// collide with explicit names that follow the "__vector_param_N" pattern.
 	VectorParamName string
 	Method          FTHybridVectorMethod
 	MethodParams    []interface{}
@@ -3716,6 +3721,23 @@ func generateVectorParamName(params map[string]interface{}) string {
 
 // FTHybridWithArgs - Executes a hybrid search with advanced options
 // FTHybridWithArgs is still experimental, the command behaviour and signature may change
+//
+// Vector data is always sent through the PARAMS mechanism, because inline vector
+// blobs are no longer supported by Redis. For every vector expression whose
+// VectorParamName is empty, a unique name is generated (e.g. "__vector_param_0")
+// and the corresponding blob is added to options.Params.
+//
+// Known limitations of the auto-generated names (set VectorParamName explicitly to
+// avoid them):
+//   - options.Params is mutated: generated entries are written into the provided
+//     options. Reusing the same *FTHybridOptions across multiple calls will keep
+//     accumulating "__vector_param_N" entries, so prefer a fresh options value per
+//     call (or set VectorParamName explicitly) when reusing options.
+//   - name collisions: if some expressions set VectorParamName explicitly to a value
+//     matching the generated "__vector_param_N" pattern while others rely on
+//     generation, a generated name may overwrite an explicit one and a VSIM clause
+//     could reference the wrong blob. Setting VectorParamName on all expressions
+//     avoids this.
 func (c cmdable) FTHybridWithArgs(ctx context.Context, index string, options *FTHybridOptions) *FTHybridCmd {
 	args := []interface{}{"FT.HYBRID", index}
 

--- a/search_commands_unit_test.go
+++ b/search_commands_unit_test.go
@@ -2,10 +2,21 @@ package redis
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 )
+
+// indexOfArg returns the index of the first argument equal to want, or -1.
+func indexOfArg(args []interface{}, want interface{}) int {
+	for i, arg := range args {
+		if reflect.DeepEqual(arg, want) {
+			return i
+		}
+	}
+	return -1
+}
 
 type legacyHybridVector struct {
 	value []any
@@ -194,5 +205,126 @@ func TestFTHybridWithArgsAcceptsVectorFP32(t *testing.T) {
 				t.Fatalf("expected raw vector blob in args, got %v", gotCmd.args)
 			}
 		})
+	}
+}
+
+// assertVectorParam verifies that the vector blob is referenced via $name right
+// after the VSIM field and that it is passed through the PARAMS section.
+func assertVectorParam(t *testing.T, args []interface{}, field, name string, blob []byte) {
+	t.Helper()
+
+	vsimIdx := indexOfArg(args, "@"+field)
+	if vsimIdx < 0 {
+		t.Fatalf("expected vector field @%s in args, got %v", field, args)
+	}
+	ref := "$" + name
+	if vsimIdx+1 >= len(args) || args[vsimIdx+1] != ref {
+		t.Fatalf("expected %q right after @%s, got %v", ref, field, args)
+	}
+	if idx := indexOfArg(args, ref); idx != vsimIdx+1 {
+		t.Fatalf("expected inline vector blob to be replaced by %q, got %v", ref, args)
+	}
+
+	paramsIdx := indexOfArg(args, "PARAMS")
+	if paramsIdx < 0 {
+		t.Fatalf("expected PARAMS in args, got %v", args)
+	}
+	nameIdx := indexOfArg(args, name)
+	if nameIdx <= paramsIdx {
+		t.Fatalf("expected param name %q after PARAMS, got %v", name, args)
+	}
+	if nameIdx+1 >= len(args) {
+		t.Fatalf("expected param value after %q, got %v", name, args)
+	}
+	gotBlob, ok := args[nameIdx+1].([]byte)
+	if !ok || string(gotBlob) != string(blob) {
+		t.Fatalf("expected param %q to carry blob %v, got %v", name, blob, args[nameIdx+1])
+	}
+}
+
+func TestFTHybridWithArgsGeneratesVectorParamName(t *testing.T) {
+	m := &mockCmdable{}
+	c := m.asCmdable()
+	blob := []byte{1, 2, 3, 4}
+	cmd := c.FTHybridWithArgs(context.Background(), "idx", &FTHybridOptions{
+		SearchExpressions: []FTHybridSearchExpression{{Query: "*"}},
+		VectorExpressions: []FTHybridVectorExpression{{
+			VectorField: "embedding",
+			VectorData:  &VectorFP32{Val: blob},
+		}},
+	})
+	if cmd.Err() != nil {
+		t.Fatalf("unexpected error: %v", cmd.Err())
+	}
+	gotCmd, ok := m.lastCmd.(*FTHybridCmd)
+	if !ok {
+		t.Fatalf("expected FTHybridCmd, got %T", m.lastCmd)
+	}
+	assertVectorParam(t, gotCmd.args, "embedding", "__vector_param_0", blob)
+}
+
+func TestFTHybridWithArgsUsesProvidedVectorParamName(t *testing.T) {
+	m := &mockCmdable{}
+	c := m.asCmdable()
+	blob := []byte{1, 2, 3, 4}
+	cmd := c.FTHybridWithArgs(context.Background(), "idx", &FTHybridOptions{
+		SearchExpressions: []FTHybridSearchExpression{{Query: "*"}},
+		VectorExpressions: []FTHybridVectorExpression{{
+			VectorField:     "embedding",
+			VectorData:      &VectorFP32{Val: blob},
+			VectorParamName: "myvec",
+		}},
+	})
+	if cmd.Err() != nil {
+		t.Fatalf("unexpected error: %v", cmd.Err())
+	}
+	gotCmd, ok := m.lastCmd.(*FTHybridCmd)
+	if !ok {
+		t.Fatalf("expected FTHybridCmd, got %T", m.lastCmd)
+	}
+	if idx := indexOfArg(gotCmd.args, "__vector_param_0"); idx >= 0 {
+		t.Fatalf("did not expect generated param name when one is provided, got %v", gotCmd.args)
+	}
+	assertVectorParam(t, gotCmd.args, "embedding", "myvec", blob)
+}
+
+func TestFTHybridWithArgsGeneratesUniqueVectorParamNames(t *testing.T) {
+	m := &mockCmdable{}
+	c := m.asCmdable()
+	blob0 := []byte{1, 2, 3, 4}
+	blob1 := []byte{5, 6, 7, 8}
+	cmd := c.FTHybridWithArgs(context.Background(), "idx", &FTHybridOptions{
+		SearchExpressions: []FTHybridSearchExpression{{Query: "*"}},
+		VectorExpressions: []FTHybridVectorExpression{
+			{VectorField: "embedding", VectorData: &VectorFP32{Val: blob0}},
+			{VectorField: "embedding2", VectorData: &VectorFP32{Val: blob1}},
+		},
+		// Pre-populate the param that would otherwise be generated first to
+		// ensure the generator skips names that are already in use.
+		Params: map[string]interface{}{"__vector_param_0": "reserved"},
+	})
+	if cmd.Err() != nil {
+		t.Fatalf("unexpected error: %v", cmd.Err())
+	}
+	gotCmd, ok := m.lastCmd.(*FTHybridCmd)
+	if !ok {
+		t.Fatalf("expected FTHybridCmd, got %T", m.lastCmd)
+	}
+	assertVectorParam(t, gotCmd.args, "embedding", "__vector_param_1", blob0)
+	assertVectorParam(t, gotCmd.args, "embedding2", "__vector_param_2", blob1)
+}
+
+func TestGenerateVectorParamName(t *testing.T) {
+	if got := generateVectorParamName(nil); got != "__vector_param_0" {
+		t.Fatalf("expected __vector_param_0 for nil params, got %q", got)
+	}
+	params := map[string]interface{}{}
+	for i := 0; i < 3; i++ {
+		name := generateVectorParamName(params)
+		want := fmt.Sprintf("__vector_param_%d", i)
+		if name != want {
+			t.Fatalf("expected %q, got %q", want, name)
+		}
+		params[name] = struct{}{}
 	}
 }

--- a/search_commands_unit_test.go
+++ b/search_commands_unit_test.go
@@ -327,3 +327,62 @@ func TestGenerateVectorParamName(t *testing.T) {
 		params[name] = struct{}{}
 	}
 }
+
+func TestFTHybridWithArgsDoesNotMutateParams(t *testing.T) {
+	m := &mockCmdable{}
+	c := m.asCmdable()
+	blob := []byte{1, 2, 3, 4}
+	options := &FTHybridOptions{
+		SearchExpressions: []FTHybridSearchExpression{{Query: "*"}},
+		VectorExpressions: []FTHybridVectorExpression{{
+			VectorField: "embedding",
+			VectorData:  &VectorFP32{Val: blob},
+		}},
+		Params: map[string]interface{}{"existing": "value"},
+	}
+	want := map[string]interface{}{"existing": "value"}
+
+	// Calling multiple times with the same options must not accumulate generated
+	// parameters in options.Params nor otherwise mutate it.
+	for i := 0; i < 3; i++ {
+		cmd := c.FTHybridWithArgs(context.Background(), "idx", options)
+		if cmd.Err() != nil {
+			t.Fatalf("unexpected error on call %d: %v", i, cmd.Err())
+		}
+		gotCmd, ok := m.lastCmd.(*FTHybridCmd)
+		if !ok {
+			t.Fatalf("expected FTHybridCmd, got %T", m.lastCmd)
+		}
+		// The generated param and the user-provided param are both emitted.
+		assertVectorParam(t, gotCmd.args, "embedding", "__vector_param_0", blob)
+		if !reflect.DeepEqual(options.Params, want) {
+			t.Fatalf("options.Params mutated after call %d: got %v, want %v", i, options.Params, want)
+		}
+	}
+}
+
+func TestFTHybridWithArgsGeneratedNameAvoidsExplicitCollision(t *testing.T) {
+	m := &mockCmdable{}
+	c := m.asCmdable()
+	blob0 := []byte{1, 2, 3, 4}
+	blob1 := []byte{5, 6, 7, 8}
+	// The first expression auto-generates a name while the second explicitly uses
+	// the name the generator would otherwise pick. The generated name must avoid
+	// the explicit one regardless of ordering.
+	cmd := c.FTHybridWithArgs(context.Background(), "idx", &FTHybridOptions{
+		SearchExpressions: []FTHybridSearchExpression{{Query: "*"}},
+		VectorExpressions: []FTHybridVectorExpression{
+			{VectorField: "embedding", VectorData: &VectorFP32{Val: blob0}},
+			{VectorField: "embedding2", VectorData: &VectorFP32{Val: blob1}, VectorParamName: "__vector_param_0"},
+		},
+	})
+	if cmd.Err() != nil {
+		t.Fatalf("unexpected error: %v", cmd.Err())
+	}
+	gotCmd, ok := m.lastCmd.(*FTHybridCmd)
+	if !ok {
+		t.Fatalf("expected FTHybridCmd, got %T", m.lastCmd)
+	}
+	assertVectorParam(t, gotCmd.args, "embedding2", "__vector_param_0", blob1)
+	assertVectorParam(t, gotCmd.args, "embedding", "__vector_param_1", blob0)
+}

--- a/search_commands_unit_test.go
+++ b/search_commands_unit_test.go
@@ -236,8 +236,7 @@ func assertVectorParam(t *testing.T, args []interface{}, field, name string, blo
 	if nameIdx+1 >= len(args) {
 		t.Fatalf("expected param value after %q, got %v", name, args)
 	}
-	gotBlob, ok := args[nameIdx+1].([]byte)
-	if !ok || string(gotBlob) != string(blob) {
+	if !reflect.DeepEqual(args[nameIdx+1], blob) {
 		t.Fatalf("expected param %q to carry blob %v, got %v", name, blob, args[nameIdx+1])
 	}
 }

--- a/search_test.go
+++ b/search_test.go
@@ -3679,7 +3679,6 @@ var _ = Describe("FT.HYBRID Commands", func() {
 
 	It("should perform basic hybrid search", Label("search", "fthybrid"), func() {
 		SkipBeforeRedisVersion(8.4, "no support")
-		SkipAfterRedisVersion(8.5, "inline vector blobs not supported in Redis 8.6+")
 		// Basic hybrid search combining text and vector search
 		searchQuery := "@color:{red}"
 		vectorData := encodeFloat32Vector([]float32{-100, -200, -200, -300})
@@ -3700,7 +3699,6 @@ var _ = Describe("FT.HYBRID Commands", func() {
 
 	It("should perform hybrid search with scorer", Label("search", "fthybrid", "scorer"), func() {
 		SkipBeforeRedisVersion(8.4, "no support")
-		SkipAfterRedisVersion(8.5, "inline vector blobs not supported in Redis 8.6+")
 		// Test with TFIDF scorer
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
@@ -3737,7 +3735,6 @@ var _ = Describe("FT.HYBRID Commands", func() {
 
 	It("should perform hybrid search with vector filter", Label("search", "fthybrid", "filter"), func() {
 		SkipBeforeRedisVersion(8.4, "no support")
-		SkipAfterRedisVersion(8.5, "inline vector blobs not supported in Redis 8.6+")
 		// This query won't have results from search, so we can validate vector filter
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
@@ -3781,7 +3778,6 @@ var _ = Describe("FT.HYBRID Commands", func() {
 
 	It("should perform hybrid search with KNN method", Label("search", "fthybrid", "knn"), func() {
 		SkipBeforeRedisVersion(8.4, "no support")
-		SkipAfterRedisVersion(8.5, "inline vector blobs not supported in Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -3807,7 +3803,6 @@ var _ = Describe("FT.HYBRID Commands", func() {
 
 	It("should perform hybrid search with RANGE method", Label("search", "fthybrid", "range"), func() {
 		SkipBeforeRedisVersion(8.4, "no support")
-		SkipAfterRedisVersion(8.5, "inline vector blobs not supported in Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -3835,7 +3830,6 @@ var _ = Describe("FT.HYBRID Commands", func() {
 
 	It("should perform hybrid search with LINEAR combine method", Label("search", "fthybrid", "combine"), func() {
 		SkipBeforeRedisVersion(8.4, "no support")
-		SkipAfterRedisVersion(8.5, "inline vector blobs not supported in Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -3866,7 +3860,6 @@ var _ = Describe("FT.HYBRID Commands", func() {
 
 	It("should perform hybrid search with RRF combine method", Label("search", "fthybrid", "rrf"), func() {
 		SkipBeforeRedisVersion(8.4, "no support")
-		SkipAfterRedisVersion(8.5, "inline vector blobs not supported in Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -3895,7 +3888,6 @@ var _ = Describe("FT.HYBRID Commands", func() {
 
 	It("should perform hybrid search with LOAD and APPLY", Label("search", "fthybrid", "load", "apply"), func() {
 		SkipBeforeRedisVersion(8.4, "no support")
-		SkipAfterRedisVersion(8.5, "inline vector blobs not supported in Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -3938,7 +3930,6 @@ var _ = Describe("FT.HYBRID Commands", func() {
 
 	It("should perform hybrid search with LIMIT", Label("search", "fthybrid", "limit"), func() {
 		SkipBeforeRedisVersion(8.4, "no support")
-		SkipAfterRedisVersion(8.5, "inline vector blobs not supported in Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -3963,7 +3954,6 @@ var _ = Describe("FT.HYBRID Commands", func() {
 
 	It("should perform hybrid search with SORTBY", Label("search", "fthybrid", "sortby"), func() {
 		SkipBeforeRedisVersion(8.4, "no support")
-		SkipAfterRedisVersion(8.5, "inline vector blobs not supported in Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{


### PR DESCRIPTION
Redis will no longer support inlined vector blobs, the only non-breaking way would be to autogenerate param names if they are not provided, 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FT.HYBRID wire format for all vector expressions (no inline blobs), which is required for newer Redis but alters command construction for existing callers.
> 
> **Overview**
> **FT.HYBRID** now always sends vector data through **PARAMS** (`$name` + blob), because Redis no longer accepts inline vector blobs. When `VectorParamName` is omitted, the client auto-generates names like `__vector_param_0` via new `generateVectorParamName`, with collision avoidance against existing `Params` and other explicit vector param names.
> 
> Command building uses a **local params map** so `FTHybridOptions.Params` is never mutated, making the same options struct safe to reuse across calls. Explicit `VectorParamName` values are still honored.
> 
> Unit tests cover PARAMS wiring, unique names, no mutation, and name collisions; integration hybrid tests no longer skip Redis **8.6+** now that PARAMS is always used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5a4485201915f1f1750f76277764774d7a71ae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->