### PR TITLE
chore: use type-safe sync/atomic value types

### DIFF
--- a/internal/once.go
+++ b/internal/once.go
@@ -27,7 +27,7 @@ import (
 // and is re-armed on failure.
 type Once struct {
 	m    sync.Mutex
-	done uint32
+	done atomic.Uint32
 }
 
 // Do calls the function f if and only if Do has not been invoked
@@ -46,17 +46,17 @@ type Once struct {
 //
 //	err := config.once.Do(func() error { return config.init(filename) })
 func (o *Once) Do(f func() error) error {
-	if atomic.LoadUint32(&o.done) == 1 {
+	if o.done.Load() == 1 {
 		return nil
 	}
 	// Slow-path.
 	o.m.Lock()
 	defer o.m.Unlock()
 	var err error
-	if o.done == 0 {
+	if o.done.Load() == 0 {
 		err = f()
 		if err == nil {
-			atomic.StoreUint32(&o.done, 1)
+			o.done.Store(1)
 		}
 	}
 	return err

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -45,7 +45,7 @@ func GetCachedTimeNs() int64 {
 }
 
 // Global atomic counter for connection IDs
-var connIDCounter uint64
+var connIDCounter atomic.Uint64
 
 // HandoffState represents the atomic state for connection handoffs
 // This struct is stored atomically to prevent race conditions between
@@ -63,7 +63,7 @@ type atomicNetConn struct {
 
 // generateConnID generates a fast unique identifier for a connection with zero allocations
 func generateConnID() uint64 {
-	return atomic.AddUint64(&connIDCounter, 1)
+	return connIDCounter.Add(1)
 }
 
 type Conn struct {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -304,6 +304,9 @@ func getMetricPendingRequestsCallback() func(ctx context.Context, delta int, cn 
 }
 
 // Stats contains pool state information and accumulated stats.
+//
+// TODO(cxl): the uint32/int64 fields below will be changed to atomic value
+// types (atomic.Uint32/atomic.Int64) in v10, which is a breaking API change.
 type Stats struct {
 	Hits           uint32 // number of times free connection was found in the pool
 	Misses         uint32 // number of times free connection was NOT found in the pool

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -394,7 +394,7 @@ type lastDialErrorWrap struct {
 type ConnPool struct {
 	cfg *Options
 
-	dialErrorsNum uint32 // atomic
+	dialErrorsNum atomic.Uint32
 	lastDialError atomic.Value
 
 	dialsInProgress chan struct{}
@@ -415,7 +415,7 @@ type ConnPool struct {
 	stats          Stats
 	waitDurationNs atomic.Int64
 
-	_closed uint32 // atomic
+	_closed atomic.Uint32
 
 	// Pool hooks manager for flexible connection processing
 	// Using atomic.Pointer for lock-free reads in hot paths (Get/Put)
@@ -651,7 +651,7 @@ func (p *ConnPool) dialConn(ctx context.Context, pooled bool) (*Conn, error) {
 		return nil, ErrClosed
 	}
 
-	if atomic.LoadUint32(&p.dialErrorsNum) >= uint32(p.cfg.PoolSize) {
+	if p.dialErrorsNum.Load() >= uint32(p.cfg.PoolSize) {
 		return nil, p.getLastDialError()
 	}
 
@@ -724,7 +724,7 @@ func (p *ConnPool) dialConn(ctx context.Context, pooled bool) (*Conn, error) {
 	internal.Logger.Printf(ctx, "redis: connection pool: failed to dial after %d attempts: %v", attempt, lastErr)
 	// All retries failed - handle error tracking
 	p.setLastDialError(lastErr)
-	if atomic.AddUint32(&p.dialErrorsNum, 1) == uint32(p.cfg.PoolSize) {
+	if p.dialErrorsNum.Add(1) == uint32(p.cfg.PoolSize) {
 		go p.tryDial()
 	}
 	return nil, lastErr
@@ -789,7 +789,7 @@ func (p *ConnPool) tryDial() {
 			continue
 		}
 
-		atomic.StoreUint32(&p.dialErrorsNum, 0)
+		p.dialErrorsNum.Store(0)
 		_ = conn.Close()
 		return
 	}
@@ -1573,7 +1573,7 @@ func (p *ConnPool) Stats() *Stats {
 }
 
 func (p *ConnPool) closed() bool {
-	return atomic.LoadUint32(&p._closed) == 1
+	return p._closed.Load() == 1
 }
 
 func (p *ConnPool) RetireConns(ctx context.Context, conns []*Conn, reason string) {
@@ -1653,7 +1653,7 @@ func (p *ConnPool) Filter(fn func(*Conn) bool) error {
 }
 
 func (p *ConnPool) Close() error {
-	if !atomic.CompareAndSwapUint32(&p._closed, 0, 1) {
+	if !p._closed.CompareAndSwap(0, 1) {
 		return ErrClosed
 	}
 

--- a/internal/pool/pool_sticky.go
+++ b/internal/pool/pool_sticky.go
@@ -35,9 +35,9 @@ func (e BadConnError) Unwrap() error {
 
 type StickyConnPool struct {
 	pool   Pooler
-	shared int32 // atomic
+	shared atomic.Int32
 
-	state uint32 // atomic
+	state atomic.Uint32
 	ch    chan *Conn
 
 	_badConnError atomic.Value
@@ -53,7 +53,7 @@ func NewStickyConnPool(pool Pooler) *StickyConnPool {
 			ch:   make(chan *Conn, 1),
 		}
 	}
-	atomic.AddInt32(&p.shared, 1)
+	p.shared.Add(1)
 	return p
 }
 
@@ -68,13 +68,13 @@ func (p *StickyConnPool) CloseConn(ctx context.Context, cn *Conn, reason string,
 func (p *StickyConnPool) Get(ctx context.Context) (*Conn, error) {
 	// In worst case this races with Close which is not a very common operation.
 	for i := 0; i < 1000; i++ {
-		switch atomic.LoadUint32(&p.state) {
+		switch p.state.Load() {
 		case stateDefault:
 			cn, err := p.pool.Get(ctx)
 			if err != nil {
 				return nil, err
 			}
-			if atomic.CompareAndSwapUint32(&p.state, stateDefault, stateInited) {
+			if p.state.CompareAndSwap(stateDefault, stateInited) {
 				return cn, nil
 			}
 			p.pool.Remove(ctx, cn, ErrClosed)
@@ -130,16 +130,16 @@ func (p *StickyConnPool) RemoveWithoutTurn(ctx context.Context, cn *Conn, reason
 }
 
 func (p *StickyConnPool) Close() error {
-	if shared := atomic.AddInt32(&p.shared, -1); shared > 0 {
+	if shared := p.shared.Add(-1); shared > 0 {
 		return nil
 	}
 
 	for i := 0; i < 1000; i++ {
-		state := atomic.LoadUint32(&p.state)
+		state := p.state.Load()
 		if state == stateClosed {
 			return ErrClosed
 		}
-		if atomic.CompareAndSwapUint32(&p.state, state, stateClosed) {
+		if p.state.CompareAndSwap(state, stateClosed) {
 			close(p.ch)
 			cn, ok := <-p.ch
 			if ok {
@@ -168,8 +168,8 @@ func (p *StickyConnPool) Reset(ctx context.Context) error {
 		return errors.New("redis: StickyConnPool does not have a Conn")
 	}
 
-	if !atomic.CompareAndSwapUint32(&p.state, stateInited, stateDefault) {
-		state := atomic.LoadUint32(&p.state)
+	if !p.state.CompareAndSwap(stateInited, stateDefault) {
+		state := p.state.Load()
 		return fmt.Errorf("redis: invalid StickyConnPool state: %d", state)
 	}
 
@@ -186,7 +186,7 @@ func (p *StickyConnPool) badConnError() error {
 }
 
 func (p *StickyConnPool) Len() int {
-	switch atomic.LoadUint32(&p.state) {
+	switch p.state.Load() {
 	case stateDefault:
 		return 0
 	case stateInited:

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -471,9 +471,9 @@ func TestDialerRetryConfiguration(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("CustomDialerRetries", func(t *testing.T) {
-		var attempts int64
+		var attempts atomic.Int64
 		failingDialer := func(ctx context.Context) (net.Conn, error) {
-			atomic.AddInt64(&attempts, 1)
+			attempts.Add(1)
 			return nil, errors.New("dial failed")
 		}
 
@@ -495,7 +495,7 @@ func TestDialerRetryConfiguration(t *testing.T) {
 
 		// Should have attempted at least 3 times (DialerRetries = 3)
 		// There might be additional attempts due to pool logic
-		finalAttempts := atomic.LoadInt64(&attempts)
+		finalAttempts := attempts.Load()
 		if finalAttempts < 3 {
 			t.Errorf("Expected at least 3 dial attempts, got %d", finalAttempts)
 		}
@@ -505,9 +505,9 @@ func TestDialerRetryConfiguration(t *testing.T) {
 	})
 
 	t.Run("DefaultDialerRetries", func(t *testing.T) {
-		var attempts int64
+		var attempts atomic.Int64
 		failingDialer := func(ctx context.Context) (net.Conn, error) {
-			atomic.AddInt64(&attempts, 1)
+			attempts.Add(1)
 			return nil, errors.New("dial failed")
 		}
 
@@ -529,7 +529,7 @@ func TestDialerRetryConfiguration(t *testing.T) {
 		// Should have attempted 5 times (default DialerRetries = 5)
 		// Note: There may be one additional attempt from tryDial() goroutine
 		// which is launched when dialErrorsNum reaches PoolSize
-		finalAttempts := atomic.LoadInt64(&attempts)
+		finalAttempts := attempts.Load()
 		if finalAttempts < 5 {
 			t.Errorf("Expected at least 5 dial attempts (default), got %d", finalAttempts)
 		}
@@ -1048,10 +1048,10 @@ var _ = Describe("queuedNewConn", func() {
 		// 7. queuedNewConn must call freeTurn()
 		// 8. Check: QueueLen should be 1 (only B holding turn), not 2 (A's turn leaked)
 
-		callCount := int32(0)
+		var callCount atomic.Int32
 
 		controlledDialer := func(ctx context.Context) (net.Conn, error) {
-			count := atomic.AddInt32(&callCount, 1)
+			count := callCount.Add(1)
 			if count == 1 {
 				// Request A's connection: takes 200ms
 				time.Sleep(200 * time.Millisecond)
@@ -1318,10 +1318,10 @@ var _ = Describe("queuedNewConn", func() {
 	})
 
 	It("should handle intermittent dial failures without queue accumulation", func() {
-		callCount := int64(0)
+		var callCount atomic.Int64
 
 		intermittentDialer := func(ctx context.Context) (net.Conn, error) {
-			count := atomic.AddInt64(&callCount, 1)
+			count := callCount.Add(1)
 			if count%2 == 0 {
 				return nil, fmt.Errorf("network timeout")
 			}
@@ -1385,7 +1385,7 @@ var _ = Describe("queuedNewConn", func() {
 		maxExpectedQueueLen := int(testPool.Size()) * 2 // Reasonable upper bound
 
 		var wg sync.WaitGroup
-		maxObservedQueueLen := int32(0)
+		var maxObservedQueueLen atomic.Int32
 
 		// Send many failed requests concurrently
 		for i := 0; i < numRequests; i++ {
@@ -1398,8 +1398,8 @@ var _ = Describe("queuedNewConn", func() {
 			// Check queue length periodically
 			if i%50 == 0 {
 				queueLen := testPool.DialsQueueLen()
-				if queueLen > int(atomic.LoadInt32(&maxObservedQueueLen)) {
-					atomic.StoreInt32(&maxObservedQueueLen, int32(queueLen))
+				if queueLen > int(maxObservedQueueLen.Load()) {
+					maxObservedQueueLen.Store(int32(queueLen))
 				}
 				Expect(queueLen).To(BeNumerically("<=", maxExpectedQueueLen),
 					fmt.Sprintf("Queue length (%d) should not exceed limit (%d)",

--- a/internal/pool/pubsub.go
+++ b/internal/pool/pubsub.go
@@ -7,6 +7,10 @@ import (
 	"sync/atomic"
 )
 
+// PubSubStats contains pub/sub connection pool stats.
+//
+// TODO(cxl): the uint32 fields below will be changed to atomic.Uint32 in v10,
+// which is a breaking API change.
 type PubSubStats struct {
 	Created   uint32
 	Untracked uint32

--- a/internal_test.go
+++ b/internal_test.go
@@ -635,7 +635,7 @@ func TestRingShardsCleanup(t *testing.T) {
 
 		var (
 			ring        *Ring
-			shouldClose int32
+			shouldClose atomic.Int32
 		)
 
 		ring = NewRing(&RingOptions{
@@ -643,7 +643,7 @@ func TestRingShardsCleanup(t *testing.T) {
 				ringShard1Name: ringShard1Addr,
 			},
 			NewClient: func(opt *Options) *Client {
-				if atomic.LoadInt32(&shouldClose) != 0 {
+				if shouldClose.Load() != 0 {
 					ring.Close()
 				}
 				createCounter.increment(opt.Addr)
@@ -658,7 +658,7 @@ func TestRingShardsCleanup(t *testing.T) {
 		createCounter.expect(map[string]int{ringShard1Addr: 1})
 		closeCounter.expect(map[string]int{})
 
-		atomic.StoreInt32(&shouldClose, 1)
+		shouldClose.Store(1)
 
 		ring.SetAddrs(map[string]string{
 			ringShard2Name: ringShard2Addr,
@@ -836,10 +836,10 @@ func TestOnCloseHooks_RegisterSameIDReplaces(t *testing.T) {
 	const id = "same-id"
 	const iterations = 10_000
 
-	var lastSeen int32
+	var lastSeen atomic.Int32
 	for i := 0; i < iterations; i++ {
 		i := int32(i)
-		h.register(id, func() error { atomic.StoreInt32(&lastSeen, i); return nil })
+		h.register(id, func() error { lastSeen.Store(i); return nil })
 	}
 
 	if got := len(h.order); got != 1 {
@@ -852,7 +852,7 @@ func TestOnCloseHooks_RegisterSameIDReplaces(t *testing.T) {
 	if err := h.run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := atomic.LoadInt32(&lastSeen); got != iterations-1 {
+	if got := lastSeen.Load(); got != iterations-1 {
 		t.Fatalf("last-registered callback not invoked: lastSeen = %d, want %d", got, iterations-1)
 	}
 }
@@ -862,17 +862,17 @@ func TestOnCloseHooks_RegisterSameIDReplaces(t *testing.T) {
 // previously registered ids.
 func TestOnCloseHooks_DistinctIDsCoexist(t *testing.T) {
 	h := &onCloseHooks{}
-	var aCount, bCount int32
+	var aCount, bCount atomic.Int32
 
-	h.register("a", func() error { atomic.AddInt32(&aCount, 1); return nil })
-	h.register("b", func() error { atomic.AddInt32(&bCount, 1); return nil })
+	h.register("a", func() error { aCount.Add(1); return nil })
+	h.register("b", func() error { bCount.Add(1); return nil })
 	// Re-registering "a" must not drop "b".
-	h.register("a", func() error { atomic.AddInt32(&aCount, 1); return nil })
+	h.register("a", func() error { aCount.Add(1); return nil })
 
 	if err := h.run(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if a, b := atomic.LoadInt32(&aCount), atomic.LoadInt32(&bCount); a != 1 || b != 1 {
+	if a, b := aCount.Load(), bCount.Load(); a != 1 || b != 1 {
 		t.Fatalf("call counts a=%d b=%d, want a=1 b=1", a, b)
 	}
 }
@@ -973,12 +973,12 @@ func TestOnCloseHooks_ConcurrentRegisterSameID(t *testing.T) {
 type entraidLikeProvider struct {
 	mu         sync.Mutex
 	listeners  []auth.CredentialsListener
-	subscribeN int32
-	unsubCalls int32
+	subscribeN atomic.Int32
+	unsubCalls atomic.Int32
 }
 
 func (p *entraidLikeProvider) Subscribe(listener auth.CredentialsListener) (auth.Credentials, auth.UnsubscribeFunc, error) {
-	atomic.AddInt32(&p.subscribeN, 1)
+	p.subscribeN.Add(1)
 
 	p.mu.Lock()
 	already := false
@@ -994,7 +994,7 @@ func (p *entraidLikeProvider) Subscribe(listener auth.CredentialsListener) (auth
 	p.mu.Unlock()
 
 	unsub := func() error {
-		atomic.AddInt32(&p.unsubCalls, 1)
+		p.unsubCalls.Add(1)
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		for i, l := range p.listeners {
@@ -1058,7 +1058,7 @@ func TestInitConn_EntraidLike_NoLeakAcrossReinits(t *testing.T) {
 	if got := provider.listenerCount(); got != 1 {
 		t.Fatalf("after %d Subscribes with same listener, listener count = %d, want 1", reinits, got)
 	}
-	if got := atomic.LoadInt32(&provider.subscribeN); got != int32(reinits) {
+	if got := provider.subscribeN.Load(); got != int32(reinits) {
 		t.Fatalf("Subscribe call count = %d, want %d", got, reinits)
 	}
 

--- a/maintnotifications/pool_hook_test.go
+++ b/maintnotifications/pool_hook_test.go
@@ -964,7 +964,7 @@ func TestConnectionHook(t *testing.T) {
 		}
 
 		// Set a dialer that will check the context timeout
-		var timeoutVerified int32 // Use atomic for thread safety
+		var timeoutVerified atomic.Int32
 		conn.SetInitConnFunc(func(ctx context.Context, cn *pool.Conn) error {
 			// Check that the context has the expected timeout
 			deadline, ok := ctx.Deadline()
@@ -980,7 +980,7 @@ func TestConnectionHook(t *testing.T) {
 				t.Errorf("Context deadline not as expected. Expected around %v, got %v (diff: %v)",
 					expectedDeadline, deadline, timeDiff)
 			} else {
-				atomic.StoreInt32(&timeoutVerified, 1)
+				timeoutVerified.Store(1)
 			}
 
 			return nil // Successful handoff
@@ -1000,7 +1000,7 @@ func TestConnectionHook(t *testing.T) {
 		// Wait for handoff to complete
 		time.Sleep(500 * time.Millisecond)
 
-		if atomic.LoadInt32(&timeoutVerified) == 0 {
+		if timeoutVerified.Load() == 0 {
 			t.Error("HandoffTimeout was not properly applied to context")
 		}
 

--- a/osscluster.go
+++ b/osscluster.go
@@ -477,13 +477,13 @@ func (opt *ClusterOptions) clientOptions() *Options {
 type clusterNode struct {
 	Client *Client
 
-	latency    uint32 // atomic
-	generation uint32 // atomic
-	failing    uint32 // atomic
-	loaded     uint32 // atomic
+	latency    atomic.Uint32
+	generation atomic.Uint32
+	failing    atomic.Uint32
+	loaded     atomic.Uint32
 
 	// last time the latency measurement was performed for the node, stored in nanoseconds from epoch
-	lastLatencyMeasurement int64 // atomic
+	lastLatencyMeasurement atomic.Int64
 }
 
 func newClusterNodeWithNodeAddress(clOpt *ClusterOptions, addr, nodeAddress string) *clusterNode {
@@ -494,7 +494,7 @@ func newClusterNodeWithNodeAddress(clOpt *ClusterOptions, addr, nodeAddress stri
 		Client: clOpt.NewClient(opt),
 	}
 
-	node.latency = math.MaxUint32
+	node.latency.Store(math.MaxUint32)
 	if clOpt.RouteByLatency {
 		go node.updateLatency()
 	}
@@ -536,46 +536,46 @@ func (n *clusterNode) updateLatency() {
 	} else {
 		latency = float64(dur) / float64(successes)
 	}
-	atomic.StoreUint32(&n.latency, uint32(latency+0.5))
+	n.latency.Store(uint32(latency + 0.5))
 	n.SetLastLatencyMeasurement(time.Now())
 }
 
 func (n *clusterNode) Latency() time.Duration {
-	latency := atomic.LoadUint32(&n.latency)
+	latency := n.latency.Load()
 	return time.Duration(latency) * time.Microsecond
 }
 
 func (n *clusterNode) MarkAsFailing() {
-	atomic.StoreUint32(&n.failing, uint32(time.Now().Unix()))
-	atomic.StoreUint32(&n.loaded, 0)
+	n.failing.Store(uint32(time.Now().Unix()))
+	n.loaded.Store(0)
 }
 
 func (n *clusterNode) Failing() bool {
 	timeout := int64(n.Client.opt.FailingTimeoutSeconds)
 
-	failing := atomic.LoadUint32(&n.failing)
+	failing := n.failing.Load()
 	if failing == 0 {
 		return false
 	}
 	if time.Now().Unix()-int64(failing) < timeout {
 		return true
 	}
-	atomic.StoreUint32(&n.failing, 0)
+	n.failing.Store(0)
 	return false
 }
 
 func (n *clusterNode) Generation() uint32 {
-	return atomic.LoadUint32(&n.generation)
+	return n.generation.Load()
 }
 
 func (n *clusterNode) LastLatencyMeasurement() int64 {
-	return atomic.LoadInt64(&n.lastLatencyMeasurement)
+	return n.lastLatencyMeasurement.Load()
 }
 
 func (n *clusterNode) SetGeneration(gen uint32) {
 	for {
-		v := atomic.LoadUint32(&n.generation)
-		if gen < v || atomic.CompareAndSwapUint32(&n.generation, v, gen) {
+		v := n.generation.Load()
+		if gen < v || n.generation.CompareAndSwap(v, gen) {
 			break
 		}
 	}
@@ -583,15 +583,15 @@ func (n *clusterNode) SetGeneration(gen uint32) {
 
 func (n *clusterNode) SetLastLatencyMeasurement(t time.Time) {
 	for {
-		v := atomic.LoadInt64(&n.lastLatencyMeasurement)
-		if t.UnixNano() < v || atomic.CompareAndSwapInt64(&n.lastLatencyMeasurement, v, t.UnixNano()) {
+		v := n.lastLatencyMeasurement.Load()
+		if t.UnixNano() < v || n.lastLatencyMeasurement.CompareAndSwap(v, t.UnixNano()) {
 			break
 		}
 	}
 }
 
 func (n *clusterNode) Loading() bool {
-	loaded := atomic.LoadUint32(&n.loaded)
+	loaded := n.loaded.Load()
 	if loaded == 1 {
 		return false
 	}
@@ -603,7 +603,7 @@ func (n *clusterNode) Loading() bool {
 	err := n.Client.Ping(ctx).Err()
 	loading := err != nil && isLoadingError(err)
 	if !loading {
-		atomic.StoreUint32(&n.loaded, 1)
+		n.loaded.Store(1)
 	}
 	return loading
 }
@@ -620,7 +620,7 @@ type clusterNodes struct {
 	closed      bool
 	onNewNode   []func(rdb *Client)
 
-	generation uint32 // atomic
+	generation atomic.Uint32
 }
 
 func newClusterNodes(opt *ClusterOptions) *clusterNodes {
@@ -685,7 +685,7 @@ func (c *clusterNodes) Addrs() ([]string, error) {
 }
 
 func (c *clusterNodes) NextGeneration() uint32 {
-	return atomic.AddUint32(&c.generation, 1)
+	return c.generation.Add(1)
 }
 
 // GC removes unused nodes.
@@ -1064,8 +1064,8 @@ type clusterStateHolder struct {
 
 	reloadInterval time.Duration
 	state          atomic.Value
-	reloading      uint32 // atomic
-	reloadPending  uint32 // atomic - set to 1 when reload is requested during active reload
+	reloading      atomic.Uint32
+	reloadPending  atomic.Uint32 // set to 1 when reload is requested during active reload
 }
 
 func newClusterStateHolder(load func(ctx context.Context) (*clusterState, error), reloadInterval time.Duration) *clusterStateHolder {
@@ -1086,8 +1086,8 @@ func (c *clusterStateHolder) Reload(ctx context.Context) (*clusterState, error) 
 
 func (c *clusterStateHolder) LazyReload() {
 	// If already reloading, mark that another reload is pending
-	if !atomic.CompareAndSwapUint32(&c.reloading, 0, 1) {
-		atomic.StoreUint32(&c.reloadPending, 1)
+	if !c.reloading.CompareAndSwap(0, 1) {
+		c.reloadPending.Store(1)
 		return
 	}
 
@@ -1095,22 +1095,22 @@ func (c *clusterStateHolder) LazyReload() {
 		for {
 			_, err := c.Reload(context.Background())
 			if err != nil {
-				atomic.StoreUint32(&c.reloadPending, 0)
-				atomic.StoreUint32(&c.reloading, 0)
+				c.reloadPending.Store(0)
+				c.reloading.Store(0)
 				return
 			}
 
 			// Clear pending flag after reload completes, before cooldown
 			// This captures notifications that arrived during the reload
-			atomic.StoreUint32(&c.reloadPending, 0)
+			c.reloadPending.Store(0)
 
 			// Wait cooldown period
 			time.Sleep(200 * time.Millisecond)
 
 			// Check if another reload was requested during cooldown
-			if atomic.LoadUint32(&c.reloadPending) == 0 {
+			if c.reloadPending.Load() == 0 {
 				// No pending reload, we're done
-				atomic.StoreUint32(&c.reloading, 0)
+				c.reloading.Store(0)
 				return
 			}
 
@@ -2520,10 +2520,8 @@ func (c *ClusterClient) NewDynamicResolver() *commandInfoResolver {
 }
 
 func appendIfNotExist[T comparable](vals []T, newVal T) []T {
-	for _, v := range vals {
-		if v == newVal {
-			return vals
-		}
+	if slices.Contains(vals, newVal) {
+		return vals
 	}
 	return append(vals, newVal)
 }

--- a/osscluster_commands.go
+++ b/osscluster_commands.go
@@ -9,19 +9,19 @@ import (
 func (c *ClusterClient) DBSize(ctx context.Context) *IntCmd {
 	cmd := NewIntCmd(ctx, "dbsize")
 	_ = c.withProcessHook(ctx, cmd, func(ctx context.Context, _ Cmder) error {
-		var size int64
+		var size atomic.Int64
 		err := c.ForEachMaster(ctx, func(ctx context.Context, master *Client) error {
 			n, err := master.DBSize(ctx).Result()
 			if err != nil {
 				return err
 			}
-			atomic.AddInt64(&size, n)
+			size.Add(n)
 			return nil
 		})
 		if err != nil {
 			cmd.SetErr(err)
 		} else {
-			cmd.val = size
+			cmd.val = size.Load()
 		}
 		return nil
 	})

--- a/race_test.go
+++ b/race_test.go
@@ -217,7 +217,7 @@ var _ = Describe("races", func() {
 	It("should BLPop", func() {
 		C := 5
 		N := 5
-		var received uint32
+		var received atomic.Uint32
 
 		wg := performAsync(C, func(id int) {
 			for {
@@ -229,7 +229,7 @@ var _ = Describe("races", func() {
 					Expect(err).NotTo(HaveOccurred())
 				}
 				Expect(v).To(Equal([]string{"list", "hello"}))
-				atomic.AddUint32(&received, 1)
+				received.Add(1)
 			}
 		})
 
@@ -241,7 +241,7 @@ var _ = Describe("races", func() {
 		})
 
 		wg.Wait()
-		Expect(atomic.LoadUint32(&received)).To(Equal(uint32(C * N)))
+		Expect(received.Load()).To(Equal(uint32(C * N)))
 	})
 })
 

--- a/redis.go
+++ b/redis.go
@@ -963,7 +963,7 @@ func (c *baseClient) _process(ctx context.Context, cmd Cmder, attempt int) (bool
 	}
 
 	var usedConn *pool.Conn
-	retryTimeout := uint32(0)
+	var retryTimeout atomic.Uint32
 	if err := c.withConn(ctx, func(ctx context.Context, cn *pool.Conn) error {
 		usedConn = cn
 		// Process any pending push notifications before executing the command
@@ -974,7 +974,7 @@ func (c *baseClient) _process(ctx context.Context, cmd Cmder, attempt int) (bool
 		if err := cn.WithWriter(c.context(ctx), c.opt.WriteTimeout, func(wr *proto.Writer) error {
 			return writeCmd(wr, cmd)
 		}); err != nil {
-			atomic.StoreUint32(&retryTimeout, 1)
+			retryTimeout.Store(1)
 			return err
 		}
 		readReplyFunc := cmd.readReply
@@ -996,16 +996,16 @@ func (c *baseClient) _process(ctx context.Context, cmd Cmder, attempt int) (bool
 			return readReplyFunc(rd)
 		}); err != nil {
 			if cmd.readTimeout() == nil {
-				atomic.StoreUint32(&retryTimeout, 1)
+				retryTimeout.Store(1)
 			} else {
-				atomic.StoreUint32(&retryTimeout, 0)
+				retryTimeout.Store(0)
 			}
 			return err
 		}
 
 		return nil
 	}); err != nil {
-		retry := shouldRetry(err, atomic.LoadUint32(&retryTimeout) == 1)
+		retry := shouldRetry(err, retryTimeout.Load() == 1)
 		return retry, usedConn, err
 	}
 

--- a/ring.go
+++ b/ring.go
@@ -262,7 +262,7 @@ func (opt *RingOptions) clientOptions() *Options {
 
 type ringShard struct {
 	Client *Client
-	down   int32
+	down   atomic.Int32
 	addr   string
 }
 
@@ -288,7 +288,7 @@ func (shard *ringShard) String() string {
 
 func (shard *ringShard) IsDown() bool {
 	const threshold = 3
-	return atomic.LoadInt32(&shard.down) >= threshold
+	return shard.down.Load() >= threshold
 }
 
 func (shard *ringShard) IsUp() bool {
@@ -299,7 +299,7 @@ func (shard *ringShard) IsUp() bool {
 func (shard *ringShard) Vote(up bool) bool {
 	if up {
 		changed := shard.IsDown()
-		atomic.StoreInt32(&shard.down, 0)
+		shard.down.Store(0)
 		return changed
 	}
 
@@ -307,7 +307,7 @@ func (shard *ringShard) Vote(up bool) bool {
 		return false
 	}
 
-	atomic.AddInt32(&shard.down, 1)
+	shard.down.Add(1)
 	return shard.IsDown()
 }
 

--- a/tls_cluster_test.go
+++ b/tls_cluster_test.go
@@ -238,13 +238,13 @@ var _ = Describe("TLS Cluster", Label("NonRedisEnterprise"), func() {
 				return client.Ping(ctx).Err()
 			}, 30*time.Second, 1*time.Second).Should(Succeed())
 
-			var shardCount int64
+			var shardCount atomic.Int64
 			err := client.ForEachShard(ctx, func(ctx context.Context, shard *redis.Client) error {
-				atomic.AddInt64(&shardCount, 1)
+				shardCount.Add(1)
 				return shard.Ping(ctx).Err()
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(atomic.LoadInt64(&shardCount)).To(BeNumerically(">", 0))
+			Expect(shardCount.Load()).To(BeNumerically(">", 0))
 		})
 
 		It("should support ForEachMaster over TLS cluster", func() {
@@ -260,13 +260,13 @@ var _ = Describe("TLS Cluster", Label("NonRedisEnterprise"), func() {
 				return client.Ping(ctx).Err()
 			}, 30*time.Second, 1*time.Second).Should(Succeed())
 
-			var masterCount int64
+			var masterCount atomic.Int64
 			err := client.ForEachMaster(ctx, func(ctx context.Context, master *redis.Client) error {
-				atomic.AddInt64(&masterCount, 1)
+				masterCount.Add(1)
 				return master.Ping(ctx).Err()
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(atomic.LoadInt64(&masterCount)).To(BeNumerically(">", 0))
+			Expect(masterCount.Load()).To(BeNumerically(">", 0))
 		})
 	})
 


### PR DESCRIPTION
Replace old-style atomic.StoreUint32/LoadUint32/AddInt32/CompareAndSwap* calls with the type-safe atomic.Uint32/Int32/Int64/Uint64 value types.

Left untouched:
- Public Stats/PubSubStats plain-uint32 fields (changing them would be a breaking API change); their atomic.Add/Load calls remain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with no auth or API surface changes beyond documentation TODOs; public Stats types remain plain integers.
> 
> **Overview**
> Replaces legacy `sync/atomic` pointer-style calls (`LoadUint32`, `StoreUint32`, `AddInt64`, `CompareAndSwap*`, etc.) with Go’s typed atomics (`atomic.Uint32`, `Int32`, `Int64`, `Uint64`) across internal code paths: **Once**, connection pool (**ConnPool**, **StickyConnPool**, conn ID counter), **cluster** node/state holders, **ring** shard health, and **redis** command retry flags.
> 
> **Public `Stats` / `PubSubStats` still expose plain `uint32`/`int64` fields** (unchanged API); counters on those structs continue to use `atomic.AddUint32` / `LoadUint32`. TODO comments note a planned v10 breaking change to typed fields on those structs.
> 
> Tests and race harnesses are updated to use typed atomics for local counters. **ClusterClient** `DBSize` aggregation uses `atomic.Int64` for concurrent shard sums. **`appendIfNotExist`** in `osscluster.go` now uses `slices.Contains` instead of a manual scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 635f2483e135030d5585f3b970514326786bdd30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->