### PR TITLE
chore(release): 9.21.0

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,51 @@
 # Release Notes
 
+# 9.21.0 (2026-06-18)
+
+This is a minor release adding new features and bug fixes. There are no breaking changes; upgrading from 9.20.x is a drop-in replacement.
+
+## 🚀 Highlights
+
+### Zero-copy `GetToBuffer` / `SetFromBuffer`
+
+Two new `StringCmdable` methods let callers read and write Redis string values directly into and from pre-allocated byte buffers, eliminating the per-call payload allocation that `Get`/`Set` incur:
+
+```go
+GetToBuffer(ctx, key, buf) *ZeroCopyStringCmd   // reads into buf; ZeroCopyStringCmd { Val() int; Bytes() []byte; Result() (int, error) }
+SetFromBuffer(ctx, key, buf) *StatusCmd
+```
+
+`GetToBuffer` decodes the bulk reply straight into the caller-owned `buf` (no intermediate allocation); a buffer that is too small returns an error after draining the payload, so the connection stays aligned for the next reply. `SetFromBuffer` is provided for API symmetry — it dispatches to the same `[]byte` writer path as `Set(ctx, key, buf, 0)` and produces byte-identical output on the wire. Available on `*Client`, `*ClusterClient`, `*Ring`, `*Conn` and `Pipeliner`.
+
+([#3834](https://github.com/redis/go-redis/pull/3834)) by [@ndyakov](https://github.com/ndyakov)
+
+### Explicit `LIMIT 0` for stream trimming
+
+Redis treats `XTRIM`/`XADD` approximate-trim (`~`) `LIMIT 0` as "disable the trimming effort cap entirely", which differs from omitting `LIMIT` (the implicit `100 * stream-node-max-entries` default). The command builders previously only emitted `LIMIT` when `limit > 0`, so callers could never send an explicit `LIMIT 0`. Following the `KeepTTL = -1` precedent, the new `XTrimLimitDisabled = -1` sentinel now emits an explicit `LIMIT 0`; `limit == 0` keeps the historical no-`LIMIT` behavior, so existing callers produce byte-identical commands.
+
+([#3848](https://github.com/redis/go-redis/pull/3848)) by [@TheRealMal](https://github.com/TheRealMal)
+
+## ✨ New Features
+
+- **Zero-copy buffer string commands**: new `GetToBuffer` / `SetFromBuffer` on `StringCmdable` and the `ZeroCopyStringCmd` result type, reading/writing string values into caller-owned buffers without per-call payload allocation ([#3834](https://github.com/redis/go-redis/pull/3834)) by [@ndyakov](https://github.com/ndyakov)
+- **`XTrimLimitDisabled` sentinel**: `XTRIM`/`XADD` approximate trimming can now send an explicit `LIMIT 0` to disable the trim effort cap, via the new `XTrimLimitDisabled = -1` sentinel ([#3848](https://github.com/redis/go-redis/pull/3848)) by [@TheRealMal](https://github.com/TheRealMal)
+- **PubSub health-check timeouts**: `channel.initHealthCheck` now bounds the `Ping` it issues with a fresh per-check timeout context (the exported `pingTimeout` / `reconnectTimeout`) instead of `context.TODO()`, so a stuck health-check Ping can no longer block indefinitely ([#3819](https://github.com/redis/go-redis/pull/3819)) by [@abdellani](https://github.com/abdellani)
+- **Skip redundant `UNWATCH` in `Tx.Close`**: a transaction now tracks whether a `WATCH` is still active (`watchArmed`) and only issues `UNWATCH` on `Close` when it is, removing an extra round trip on the common `WATCH`/.../`EXEC` and no-key `Watch` paths while never returning a connection to the pool with an active watch ([#3854](https://github.com/redis/go-redis/pull/3854)) by [@fcostaoliveira](https://github.com/fcostaoliveira)
+
+## 🐛 Bug Fixes
+
+- **`maintnotifications` `ModeAuto` fail-open**: `ModeAuto` now stays fail-open when the server does not support maintenance notifications — connections are retired and tracking is guarded during downgrade so the client keeps working instead of erroring ([#3853](https://github.com/redis/go-redis/pull/3853)) by [@terrorobe](https://github.com/terrorobe)
+
+## 👥 Contributors
+
+We'd like to thank all the contributors who worked on this release!
+
+[@abdellani](https://github.com/abdellani), [@fcostaoliveira](https://github.com/fcostaoliveira), [@ndyakov](https://github.com/ndyakov), [@terrorobe](https://github.com/terrorobe), [@TheRealMal](https://github.com/TheRealMal)
+
+---
+
+**Full Changelog**: https://github.com/redis/go-redis/compare/v9.20.1...v9.21.0
+
 # 9.20.1 (2026-06-11)
 
 This is a patch release containing bug fixes only. There are no new features or breaking changes; upgrading from 9.20.0 is a drop-in replacement.

--- a/example/cluster-mget/go.mod
+++ b/example/cluster-mget/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.1
+require github.com/redis/go-redis/v9 v9.21.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/del-keys-without-ttl/go.mod
+++ b/example/del-keys-without-ttl/go.mod
@@ -5,7 +5,7 @@ go 1.24
 replace github.com/redis/go-redis/v9 => ../..
 
 require (
-	github.com/redis/go-redis/v9 v9.20.1
+	github.com/redis/go-redis/v9 v9.21.0
 	go.uber.org/zap v1.24.0
 )
 

--- a/example/digest-optimistic-locking/go.mod
+++ b/example/digest-optimistic-locking/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.1
+require github.com/redis/go-redis/v9 v9.21.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/disable-maintnotifications/go.mod
+++ b/example/disable-maintnotifications/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.1
+require github.com/redis/go-redis/v9 v9.21.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/hll/go.mod
+++ b/example/hll/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.1
+require github.com/redis/go-redis/v9 v9.21.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/hset-struct/go.mod
+++ b/example/hset-struct/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/redis/go-redis/v9 v9.20.1
+	github.com/redis/go-redis/v9 v9.21.0
 )
 
 require (

--- a/example/lua-scripting/go.mod
+++ b/example/lua-scripting/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.1
+require github.com/redis/go-redis/v9 v9.21.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/maintnotifiations-pubsub/go.mod
+++ b/example/maintnotifiations-pubsub/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.1
+require github.com/redis/go-redis/v9 v9.21.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/otel-metrics/go.mod
+++ b/example/otel-metrics/go.mod
@@ -7,8 +7,8 @@ replace github.com/redis/go-redis/v9 => ../..
 replace github.com/redis/go-redis/extra/redisotel-native/v9 => ../../extra/redisotel-native
 
 require (
-	github.com/redis/go-redis/extra/redisotel-native/v9 v9.20.1
-	github.com/redis/go-redis/v9 v9.20.1
+	github.com/redis/go-redis/extra/redisotel-native/v9 v9.21.0
+	github.com/redis/go-redis/v9 v9.21.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0

--- a/example/otel/go.mod
+++ b/example/otel/go.mod
@@ -9,8 +9,8 @@ replace github.com/redis/go-redis/extra/redisotel/v9 => ../../extra/redisotel
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../../extra/rediscmd
 
 require (
-	github.com/redis/go-redis/extra/redisotel/v9 v9.20.1
-	github.com/redis/go-redis/v9 v9.20.1
+	github.com/redis/go-redis/extra/redisotel/v9 v9.21.0
+	github.com/redis/go-redis/v9 v9.21.0
 	github.com/uptrace/uptrace-go v1.41.1
 	go.opentelemetry.io/otel v1.43.0
 )
@@ -22,7 +22,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.20.1 // indirect
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.21.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0 // indirect
 	go.opentelemetry.io/contrib/processors/minsev v0.16.0 // indirect

--- a/example/redis-bloom/go.mod
+++ b/example/redis-bloom/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.1
+require github.com/redis/go-redis/v9 v9.21.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/scan-struct/go.mod
+++ b/example/scan-struct/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/redis/go-redis/v9 v9.20.1
+	github.com/redis/go-redis/v9 v9.21.0
 )
 
 require (

--- a/example/search-aggregate-steps/go.mod
+++ b/example/search-aggregate-steps/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.1
+require github.com/redis/go-redis/v9 v9.21.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/tls-cert-auth/go.mod
+++ b/example/tls-cert-auth/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.1
+require github.com/redis/go-redis/v9 v9.21.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/tls-connection/go.mod
+++ b/example/tls-connection/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.20.1
+require github.com/redis/go-redis/v9 v9.21.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/extra/rediscensus/go.mod
+++ b/extra/rediscensus/go.mod
@@ -7,8 +7,8 @@ replace github.com/redis/go-redis/v9 => ../..
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../rediscmd
 
 require (
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.20.1
-	github.com/redis/go-redis/v9 v9.20.1
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.21.0
+	github.com/redis/go-redis/v9 v9.21.0
 	go.opencensus.io v0.24.0
 )
 

--- a/extra/rediscmd/go.mod
+++ b/extra/rediscmd/go.mod
@@ -7,7 +7,7 @@ replace github.com/redis/go-redis/v9 => ../..
 require (
 	github.com/bsm/ginkgo/v2 v2.12.0
 	github.com/bsm/gomega v1.27.10
-	github.com/redis/go-redis/v9 v9.20.1
+	github.com/redis/go-redis/v9 v9.21.0
 )
 
 require (

--- a/extra/redisotel-native/go.mod
+++ b/extra/redisotel-native/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/redis/go-redis/v9 => ../..
 
 require (
-	github.com/redis/go-redis/v9 v9.20.1
+	github.com/redis/go-redis/v9 v9.21.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0

--- a/extra/redisotel/go.mod
+++ b/extra/redisotel/go.mod
@@ -7,8 +7,8 @@ replace github.com/redis/go-redis/v9 => ../..
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../rediscmd
 
 require (
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.20.1
-	github.com/redis/go-redis/v9 v9.20.1
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.21.0
+	github.com/redis/go-redis/v9 v9.21.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/extra/redisprometheus/go.mod
+++ b/extra/redisprometheus/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redis/go-redis/v9 v9.20.1
+	github.com/redis/go-redis/v9 v9.21.0
 )
 
 require (

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package redis
 
 // Version is the current release version.
 func Version() string {
-	return "9.20.1"
+	return "9.21.0"
 }


### PR DESCRIPTION
* bump version to 9.21.0
* add release notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and documentation updates only; no runtime code changes in this diff.
> 
> **Overview**
> **Release packaging for v9.21.0** — bumps the library version from **9.20.1** to **9.21.0** in `version.go` and aligns every `example/*` and `extra/*` `go.mod` (including OTel-related modules) on `v9.21.0`.
> 
> Adds a **9.21.0** section to `RELEASE-NOTES.md` that documents what ships in this tag (no breaking changes vs 9.20.x): zero-copy **`GetToBuffer` / `SetFromBuffer`**, **`XTrimLimitDisabled`** for explicit stream trim `LIMIT 0`, bounded PubSub health-check pings, conditional **`UNWATCH`** on `Tx.Close`, and **`maintnotifications` `ModeAuto` fail-open** — with contributor links and changelog URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83636d68dffcc4030f2545fb15bb66338006e5e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->