### PR TITLE
feat(streams): support explicit `LIMIT 0` in XTRIM/XADD trimming via `XTrimLimitDisabled` sentinel

### DIFF
--- a/stream_commands.go
+++ b/stream_commands.go
@@ -9,6 +9,33 @@ import (
 	"github.com/redis/go-redis/v9/internal/otel"
 )
 
+// XTrimLimitDisabled is a sentinel value for the LIMIT argument of stream
+// trimming (XAddArgs.Limit and the XTrim*Approx* commands). Passing it emits
+// an explicit "LIMIT 0", which tells Redis to disable the trimming effort cap
+// entirely. This differs from passing 0, which keeps the historical behavior:
+// no LIMIT clause is sent and Redis applies its implicit default
+// (100 * stream-node-max-entries examined entries).
+//
+// LIMIT is only valid together with the "~" (approximate) trimming flag;
+// Redis rejects LIMIT used with exact ("=") trimming.
+const XTrimLimitDisabled = -1
+
+// appendXTrimLimit appends the LIMIT clause used by XADD and XTRIM trimming:
+//   - limit > 0 emits "LIMIT <limit>";
+//   - limit < 0 (see XTrimLimitDisabled) emits "LIMIT 0", disabling the
+//     trimming effort cap;
+//   - limit == 0 omits the clause, so Redis applies its implicit default.
+func appendXTrimLimit(args []interface{}, limit int64) []interface{} {
+	switch {
+	case limit > 0:
+		return append(args, "limit", limit)
+	case limit < 0:
+		return append(args, "limit", int64(0))
+	default:
+		return args
+	}
+}
+
 type StreamCmdable interface {
 	XAdd(ctx context.Context, a *XAddArgs) *StringCmd
 	XAckDel(ctx context.Context, stream string, group string, mode string, ids ...string) *SliceCmd
@@ -73,7 +100,14 @@ type XAddArgs struct {
 	MaxLen     int64 // MAXLEN N
 	MinID      string
 	// Approx causes MaxLen and MinID to use "~" matcher (instead of "=").
-	Approx         bool
+	Approx bool
+	// Limit caps the trimming effort:
+	//   - 0 omits the LIMIT clause (Redis applies its implicit default);
+	//   - a positive value emits "LIMIT <n>";
+	//   - a negative value (see XTrimLimitDisabled) emits "LIMIT 0",
+	//     disabling the effort cap entirely.
+	// LIMIT requires Approx to be true; Redis rejects LIMIT together with
+	// exact ("=") trimming.
 	Limit          int64
 	Mode           string
 	ID             string
@@ -118,9 +152,7 @@ func (c cmdable) XAdd(ctx context.Context, a *XAddArgs) *StringCmd {
 			args = append(args, "minid", "=", a.MinID)
 		}
 	}
-	if a.Limit > 0 {
-		args = append(args, "limit", a.Limit)
-	}
+	args = appendXTrimLimit(args, a.Limit)
 
 	if a.ID != "" {
 		args = append(args, a.ID)
@@ -542,6 +574,10 @@ func xClaimArgs(a *XClaimArgs) []interface{} {
 //	XTRIM key MAXLEN/MINID ~ threshold LIMIT limit.
 //
 // The redis-server version is lower than 6.2, please set limit to 0.
+//
+// limit == 0 omits the LIMIT clause, a positive limit emits "LIMIT <limit>",
+// and a negative limit (see XTrimLimitDisabled) emits "LIMIT 0" to disable
+// the trimming effort cap. LIMIT requires approx; Redis rejects it otherwise.
 func (c cmdable) xTrim(
 	ctx context.Context, key, strategy string,
 	approx bool, threshold interface{}, limit int64,
@@ -554,9 +590,7 @@ func (c cmdable) xTrim(
 		args = append(args, "=")
 	}
 	args = append(args, threshold)
-	if limit > 0 {
-		args = append(args, "limit", limit)
-	}
+	args = appendXTrimLimit(args, limit)
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -568,6 +602,12 @@ func (c cmdable) XTrimMaxLen(ctx context.Context, key string, maxLen int64) *Int
 	return c.xTrim(ctx, key, "maxlen", false, maxLen, 0)
 }
 
+// XTrimMaxLenApprox trims the stream using the `~` rule.
+// cmd: XTRIM key MAXLEN ~ maxLen [LIMIT limit]
+//
+// limit == 0 omits the LIMIT clause, limit > 0 emits "LIMIT <limit>", and a
+// negative limit (see XTrimLimitDisabled) emits "LIMIT 0" to disable the
+// trimming effort cap.
 func (c cmdable) XTrimMaxLenApprox(ctx context.Context, key string, maxLen, limit int64) *IntCmd {
 	return c.xTrim(ctx, key, "maxlen", true, maxLen, limit)
 }
@@ -576,10 +616,18 @@ func (c cmdable) XTrimMinID(ctx context.Context, key string, minID string) *IntC
 	return c.xTrim(ctx, key, "minid", false, minID, 0)
 }
 
+// XTrimMinIDApprox trims the stream using the `~` rule.
+// cmd: XTRIM key MINID ~ minID [LIMIT limit]
+//
+// limit == 0 omits the LIMIT clause, limit > 0 emits "LIMIT <limit>", and a
+// negative limit (see XTrimLimitDisabled) emits "LIMIT 0" to disable the
+// trimming effort cap.
 func (c cmdable) XTrimMinIDApprox(ctx context.Context, key string, minID string, limit int64) *IntCmd {
 	return c.xTrim(ctx, key, "minid", true, minID, limit)
 }
 
+// xTrimMode is xTrim with a trailing trimming mode argument (e.g. KEEPREF).
+// The limit semantics are the same as xTrim's.
 func (c cmdable) xTrimMode(
 	ctx context.Context, key, strategy string,
 	approx bool, threshold interface{}, limit int64,
@@ -593,9 +641,7 @@ func (c cmdable) xTrimMode(
 		args = append(args, "=")
 	}
 	args = append(args, threshold)
-	if limit > 0 {
-		args = append(args, "limit", limit)
-	}
+	args = appendXTrimLimit(args, limit)
 	args = append(args, mode)
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)

--- a/stream_commands_unit_test.go
+++ b/stream_commands_unit_test.go
@@ -1,0 +1,196 @@
+package redis
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+// These tests assert the argument lists built by the XTRIM/XADD trimming
+// commands without dispatching them to a server, with particular focus on
+// the LIMIT clause semantics:
+//   - limit == 0 omits the LIMIT clause (historical behavior);
+//   - limit > 0 emits "LIMIT <limit>";
+//   - limit < 0 (XTrimLimitDisabled) emits an explicit "LIMIT 0";
+//   - exact ("=") trim commands never emit LIMIT.
+
+func TestXTrim_LimitArgs(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		call func(c cmdable) Cmder
+		want []interface{}
+	}{
+		{
+			name: "maxlen_approx_limit_omitted",
+			call: func(c cmdable) Cmder { return c.XTrimMaxLenApprox(ctx, "stream", 100, 0) },
+			want: []interface{}{"xtrim", "stream", "maxlen", "~", int64(100)},
+		},
+		{
+			name: "maxlen_approx_positive_limit",
+			call: func(c cmdable) Cmder { return c.XTrimMaxLenApprox(ctx, "stream", 100, 1000) },
+			want: []interface{}{"xtrim", "stream", "maxlen", "~", int64(100), "limit", int64(1000)},
+		},
+		{
+			name: "maxlen_approx_limit_disabled",
+			call: func(c cmdable) Cmder { return c.XTrimMaxLenApprox(ctx, "stream", 100, XTrimLimitDisabled) },
+			want: []interface{}{"xtrim", "stream", "maxlen", "~", int64(100), "limit", int64(0)},
+		},
+		{
+			name: "minid_approx_limit_omitted",
+			call: func(c cmdable) Cmder { return c.XTrimMinIDApprox(ctx, "stream", "4-0", 0) },
+			want: []interface{}{"xtrim", "stream", "minid", "~", "4-0"},
+		},
+		{
+			name: "minid_approx_positive_limit",
+			call: func(c cmdable) Cmder { return c.XTrimMinIDApprox(ctx, "stream", "4-0", 42) },
+			want: []interface{}{"xtrim", "stream", "minid", "~", "4-0", "limit", int64(42)},
+		},
+		{
+			name: "minid_approx_limit_disabled",
+			call: func(c cmdable) Cmder { return c.XTrimMinIDApprox(ctx, "stream", "4-0", XTrimLimitDisabled) },
+			want: []interface{}{"xtrim", "stream", "minid", "~", "4-0", "limit", int64(0)},
+		},
+		{
+			name: "maxlen_exact_never_emits_limit",
+			call: func(c cmdable) Cmder { return c.XTrimMaxLen(ctx, "stream", 100) },
+			want: []interface{}{"xtrim", "stream", "maxlen", "=", int64(100)},
+		},
+		{
+			name: "minid_exact_never_emits_limit",
+			call: func(c cmdable) Cmder { return c.XTrimMinID(ctx, "stream", "4-0") },
+			want: []interface{}{"xtrim", "stream", "minid", "=", "4-0"},
+		},
+		{
+			name: "maxlen_approx_mode_limit_omitted",
+			call: func(c cmdable) Cmder { return c.XTrimMaxLenApproxMode(ctx, "stream", 100, 0, "KEEPREF") },
+			want: []interface{}{"xtrim", "stream", "maxlen", "~", int64(100), "KEEPREF"},
+		},
+		{
+			name: "maxlen_approx_mode_positive_limit",
+			call: func(c cmdable) Cmder { return c.XTrimMaxLenApproxMode(ctx, "stream", 100, 1000, "KEEPREF") },
+			want: []interface{}{"xtrim", "stream", "maxlen", "~", int64(100), "limit", int64(1000), "KEEPREF"},
+		},
+		{
+			name: "maxlen_approx_mode_limit_disabled",
+			call: func(c cmdable) Cmder {
+				return c.XTrimMaxLenApproxMode(ctx, "stream", 100, XTrimLimitDisabled, "KEEPREF")
+			},
+			want: []interface{}{"xtrim", "stream", "maxlen", "~", int64(100), "limit", int64(0), "KEEPREF"},
+		},
+		{
+			name: "minid_approx_mode_limit_disabled",
+			call: func(c cmdable) Cmder {
+				return c.XTrimMinIDApproxMode(ctx, "stream", "4-0", XTrimLimitDisabled, "DELREF")
+			},
+			want: []interface{}{"xtrim", "stream", "minid", "~", "4-0", "limit", int64(0), "DELREF"},
+		},
+		{
+			name: "maxlen_exact_mode_never_emits_limit",
+			call: func(c cmdable) Cmder { return c.XTrimMaxLenMode(ctx, "stream", 100, "KEEPREF") },
+			want: []interface{}{"xtrim", "stream", "maxlen", "=", int64(100), "KEEPREF"},
+		},
+		{
+			name: "minid_exact_mode_never_emits_limit",
+			call: func(c cmdable) Cmder { return c.XTrimMinIDMode(ctx, "stream", "4-0", "DELREF") },
+			want: []interface{}{"xtrim", "stream", "minid", "=", "4-0", "DELREF"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured Cmder
+			c := captureCmdable(&captured)
+			cmd := tt.call(c)
+			if cmd == nil {
+				t.Fatalf("command builder returned nil")
+			}
+			if !reflect.DeepEqual(cmd.Args(), tt.want) {
+				t.Errorf("args mismatch\n got: %#v\nwant: %#v", cmd.Args(), tt.want)
+			}
+		})
+	}
+}
+
+func TestXAdd_TrimLimitArgs(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		args *XAddArgs
+		want []interface{}
+	}{
+		{
+			name: "approx_limit_omitted",
+			args: &XAddArgs{
+				Stream: "stream",
+				MaxLen: 100,
+				Approx: true,
+				ID:     "1-0",
+				Values: []string{"k", "v"},
+			},
+			want: []interface{}{"xadd", "stream", "maxlen", "~", int64(100), "1-0", "k", "v"},
+		},
+		{
+			name: "approx_positive_limit",
+			args: &XAddArgs{
+				Stream: "stream",
+				MaxLen: 100,
+				Approx: true,
+				Limit:  1000,
+				ID:     "1-0",
+				Values: []string{"k", "v"},
+			},
+			want: []interface{}{"xadd", "stream", "maxlen", "~", int64(100), "limit", int64(1000), "1-0", "k", "v"},
+		},
+		{
+			name: "approx_limit_disabled",
+			args: &XAddArgs{
+				Stream: "stream",
+				MaxLen: 100,
+				Approx: true,
+				Limit:  XTrimLimitDisabled,
+				ID:     "1-0",
+				Values: []string{"k", "v"},
+			},
+			want: []interface{}{"xadd", "stream", "maxlen", "~", int64(100), "limit", int64(0), "1-0", "k", "v"},
+		},
+		{
+			name: "minid_approx_limit_disabled",
+			args: &XAddArgs{
+				Stream: "stream",
+				MinID:  "4-0",
+				Approx: true,
+				Limit:  XTrimLimitDisabled,
+				ID:     "5-0",
+				Values: []string{"k", "v"},
+			},
+			want: []interface{}{"xadd", "stream", "minid", "~", "4-0", "limit", int64(0), "5-0", "k", "v"},
+		},
+		{
+			name: "exact_zero_limit_omitted",
+			args: &XAddArgs{
+				Stream: "stream",
+				MaxLen: 100,
+				ID:     "1-0",
+				Values: []string{"k", "v"},
+			},
+			want: []interface{}{"xadd", "stream", "maxlen", "=", int64(100), "1-0", "k", "v"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured Cmder
+			c := captureCmdable(&captured)
+			cmd := c.XAdd(ctx, tt.args)
+			if cmd == nil {
+				t.Fatalf("XAdd returned nil")
+			}
+			if !reflect.DeepEqual(cmd.Args(), tt.want) {
+				t.Errorf("args mismatch\n got: %#v\nwant: %#v", cmd.Args(), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Redis distinguishes between *omitting* the `LIMIT` clause and passing `LIMIT 0` when trimming a stream with the approximate (`~`) strategy:

- **No `LIMIT` clause** — Redis applies an implicit effort cap of `100 * stream-node-max-entries` examined entries per call.
- **`LIMIT 0`** — the effort cap is disabled entirely; Redis trims as many macro nodes as the threshold requires in a single call.

(See the [`XADD`](https://redis.io/docs/latest/commands/xadd/) / [`XTRIM`](https://redis.io/docs/latest/commands/xtrim/) docs: *"Specifying the value 0 as count disables the limiting mechanism entirely."*)

Today the library cannot express the second form. `xTrim`, `xTrimMode`, and `XAdd` all build the clause with:

```go
if limit > 0 {
    args = append(args, "limit", limit)
}
```

so `0` is silently swallowed and there is no way to send `XTRIM key MINID ~ <id> LIMIT 0` through the typed API. This matters in practice for periodic cleaners on busy streams: with the implicit default cap, a single `XTRIM ... ~` call may not reclaim a large backlog, and the only workaround is dropping down to raw `Do()`.

## Changes

Introduces a documented negative-value sentinel, following the existing `KeepTTL = -1` precedent in `commands.go` (the same "zero value already has a meaning, a third state is needed" problem for `SET`):

```go
const XTrimLimitDisabled = -1
```

The `limit` parameter of `XTrimMaxLenApprox`, `XTrimMinIDApprox`, `XTrimMaxLenApproxMode`, `XTrimMinIDApproxMode`, and the `XAddArgs.Limit` field now have three documented states:

| Value | Emitted clause | Notes |
|---|---|---|
| `0` | *(none)* | unchanged historical behavior — Redis applies its implicit default cap |
| `> 0` | `LIMIT <n>` | unchanged |
| `< 0` (`XTrimLimitDisabled`) | `LIMIT 0` | **new** — disables the effort cap |

Implementation is a single shared helper, `appendXTrimLimit`, used by `XAdd`, `xTrim`, and `xTrimMode`, replacing the three duplicated `if limit > 0` blocks.

Usage:

```go
rdb.XTrimMinIDApprox(ctx, "stream", "1716000000000-0", redis.XTrimLimitDisabled)
// XTRIM stream MINID ~ 1716000000000-0 LIMIT 0
```

## Backward compatibility

- **No public API changes**: all exported signatures and struct fields are unchanged.
- **No behavior change for existing callers**: `limit = 0` still omits the clause; positive values are emitted as before. Only previously-meaningless negative values gain a meaning.
- Exact-trim commands (`XTrimMaxLen`, `XTrimMinID`, and their `Mode` variants) take no limit parameter and still can never emit `LIMIT` — Redis rejects `LIMIT` without `~` (`ERR syntax error, LIMIT cannot be used without the special ~ option`). For `XAddArgs` the library keeps its existing stance of not validating the `Approx`/`Limit` combination client-side (matching how the conflicting `MaxLen`/`MinID` pair is handled); this is now stated explicitly in the `Limit` field docs instead of being implicit.

## Testing

Added server-less unit tests asserting the constructed command args via the existing `captureCmdable` pattern (`stream_commands_unit_test.go`):

- `TestXTrim_LimitArgs` — 13 cases covering omitted / positive / disabled limit across `XTrimMaxLenApprox`, `XTrimMinIDApprox`, their `Mode` variants, and pinning that exact-trim commands never emit `LIMIT`.
- `TestXAdd_TrimLimitArgs` — 5 cases covering the `XAddArgs.Limit` path, including clause ordering relative to the entry ID.

`go build ./...`, `go vet ./...`, and `gofmt` are clean; the pre-existing unit test suite passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive sentinel and command-building change only; existing `limit` 0 and positive values behave the same, with coverage for emitted Redis args.
> 
> **Overview**
> Adds **`XTrimLimitDisabled` (-1)** so approximate stream trimming (`XADD` / `XTRIM` with `~`) can send an explicit **`LIMIT 0`** to Redis, disabling the default trimming effort cap—something the client could not express before because only `limit > 0` ever emitted a `LIMIT` clause.
> 
> A shared **`appendXTrimLimit`** helper centralizes the three behaviors: omit `LIMIT` when `limit == 0` (unchanged), `LIMIT n` when positive, and **`LIMIT 0`** when negative. **`XAdd`**, **`xTrim`**, and **`xTrimMode`** use it instead of duplicated checks. **`XAddArgs.Limit`** and the `*Approx*` trim APIs are documented accordingly.
> 
> New **`stream_commands_unit_test.go`** tests assert built command args via **`captureCmdable`** for omitted, positive, and disabled limits across trim variants and **`XAdd`**, including that exact (`=`) trims never emit `LIMIT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87acd5d8dbf076683b593d2d76e14b5c91527b97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->