### PR TITLE
chore(release): 9.20.1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,34 @@
 # Release Notes
 
+# 9.20.1 (2026-06-11)
+
+This is a patch release containing bug fixes only. There are no new features or breaking changes; upgrading from 9.20.0 is a drop-in replacement.
+
+## 🚀 Highlights
+
+### RESP3 pub/sub message loss fixed
+
+`PeekPushNotificationName` previously inspected only the bytes already buffered by `bufio`, so when a push frame header straddled a buffer fill boundary it could return a **truncated** notification name (e.g. `"messa"` instead of `"message"`). The push processor then mis-routed the frame and `ReadReply` silently dropped it, causing intermittent RESP3 pub/sub message loss. The peek now grows its window (36 bytes → up to 4 KiB) and reads more from the connection until the header is complete, cleanly separating incomplete prefixes from corrupt frames (including overflow-safe bulk-length handling). Fixes [#3839](https://github.com/redis/go-redis/issues/3839).
+
+([#3842](https://github.com/redis/go-redis/pull/3842)) by [@ndyakov](https://github.com/ndyakov)
+
+## 🐛 Bug Fixes
+
+- **RESP3 push peeking**: `PeekPushNotificationName` no longer returns a truncated notification name when a push frame header spans a buffer boundary, preventing silent RESP3 pub/sub message loss (fixes [#3839](https://github.com/redis/go-redis/issues/3839)) ([#3842](https://github.com/redis/go-redis/pull/3842)) by [@ndyakov](https://github.com/ndyakov)
+- **`FT.HYBRID` vector params**: Vector data is now always sent via `PARAMS` with auto-generated param names (`__vector_param_N`, with collision avoidance) when `VectorParamName` is omitted, since Redis no longer accepts inline vector blobs; the `FTHybridOptions.Params` map is no longer mutated, so the same options struct can be reused across calls ([#3844](https://github.com/redis/go-redis/pull/3844)) by [@ndyakov](https://github.com/ndyakov)
+- **`CLUSTER SHARDS` forward compatibility**: Unknown shard- and node-level attributes in the `CLUSTER SHARDS` reply are now skipped via `DiscardNext()` instead of erroring, so clients keep working when the server introduces new fields ([#3843](https://github.com/redis/go-redis/pull/3843)) by [@madolson](https://github.com/madolson)
+- **PubSub double reconnect**: `PubSub.releaseConn` no longer reconnects twice when a connection is both unusable (or pending handoff) and reports a bad-connection error, avoiding a wasted connection establish-then-close cycle ([#3833](https://github.com/redis/go-redis/pull/3833)) by [@cxljs](https://github.com/cxljs)
+
+## 👥 Contributors
+
+We'd like to thank all the contributors who worked on this release!
+
+[@cxljs](https://github.com/cxljs), [@madolson](https://github.com/madolson), [@ndyakov](https://github.com/ndyakov)
+
+---
+
+**Full Changelog**: https://github.com/redis/go-redis/compare/v9.20.0...v9.20.1
+
 # 9.20.0 (2026-05-28)
 
 ## 🚀 Highlights

--- a/example/cluster-mget/go.mod
+++ b/example/cluster-mget/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.0
+require github.com/redis/go-redis/v9 v9.20.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/del-keys-without-ttl/go.mod
+++ b/example/del-keys-without-ttl/go.mod
@@ -5,7 +5,7 @@ go 1.24
 replace github.com/redis/go-redis/v9 => ../..
 
 require (
-	github.com/redis/go-redis/v9 v9.20.0
+	github.com/redis/go-redis/v9 v9.20.1
 	go.uber.org/zap v1.24.0
 )
 

--- a/example/digest-optimistic-locking/go.mod
+++ b/example/digest-optimistic-locking/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.0
+require github.com/redis/go-redis/v9 v9.20.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/disable-maintnotifications/go.mod
+++ b/example/disable-maintnotifications/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.0
+require github.com/redis/go-redis/v9 v9.20.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/hll/go.mod
+++ b/example/hll/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.0
+require github.com/redis/go-redis/v9 v9.20.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/hset-struct/go.mod
+++ b/example/hset-struct/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/redis/go-redis/v9 v9.20.0
+	github.com/redis/go-redis/v9 v9.20.1
 )
 
 require (

--- a/example/lua-scripting/go.mod
+++ b/example/lua-scripting/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.0
+require github.com/redis/go-redis/v9 v9.20.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/maintnotifiations-pubsub/go.mod
+++ b/example/maintnotifiations-pubsub/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.0
+require github.com/redis/go-redis/v9 v9.20.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/otel-metrics/go.mod
+++ b/example/otel-metrics/go.mod
@@ -7,8 +7,8 @@ replace github.com/redis/go-redis/v9 => ../..
 replace github.com/redis/go-redis/extra/redisotel-native/v9 => ../../extra/redisotel-native
 
 require (
-	github.com/redis/go-redis/extra/redisotel-native/v9 v9.20.0
-	github.com/redis/go-redis/v9 v9.20.0
+	github.com/redis/go-redis/extra/redisotel-native/v9 v9.20.1
+	github.com/redis/go-redis/v9 v9.20.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0

--- a/example/otel/go.mod
+++ b/example/otel/go.mod
@@ -9,8 +9,8 @@ replace github.com/redis/go-redis/extra/redisotel/v9 => ../../extra/redisotel
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../../extra/rediscmd
 
 require (
-	github.com/redis/go-redis/extra/redisotel/v9 v9.20.0
-	github.com/redis/go-redis/v9 v9.20.0
+	github.com/redis/go-redis/extra/redisotel/v9 v9.20.1
+	github.com/redis/go-redis/v9 v9.20.1
 	github.com/uptrace/uptrace-go v1.41.1
 	go.opentelemetry.io/otel v1.43.0
 )
@@ -22,7 +22,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.20.0 // indirect
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.20.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0 // indirect
 	go.opentelemetry.io/contrib/processors/minsev v0.16.0 // indirect

--- a/example/redis-bloom/go.mod
+++ b/example/redis-bloom/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.0
+require github.com/redis/go-redis/v9 v9.20.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/scan-struct/go.mod
+++ b/example/scan-struct/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/redis/go-redis/v9 v9.20.0
+	github.com/redis/go-redis/v9 v9.20.1
 )
 
 require (

--- a/example/search-aggregate-steps/go.mod
+++ b/example/search-aggregate-steps/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.0
+require github.com/redis/go-redis/v9 v9.20.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/tls-cert-auth/go.mod
+++ b/example/tls-cert-auth/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.0
+require github.com/redis/go-redis/v9 v9.20.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/tls-connection/go.mod
+++ b/example/tls-connection/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.0
+require github.com/redis/go-redis/v9 v9.20.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/extra/rediscensus/go.mod
+++ b/extra/rediscensus/go.mod
@@ -7,8 +7,8 @@ replace github.com/redis/go-redis/v9 => ../..
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../rediscmd
 
 require (
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.20.0
-	github.com/redis/go-redis/v9 v9.20.0
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.20.1
+	github.com/redis/go-redis/v9 v9.20.1
 	go.opencensus.io v0.24.0
 )
 

--- a/extra/rediscmd/go.mod
+++ b/extra/rediscmd/go.mod
@@ -7,7 +7,7 @@ replace github.com/redis/go-redis/v9 => ../..
 require (
 	github.com/bsm/ginkgo/v2 v2.12.0
 	github.com/bsm/gomega v1.27.10
-	github.com/redis/go-redis/v9 v9.20.0
+	github.com/redis/go-redis/v9 v9.20.1
 )
 
 require (

--- a/extra/redisotel-native/go.mod
+++ b/extra/redisotel-native/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/redis/go-redis/v9 => ../..
 
 require (
-	github.com/redis/go-redis/v9 v9.20.0
+	github.com/redis/go-redis/v9 v9.20.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0

--- a/extra/redisotel/go.mod
+++ b/extra/redisotel/go.mod
@@ -7,8 +7,8 @@ replace github.com/redis/go-redis/v9 => ../..
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../rediscmd
 
 require (
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.20.0
-	github.com/redis/go-redis/v9 v9.20.0
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.20.1
+	github.com/redis/go-redis/v9 v9.20.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/extra/redisprometheus/go.mod
+++ b/extra/redisprometheus/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redis/go-redis/v9 v9.20.0
+	github.com/redis/go-redis/v9 v9.20.1
 )
 
 require (

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package redis
 
 // Version is the current release version.
 func Version() string {
-	return "9.20.0"
+	return "9.20.1"
 }


### PR DESCRIPTION
Release patch version with bugfixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No library source changes in the diff—only version strings, go.mod pins, and release notes for already-merged fixes.
> 
> **Overview**
> Cuts **v9.20.1** as a bug-fix-only patch: `Version()` moves from `9.20.0` to `9.20.1`, and example/`extra/*` `go.mod` files pin the same tag.
> 
> **RELEASE-NOTES.md** documents the fixes shipped in this tag (implementation landed in earlier PRs): RESP3 pub/sub loss via improved `PeekPushNotificationName` buffering; `FT.HYBRID` vectors sent through `PARAMS` without mutating `FTHybridOptions.Params`; forward-compatible `CLUSTER SHARDS` parsing via `DiscardNext()` on unknown fields; and a single reconnect path in `PubSub.releaseConn` when the connection is bad and pending handoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548304497d67c7b0450aba9819e2e1e0260da0b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->