### PR TITLE
fix(ring): data race on onNewNode during SetAddrs

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -369,9 +369,10 @@ func (c *ringSharding) SetAddrs(addrs map[string]string) {
 		return
 	}
 	existing := c.shards
+	onNewNode := c.onNewNode
 	c.mu.RUnlock()
 
-	shards, created, unused := c.newRingShards(addrs, existing)
+	shards, created, unused := c.newRingShards(addrs, existing, onNewNode)
 
 	c.mu.Lock()
 	if c.closed {
@@ -387,7 +388,7 @@ func (c *ringSharding) SetAddrs(addrs map[string]string) {
 }
 
 func (c *ringSharding) newRingShards(
-	addrs map[string]string, existing *ringShards,
+	addrs map[string]string, existing *ringShards, onNewNode []func(rdb *Client),
 ) (shards *ringShards, created, unused map[string]*ringShard) {
 	shards = &ringShards{m: make(map[string]*ringShard, len(addrs))}
 	created = make(map[string]*ringShard) // indexed by addr
@@ -408,7 +409,7 @@ func (c *ringSharding) newRingShards(
 			shards.m[name] = shard
 			created[addr] = shard
 
-			for _, fn := range c.onNewNode {
+			for _, fn := range onNewNode {
 				fn(shard.Client)
 			}
 		}

--- a/ring_sharding_race_test.go
+++ b/ring_sharding_race_test.go
@@ -1,0 +1,55 @@
+package redis
+
+import (
+	"sync"
+	"testing"
+)
+
+// SetAddrs snapshots c.shards under c.mu before calling newRingShards, but
+// newRingShards then ranges over c.onNewNode without holding c.mu, while
+// OnNewNode appends to that slice under the lock. A goroutine resharding via
+// SetAddrs and one registering a callback via OnNewNode therefore race on the
+// onNewNode slice. clusterNodes.GetOrCreateWithNodeAddress reads the same kind
+// of callback list under its lock; the ring path missed it. Run with -race
+// against the pre-fix tree to see the report at ring.go.
+func TestRingShardingOnNewNodeConcurrent(t *testing.T) {
+	opt := &RingOptions{Addrs: map[string]string{"shard0": ":6390"}}
+	opt.init()
+
+	c := newRingSharding(opt)
+	defer c.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Register callbacks continuously for the whole duration of the resharding
+	// loop so an append is in flight while newRingShards iterates the slice.
+	done := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				c.OnNewNode(func(*Client) {})
+			}
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		defer close(done)
+		for i := 0; i < 50; i++ {
+			// Toggle the shard set so newRingShards creates a fresh shard on the
+			// even iterations, which is what makes it iterate onNewNode.
+			if i%2 == 0 {
+				c.SetAddrs(map[string]string{"shard0": ":6390", "shard1": ":6391"})
+			} else {
+				c.SetAddrs(map[string]string{"shard0": ":6390"})
+			}
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
go test -race, registering a callback while resharding:

    WARNING: DATA RACE
    Read at ... by goroutine 11:
      (*ringSharding).newRingShards()  ring.go:411
      (*ringSharding).SetAddrs()       ring.go:374
    Previous write at ... by goroutine 10:
      (*ringSharding).OnNewNode()      ring.go:347

OnNewNode appends to c.onNewNode under c.mu, but SetAddrs runs newRingShards after dropping the lock and ranges over c.onNewNode unguarded when a new shard gets created, so a reshard racing a callback registration touches the slice header from two goroutines. Snapshot the slice under the same RLock that already captures c.shards and pass it in; clusterNodes.GetOrCreateWithNodeAddress reads the equivalent list under its lock already.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small synchronization fix in ring sharding with a dedicated race test; behavior for callers is unchanged aside from eliminating undefined concurrent access.
> 
> **Overview**
> Fixes a **data race** when `SetAddrs` reshards the ring while another goroutine calls `OnNewNode`.
> 
> `SetAddrs` already snapshots `c.shards` under `c.mu` before `newRingShards`, but `newRingShards` iterated `c.onNewNode` without the lock while `OnNewNode` appends under the lock. The fix **copies the callback slice under the same read lock** and passes it into `newRingShards`, matching how the cluster client handles equivalent callbacks.
> 
> Adds `TestRingShardingOnNewNodeConcurrent` to exercise concurrent registration and resharding under `-race`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8202a0faeff4e765242834d38bd9b1d1a56c8703. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->