### PR TITLE
fix: avoid sync.Pool boxing and clear slice pointers on release

### DIFF
--- a/autopipeline.go
+++ b/autopipeline.go
@@ -316,7 +316,7 @@ var closedQueuedCmd = &queuedCmd{
 
 // processWithQueuedCmd is the internal method that queues a command and returns the queuedCmd.
 // The caller is responsible for returning the queuedCmd to the pool after use.
-func (ap *AutoPipeliner) processWithQueuedCmd(ctx context.Context, cmd Cmder) *queuedCmd {
+func (ap *AutoPipeliner) processWithQueuedCmd(_ context.Context, cmd Cmder) *queuedCmd {
 	if ap.closed.Load() {
 		cmd.SetErr(ErrClosed)
 		return closedQueuedCmd
@@ -354,9 +354,9 @@ func (ap *AutoPipeliner) processWithQueuedCmd(ctx context.Context, cmd Cmder) *q
 }
 
 // process is the internal method that queues a command and returns its done channel.
-func (ap *AutoPipeliner) process(ctx context.Context, cmd Cmder) <-chan struct{} {
-	return ap.processWithQueuedCmd(ctx, cmd).done
-}
+// func (ap *AutoPipeliner) process(ctx context.Context, cmd Cmder) <-chan struct{} {
+//  	return ap.processWithQueuedCmd(ctx, cmd).done
+// }
 
 // Close stops the autopipeliner and flushes any pending commands.
 func (ap *AutoPipeliner) Close() error {

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -123,22 +123,25 @@ func putQueuedCmd(qc *queuedCmd) {
 	queuedCmdPool.Put(qc)
 }
 
-// queueSlicePool is a sync.Pool for queue slices to reduce allocations
+// queueSlicePool is a sync.Pool for queue slices to reduce allocations.
+// We store *[]*queuedCmd rather than []*queuedCmd so that Put doesn't
+// allocate a boxed interface value for the slice header (staticcheck SA6002).
 var queueSlicePool = sync.Pool{
 	New: func() interface{} {
 		// Create a slice with capacity for typical batch size
-		return make([]*queuedCmd, 0, 100)
+		s := make([]*queuedCmd, 0, 100)
+		return &s
 	},
 }
 
 // getQueueSlice gets a queue slice from the pool
 func getQueueSlice(capacity int) []*queuedCmd {
-	slice := queueSlicePool.Get().([]*queuedCmd)
+	slice := *queueSlicePool.Get().(*[]*queuedCmd)
 	// Clear the slice but keep capacity
 	slice = slice[:0]
 	// If the capacity is too small, allocate a new one
 	if cap(slice) < capacity {
-		queueSlicePool.Put(slice)
+		queueSlicePool.Put(&slice)
 		return make([]*queuedCmd, 0, capacity)
 	}
 	return slice
@@ -148,11 +151,12 @@ func getQueueSlice(capacity int) []*queuedCmd {
 func putQueueSlice(slice []*queuedCmd) {
 	// Only pool slices that aren't too large (avoid memory bloat)
 	if cap(slice) <= 1000 {
-		// Clear all pointers to avoid holding references
-		for i := range slice {
-			slice[i] = nil
+		// Clear all pointers up to capacity to avoid holding references.
+		full := slice[:cap(slice)]
+		for i := range full {
+			full[i] = nil
 		}
-		queueSlicePool.Put(slice[:0])
+		queueSlicePool.Put(&slice)
 	}
 }
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -15,17 +15,20 @@ var pipelinePool = sync.Pool{
 	},
 }
 
-// cmdSlicePool is a sync.Pool for command slices to reduce allocations
+// cmdSlicePool is a sync.Pool for command slices to reduce allocations.
+// We store *[]Cmder rather than []Cmder so that Put doesn't allocate a
+// boxed interface value for the slice header (staticcheck SA6002).
 var cmdSlicePool = sync.Pool{
 	New: func() interface{} {
 		// Pre-allocate with reasonable capacity for typical batch sizes
-		return make([]Cmder, 0, 100)
+		s := make([]Cmder, 0, 100)
+		return &s
 	},
 }
 
 // getCmdSlice gets a command slice from the pool
 func getCmdSlice() []Cmder {
-	slice := cmdSlicePool.Get().([]Cmder)
+	slice := *cmdSlicePool.Get().(*[]Cmder)
 	// Clear the slice but keep capacity
 	return slice[:0]
 }
@@ -34,7 +37,11 @@ func getCmdSlice() []Cmder {
 func putCmdSlice(slice []Cmder) {
 	// Only pool slices that aren't too large (avoid memory bloat)
 	if cap(slice) <= 1000 {
-		cmdSlicePool.Put(slice)
+		full := slice[:cap(slice)]
+		for i := range full {
+			full[i] = nil
+		}
+		cmdSlicePool.Put(&slice)
 	}
 }
 
@@ -173,8 +180,6 @@ func putPipeliner(pipe Pipeliner) {
 		putPipeline(p)
 	}
 }
-
-
 
 func (c *Pipeline) Pipeline() Pipeliner {
 	return c


### PR DESCRIPTION
sync.Pool stored []Cmder / []*queuedCmd directly. Putting a slice header into an interface{} boxes it (staticcheck SA6002), allocating on every Put and defeating the pool. Store *[]T instead so Put takes a pointer.

Also clear slice elements up to cap(slice) before returning to the pool. Previously only the [:0] view was reset, leaving pointers in [len:cap] alive and preventing GC of the referenced commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Allocation/GC hygiene in internal pooling only; behavior of pipelining and autopipeline batching is unchanged aside from fixing potential memory retention.
> 
> **Overview**
> Fixes **sync.Pool** usage for reused command and queue slices so pooling actually cuts allocations and doesn’t retain command references.
> 
> **`queueSlicePool`** (`autopipeline.go`) and **`cmdSlicePool`** (`pipeline.go`) now store `*[]T` instead of slice values, avoiding per-`Put` boxing of slice headers (staticcheck **SA6002**). Get/Put paths were updated to dereference and pass pointers consistently.
> 
> On return to the pool, slices are zeroed across **`cap(slice)`**, not only the `[:0]` length, so stale `Cmder` / `*queuedCmd` pointers in the unused capacity can be collected.
> 
> Minor cleanup: unused `ctx` renamed to `_` in `processWithQueuedCmd`, the unused `AutoPipeliner.process` helper is commented out, and stray blank lines were removed in `pipeline.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 306295ffb01adf2b94769fd8cd39ca2fc7876286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->