### PR TITLE
fix(cluster): data race appending to shared masters/slaves slices

### DIFF
--- a/osscluster.go
+++ b/osscluster.go
@@ -1649,12 +1649,15 @@ func (c *ClusterClient) mapCmdsByNode(ctx context.Context, cmdsMap *cmdsMap, cmd
 				if len(state.Masters) == 0 {
 					return errClusterNoNodes
 				}
-				// For read-only keyless commands, pick from all nodes (masters + slaves)
-				allNodes := make([]*clusterNode, 0, len(state.Masters)+len(state.Slaves))
-				allNodes = append(allNodes, state.Masters...)
-				allNodes = append(allNodes, state.Slaves...)
-				idx := c.opt.ShardPicker.Next(len(allNodes))
-				node = allNodes[idx]
+				// For read-only keyless commands, pick from all nodes (masters + slaves).
+				// Index directly instead of building a combined slice, which would
+				// append into the shared snapshot's spare capacity and race.
+				idx := c.opt.ShardPicker.Next(len(state.Masters) + len(state.Slaves))
+				if idx < len(state.Masters) {
+					node = state.Masters[idx]
+				} else {
+					node = state.Slaves[idx-len(state.Masters)]
+				}
 			} else {
 				node, err = c.slotReadOnlyNode(state, slot)
 				if err != nil {

--- a/osscluster.go
+++ b/osscluster.go
@@ -1650,7 +1650,9 @@ func (c *ClusterClient) mapCmdsByNode(ctx context.Context, cmdsMap *cmdsMap, cmd
 					return errClusterNoNodes
 				}
 				// For read-only keyless commands, pick from all nodes (masters + slaves)
-				allNodes := append(state.Masters, state.Slaves...)
+				allNodes := make([]*clusterNode, 0, len(state.Masters)+len(state.Slaves))
+				allNodes = append(allNodes, state.Masters...)
+				allNodes = append(allNodes, state.Slaves...)
 				idx := c.opt.ShardPicker.Next(len(allNodes))
 				node = allNodes[idx]
 			} else {

--- a/osscluster_router.go
+++ b/osscluster_router.go
@@ -85,7 +85,9 @@ func (c *ClusterClient) executeOnAllNodes(ctx context.Context, cmd Cmder, policy
 		return err
 	}
 
-	nodes := append(state.Masters, state.Slaves...)
+	nodes := make([]*clusterNode, 0, len(state.Masters)+len(state.Slaves))
+	nodes = append(nodes, state.Masters...)
+	nodes = append(nodes, state.Slaves...)
 	if len(nodes) == 0 {
 		return errClusterNoNodes
 	}
@@ -494,7 +496,9 @@ func (c *ClusterClient) pickArbitraryNode(ctx context.Context) *clusterNode {
 		return nil
 	}
 
-	allNodes := append(state.Masters, state.Slaves...)
+	allNodes := make([]*clusterNode, 0, len(state.Masters)+len(state.Slaves))
+	allNodes = append(allNodes, state.Masters...)
+	allNodes = append(allNodes, state.Slaves...)
 
 	idx := c.opt.ShardPicker.Next(len(allNodes))
 	return allNodes[idx]

--- a/osscluster_router.go
+++ b/osscluster_router.go
@@ -496,12 +496,14 @@ func (c *ClusterClient) pickArbitraryNode(ctx context.Context) *clusterNode {
 		return nil
 	}
 
-	allNodes := make([]*clusterNode, 0, len(state.Masters)+len(state.Slaves))
-	allNodes = append(allNodes, state.Masters...)
-	allNodes = append(allNodes, state.Slaves...)
-
-	idx := c.opt.ShardPicker.Next(len(allNodes))
-	return allNodes[idx]
+	// Index into masters+slaves without materializing a combined slice.
+	// append(state.Masters, state.Slaves...) writes into the shared snapshot's
+	// spare capacity and races other routers, so pick directly.
+	idx := c.opt.ShardPicker.Next(len(state.Masters) + len(state.Slaves))
+	if idx < len(state.Masters) {
+		return state.Masters[idx]
+	}
+	return state.Slaves[idx-len(state.Masters)]
 }
 
 // hasKeys checks if a command operates on keys

--- a/osscluster_router_test.go
+++ b/osscluster_router_test.go
@@ -1,0 +1,52 @@
+package redis
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9/internal/routing"
+)
+
+// clusterState is published as an immutable snapshot shared by every concurrent
+// caller. Building the routed node list with append(state.Masters,
+// state.Slaves...) reuses the spare capacity of the shared Masters backing array
+// (newClusterState grows it via appendIfNotExist, so cap > len is common), so two
+// goroutines routing commands at the same time write the same slots. Run with
+// -race against the pre-fix tree to see the report at osscluster_router.go.
+func TestPickArbitraryNodeConcurrent(t *testing.T) {
+	// len 3, cap 4 mirrors the appendIfNotExist growth for a 3-master cluster;
+	// one replica fits the spare slot, so append would alias without the fix.
+	masters := make([]*clusterNode, 0, 4)
+	masters = append(masters, &clusterNode{}, &clusterNode{}, &clusterNode{})
+	state := &clusterState{
+		Masters:   masters,
+		Slaves:    []*clusterNode{{}},
+		createdAt: time.Now(),
+	}
+
+	c := &ClusterClient{
+		opt: &ClusterOptions{ShardPicker: &routing.RoundRobinPicker{}},
+		state: newClusterStateHolder(
+			func(ctx context.Context) (*clusterState, error) { return state, nil },
+			time.Hour,
+		),
+	}
+	c.state.state.Store(state)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				if node := c.pickArbitraryNode(context.Background()); node == nil {
+					t.Error("pickArbitraryNode returned nil")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Concurrent command routing on a ClusterClient trips the race detector:

    WARNING: DATA RACE
    Write at 0x00c00007d498 by goroutine 10:
      runtime.slicecopy()
      redis.(*ClusterClient).pickArbitraryNode()
          osscluster_router.go:497
    Previous write at 0x00c00007d498 by goroutine 40:
      runtime.slicecopy()
      redis.(*ClusterClient).pickArbitraryNode()
          osscluster_router.go:497

clusterState is published as a shared immutable snapshot, but its Masters slice is grown with appendIfNotExist and keeps spare capacity, so `append(state.Masters, state.Slaves...)` writes the slaves into the shared backing array instead of allocating. Two goroutines routing at the same time then write the same slots. The same construct sits in executeOnAllNodes, pickArbitraryNode and mapCmdsByNode, and is reachable in the default config (RoundRobinPicker, routing policies on).

Copy into a fresh slice at each site so the snapshot is never mutated. The added test fails under `-race` before the change and passes after.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot concurrent cluster routing paths used with default ShardPicker and routing policies; the change is a targeted concurrency fix with a race test.
> 
> **Overview**
> Fixes a **data race** in concurrent `ClusterClient` routing when code built a combined master+replica list with `append(state.Masters, state.Slaves...)`. That append can write into spare capacity on the shared `clusterState` snapshot (grown via `appendIfNotExist`), so parallel routers corrupt the same backing array.
> 
> **`executeOnAllNodes`** now copies masters and slaves into a **new slice** before fan-out. **`pickArbitraryNode`** and **read-only keyless pipeline routing** in **`mapCmdsByNode`** avoid a combined slice entirely by indexing `ShardPicker` across `len(Masters)+len(Slaves)` and choosing from `Masters` or `Slaves` by index.
> 
> Adds **`TestPickArbitraryNodeConcurrent`** to exercise `pickArbitraryNode` under concurrency (fails under `-race` before the fix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96919052dfbb4cbcb74e70d88335344a03d5d4a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->