### PR TITLE
feat(autopipeline): #2 add pipeline pool

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.x"
+          go-version: "1.26.5"
           cache: true
 
       - name: Install govulncheck

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -315,15 +315,46 @@ type AutoPipeliner struct {
 
 // apShard is one queue + flusher. Its fields are touched only by enqueuing
 // goroutines (under mu) and by its own single flusher goroutine.
-type apShard struct {
-	ap *AutoPipeliner
+// apEnqueueStripes is how many enqueue stripes a shard runs when striping is
+// safe (unordered configs, and every blocking-face shard — a blocking caller
+// waits for each command, so stripes cannot reorder its stream). The
+// enqueue mutex is the hottest lock in the engine (128 concurrent callers on
+// one shard spend ~half their CPU in lock slow paths); striping the queue
+// spreads that contention while the flusher still drains every stripe into ONE
+// merged pipeline, so batches stay deep. Ordered shards always use a single
+// stripe: with several stripes a caller's consecutive commands can land in
+// stripes on opposite sides of an in-progress drain and execute out of order.
+const apEnqueueStripes = 8
 
+// apStripe is one striped slice of a shard's enqueue queue. Each stripe has
+// its own batch-completion signal so a drain can take stripes one lock at a
+// time; every batch taken in one drain completes together after the merged
+// pipeline executes. Padded so neighbouring stripes' mutexes do not share a
+// cache line.
+type apStripe struct {
 	mu       sync.Mutex
 	queue    []Cmder
 	queueLen atomic.Int32
-	curBatch *apBatch                // completion signal for currently-queued cmds
-	notify   chan struct{}           // buffered (cap 1) enqueue wake-up
-	sem      *internal.FIFOSemaphore // per-shard concurrent-batch budget
+	curBatch *apBatch // completion signal for currently-queued cmds
+	_        [40]byte // pad against false sharing
+}
+
+type apShard struct {
+	ap *AutoPipeliner
+
+	next    atomic.Uint32           // round-robin stripe pick (unordered mode)
+	stripes []apStripe              // 1 stripe when ordered, apEnqueueStripes when Unordered
+	notify  chan struct{}           // buffered (cap 1) enqueue wake-up
+	sem     *internal.FIFOSemaphore // per-shard concurrent-batch budget
+}
+
+// stripe picks the enqueue stripe for the next command: the single stripe in
+// ordered mode (preserving strict FIFO), round-robin in unordered mode.
+func (s *apShard) stripe() *apStripe {
+	if len(s.stripes) == 1 {
+		return &s.stripes[0]
+	}
+	return &s.stripes[s.next.Add(1)%uint32(len(s.stripes))]
 }
 
 // newAutoPipeliner builds an autopipeliner in either blocking or deferred mode.
@@ -410,12 +441,24 @@ func newAutoPipeliner(pipeliner cmdableClient, config *AutoPipelineConfig, block
 		if i < remainder {
 			permits++
 		}
+		// Stripe when reordering is impossible or waived: a BLOCKING caller
+		// waits for each command before issuing its next, so its per-goroutine
+		// order holds no matter which stripe each command lands in; the async
+		// face may only stripe when the user set Unordered. The remaining case
+		// (async, ordered) keeps one stripe to preserve strict submit order.
+		nStripes := 1
+		if config.Unordered || blocking {
+			nStripes = apEnqueueStripes
+		}
 		s := &apShard{
-			ap:       ap,
-			notify:   make(chan struct{}, 1),
-			queue:    getQueueSlice(config.MaxBatchSize),
-			sem:      internal.NewFIFOSemaphore(int32(permits)),
-			curBatch: newAPBatch(),
+			ap:      ap,
+			notify:  make(chan struct{}, 1),
+			stripes: make([]apStripe, nStripes),
+			sem:     internal.NewFIFOSemaphore(int32(permits)),
+		}
+		for j := range s.stripes {
+			s.stripes[j].queue = getQueueSlice(config.MaxBatchSize)
+			s.stripes[j].curBatch = newAPBatch()
 		}
 		ap.shards[i] = s
 		ap.wg.Add(1)
@@ -560,19 +603,20 @@ func (ap *AutoPipeliner) enqueue(cmd Cmder) *apBatch {
 		s = ap.shards[int(ap.next.Add(1)-1)%len(ap.shards)]
 	}
 
-	s.mu.Lock()
-	// Re-check closed under the shard lock (see Close): either we win the lock
+	st := s.stripe()
+	st.mu.Lock()
+	// Re-check closed under the stripe lock (see Close): either we win the lock
 	// first and the shutdown drain flushes us, or the drain ran first and we
 	// reject here — so a late enqueue never hangs on an unclosed done.
 	if ap.closed.Load() {
-		s.mu.Unlock()
+		st.mu.Unlock()
 		cmd.SetErr(ErrClosed)
 		return closedBatch
 	}
-	batch := s.curBatch
-	s.queue = append(s.queue, cmd)
-	s.queueLen.Store(int32(len(s.queue)))
-	s.mu.Unlock()
+	batch := st.curBatch
+	st.queue = append(st.queue, cmd)
+	st.queueLen.Store(int32(len(st.queue)))
+	st.mu.Unlock()
 
 	s.wake()
 	return batch
@@ -802,22 +846,29 @@ func (s *apShard) accumulateBatch() {
 func (s *apShard) flushBatchSlice() {
 	ap := s.ap
 
-	s.mu.Lock()
-	if len(s.queue) == 0 {
-		s.mu.Unlock()
-		s.queueLen.Store(0)
+	// Drain every stripe into one combined batch and roll fresh queues for the
+	// commands enqueued after this point. Striped enqueue spreads the hot
+	// mutex; one merged flush keeps the pipeline deep. accumulateBatch already
+	// bounds the total to roughly MaxBatchSize before we get here.
+	queues := make([][]Cmder, 0, len(s.stripes))
+	batches := make([]*apBatch, 0, len(s.stripes))
+	total := 0
+	for i := range s.stripes {
+		st := &s.stripes[i]
+		st.mu.Lock()
+		if len(st.queue) > 0 {
+			queues = append(queues, st.queue)
+			batches = append(batches, st.curBatch)
+			total += len(st.queue)
+			st.queue = getQueueSlice(ap.config.MaxBatchSize)
+			st.curBatch = newAPBatch()
+			st.queueLen.Store(0)
+		}
+		st.mu.Unlock()
+	}
+	if total == 0 {
 		return
 	}
-	// Take the whole queue as this batch and roll a fresh batch for the
-	// commands enqueued after this point. accumulateBatch already bounds the
-	// queue to roughly MaxBatchSize before we get here, so taking it whole
-	// keeps batches large without a split that would span two batch signals.
-	queuedCmds := s.queue
-	batch := s.curBatch
-	s.queue = getQueueSlice(ap.config.MaxBatchSize)
-	s.curBatch = newAPBatch()
-	s.queueLen.Store(0)
-	s.mu.Unlock()
 
 	// Acquire a concurrency permit. The wait is bounded by ap.ctx (cancelled on
 	// Close) with a generous backstop deadline against a wedged semaphore. The
@@ -835,24 +886,26 @@ func (s *apShard) flushBatchSlice() {
 			if ap.ctx.Err() != nil {
 				batchErr = ErrClosed
 			}
-			for _, qc := range queuedCmds {
-				qc.SetErr(batchErr)
+			for i := range queues {
+				for _, qc := range queues[i] {
+					qc.SetErr(batchErr)
+				}
+				close(batches[i].done)
+				putQueueSlice(queues[i])
 			}
-			close(batch.done)
-			putQueueSlice(queuedCmds)
 			return
 		}
 	}
 
-	// Fast path for single command. Run inside a func so close(batch.done) and
+	// Fast path for single command. Run inside a func so the batch close and
 	// the semaphore release are deferred: a panic in Process still signals
 	// completion (waking await()) and frees the permit before it propagates.
-	if len(queuedCmds) == 1 {
+	if total == 1 {
 		func() {
 			defer s.sem.Release()
-			defer putQueueSlice(queuedCmds)
-			defer close(batch.done)
-			_ = ap.pipeliner.Process(ap.ctx, queuedCmds[0])
+			defer putQueueSlice(queues[0])
+			defer close(batches[0].done)
+			_ = ap.pipeliner.Process(ap.ctx, queues[0][0])
 		}()
 		return
 	}
@@ -863,12 +916,17 @@ func (s *apShard) flushBatchSlice() {
 	go func() {
 		defer ap.batchWg.Done()
 		defer s.sem.Release()
-		defer putQueueSlice(queuedCmds)
-		// Signal completion with a single close. Deferred so a panic in
-		// Process/Exec (e.g. a malformed command or encoder panic) still wakes
-		// every waiter in await() instead of hanging them forever; the close
-		// runs after Exec on the happy path, so results are populated first.
-		defer close(batch.done)
+		// Signal completion with one close per taken stripe. Deferred so a
+		// panic in Process/Exec (e.g. a malformed command or encoder panic)
+		// still wakes every waiter in await() instead of hanging them forever;
+		// the closes run after Exec on the happy path, so results are
+		// populated first.
+		defer func() {
+			for i := range queues {
+				close(batches[i].done)
+				putQueueSlice(queues[i])
+			}
+		}()
 
 		// Use the autopipeliner's long-lived context (cancelled by Close)
 		// rather than a per-batch context.WithTimeout, which allocated a timer
@@ -878,8 +936,10 @@ func (s *apShard) flushBatchSlice() {
 		pipe := ap.Pipeline()
 		defer putPipeliner(pipe)
 
-		for _, qc := range queuedCmds {
-			_ = pipe.Process(ctx, qc)
+		for i := range queues {
+			for _, qc := range queues[i] {
+				_ = pipe.Process(ctx, qc)
+			}
 		}
 		_, _ = pipe.Exec(ctx)
 	}()
@@ -893,33 +953,45 @@ func (s *apShard) flushBatchSliceShutdown() {
 	ap := s.ap
 	// Flush all remaining commands synchronously to preserve order.
 	//
-	// The loop condition is checked UNDER the lock (not via the unlocked
-	// s.Len()): a late enqueue appends to s.queue and updates queueLen under
-	// s.mu, so reading queueLen without the lock could miss a command that was
-	// just appended (seeing 0 and exiting while a command sits in the queue).
-	// Locking first makes "is the queue empty?" and "take the queue" atomic
-	// against that enqueue — this is what closes the lost-command race on Close.
+	// The loop condition is checked UNDER each stripe's lock (not via the
+	// unlocked s.Len()): a late enqueue appends to a stripe's queue and updates
+	// its queueLen under that stripe's mutex, so reading queueLen without the
+	// lock could miss a command that was just appended (seeing 0 and exiting
+	// while a command sits in the queue). Locking first makes "is the stripe
+	// empty?" and "take the stripe" atomic against that enqueue — this is what
+	// closes the lost-command race on Close.
 	for {
-		s.mu.Lock()
-		if len(s.queue) == 0 {
-			s.mu.Unlock()
-			s.queueLen.Store(0)
+		// Take every stripe's queue as one merged batch and roll fresh queues.
+		queues := make([][]Cmder, 0, len(s.stripes))
+		batches := make([]*apBatch, 0, len(s.stripes))
+		total := 0
+		for i := range s.stripes {
+			st := &s.stripes[i]
+			st.mu.Lock()
+			if len(st.queue) > 0 {
+				queues = append(queues, st.queue)
+				batches = append(batches, st.curBatch)
+				total += len(st.queue)
+				st.queue = getQueueSlice(ap.config.MaxBatchSize)
+				st.curBatch = newAPBatch()
+				st.queueLen.Store(0)
+			}
+			st.mu.Unlock()
+		}
+		if total == 0 {
 			return
 		}
-		// Take the whole queue as one batch and roll a fresh batch.
-		queuedCmds := s.queue
-		batch := s.curBatch
-		s.queue = getQueueSlice(ap.config.MaxBatchSize)
-		s.curBatch = newAPBatch()
-		s.queueLen.Store(0)
-		s.mu.Unlock()
 
 		// Execute each batch in a func so close(batch.done) is deferred: a panic
 		// in Process/Exec still signals completion (waking await()) before it
 		// propagates, instead of leaving shutdown waiters hung.
 		func() {
-			defer putQueueSlice(queuedCmds)
-			defer close(batch.done)
+			defer func() {
+				for i := range queues {
+					close(batches[i].done)
+					putQueueSlice(queues[i])
+				}
+			}()
 
 			// ap.ctx is already cancelled here (Close cancels it before draining),
 			// so use a fresh background context with no artificial deadline. The
@@ -933,8 +1005,10 @@ func (s *apShard) flushBatchSliceShutdown() {
 			ctx := context.Background()
 			pipe := ap.Pipeline()
 			defer putPipeliner(pipe)
-			for _, qc := range queuedCmds {
-				_ = pipe.Process(ctx, qc)
+			for i := range queues {
+				for _, qc := range queues[i] {
+					_ = pipe.Process(ctx, qc)
+				}
 			}
 			_, _ = pipe.Exec(ctx)
 		}()
@@ -943,7 +1017,11 @@ func (s *apShard) flushBatchSliceShutdown() {
 
 // Len returns the number of queued commands in this shard.
 func (s *apShard) Len() int {
-	return int(s.queueLen.Load())
+	n := 0
+	for i := range s.stripes {
+		n += int(s.stripes[i].queueLen.Load())
+	}
+	return n
 }
 
 // Len returns the current number of queued commands across all shards.

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -943,7 +943,7 @@ func (s *apShard) accumulateBatch() {
 // flush.
 const (
 	silenceGapFloor = 200 * time.Microsecond
-	silenceGapCeil  = 5 * time.Millisecond
+	silenceGapCeil  = 2 * time.Millisecond
 )
 
 // coalesceMinFlush is the smallest pipeline worth dispatching while other

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -79,11 +79,11 @@ type AutoPipelineConfig struct {
 	//
 	// Based on benchmarks, 100μs can reduce CPU usage by 50%
 	// while adding only ~100μs average latency per command.
-	// Default: 0. Note that 0 does not mean "flush instantly": the flusher
-	// still applies a small default coalescing window (~200µs, ending early
-	// once the queue stops growing)
-	// so concurrently-enqueued commands can batch. Set a value here only to
-	// widen that window.
+	// Default: 0, meaning the flusher applies no coalescing wait — it flushes
+	// each batch as soon as the queue is ready and lets in-flight backpressure
+	// coalesce concurrent callers (see accumulateBatch). Set a value here to add
+	// an explicit accumulation window, trading latency for larger batches / less
+	// CPU as described above.
 	MaxFlushDelay time.Duration
 
 	// AdaptiveDelay enables smart delay calculation based on queue fill level.
@@ -98,22 +98,6 @@ type AutoPipelineConfig struct {
 	// Default: false (use fixed MaxFlushDelay)
 	AdaptiveDelay bool
 }
-
-// defaultAccumulateWindow is the batch-coalescing window used by the flusher
-// when MaxFlushDelay is not set. It is only the upper bound on how long the
-// flusher waits: with the default window the stops-growing check in
-// accumulateBatch returns as soon as the queue stops filling, so a lone caller
-// is not taxed the whole window while concurrent callers still coalesce into a
-// pipeline. It is a var (not a const) so tests can enlarge it and observe the
-// stops-growing behavior without depending on sub-millisecond wall-clock timing.
-var defaultAccumulateWindow = 200 * time.Microsecond
-
-// defaultAccumulateGap is the "stops growing" gap used with the default window:
-// if no new command arrives for a whole gap, the callers that already enqueued
-// are blocked on their results and nothing more is coming, so the flusher stops
-// waiting. Small enough to keep single-caller latency near a raw round-trip,
-// large enough to still coalesce a concurrent burst into one pipeline.
-const defaultAccumulateGap = 20 * time.Microsecond
 
 // autoPipelinePermitBackstop bounds how long a flush waits for a concurrency
 // permit when all are busy. It is only a safety net against a wedged semaphore:
@@ -159,7 +143,7 @@ func DefaultAutoPipelineConfig() *AutoPipelineConfig {
 	return &AutoPipelineConfig{
 		MaxBatchSize:         200,
 		MaxConcurrentBatches: 1, // ordered by default
-		MaxFlushDelay:        0, // lowest latency; flusher still uses the default coalescing window
+		MaxFlushDelay:        0, // lowest latency; no coalescing wait (batch via in-flight backpressure)
 	}
 }
 
@@ -169,8 +153,8 @@ func DefaultAutoPipelineConfig() *AutoPipelineConfig {
 // minimizes latency for the blocking face: with one batch in flight, callers whose
 // commands return while it executes re-enqueue and flush together as the next
 // batch, so batches stay deep (a near-continuous, double-buffered pipeline),
-// while a lone caller still flushes promptly via the stops-growing window in
-// accumulateBatch. More parallel permits (MaxConcurrentBatches>1) do the
+// while a lone caller flushes promptly in a single round-trip (no coalescing
+// wait — see accumulateBatch). More parallel permits (MaxConcurrentBatches>1) do the
 // opposite: each command finds a free permit and flushes on its own before
 // others accumulate, collapsing batch size — and throughput — toward one command
 // per round-trip while latency rises. For maximum throughput use the async face
@@ -271,9 +255,10 @@ func putQueueSlice(slice []Cmder) {
 //
 // AutoPipeliner works by collecting commands from multiple goroutines into a
 // shared queue and flushing them as one Redis pipeline when the batch reaches
-// MaxBatchSize, or when the coalescing window elapses (MaxFlushDelay if set;
-// otherwise a small default window that ends as soon as the queue stops
-// growing — a lone command flushes almost immediately).
+// MaxBatchSize or a configured coalescing window (MaxFlushDelay) elapses. By
+// default there is no window: each batch flushes as soon as the queue is ready
+// and concurrent callers coalesce via in-flight backpressure, so a lone command
+// flushes in a single round-trip while batches stay deep under load.
 //
 // This provides significant performance improvements for workloads with many
 // concurrent small operations, as it reduces the number of network round-trips.
@@ -335,16 +320,25 @@ type AutoPipeliner struct {
 	// batch across nodes). When nil, commands are assigned round-robin.
 	shardFn func(Cmder) int
 
+	// resubmitDebt counts callers who were just woken by a completed batch and
+	// are expected to re-enqueue: each completed batch of N≥2 commands credits
+	// N (its waiters wake together and, in a closed loop, resubmit), and every
+	// enqueue debits 1. The default coalescing wait (coalesceCohort) holds the
+	// flusher while debt remains, so a wakeup herd flushes as one deep pipeline
+	// — the exact herd size, not a smoothed estimate, which cannot ratchet into
+	// fragmentation. Single-command batches credit nothing, so a lone caller
+	// and open-loop traffic never wait. May transiently go negative (arrivals
+	// with no outstanding debt); readers clamp to zero. Pipeliner-global, not
+	// per-shard: cluster routing may land a resubmission on a different shard
+	// than the batch that woke it.
+	resubmitDebt atomic.Int64
+
 	// execEWMA is an exponentially-weighted moving average (alpha 1/8) of
 	// batch execution time in nanoseconds — the engine's own view of the
-	// server round-trip. It drives the adaptive coalescing timings on the
-	// implicit default window (see adaptiveCoalesce): on loopback it clamps to
-	// the historical 20µs gap / 200µs window, while at WAN round-trip times it
-	// widens both so a reply-wakeup herd coalesces into one batch per RTT
-	// instead of fragmenting into serialized partial batches (each split costs
-	// a full RTT). Updates are racy read-modify-writes by design: losing an
-	// occasional sample is harmless for a smoothing heuristic, and it keeps
-	// the batch hot path free of CAS loops. 0 means "no sample yet".
+	// server round-trip. It scales coalesceCohort's silence fallback so a herd
+	// staggered by scheduling on a slow link is not split mid-landing. Updates
+	// are racy read-modify-writes by design: losing an occasional sample is
+	// harmless for a smoothing heuristic. 0 means "no sample yet".
 	execEWMA atomic.Int64
 
 	// Lifecycle
@@ -353,59 +347,6 @@ type AutoPipeliner struct {
 	wg      sync.WaitGroup // Tracks flusher goroutines
 	batchWg sync.WaitGroup // Tracks batch execution goroutines
 	closed  atomic.Bool
-}
-
-// observeBatchExec folds one batch execution duration into execEWMA.
-func (ap *AutoPipeliner) observeBatchExec(d time.Duration) {
-	sample := int64(d)
-	if sample <= 0 {
-		return
-	}
-	old := ap.execEWMA.Load()
-	if old == 0 {
-		ap.execEWMA.Store(sample)
-		return
-	}
-	ap.execEWMA.Store(old + (sample-old)/8)
-}
-
-// adaptiveCoalesce derives the default-window coalescing timings from the
-// observed batch round-trip time. Pure function of the EWMA so it is unit
-// testable. Floors keep loopback behavior identical to the fixed constants;
-// ceilings bound the latency a lone late command can be taxed.
-//
-//	gap    = clamp(rtt/64, defaultAccumulateGap, 3ms)
-//	window = clamp(rtt/4, floorWindow, 15ms)
-//
-// floorWindow is defaultAccumulateWindow (a var so tests can enlarge it; when
-// a test raises it above the ceiling, the floor wins — the window never
-// shrinks below its configured floor).
-func adaptiveCoalesce(ewmaNs int64, floorWindow time.Duration) (gap, window time.Duration) {
-	const (
-		gapCeil    = 3 * time.Millisecond
-		windowCeil = 15 * time.Millisecond
-	)
-	gap = defaultAccumulateGap
-	window = floorWindow
-	if ewmaNs <= 0 {
-		return gap, window
-	}
-	if g := time.Duration(ewmaNs / 64); g > gap {
-		if g > gapCeil {
-			g = gapCeil
-		}
-		gap = g
-	}
-	if w := time.Duration(ewmaNs / 4); w > window {
-		if w > windowCeil {
-			w = windowCeil
-		}
-		window = w
-	}
-	if gap > window {
-		gap = window
-	}
-	return gap, window
 }
 
 // apShard is one queue + flusher. Its fields are touched only by enqueuing
@@ -445,6 +386,13 @@ type apShard struct {
 	stripes []apStripe              // 1 stripe when ordered, apEnqueueStripes when Unordered
 	notify  chan struct{}           // buffered (cap 1) enqueue wake-up
 	sem     *internal.FIFOSemaphore // per-shard concurrent-batch budget
+
+	// inFlight counts this shard's dispatched-but-unfinished batches. When it
+	// is zero and no resubmission debt is outstanding, the shard is idle and a
+	// new command flushes immediately; when batches are in flight, arrivals
+	// are mid-stream and the flusher holds them briefly to coalesce (see
+	// coalesceCohort).
+	inFlight atomic.Int32
 }
 
 // stripe picks the enqueue stripe for the next command: the single stripe in
@@ -799,6 +747,9 @@ func (ap *AutoPipeliner) enqueue(cmd Cmder) *apBatch {
 	st.queueLen.Store(int32(len(st.queue)))
 	st.mu.Unlock()
 
+	// One expected resubmission has landed (see resubmitDebt).
+	ap.resubmitDebt.Add(-1)
+
 	s.wake()
 	return batch
 }
@@ -894,11 +845,10 @@ func (s *apShard) flusher() {
 			return
 		}
 
-		// Coalesce: after the first command wakes us, briefly wait for more
-		// commands to accumulate so we flush a full batch instead of one
-		// command at a time. This is what makes autopipelining batch under
-		// concurrent load. We stop waiting as soon as the queue reaches
-		// MaxBatchSize or MaxFlushDelay elapses (whichever comes first).
+		// Apply the coalescing window if one is configured (MaxFlushDelay /
+		// AdaptiveDelay). With the default config this returns at once: batching
+		// under concurrent load comes from in-flight backpressure, not a wait —
+		// see accumulateBatch.
 		s.accumulateBatch()
 
 		// Flush all pending commands
@@ -913,8 +863,9 @@ func (s *apShard) flusher() {
 
 			s.flushBatchSlice()
 
-			// Between batches, briefly coalesce again so the next pipeline is
-			// also full rather than draining one straggler at a time.
+			// Between batches, apply the configured window again so the next
+			// pipeline is also full. A no-op with the default config (see
+			// accumulateBatch); the next drain picks up whatever has queued.
 			if s.Len() > 0 && s.Len() < ap.config.MaxBatchSize {
 				s.accumulateBatch()
 			}
@@ -922,21 +873,18 @@ func (s *apShard) flusher() {
 	}
 }
 
-// accumulateBatch waits briefly for commands to pile up before the flusher
-// drains the queue, so pipelines carry many commands instead of one. It
-// returns as soon as any of these holds:
+// accumulateBatch lets commands pile up before the flusher drains the queue,
+// so pipelines carry many commands instead of one. It returns as soon as any
+// of these holds:
 //
 //   - the queue reaches MaxBatchSize (batch is full);
 //   - a configured MaxFlushDelay / AdaptiveDelay window elapses; or
-//   - with the implicit default window (no delay configured), no new command
-//     arrives for a whole defaultAccumulateGap — the callers that enqueued are
-//     then blocked on their results, so nothing more is coming right now.
+//   - with no configured window (the default), the expected resubmission
+//     cohort has landed — see coalesceCohort.
 //
-// The stops-growing gap applies only to the default window: an explicit
-// MaxFlushDelay is an intentional "wait this long to accumulate a fuller batch"
-// and is honored in full. It is what keeps single-caller latency low — a lone
-// caller flushes one gap after its command instead of waiting the whole window,
-// while under concurrent load each enqueue extends the gap so the batch grows.
+// A configured MaxFlushDelay / AdaptiveDelay is an intentional accumulation
+// window and is waited in full (AdaptiveDelay scales it down as the queue fills
+// and returns 0 — flush now — once the queue is ≥75% full).
 func (s *apShard) accumulateBatch() {
 	ap := s.ap
 	batchSize := ap.config.MaxBatchSize
@@ -947,88 +895,167 @@ func (s *apShard) accumulateBatch() {
 		return
 	}
 
-	// Pick the accumulation window. With AdaptiveDelay set, calculateDelay scales
-	// it down as this shard's queue fills (and returns 0 once it's ≥75% full,
-	// flushing immediately); otherwise it's the fixed MaxFlushDelay. Fall back to
-	// the default window only when no delay is configured at all. The fill level
-	// is this shard's own length — each shard flushes independently, so a global
-	// count would mis-tune a quiet shard while another is busy.
+	// Pick the accumulation window. calculateDelay returns 0 both when no
+	// MaxFlushDelay is configured (the default) and when AdaptiveDelay resolves
+	// the current fill level to "flush immediately". The fill level is this
+	// shard's own length — each shard flushes independently, so a global count
+	// would mis-tune a quiet shard while another is busy.
 	window := ap.calculateDelay(s.Len())
-
-	// stopsGrowing enables the "flush once the queue stops filling" early exit,
-	// but only for the implicit default window. An explicit MaxFlushDelay (or
-	// AdaptiveDelay) is an intentional accumulation window and is waited in full.
-	stopsGrowing := false
 	if window <= 0 {
-		if ap.config.MaxFlushDelay > 0 || ap.config.AdaptiveDelay {
-			// A delay/adaptive mode was configured and the current fill level
-			// resolved to "flush now" — don't wait.
-			return
+		if ap.config.MaxFlushDelay == 0 && !ap.config.AdaptiveDelay {
+			// Default: coalesce by expected cohort size, not by wall-clock.
+			s.coalesceCohort(batchSize)
 		}
-		// Adaptive default window: scale the coalescing timings by the
-		// observed batch round-trip. On loopback this clamps to the fixed
-		// constants; on a slow network it holds the window open long enough
-		// for a reply-wakeup herd (hundreds of goroutines waking over
-		// milliseconds) to coalesce into ONE batch per round trip instead of
-		// fragmenting into serialized partial batches.
-		_, window = adaptiveCoalesce(ap.execEWMA.Load(), defaultAccumulateWindow)
-		stopsGrowing = true
+		return
 	}
 
-	if !stopsGrowing {
-		// Explicit window: wait the whole delay (or until the batch fills). Each
-		// enqueue sends on notify, so we re-check the queue length on every
-		// wake-up and return once the batch is full.
-		deadline := time.NewTimer(window)
-		defer deadline.Stop()
-		for {
-			select {
-			case <-ap.ctx.Done():
-				return
-			case <-deadline.C:
-				return
-			case <-s.notify:
-				if s.Len() >= batchSize {
-					return
-				}
-			}
-		}
-	}
-
-	// Default window: flush as soon as the queue stops growing. A single timer
-	// acts as a debounce gap — each enqueue extends it — bounded by the window
-	// deadline so a steadily-growing queue still flushes a full pipeline at the
-	// cap, while a lone caller flushes one gap after enqueuing. The gap is
-	// RTT-adaptive (see adaptiveCoalesce): 20µs on loopback, wider on slow
-	// links so staggered reply-wakeups extend one batch instead of splitting
-	// it. Reset is drain-safe on Go 1.23+ (see go.mod: go 1.24).
-	gap, _ := adaptiveCoalesce(ap.execEWMA.Load(), defaultAccumulateWindow)
-	if gap > window {
-		gap = window
-	}
-	deadline := time.Now().Add(window)
-	burst := time.NewTimer(gap)
-	defer burst.Stop()
+	// Explicit window: wait the whole delay (or until the batch fills). Each
+	// enqueue sends on notify, so we re-check the queue length on every wake-up
+	// and return once the batch is full.
+	deadline := time.NewTimer(window)
+	defer deadline.Stop()
 	for {
 		select {
 		case <-ap.ctx.Done():
 			return
-		case <-burst.C:
-			// No new command for a whole gap: the burst is over, flush now.
+		case <-deadline.C:
 			return
 		case <-s.notify:
 			if s.Len() >= batchSize {
 				return
 			}
-			// Extend the gap to keep coalescing, but never past the window cap.
-			d := gap
-			if rem := time.Until(deadline); rem < d {
-				if rem <= 0 {
-					return
-				}
-				d = rem
+		}
+	}
+}
+
+// coalesceGapFloor / coalesceGapCeil bound coalesceCohort's silence fallback.
+// The floor covers fast links; the RTT-scaled value (execEWMA/8) takes over on
+// slow ones, where a wakeup herd staggered by goroutine scheduling can pause
+// longer than the floor mid-landing and a premature flush is expensive (each
+// batch fragment occupies a pipeline connection for a full round trip). The
+// ceiling bounds how long stale debt (callers that left) can delay a flush.
+const (
+	coalesceGapFloor = 200 * time.Microsecond
+	coalesceGapCeil  = 5 * time.Millisecond
+)
+
+// coalesceMinFlush is the smallest pipeline worth dispatching while other
+// batches are still executing. Below it, a gap-fire holds the queued
+// stragglers for the next herd instead of burning a connection on a
+// near-empty flush; once nothing is in flight, any size flushes immediately.
+const coalesceMinFlush = 8
+
+// observeBatchExec folds one batch execution duration into execEWMA.
+func (ap *AutoPipeliner) observeBatchExec(d time.Duration) {
+	sample := int64(d)
+	if sample <= 0 {
+		return
+	}
+	old := ap.execEWMA.Load()
+	if old == 0 {
+		ap.execEWMA.Store(sample)
+		return
+	}
+	ap.execEWMA.Store(old + (sample-old)/8)
+}
+
+// cohortGap returns the silence fallback for coalesceCohort, scaled to the
+// observed batch round-trip: clamp(execEWMA/8, floor, ceil).
+func (ap *AutoPipeliner) cohortGap() time.Duration {
+	g := time.Duration(ap.execEWMA.Load() / 8)
+	if g < coalesceGapFloor {
+		return coalesceGapFloor
+	}
+	if g > coalesceGapCeil {
+		return coalesceGapCeil
+	}
+	return g
+}
+
+// coalesceCohort holds the flusher while related work is in motion, so
+// commands flush as deep pipelines instead of fragmenting into small batches
+// (each fragment costs a pipeline connection for a full round trip). Two
+// signals — both facts the engine already has, not wall-clock guesses — decide
+// whether anything is imminent:
+//
+//   - resubmitDebt: a completed batch of N commands wakes its N waiters
+//     together, and in a closed loop they resubmit. The exact count is
+//     credited at batch completion and debited per enqueue; the wait ends the
+//     moment it drains (the herd has landed). An exact per-herd count has no
+//     failure mode where an averaged estimate undershoots the true herd and
+//     locks the engine into fragmented flushes.
+//   - inFlight: batches still executing mean their waiters will wake shortly
+//     and stragglers are mid-stream — worth holding a moment to coalesce with,
+//     bounded by the silence gap. This also recovers a fragmented state (many
+//     singles in flight, which credit no debt): their staggered returns land
+//     within one gap, merge into a real batch, and debt tracking resumes.
+//
+// When neither holds, the shard is idle and the flush happens immediately: a
+// lone caller pays a single round trip with no timer armed. That is the point
+// of the design — the previous fixed ~20µs debounce timer armed on every flush
+// fires ~1ms late on an idle or low-core host (wakeup latency dominates the
+// requested delay), taxing every low-concurrency command ~5x its round trip.
+// Here the gap timer never fires in steady state, closed loop or open; it only
+// ends waits for callers that left.
+func (s *apShard) coalesceCohort(batchSize int) {
+	ap := s.ap
+	debt := ap.resubmitDebt.Load()
+	if debt < 0 {
+		// Arrivals outran outstanding debt (open-loop traffic); re-zero so the
+		// deficit does not mask the next herd. CAS: only clear the value we
+		// saw, never a concurrent credit.
+		ap.resubmitDebt.CompareAndSwap(debt, 0)
+		debt = 0
+	}
+	herdExpected := debt > 0
+	if !herdExpected && s.inFlight.Load() == 0 {
+		// Idle shard: nothing imminent, flush in one round trip.
+		return
+	}
+
+	gap := ap.cohortGap()
+	// Reset is drain-safe on Go 1.23+ (see go.mod: go 1.24).
+	fallback := time.NewTimer(gap)
+	defer fallback.Stop()
+	for {
+		select {
+		case <-ap.ctx.Done():
+			return
+		case <-fallback.C:
+			if !herdExpected && s.Len() < coalesceMinFlush && s.inFlight.Load() > 0 {
+				// Only stragglers queued while batches are still executing:
+				// flushing a near-empty pipeline burns a connection for a full
+				// round trip (measured at high WAN concurrency: straggler
+				// flushes of 1-3 commands starved the connection pool and
+				// doubled p50). Hold them — the next completed batch's herd
+				// sweeps them along, and the herd path below flushes promptly.
+				fallback.Reset(gap)
+				continue
 			}
-			burst.Reset(d)
+			if herdExpected {
+				// A whole gap with no arrivals: the debtors left (workload
+				// shrank). Drop the stale debt so future flushes don't wait
+				// for ghosts.
+				ap.resubmitDebt.Store(0)
+			}
+			return
+		case <-s.notify:
+			if s.Len() >= batchSize {
+				return
+			}
+			if d := ap.resubmitDebt.Load(); d > 0 {
+				// An in-flight batch completed mid-wait: its herd is now the
+				// thing to wait out, with the exact-count exit below.
+				herdExpected = true
+			} else if herdExpected {
+				// The herd has fully landed; flush it as one batch.
+				return
+			} else if s.inFlight.Load() == 0 {
+				// Nothing executing and no herd expected: no completion will
+				// wake more callers, so flush what we have now.
+				return
+			}
+			fallback.Reset(gap)
 		}
 	}
 }
@@ -1110,12 +1137,12 @@ func (s *apShard) flushBatchSlice() {
 		// without them locks the herd into two alternating cohorts — each
 		// observing two round trips, at half throughput — a state that is
 		// stable once entered (measured: p50 pinned at 2xRTT for entire runs
-		// at mid worker counts on a 52ms link). On the default window,
-		// debounce the resubmission herd and fold it into this batch before
-		// executing, which merges the cohorts back into one batch per round
-		// trip. Explicit-delay configs keep their own timing.
+		// at mid worker counts on a 52ms link). On the default window, let the
+		// resubmission herd land and fold it into this batch before executing,
+		// which merges the cohorts back into one batch per round trip.
+		// Explicit-delay configs keep their own timing.
 		if ap.config.MaxFlushDelay == 0 && !ap.config.AdaptiveDelay {
-			s.accumulateBatch()
+			s.coalesceCohort(ap.config.MaxBatchSize)
 			for i := range s.stripes {
 				st := &s.stripes[i]
 				if st.queueLen.Load() == 0 {
@@ -1135,11 +1162,21 @@ func (s *apShard) flushBatchSlice() {
 		}
 	}
 
-	// Fast path for single command. Run inside a func so the batch close and
-	// the semaphore release are deferred: a panic in Process still signals
-	// completion (waking await()) and frees the permit before it propagates.
+	// Fast path for single command: skip the pipeline and Process directly, in
+	// its own goroutine. The dispatch MUST NOT run inline in the flusher: a
+	// synchronous Process blocks the flusher for a full round trip, and on a
+	// slow link a solo straggler then holds up an entire landed herd for one
+	// RTT — whose flush then delays the straggler's next command in turn, a
+	// stable phase-lock where everyone pays 2x RTT (measured: ~25% of runs on
+	// a 57ms link locked at exactly 2x RTT until perturbed).
+	// No resubmitDebt credit: a single waiter waking is the lone-caller case,
+	// which must keep flushing immediately.
 	if total == 1 {
-		func() {
+		ap.batchWg.Add(1)
+		s.inFlight.Add(1)
+		go func() {
+			defer ap.batchWg.Done()
+			defer s.inFlight.Add(-1)
 			defer s.sem.Release()
 			defer putQueueSlice(queues[0])
 			defer close(batches[0].done)
@@ -1155,8 +1192,10 @@ func (s *apShard) flushBatchSlice() {
 	// Track this goroutine in the batchWg so Close() waits for it.
 	// IMPORTANT: Add to WaitGroup AFTER semaphore is acquired to avoid deadlock.
 	ap.batchWg.Add(1)
+	s.inFlight.Add(1)
 	go func() {
 		defer ap.batchWg.Done()
+		defer s.inFlight.Add(-1)
 		defer s.sem.Release()
 		// Signal completion with one close per taken stripe. Deferred so a
 		// panic in Process/Exec (e.g. a malformed command or encoder panic)
@@ -1190,6 +1229,11 @@ func (s *apShard) flushBatchSlice() {
 		execStart := time.Now()
 		_, _ = pipe.Exec(ctx)
 		ap.observeBatchExec(time.Since(execStart))
+
+		// Credit the resubmission debt BEFORE the deferred closes wake this
+		// batch's waiters, so the flusher sees the expected herd the moment the
+		// first resubmit lands (see resubmitDebt).
+		ap.resubmitDebt.Add(int64(total))
 	}()
 }
 

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -135,17 +135,22 @@ func DefaultAutoPipelineConfig() *AutoPipelineConfig {
 }
 
 // DefaultBlockingAutoPipelineConfig is the default for the blocking face
-// (Client.AutoPipeline). It runs many batches in parallel (MaxConcurrentBatches:
-// 50) for high throughput. Unordered is set because the engine requires it for
-// MaxConcurrentBatches>1 — but a blocking caller still observes per-goroutine
-// ordering, since it waits for each command's result before issuing the next.
-// Global cross-goroutine order (which is not meaningful for independent callers)
-// is what Unordered relaxes.
+// (Client.AutoPipeline). It uses a single ordered batch stream
+// (MaxConcurrentBatches: 1). Counterintuitively this maximizes both throughput
+// AND latency for the blocking face: with one batch in flight, callers whose
+// commands return while it executes re-enqueue and flush together as the next
+// batch, so batches stay deep (a near-continuous, double-buffered pipeline),
+// while a lone caller still flushes promptly via the stops-growing window in
+// accumulateBatch. More parallel permits (MaxConcurrentBatches>1) do the
+// opposite: each command finds a free permit and flushes on its own before
+// others accumulate, collapsing batch size — and throughput — toward one command
+// per round-trip while latency rises. For maximum throughput use the async face
+// (AsyncAutoPipeline) with a window of in-flight commands (inflight>1); it keeps
+// MaxConcurrentBatches: 1 as well.
 func DefaultBlockingAutoPipelineConfig() *AutoPipelineConfig {
 	return &AutoPipelineConfig{
 		MaxBatchSize:         300,
-		MaxConcurrentBatches: 50,
-		Unordered:            true,
+		MaxConcurrentBatches: 1,
 	}
 }
 

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -44,17 +44,27 @@ type AutoPipelineConfig struct {
 	// is a configuration error.
 	Unordered bool
 
+	// contentSharded is set internally by cluster wiring when commands are
+	// routed to shards by content (slot), so same-key commands always share a
+	// shard and per-key order holds even with several shards. It exempts that
+	// wiring from the NumShards ordering check in newAutoPipeliner. Never set
+	// by users (unexported).
+	contentSharded bool
+
 	// NumShards is the number of independent queue+flusher shards the
 	// autopipeliner runs. 0 (the default) means auto: a single shard, which
 	// funnels every caller into one queue so batches stay deep — measured
 	// throughput and latency are best with one shard even under heavy
-	// goroutine concurrency. Cluster clients default to several shards
-	// instead (commands are routed to shards by slot, so each shard's batch
-	// stays on one node). Raising NumShards splits the queue: it reduces
-	// enqueue-mutex contention but fragments batches, which usually costs far
-	// more than the contention saves. Every shard always has at least one
-	// concurrency permit, so the effective global batch concurrency is
-	// max(NumShards, MaxConcurrentBatches).
+	// goroutine concurrency. Cluster clients default to several slot-routed
+	// shards instead, so commands for different nodes queue independently
+	// (per-key order still holds: a key's slot always maps to the same
+	// shard). Raising NumShards splits the queue: it reduces enqueue-mutex
+	// contention but fragments batches, which usually costs far more than the
+	// contention saves. Every shard always has at least one concurrency
+	// permit, so the effective global batch concurrency is
+	// max(NumShards, MaxConcurrentBatches) — and because shards flush
+	// concurrently, NumShards > 1 on the deferred (async) face requires
+	// Unordered: true (construction fails otherwise).
 	NumShards int
 
 	// MaxFlushDelay is the maximum delay after flushing before checking for more commands.
@@ -114,16 +124,16 @@ var defaultAccumulateGap = 20 * time.Microsecond
 const autoPipelinePermitBackstop = 30 * time.Second
 
 // numAutoPipelineShards is the shard-count default used by CLUSTER wiring,
-// where commands are routed to shards by slot and several shards keep each
-// batch on a single node. It is NOT used for standalone clients: those default
+// where commands are routed to shards by slot so different nodes' batches
+// queue independently (every shard keeps at least one concurrency permit, so
+// several shards can flush to their nodes in parallel regardless of
+// MaxConcurrentBatches). It is NOT used for standalone clients: those default
 // to one shard (see newAutoPipeliner), because a single deep queue pipelines
-// far better than a fragmented one. There is no point exceeding the
-// concurrent-batch budget or the number of CPUs.
-func numAutoPipelineShards(maxConcurrentBatches int) int {
+// far better than a fragmented one. Deliberately NOT derived from
+// MaxConcurrentBatches — coupling shard count to the permit budget silently
+// collapsed cluster slot routing to a single shard at the default budget.
+func numAutoPipelineShards() int {
 	n := runtime.GOMAXPROCS(0)
-	if n > maxConcurrentBatches {
-		n = maxConcurrentBatches
-	}
 	if n < 1 {
 		n = 1
 	}
@@ -151,8 +161,8 @@ func DefaultAutoPipelineConfig() *AutoPipelineConfig {
 
 // DefaultBlockingAutoPipelineConfig is the default for the blocking face
 // (Client.AutoPipeline). It uses a single ordered batch stream
-// (MaxConcurrentBatches: 1). Counterintuitively this maximizes both throughput
-// AND latency for the blocking face: with one batch in flight, callers whose
+// (MaxConcurrentBatches: 1). Counterintuitively this maximizes throughput AND
+// minimizes latency for the blocking face: with one batch in flight, callers whose
 // commands return while it executes re-enqueue and flush together as the next
 // batch, so batches stay deep (a near-continuous, double-buffered pipeline),
 // while a lone caller still flushes promptly via the stops-growing window in
@@ -192,6 +202,11 @@ func (cfg *AutoPipelineConfig) Validate() error {
 	}
 	if cfg.NumShards < 0 {
 		return fmt.Errorf("redis: AutoPipelineConfig.NumShards=%d must be >= 0", cfg.NumShards)
+	}
+	if cfg.AdaptiveDelay && cfg.MaxFlushDelay <= 0 {
+		return fmt.Errorf("redis: AutoPipelineConfig.AdaptiveDelay requires MaxFlushDelay > 0 " +
+			"(adaptive delay scales MaxFlushDelay by queue fill; with no MaxFlushDelay it would " +
+			"silently disable batch accumulation entirely)")
 	}
 	return nil
 }
@@ -336,7 +351,11 @@ type apStripe struct {
 	queue    []Cmder
 	queueLen atomic.Int32
 	curBatch *apBatch // completion signal for currently-queued cmds
-	_        [40]byte // pad against false sharing
+	// Pad the struct to a 128-byte stride (2 cache lines): with the previous
+	// 88-byte stride, one stripe's hot fields (curBatch/queueLen) shared a
+	// cache line with the NEXT stripe's contended mutex — exactly the false
+	// sharing the pad exists to prevent.
+	_ [80]byte
 }
 
 type apShard struct {
@@ -389,6 +408,20 @@ func newAutoPipeliner(pipeliner cmdableClient, config *AutoPipelineConfig, block
 	// AsyncAutoPipeline calls never panic on a bad config.
 	if err := config.Validate(); err != nil {
 		return nil, err
+	}
+
+	// NumShards > 1 on the deferred (async) face distributes commands
+	// round-robin across shards that flush concurrently, so submit order is
+	// not preserved — require the explicit Unordered opt-in, exactly like
+	// MaxConcurrentBatches > 1. The blocking face is exempt (each caller waits
+	// per command, and Submit is rejected there), as is cluster slot sharding
+	// (contentSharded: same-key commands always land in the same shard, so
+	// per-key order holds).
+	if config.NumShards > 1 && !config.Unordered && !blocking && !config.contentSharded {
+		return nil, fmt.Errorf(
+			"redis: AutoPipelineConfig.NumShards=%d requires Unordered:true on the deferred (async) face "+
+				"(commands are distributed round-robin across shards, which flush concurrently and do not preserve submit order)",
+			config.NumShards)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -468,33 +501,43 @@ func newAutoPipeliner(pipeliner cmdableClient, config *AutoPipelineConfig, block
 	return ap, nil
 }
 
-// Do queues a command for autopipelined execution, following the
-// autopipeliner's mode. On a deferred (async) autopipeliner it returns
-// immediately and the returned command blocks when you access its result
-// (Err/Val/Result) until the batch has executed; on a blocking autopipeliner
-// the call blocks until the command has executed (the result is already there).
-//
-// This allows sequential usage without goroutines:
-//
-//	cmd1 := ap.Do(ctx, "GET", "key1")
-//	cmd2 := ap.Do(ctx, "GET", "key2")
-//	// Commands are queued, will be batched and flushed automatically
-//	val1, err1 := cmd1.Result()  // Blocks until command executes
-//	val2, err2 := cmd2.Result()  // Blocks until command executes
+// Do executes a raw command on a NORMAL connection, outside the pipeline.
+// Arbitrary command names can carry connection state (SELECT, MULTI, SUBSCRIBE,
+// CLIENT ...) or block the connection (BLPOP ...); batching those onto a shared
+// pipeline connection would silently poison it for every later batch, or stall
+// unrelated commands. The typed surface (ap.Set, ap.Get, ...) is safe by
+// construction and IS batched — prefer it. Do carries the same caveats as
+// Client.Do: a stateful command still affects the (normal, non-pipeline)
+// pooled connection it runs on. Do keeps each face's call shape: on
+// a blocking autopipeliner the call blocks until the command has executed; on a
+// deferred (async) one it returns immediately and the command's result
+// accessors (Err/Val/Result) block until it completes.
 func (ap *AutoPipeliner) Do(ctx context.Context, args ...interface{}) Cmder {
 	cmd := NewCmd(ctx, args...)
 	if len(args) == 0 {
+		cmd.SetErr(fmt.Errorf("redis: AutoPipeliner.Do requires at least one argument"))
+		return cmd
+	}
+	if ap.closed.Load() {
 		cmd.SetErr(ErrClosed)
 		return cmd
 	}
 
-	// Follow the autopipeliner's mode: blocking executes before returning,
-	// deferred returns immediately (read the result to block).
 	if ap.blocking {
-		_ = ap.processBlocking(ctx, cmd)
-	} else {
-		_ = ap.processAsync(ctx, cmd)
+		_ = ap.pipeliner.Process(ctx, cmd)
+		return cmd
 	}
+	// Deferred face: keep the returns-immediately shape. Run on a normal
+	// connection in the background; the ready channel makes the command's
+	// result accessors block until it completes. Not tracked by batchWg — a
+	// Do racing Close simply fails with a closed-pool error like any other
+	// in-flight command on a closing client.
+	done := make(chan struct{})
+	cmd.setReady(done)
+	go func() {
+		defer close(done)
+		_ = ap.pipeliner.Process(ctx, cmd)
+	}()
 	return cmd
 }
 
@@ -516,7 +559,15 @@ type AutoFuture struct {
 }
 
 // Wait blocks until the submitted command has executed, then returns its error.
+// The zero AutoFuture (no submitted command) returns an error rather than
+// panicking.
 func (f AutoFuture) Wait() error {
+	if f.batch == nil {
+		if f.cmd != nil {
+			return f.cmd.Err()
+		}
+		return fmt.Errorf("redis: Wait on a zero AutoFuture")
+	}
 	<-f.batch.done
 	return f.cmd.Err()
 }
@@ -540,11 +591,26 @@ func (ap *AutoPipeliner) submit(ctx context.Context, cmd Cmder) AutoFuture {
 	return AutoFuture{cmd: cmd, batch: ap.enqueue(cmd)}
 }
 
+// errSubmitBlockingFace rejects Submit on the blocking face: Submit does not
+// wait, so a windowed caller could have several commands in flight at once —
+// but the blocking face stripes its enqueue queue on the strength of every
+// caller waiting per command, and a non-waiting window there can be reordered.
+// The deferred face (AsyncAutoPipeline) is built for exactly that usage.
+var errSubmitBlockingFace = fmt.Errorf(
+	"redis: Submit requires the deferred autopipeliner (AsyncAutoPipeline); on the blocking face use the typed methods or Do")
+
 // Submit queues a command without blocking and returns an AutoFuture; Wait on
 // it when the result is needed. This is the explicit form for working with raw
-// Cmders; the typed methods (Set, Get, ...) provide the same deferred behaviour
-// returning the usual *XxxCmd.
+// Cmders on the deferred (async) face, where the typed methods (Set, Get, ...)
+// provide the same deferred behaviour returning the usual *XxxCmd. On a
+// BLOCKING autopipeliner Submit is rejected (the future's Wait returns an
+// error): the blocking face's ordering relies on every caller waiting for each
+// command before issuing the next, which Submit by design does not do.
 func (ap *AutoPipeliner) Submit(ctx context.Context, cmd Cmder) AutoFuture {
+	if ap.blocking {
+		cmd.SetErr(errSubmitBlockingFace)
+		return AutoFuture{cmd: cmd, batch: closedBatch}
+	}
 	return ap.submit(ctx, cmd)
 }
 
@@ -600,7 +666,9 @@ func (ap *AutoPipeliner) enqueue(cmd Cmder) *apBatch {
 		}
 		s = ap.shards[idx%len(ap.shards)]
 	} else {
-		s = ap.shards[int(ap.next.Add(1)-1)%len(ap.shards)]
+		// Unsigned modulo: converting to int first goes negative after the
+		// uint32 counter passes 2^31 on 32-bit platforms and panics.
+		s = ap.shards[int((ap.next.Add(1)-1)%uint32(len(ap.shards)))]
 	}
 
 	st := s.stripe()
@@ -870,22 +938,19 @@ func (s *apShard) flushBatchSlice() {
 		return
 	}
 
-	// Acquire a concurrency permit. The wait is bounded by ap.ctx (cancelled on
-	// Close) with a generous backstop deadline against a wedged semaphore. The
-	// backstop is deliberately well above both the default ReadTimeout and a
-	// maintnotifications relaxed window, so a legitimately slow batch (e.g. during
-	// a failover) holding a permit does not cause waiters to spuriously fail.
+	// Acquire a concurrency permit. The wait runs on a background context with
+	// a generous backstop deadline against a wedged semaphore: commands taken
+	// from the queue were already ACCEPTED, so a concurrent Close must not
+	// cancel them mid-acquire — Close's contract is to flush pending commands
+	// (it waits for this dispatch via wg/batchWg before tearing anything
+	// down). The backstop is deliberately well above both the default
+	// ReadTimeout and a maintnotifications relaxed window, so a legitimately
+	// slow batch (e.g. during a failover) holding a permit does not cause
+	// waiters to spuriously fail.
 	if !s.sem.TryAcquire() {
-		err := s.sem.Acquire(ap.ctx, autoPipelinePermitBackstop, context.DeadlineExceeded)
+		err := s.sem.Acquire(context.Background(), autoPipelinePermitBackstop, context.DeadlineExceeded)
 		if err != nil {
-			// Distinguish a real shutdown (ap.ctx cancelled) from the backstop
-			// firing: ErrClosed only when the client/pipeliner is actually closing;
-			// otherwise propagate the timeout as-is so callers see a deadline, not
-			// a misleading "closed".
 			batchErr := err
-			if ap.ctx.Err() != nil {
-				batchErr = ErrClosed
-			}
 			for i := range queues {
 				for _, qc := range queues[i] {
 					qc.SetErr(batchErr)
@@ -905,7 +970,9 @@ func (s *apShard) flushBatchSlice() {
 			defer s.sem.Release()
 			defer putQueueSlice(queues[0])
 			defer close(batches[0].done)
-			_ = ap.pipeliner.Process(ap.ctx, queues[0][0])
+			// Background for the same reason as the batch goroutine below:
+			// accepted commands execute even under a concurrent Close.
+			_ = ap.pipeliner.Process(context.Background(), queues[0][0])
 		}()
 		return
 	}
@@ -928,10 +995,14 @@ func (s *apShard) flushBatchSlice() {
 			}
 		}()
 
-		// Use the autopipeliner's long-lived context (cancelled by Close)
-		// rather than a per-batch context.WithTimeout, which allocated a timer
-		// and spawned a runtime timer goroutine for every batch.
-		ctx := ap.ctx
+		// Execute on a background context: these commands were accepted before
+		// any concurrent Close, and Close waits for this goroutine (batchWg)
+		// before the client tears down its pools — cancelling here would
+		// error already-accepted commands while the shutdown sweep flushes
+		// later ones, an inverted outcome. The wire timeouts (Read/Write
+		// Timeout, or maintnotifications relaxed windows) still bound the
+		// execution; no per-batch timer is allocated.
+		ctx := context.Background()
 
 		pipe := ap.Pipeline()
 		defer putPipeliner(pipe)
@@ -982,10 +1053,25 @@ func (s *apShard) flushBatchSliceShutdown() {
 			return
 		}
 
+		// Serialize with any still-running in-flight batch: the shutdown drain
+		// used to bypass the per-shard permit, so under MaxConcurrentBatches:1
+		// a drained command could execute CONCURRENTLY with the in-flight
+		// batch during Close and be observed out of order. Acquire the permit
+		// (bounded by the backstop, on a background context — ap.ctx is
+		// already cancelled here); if the backstop expires the permit holder
+		// is wedged and we proceed anyway rather than strand the commands.
+		acquired := s.sem.TryAcquire()
+		if !acquired {
+			acquired = s.sem.Acquire(context.Background(), autoPipelinePermitBackstop, context.DeadlineExceeded) == nil
+		}
+
 		// Execute each batch in a func so close(batch.done) is deferred: a panic
 		// in Process/Exec still signals completion (waking await()) before it
 		// propagates, instead of leaving shutdown waiters hung.
 		func() {
+			if acquired {
+				defer s.sem.Release()
+			}
 			defer func() {
 				for i := range queues {
 					close(batches[i].done)

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -9,6 +9,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/sys/cpu"
+
 	"github.com/redis/go-redis/v9/internal"
 )
 
@@ -373,11 +375,14 @@ type apStripe struct {
 	queue    []Cmder
 	queueLen atomic.Int32
 	curBatch *apBatch // completion signal for currently-queued cmds
-	// Pad the struct to a 128-byte stride (2 cache lines): with the previous
-	// 88-byte stride, one stripe's hot fields (curBatch/queueLen) shared a
-	// cache line with the NEXT stripe's contended mutex — exactly the false
-	// sharing the pad exists to prevent.
-	_ [80]byte
+	// Pad each stripe onto its own cache line(s). Without it, one stripe's hot
+	// fields (queueLen/curBatch) share a cache line with the NEXT stripe's
+	// contended mutex, so a lock-free counter bump on stripe i invalidates the
+	// line a different core is trying to lock stripe i+1 on — false sharing
+	// that measured ~16x on a contended microbenchmark. cpu.CacheLinePad is
+	// sized per GOARCH (64 B on x86-64/arm64, 128 B on ppc64, 256 B on s390x),
+	// so this is correct on every target rather than a hand-tuned constant.
+	_ cpu.CacheLinePad
 }
 
 type apShard struct {

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -591,6 +591,12 @@ func (f AutoFuture) Wait() error {
 // still executes and its result remains readable once its batch completes —
 // ctx abandons only this wait, it does not cancel the command (per-command
 // contexts are not honored after enqueue; see the AutoPipeliner doc).
+//
+// After a ctx error the result may simply not be there YET: the batch is
+// still in flight and may populate the command at any moment, so do not read
+// Cmd()'s value or error directly — that races the executing batch. Call Wait
+// (or WaitContext with a fresh context) again; once it returns a non-context
+// error, the command's result is complete and safe to read.
 func (f AutoFuture) WaitContext(ctx context.Context) error {
 	if f.batch == nil {
 		if f.cmd != nil {

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -1017,6 +1017,8 @@ func (s *apShard) coalesceCohort(batchSize int) {
 	// Reset is drain-safe on Go 1.23+ (see go.mod: go 1.24).
 	fallback := time.NewTimer(gap)
 	defer fallback.Stop()
+	lastSeenDebt := debt    // debt as of the most recent timer (re)arm
+	var holdStart time.Time // set on the first straggler-hold gap fire
 	for {
 		select {
 		case <-ap.ctx.Done():
@@ -1029,14 +1031,30 @@ func (s *apShard) coalesceCohort(batchSize int) {
 				// flushes of 1-3 commands starved the connection pool and
 				// doubled p50). Hold them — the next completed batch's herd
 				// sweeps them along, and the herd path below flushes promptly.
-				fallback.Reset(gap)
-				continue
+				// The hold is bounded like the permit wait: with read timeouts
+				// disabled a wedged batch could pin inFlight forever, and the
+				// held stragglers must not hang with it.
+				if holdStart.IsZero() {
+					holdStart = time.Now()
+				}
+				if time.Since(holdStart) < autoPipelinePermitBackstop {
+					lastSeenDebt = ap.resubmitDebt.Load()
+					fallback.Reset(gap)
+					continue
+				}
 			}
 			if herdExpected {
-				// A whole gap with no arrivals: the debtors left (workload
-				// shrank). Drop the stale debt so future flushes don't wait
-				// for ghosts.
-				ap.resubmitDebt.Store(0)
+				// A whole gap passed with no arrivals on this shard: the
+				// debtors left (workload shrank), so drop the stale debt or
+				// future flushes will wait for ghosts. But only if it did not
+				// GROW during the silent gap — growth means a batch elsewhere
+				// (another shard, or racing this fire) credited a fresh herd,
+				// and erasing that would fragment a herd that is really
+				// coming. CAS, never a blind store, so a credit racing the
+				// reset itself also survives.
+				if d := ap.resubmitDebt.Load(); d > 0 && d <= lastSeenDebt {
+					ap.resubmitDebt.CompareAndSwap(d, 0)
+				}
 			}
 			return
 		case <-s.notify:
@@ -1047,6 +1065,7 @@ func (s *apShard) coalesceCohort(batchSize int) {
 				// An in-flight batch completed mid-wait: its herd is now the
 				// thing to wait out, with the exact-count exit below.
 				herdExpected = true
+				lastSeenDebt = d
 			} else if herdExpected {
 				// The herd has fully landed; flush it as one batch.
 				return

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -335,12 +335,77 @@ type AutoPipeliner struct {
 	// batch across nodes). When nil, commands are assigned round-robin.
 	shardFn func(Cmder) int
 
+	// execEWMA is an exponentially-weighted moving average (alpha 1/8) of
+	// batch execution time in nanoseconds — the engine's own view of the
+	// server round-trip. It drives the adaptive coalescing timings on the
+	// implicit default window (see adaptiveCoalesce): on loopback it clamps to
+	// the historical 20µs gap / 200µs window, while at WAN round-trip times it
+	// widens both so a reply-wakeup herd coalesces into one batch per RTT
+	// instead of fragmenting into serialized partial batches (each split costs
+	// a full RTT). Updates are racy read-modify-writes by design: losing an
+	// occasional sample is harmless for a smoothing heuristic, and it keeps
+	// the batch hot path free of CAS loops. 0 means "no sample yet".
+	execEWMA atomic.Int64
+
 	// Lifecycle
 	ctx     context.Context
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup // Tracks flusher goroutines
 	batchWg sync.WaitGroup // Tracks batch execution goroutines
 	closed  atomic.Bool
+}
+
+// observeBatchExec folds one batch execution duration into execEWMA.
+func (ap *AutoPipeliner) observeBatchExec(d time.Duration) {
+	sample := int64(d)
+	if sample <= 0 {
+		return
+	}
+	old := ap.execEWMA.Load()
+	if old == 0 {
+		ap.execEWMA.Store(sample)
+		return
+	}
+	ap.execEWMA.Store(old + (sample-old)/8)
+}
+
+// adaptiveCoalesce derives the default-window coalescing timings from the
+// observed batch round-trip time. Pure function of the EWMA so it is unit
+// testable. Floors keep loopback behavior identical to the fixed constants;
+// ceilings bound the latency a lone late command can be taxed.
+//
+//	gap    = clamp(rtt/64, defaultAccumulateGap, 3ms)
+//	window = clamp(rtt/4, floorWindow, 15ms)
+//
+// floorWindow is defaultAccumulateWindow (a var so tests can enlarge it; when
+// a test raises it above the ceiling, the floor wins — the window never
+// shrinks below its configured floor).
+func adaptiveCoalesce(ewmaNs int64, floorWindow time.Duration) (gap, window time.Duration) {
+	const (
+		gapCeil    = 3 * time.Millisecond
+		windowCeil = 15 * time.Millisecond
+	)
+	gap = defaultAccumulateGap
+	window = floorWindow
+	if ewmaNs <= 0 {
+		return gap, window
+	}
+	if g := time.Duration(ewmaNs / 64); g > gap {
+		if g > gapCeil {
+			g = gapCeil
+		}
+		gap = g
+	}
+	if w := time.Duration(ewmaNs / 4); w > window {
+		if w > windowCeil {
+			w = windowCeil
+		}
+		window = w
+	}
+	if gap > window {
+		gap = window
+	}
+	return gap, window
 }
 
 // apShard is one queue + flusher. Its fields are touched only by enqueuing
@@ -900,7 +965,13 @@ func (s *apShard) accumulateBatch() {
 			// resolved to "flush now" — don't wait.
 			return
 		}
-		window = defaultAccumulateWindow
+		// Adaptive default window: scale the coalescing timings by the
+		// observed batch round-trip. On loopback this clamps to the fixed
+		// constants; on a slow network it holds the window open long enough
+		// for a reply-wakeup herd (hundreds of goroutines waking over
+		// milliseconds) to coalesce into ONE batch per round trip instead of
+		// fragmenting into serialized partial batches.
+		_, window = adaptiveCoalesce(ap.execEWMA.Load(), defaultAccumulateWindow)
 		stopsGrowing = true
 	}
 
@@ -927,9 +998,11 @@ func (s *apShard) accumulateBatch() {
 	// Default window: flush as soon as the queue stops growing. A single timer
 	// acts as a debounce gap — each enqueue extends it — bounded by the window
 	// deadline so a steadily-growing queue still flushes a full pipeline at the
-	// cap, while a lone caller flushes one gap after enqueuing. Reset is
-	// drain-safe on Go 1.23+ (see go.mod: go 1.24).
-	gap := defaultAccumulateGap
+	// cap, while a lone caller flushes one gap after enqueuing. The gap is
+	// RTT-adaptive (see adaptiveCoalesce): 20µs on loopback, wider on slow
+	// links so staggered reply-wakeups extend one batch instead of splitting
+	// it. Reset is drain-safe on Go 1.23+ (see go.mod: go 1.24).
+	gap, _ := adaptiveCoalesce(ap.execEWMA.Load(), defaultAccumulateWindow)
 	if gap > window {
 		gap = window
 	}
@@ -1042,7 +1115,9 @@ func (s *apShard) flushBatchSlice() {
 			defer close(batches[0].done)
 			// Background for the same reason as the batch goroutine below:
 			// accepted commands execute even under a concurrent Close.
+			execStart := time.Now()
 			_ = ap.pipeliner.Process(context.Background(), queues[0][0])
+			ap.observeBatchExec(time.Since(execStart))
 		}()
 		return
 	}
@@ -1082,7 +1157,9 @@ func (s *apShard) flushBatchSlice() {
 				_ = pipe.Process(ctx, qc)
 			}
 		}
+		execStart := time.Now()
 		_, _ = pipe.Exec(ctx)
+		ap.observeBatchExec(time.Since(execStart))
 	}()
 }
 

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -1103,6 +1103,36 @@ func (s *apShard) flushBatchSlice() {
 			}
 			return
 		}
+
+		// Cohort merge. We took the queue and then waited a full batch round
+		// trip for the permit; callers whose replies landed just after our
+		// take re-submitted into the FRESH queue during that wait. Executing
+		// without them locks the herd into two alternating cohorts — each
+		// observing two round trips, at half throughput — a state that is
+		// stable once entered (measured: p50 pinned at 2xRTT for entire runs
+		// at mid worker counts on a 52ms link). On the default window,
+		// debounce the resubmission herd and fold it into this batch before
+		// executing, which merges the cohorts back into one batch per round
+		// trip. Explicit-delay configs keep their own timing.
+		if ap.config.MaxFlushDelay == 0 && !ap.config.AdaptiveDelay {
+			s.accumulateBatch()
+			for i := range s.stripes {
+				st := &s.stripes[i]
+				if st.queueLen.Load() == 0 {
+					continue
+				}
+				st.mu.Lock()
+				if len(st.queue) > 0 {
+					queues = append(queues, st.queue)
+					batches = append(batches, st.curBatch)
+					total += len(st.queue)
+					st.queue = getQueueSlice(ap.config.MaxBatchSize)
+					st.curBatch = newAPBatch()
+					st.queueLen.Store(0)
+				}
+				st.mu.Unlock()
+			}
+		}
 	}
 
 	// Fast path for single command. Run inside a func so the batch close and

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -44,6 +44,19 @@ type AutoPipelineConfig struct {
 	// is a configuration error.
 	Unordered bool
 
+	// NumShards is the number of independent queue+flusher shards the
+	// autopipeliner runs. 0 (the default) means auto: a single shard, which
+	// funnels every caller into one queue so batches stay deep — measured
+	// throughput and latency are best with one shard even under heavy
+	// goroutine concurrency. Cluster clients default to several shards
+	// instead (commands are routed to shards by slot, so each shard's batch
+	// stays on one node). Raising NumShards splits the queue: it reduces
+	// enqueue-mutex contention but fragments batches, which usually costs far
+	// more than the contention saves. Every shard always has at least one
+	// concurrency permit, so the effective global batch concurrency is
+	// max(NumShards, MaxConcurrentBatches).
+	NumShards int
+
 	// MaxFlushDelay is the maximum delay after flushing before checking for more commands.
 	// A small delay (e.g., 100μs) can significantly reduce CPU usage by allowing
 	// more commands to batch together, at the cost of slightly higher latency.
@@ -100,10 +113,12 @@ var defaultAccumulateGap = 20 * time.Microsecond
 // ap.ctx is cancelled by Close.
 const autoPipelinePermitBackstop = 30 * time.Second
 
-// numAutoPipelineShards chooses how many independent queue+flusher shards to
-// run. More shards reduce enqueue mutex contention and let several batches be
-// assembled in parallel, but there is no point exceeding the concurrent-batch
-// budget or the number of CPUs.
+// numAutoPipelineShards is the shard-count default used by CLUSTER wiring,
+// where commands are routed to shards by slot and several shards keep each
+// batch on a single node. It is NOT used for standalone clients: those default
+// to one shard (see newAutoPipeliner), because a single deep queue pipelines
+// far better than a fragmented one. There is no point exceeding the
+// concurrent-batch budget or the number of CPUs.
 func numAutoPipelineShards(maxConcurrentBatches int) int {
 	n := runtime.GOMAXPROCS(0)
 	if n > maxConcurrentBatches {
@@ -174,6 +189,9 @@ func (cfg *AutoPipelineConfig) Validate() error {
 	}
 	if cfg.MaxFlushDelay < 0 {
 		return fmt.Errorf("redis: AutoPipelineConfig.MaxFlushDelay=%s must be >= 0", cfg.MaxFlushDelay)
+	}
+	if cfg.NumShards < 0 {
+		return fmt.Errorf("redis: AutoPipelineConfig.NumShards=%d must be >= 0", cfg.NumShards)
 	}
 	return nil
 }
@@ -361,11 +379,17 @@ func newAutoPipeliner(pipeliner cmdableClient, config *AutoPipelineConfig, block
 		ap.cmdable = ap.processAsync
 	}
 
-	// Pick a shard count: enough to spread mutex/flusher contention across
-	// cores, but never more than the concurrent-batch budget (extra shards
-	// could not all flush at once anyway) and capped so tiny configs stay
-	// single-shard.
-	nShards := numAutoPipelineShards(config.MaxConcurrentBatches)
+	// Pick the shard count. NumShards=0 (auto) means ONE shard: a single deep
+	// queue outperforms a sharded one because batches stay large — sharding by
+	// core count coupled batch fragmentation to MaxConcurrentBatches and
+	// collapsed pipelining (measured: 16 shards cut async throughput ~4x and
+	// tripled latency versus one shard at the same permit count). Cluster
+	// wiring passes an explicit NumShards so slot-routed shards keep each
+	// batch on one node.
+	nShards := config.NumShards
+	if nShards <= 0 {
+		nShards = 1
+	}
 	// Split the concurrent-batch budget across shards so each shard has its own
 	// semaphore. A single shared semaphore became a contention point once the
 	// per-shard queue mutexes were no longer the bottleneck. Integer division

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -75,10 +75,20 @@ type AutoPipelineConfig struct {
 }
 
 // defaultAccumulateWindow is the batch-coalescing window used by the flusher
-// when MaxFlushDelay is not set. It is small enough to add negligible latency
-// but long enough to let concurrent callers fill a pipeline instead of each
-// command being flushed on its own.
-const defaultAccumulateWindow = 200 * time.Microsecond
+// when MaxFlushDelay is not set. It is only the upper bound on how long the
+// flusher waits: with the default window the stops-growing check in
+// accumulateBatch returns as soon as the queue stops filling, so a lone caller
+// is not taxed the whole window while concurrent callers still coalesce into a
+// pipeline. It is a var (not a const) so tests can enlarge it and observe the
+// stops-growing behavior without depending on sub-millisecond wall-clock timing.
+var defaultAccumulateWindow = 200 * time.Microsecond
+
+// defaultAccumulateGap is the "stops growing" gap used with the default window:
+// if no new command arrives for a whole gap, the callers that already enqueued
+// are blocked on their results and nothing more is coming, so the flusher stops
+// waiting. Small enough to keep single-caller latency near a raw round-trip,
+// large enough to still coalesce a concurrent burst into one pipeline.
+var defaultAccumulateGap = 20 * time.Microsecond
 
 // autoPipelinePermitBackstop bounds how long a flush waits for a concurrency
 // permit when all are busy. It is only a safety net against a wedged semaphore:
@@ -657,13 +667,16 @@ func (s *apShard) flusher() {
 // returns as soon as any of these holds:
 //
 //   - the queue reaches MaxBatchSize (batch is full);
-//   - the queue stops growing between two polls (all current callers are
-//     blocked on their results, so no more commands are coming right now);
-//   - MaxFlushDelay (or defaultAccumulateWindow when unset) elapses.
+//   - a configured MaxFlushDelay / AdaptiveDelay window elapses; or
+//   - with the implicit default window (no delay configured), no new command
+//     arrives for a whole defaultAccumulateGap — the callers that enqueued are
+//     then blocked on their results, so nothing more is coming right now.
 //
-// The "stops growing" check is what keeps latency low: with N concurrent
-// blocking callers the queue fills to N within a couple of polls and flushes
-// immediately, rather than always waiting the whole window.
+// The stops-growing gap applies only to the default window: an explicit
+// MaxFlushDelay is an intentional "wait this long to accumulate a fuller batch"
+// and is honored in full. It is what keeps single-caller latency low — a lone
+// caller flushes one gap after its command instead of waiting the whole window,
+// while under concurrent load each enqueue extends the gap so the batch grows.
 func (s *apShard) accumulateBatch() {
 	ap := s.ap
 	batchSize := ap.config.MaxBatchSize
@@ -681,6 +694,11 @@ func (s *apShard) accumulateBatch() {
 	// is this shard's own length — each shard flushes independently, so a global
 	// count would mis-tune a quiet shard while another is busy.
 	window := ap.calculateDelay(s.Len())
+
+	// stopsGrowing enables the "flush once the queue stops filling" early exit,
+	// but only for the implicit default window. An explicit MaxFlushDelay (or
+	// AdaptiveDelay) is an intentional accumulation window and is waited in full.
+	stopsGrowing := false
 	if window <= 0 {
 		if ap.config.MaxFlushDelay > 0 || ap.config.AdaptiveDelay {
 			// A delay/adaptive mode was configured and the current fill level
@@ -688,23 +706,61 @@ func (s *apShard) accumulateBatch() {
 			return
 		}
 		window = defaultAccumulateWindow
+		stopsGrowing = true
 	}
 
-	// Wait for enqueue wake-ups (no polling, no sleep) until the batch is full
-	// or the window elapses. Each enqueue sends on notify, so we re-check the
-	// queue length on every wake-up and return as soon as a full batch is ready.
-	deadline := time.NewTimer(window)
-	defer deadline.Stop()
+	if !stopsGrowing {
+		// Explicit window: wait the whole delay (or until the batch fills). Each
+		// enqueue sends on notify, so we re-check the queue length on every
+		// wake-up and return once the batch is full.
+		deadline := time.NewTimer(window)
+		defer deadline.Stop()
+		for {
+			select {
+			case <-ap.ctx.Done():
+				return
+			case <-deadline.C:
+				return
+			case <-s.notify:
+				if s.Len() >= batchSize {
+					return
+				}
+			}
+		}
+	}
+
+	// Default window: flush as soon as the queue stops growing. A single timer
+	// acts as a debounce gap — each enqueue extends it — bounded by the window
+	// deadline so a steadily-growing queue still flushes a full pipeline at the
+	// cap, while a lone caller flushes one gap after enqueuing. Reset is
+	// drain-safe on Go 1.23+ (see go.mod: go 1.24).
+	gap := defaultAccumulateGap
+	if gap > window {
+		gap = window
+	}
+	deadline := time.Now().Add(window)
+	burst := time.NewTimer(gap)
+	defer burst.Stop()
 	for {
 		select {
 		case <-ap.ctx.Done():
 			return
-		case <-deadline.C:
+		case <-burst.C:
+			// No new command for a whole gap: the burst is over, flush now.
 			return
 		case <-s.notify:
 			if s.Len() >= batchSize {
 				return
 			}
+			// Extend the gap to keep coalescing, but never past the window cap.
+			d := gap
+			if rem := time.Until(deadline); rem < d {
+				if rem <= 0 {
+					return
+				}
+				d = rem
+			}
+			burst.Reset(d)
 		}
 	}
 }

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -320,23 +320,24 @@ type AutoPipeliner struct {
 	// batch across nodes). When nil, commands are assigned round-robin.
 	shardFn func(Cmder) int
 
-	// resubmitDebt counts callers who were just woken by a completed batch and
-	// are expected to re-enqueue: each completed batch of N≥2 commands credits
-	// N (its waiters wake together and, in a closed loop, resubmit), and every
-	// enqueue debits 1. The default coalescing wait (coalesceCohort) holds the
-	// flusher while debt remains, so a wakeup herd flushes as one deep pipeline
-	// — the exact herd size, not a smoothed estimate, which cannot ratchet into
-	// fragmentation. Single-command batches credit nothing, so a lone caller
-	// and open-loop traffic never wait. May transiently go negative (arrivals
-	// with no outstanding debt); readers clamp to zero. Pipeliner-global, not
-	// per-shard: cluster routing may land a resubmission on a different shard
-	// than the batch that woke it.
-	resubmitDebt atomic.Int64
+	// expectedArrivals counts how many commands the engine expects to arrive
+	// at any moment: a completed batch of N≥2 commands wakes its N waiters
+	// together, and in a closed loop each immediately submits its next command
+	// — so completion announces N expected arrivals, and every enqueue accounts
+	// for one. The default coalescing wait (awaitExpectedArrivals) holds the
+	// flusher while arrivals are still expected, so the whole wakeup wave
+	// flushes as one deep pipeline — an exact count, not a smoothed estimate,
+	// which cannot ratchet into fragmentation. Single-command batches announce
+	// nothing, so a lone caller and open-loop traffic never wait. May
+	// transiently go negative (arrivals nobody announced); readers clamp to
+	// zero. Pipeliner-global, not per-shard: cluster routing may land a
+	// follow-up on a different shard than the batch that woke its caller.
+	expectedArrivals atomic.Int64
 
 	// execEWMA is an exponentially-weighted moving average (alpha 1/8) of
 	// batch execution time in nanoseconds — the engine's own view of the
-	// server round-trip. It scales coalesceCohort's silence fallback so a herd
-	// staggered by scheduling on a slow link is not split mid-landing. Updates
+	// server round-trip. It scales awaitExpectedArrivals's silence fallback so a
+	// wave staggered by scheduling on a slow link is not split mid-landing. Updates
 	// are racy read-modify-writes by design: losing an occasional sample is
 	// harmless for a smoothing heuristic. 0 means "no sample yet".
 	execEWMA atomic.Int64
@@ -388,10 +389,10 @@ type apShard struct {
 	sem     *internal.FIFOSemaphore // per-shard concurrent-batch budget
 
 	// inFlight counts this shard's dispatched-but-unfinished batches. When it
-	// is zero and no resubmission debt is outstanding, the shard is idle and a
+	// is zero and no arrivals are expected, the shard is idle and a
 	// new command flushes immediately; when batches are in flight, arrivals
 	// are mid-stream and the flusher holds them briefly to coalesce (see
-	// coalesceCohort).
+	// awaitExpectedArrivals).
 	inFlight atomic.Int32
 }
 
@@ -747,8 +748,8 @@ func (ap *AutoPipeliner) enqueue(cmd Cmder) *apBatch {
 	st.queueLen.Store(int32(len(st.queue)))
 	st.mu.Unlock()
 
-	// One expected resubmission has landed (see resubmitDebt).
-	ap.resubmitDebt.Add(-1)
+	// One expected arrival has landed (see expectedArrivals).
+	ap.expectedArrivals.Add(-1)
 
 	s.wake()
 	return batch
@@ -880,7 +881,7 @@ func (s *apShard) flusher() {
 //   - the queue reaches MaxBatchSize (batch is full);
 //   - a configured MaxFlushDelay / AdaptiveDelay window elapses; or
 //   - with no configured window (the default), the expected resubmission
-//     cohort has landed — see coalesceCohort.
+//     wave of arrivals has landed — see awaitExpectedArrivals.
 //
 // A configured MaxFlushDelay / AdaptiveDelay is an intentional accumulation
 // window and is waited in full (AdaptiveDelay scales it down as the queue fills
@@ -903,8 +904,8 @@ func (s *apShard) accumulateBatch() {
 	window := ap.calculateDelay(s.Len())
 	if window <= 0 {
 		if ap.config.MaxFlushDelay == 0 && !ap.config.AdaptiveDelay {
-			// Default: coalesce by expected cohort size, not by wall-clock.
-			s.coalesceCohort(batchSize)
+			// Default: coalesce by expected-arrival count, not by wall-clock.
+			s.awaitExpectedArrivals(batchSize)
 		}
 		return
 	}
@@ -928,20 +929,21 @@ func (s *apShard) accumulateBatch() {
 	}
 }
 
-// coalesceGapFloor / coalesceGapCeil bound coalesceCohort's silence fallback.
+// silenceGapFloor / silenceGapCeil bound awaitExpectedArrivals's silence fallback.
 // The floor covers fast links; the RTT-scaled value (execEWMA/8) takes over on
-// slow ones, where a wakeup herd staggered by goroutine scheduling can pause
+// slow ones, where a wakeup wave staggered by goroutine scheduling can pause
 // longer than the floor mid-landing and a premature flush is expensive (each
 // batch fragment occupies a pipeline connection for a full round trip). The
-// ceiling bounds how long stale debt (callers that left) can delay a flush.
+// ceiling bounds how long a stale expectation (callers that left) can delay a
+// flush.
 const (
-	coalesceGapFloor = 200 * time.Microsecond
-	coalesceGapCeil  = 5 * time.Millisecond
+	silenceGapFloor = 200 * time.Microsecond
+	silenceGapCeil  = 5 * time.Millisecond
 )
 
 // coalesceMinFlush is the smallest pipeline worth dispatching while other
 // batches are still executing. Below it, a gap-fire holds the queued
-// stragglers for the next herd instead of burning a connection on a
+// stragglers for the next wave instead of burning a connection on a
 // near-empty flush; once nothing is in flight, any size flushes immediately.
 const coalesceMinFlush = 8
 
@@ -959,36 +961,37 @@ func (ap *AutoPipeliner) observeBatchExec(d time.Duration) {
 	ap.execEWMA.Store(old + (sample-old)/8)
 }
 
-// cohortGap returns the silence fallback for coalesceCohort, scaled to the
+// silenceGap returns the silence fallback for awaitExpectedArrivals, scaled to the
 // observed batch round-trip: clamp(execEWMA/8, floor, ceil).
-func (ap *AutoPipeliner) cohortGap() time.Duration {
+func (ap *AutoPipeliner) silenceGap() time.Duration {
 	g := time.Duration(ap.execEWMA.Load() / 8)
-	if g < coalesceGapFloor {
-		return coalesceGapFloor
+	if g < silenceGapFloor {
+		return silenceGapFloor
 	}
-	if g > coalesceGapCeil {
-		return coalesceGapCeil
+	if g > silenceGapCeil {
+		return silenceGapCeil
 	}
 	return g
 }
 
-// coalesceCohort holds the flusher while related work is in motion, so
+// awaitExpectedArrivals holds the flusher while related work is in motion, so
 // commands flush as deep pipelines instead of fragmenting into small batches
 // (each fragment costs a pipeline connection for a full round trip). Two
 // signals — both facts the engine already has, not wall-clock guesses — decide
 // whether anything is imminent:
 //
-//   - resubmitDebt: a completed batch of N commands wakes its N waiters
-//     together, and in a closed loop they resubmit. The exact count is
-//     credited at batch completion and debited per enqueue; the wait ends the
-//     moment it drains (the herd has landed). An exact per-herd count has no
-//     failure mode where an averaged estimate undershoots the true herd and
-//     locks the engine into fragmented flushes.
+//   - expectedArrivals: a completed batch of N commands wakes its N waiters
+//     together, and in a closed loop each immediately submits its next
+//     command. Completion announces the exact count; every enqueue accounts
+//     for one; the wait ends the moment the count drains — the wave of
+//     arrivals has fully landed. An exact per-wave count has no failure mode
+//     where an averaged estimate undershoots the true wave and locks the
+//     engine into fragmented flushes.
 //   - inFlight: batches still executing mean their waiters will wake shortly
 //     and stragglers are mid-stream — worth holding a moment to coalesce with,
 //     bounded by the silence gap. This also recovers a fragmented state (many
-//     singles in flight, which credit no debt): their staggered returns land
-//     within one gap, merge into a real batch, and debt tracking resumes.
+//     singles in flight, which announce nothing): their staggered returns land
+//     within one gap, merge into a real batch, and arrival tracking resumes.
 //
 // When neither holds, the shard is idle and the flush happens immediately: a
 // lone caller pays a single round trip with no timer armed. That is the point
@@ -997,40 +1000,40 @@ func (ap *AutoPipeliner) cohortGap() time.Duration {
 // requested delay), taxing every low-concurrency command ~5x its round trip.
 // Here the gap timer never fires in steady state, closed loop or open; it only
 // ends waits for callers that left.
-func (s *apShard) coalesceCohort(batchSize int) {
+func (s *apShard) awaitExpectedArrivals(batchSize int) {
 	ap := s.ap
-	debt := ap.resubmitDebt.Load()
-	if debt < 0 {
-		// Arrivals outran outstanding debt (open-loop traffic); re-zero so the
-		// deficit does not mask the next herd. CAS: only clear the value we
-		// saw, never a concurrent credit.
-		ap.resubmitDebt.CompareAndSwap(debt, 0)
-		debt = 0
+	expected := ap.expectedArrivals.Load()
+	if expected < 0 {
+		// Arrivals outran what was announced (open-loop traffic); re-zero so
+		// the deficit does not mask the next wave. CAS: only clear the value
+		// we saw, never a concurrent announcement.
+		ap.expectedArrivals.CompareAndSwap(expected, 0)
+		expected = 0
 	}
-	herdExpected := debt > 0
-	if !herdExpected && s.inFlight.Load() == 0 {
+	expectingWave := expected > 0
+	if !expectingWave && s.inFlight.Load() == 0 {
 		// Idle shard: nothing imminent, flush in one round trip.
 		return
 	}
 
-	gap := ap.cohortGap()
+	gap := ap.silenceGap()
 	// Reset is drain-safe on Go 1.23+ (see go.mod: go 1.24).
 	fallback := time.NewTimer(gap)
 	defer fallback.Stop()
-	lastSeenDebt := debt    // debt as of the most recent timer (re)arm
-	var holdStart time.Time // set on the first straggler-hold gap fire
+	lastSeenExpected := expected // count as of the most recent timer (re)arm
+	var holdStart time.Time      // set on the first straggler-hold gap fire
 	for {
 		select {
 		case <-ap.ctx.Done():
 			return
 		case <-fallback.C:
-			if !herdExpected && s.Len() < coalesceMinFlush && s.inFlight.Load() > 0 {
+			if !expectingWave && s.Len() < coalesceMinFlush && s.inFlight.Load() > 0 {
 				// Only stragglers queued while batches are still executing:
 				// flushing a near-empty pipeline burns a connection for a full
 				// round trip (measured at high WAN concurrency: straggler
 				// flushes of 1-3 commands starved the connection pool and
-				// doubled p50). Hold them — the next completed batch's herd
-				// sweeps them along, and the herd path below flushes promptly.
+				// doubled p50). Hold them — the next completed batch's wave
+				// sweeps them along, and the wave path below flushes promptly.
 				// The hold is bounded like the permit wait: with read timeouts
 				// disabled a wedged batch could pin inFlight forever, and the
 				// held stragglers must not hang with it.
@@ -1038,22 +1041,22 @@ func (s *apShard) coalesceCohort(batchSize int) {
 					holdStart = time.Now()
 				}
 				if time.Since(holdStart) < autoPipelinePermitBackstop {
-					lastSeenDebt = ap.resubmitDebt.Load()
+					lastSeenExpected = ap.expectedArrivals.Load()
 					fallback.Reset(gap)
 					continue
 				}
 			}
-			if herdExpected {
+			if expectingWave {
 				// A whole gap passed with no arrivals on this shard: the
-				// debtors left (workload shrank), so drop the stale debt or
-				// future flushes will wait for ghosts. But only if it did not
-				// GROW during the silent gap — growth means a batch elsewhere
-				// (another shard, or racing this fire) credited a fresh herd,
-				// and erasing that would fragment a herd that is really
-				// coming. CAS, never a blind store, so a credit racing the
-				// reset itself also survives.
-				if d := ap.resubmitDebt.Load(); d > 0 && d <= lastSeenDebt {
-					ap.resubmitDebt.CompareAndSwap(d, 0)
+				// expected callers left (workload shrank), so clear the stale
+				// expectation or future flushes will wait for ghosts. But only
+				// if it did not GROW during the silent gap — growth means a
+				// batch elsewhere (another shard, or racing this fire)
+				// announced a fresh wave, and erasing that would fragment a
+				// wave that is really coming. CAS, never a blind store, so an
+				// announcement racing the reset itself also survives.
+				if d := ap.expectedArrivals.Load(); d > 0 && d <= lastSeenExpected {
+					ap.expectedArrivals.CompareAndSwap(d, 0)
 				}
 			}
 			return
@@ -1061,16 +1064,16 @@ func (s *apShard) coalesceCohort(batchSize int) {
 			if s.Len() >= batchSize {
 				return
 			}
-			if d := ap.resubmitDebt.Load(); d > 0 {
-				// An in-flight batch completed mid-wait: its herd is now the
+			if d := ap.expectedArrivals.Load(); d > 0 {
+				// An in-flight batch completed mid-wait: its wave is now the
 				// thing to wait out, with the exact-count exit below.
-				herdExpected = true
-				lastSeenDebt = d
-			} else if herdExpected {
-				// The herd has fully landed; flush it as one batch.
+				expectingWave = true
+				lastSeenExpected = d
+			} else if expectingWave {
+				// The wave has fully landed; flush it as one batch.
 				return
 			} else if s.inFlight.Load() == 0 {
-				// Nothing executing and no herd expected: no completion will
+				// Nothing executing, no wave expected: no completion will
 				// wake more callers, so flush what we have now.
 				return
 			}
@@ -1150,18 +1153,18 @@ func (s *apShard) flushBatchSlice() {
 			return
 		}
 
-		// Cohort merge. We took the queue and then waited a full batch round
+		// Wave merge. We took the queue and then waited a full batch round
 		// trip for the permit; callers whose replies landed just after our
 		// take re-submitted into the FRESH queue during that wait. Executing
-		// without them locks the herd into two alternating cohorts — each
+		// without them splits the group into two alternating waves — each
 		// observing two round trips, at half throughput — a state that is
 		// stable once entered (measured: p50 pinned at 2xRTT for entire runs
 		// at mid worker counts on a 52ms link). On the default window, let the
-		// resubmission herd land and fold it into this batch before executing,
-		// which merges the cohorts back into one batch per round trip.
-		// Explicit-delay configs keep their own timing.
+		// wave of follow-ups land and fold it into this batch before
+		// executing, which merges the waves back into one batch per round
+		// trip. Explicit-delay configs keep their own timing.
 		if ap.config.MaxFlushDelay == 0 && !ap.config.AdaptiveDelay {
-			s.coalesceCohort(ap.config.MaxBatchSize)
+			s.awaitExpectedArrivals(ap.config.MaxBatchSize)
 			for i := range s.stripes {
 				st := &s.stripes[i]
 				if st.queueLen.Load() == 0 {
@@ -1184,12 +1187,12 @@ func (s *apShard) flushBatchSlice() {
 	// Fast path for single command: skip the pipeline and Process directly, in
 	// its own goroutine. The dispatch MUST NOT run inline in the flusher: a
 	// synchronous Process blocks the flusher for a full round trip, and on a
-	// slow link a solo straggler then holds up an entire landed herd for one
+	// slow link a solo straggler then holds up an entire landed wave for one
 	// RTT — whose flush then delays the straggler's next command in turn, a
 	// stable phase-lock where everyone pays 2x RTT (measured: ~25% of runs on
 	// a 57ms link locked at exactly 2x RTT until perturbed).
-	// No resubmitDebt credit: a single waiter waking is the lone-caller case,
-	// which must keep flushing immediately.
+	// No expectedArrivals announcement: a single waiter waking is the
+	// lone-caller case, which must keep flushing immediately.
 	if total == 1 {
 		ap.batchWg.Add(1)
 		s.inFlight.Add(1)
@@ -1249,10 +1252,10 @@ func (s *apShard) flushBatchSlice() {
 		_, _ = pipe.Exec(ctx)
 		ap.observeBatchExec(time.Since(execStart))
 
-		// Credit the resubmission debt BEFORE the deferred closes wake this
-		// batch's waiters, so the flusher sees the expected herd the moment the
-		// first resubmit lands (see resubmitDebt).
-		ap.resubmitDebt.Add(int64(total))
+		// Announce the expected arrivals BEFORE the deferred closes wake this
+		// batch's waiters, so the flusher knows the wave size the moment its
+		// first command lands (see expectedArrivals).
+		ap.expectedArrivals.Add(int64(total))
 	}()
 }
 

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"runtime"
 	"sync"
@@ -79,7 +80,8 @@ type AutoPipelineConfig struct {
 	// Based on benchmarks, 100μs can reduce CPU usage by 50%
 	// while adding only ~100μs average latency per command.
 	// Default: 0. Note that 0 does not mean "flush instantly": the flusher
-	// still applies a small default coalescing window (defaultAccumulateWindow)
+	// still applies a small default coalescing window (~200µs, ending early
+	// once the queue stops growing)
 	// so concurrently-enqueued commands can batch. Set a value here only to
 	// widen that window.
 	MaxFlushDelay time.Duration
@@ -111,7 +113,7 @@ var defaultAccumulateWindow = 200 * time.Microsecond
 // are blocked on their results and nothing more is coming, so the flusher stops
 // waiting. Small enough to keep single-caller latency near a raw round-trip,
 // large enough to still coalesce a concurrent burst into one pipeline.
-var defaultAccumulateGap = 20 * time.Microsecond
+const defaultAccumulateGap = 20 * time.Microsecond
 
 // autoPipelinePermitBackstop bounds how long a flush waits for a concurrency
 // permit when all are busy. It is only a safety net against a wedged semaphore:
@@ -119,8 +121,10 @@ var defaultAccumulateGap = 20 * time.Microsecond
 // bounded by the connection's read/write timeout, so in normal operation a
 // permit frees long before this. It is set well above the default ReadTimeout
 // and a maintnotifications relaxed window so a legitimately slow in-flight batch
-// never makes waiters fail spuriously. The wait also ends immediately when
-// ap.ctx is cancelled by Close.
+// never makes waiters fail spuriously. The wait deliberately does NOT end on
+// Close: commands taken from the queue were already accepted, and Close's
+// contract is to flush them (it waits via wg/batchWg), so permit waits run on
+// a background context bounded only by this backstop.
 const autoPipelinePermitBackstop = 30 * time.Second
 
 // numAutoPipelineShards is the shard-count default used by CLUSTER wiring,
@@ -159,8 +163,8 @@ func DefaultAutoPipelineConfig() *AutoPipelineConfig {
 	}
 }
 
-// DefaultBlockingAutoPipelineConfig is the default for the blocking face
-// (Client.AutoPipeline). It uses a single ordered batch stream
+// DefaultBlockingAutoPipelineConfig returns the default config for the
+// blocking face (Client.AutoPipeline). It uses a single ordered batch stream
 // (MaxConcurrentBatches: 1). Counterintuitively this maximizes throughput AND
 // minimizes latency for the blocking face: with one batch in flight, callers whose
 // commands return while it executes re-enqueue and flush together as the next
@@ -250,9 +254,13 @@ func getQueueSlice(capacity int) []Cmder {
 
 func putQueueSlice(slice []Cmder) {
 	if cap(slice) <= 1000 {
-		full := slice[:cap(slice)]
-		for i := range full {
-			full[i] = nil
+		// Zero only the used prefix: elements beyond len are already nil —
+		// slices enter the pool fully zeroed (here) and are only appended to
+		// afterwards, so the tail invariant holds. Zeroing the whole capacity
+		// memclr'd up to 8 KB per flush for small batches on large recycled
+		// arrays.
+		for i := range slice {
+			slice[i] = nil
 		}
 		queueSlicePool.Put(&slice)
 	}
@@ -261,17 +269,18 @@ func putQueueSlice(slice []Cmder) {
 // AutoPipeliner automatically batches commands and executes them in pipelines.
 // It's safe for concurrent use by multiple goroutines.
 //
-// AutoPipeliner works by:
-// 1. Collecting commands from multiple goroutines into a shared queue
-// 2. Automatically flushing the queue when:
-//   - The batch size reaches MaxBatchSize
-//
-// 3. Executing batched commands using Redis pipelining
+// AutoPipeliner works by collecting commands from multiple goroutines into a
+// shared queue and flushing them as one Redis pipeline when the batch reaches
+// MaxBatchSize, or when the coalescing window elapses (MaxFlushDelay if set;
+// otherwise a small default window that ends as soon as the queue stops
+// growing — a lone command flushes almost immediately).
 //
 // This provides significant performance improvements for workloads with many
 // concurrent small operations, as it reduces the number of network round-trips.
 //
-// AutoPipeliner implements the Cmdable interface, so you can use it like a regular client.
+// AutoPipeliner implements the Cmdable interface, so you can use it like a
+// regular client. Prefer the typed methods (Set, Get, ...); Do runs OUTSIDE
+// the pipeline on a normal connection (see Do).
 // AutoPipeline / AsyncAutoPipeline return an error for an invalid config, so check it once:
 //
 //	ap, err := client.AutoPipeline()
@@ -290,6 +299,12 @@ func putQueueSlice(slice []Cmder) {
 // The one exception is a blocking command (readTimeout() != nil, e.g. BLPOP):
 // it is never batched and runs directly on the caller's context, which is
 // honored as usual.
+//
+// Retries: like any pipeline, a batch that fails on a network error is retried
+// as a whole (up to Options.MaxRetries). If the connection drops after the
+// server executed part of the batch, non-idempotent commands (INCR, LPUSH, ...)
+// may execute twice. Run commands that must not be retransmitted on a plain
+// client, or set MaxRetries: -1.
 //
 // Lifetime: AutoPipeline() returns a single, client-owned instance shared by all
 // callers. Close()ing it (or closing the client) stops the shared pipeliner for
@@ -515,7 +530,7 @@ func newAutoPipeliner(pipeliner cmdableClient, config *AutoPipelineConfig, block
 func (ap *AutoPipeliner) Do(ctx context.Context, args ...interface{}) Cmder {
 	cmd := NewCmd(ctx, args...)
 	if len(args) == 0 {
-		cmd.SetErr(fmt.Errorf("redis: AutoPipeliner.Do requires at least one argument"))
+		cmd.SetErr(errDoNoArgs)
 		return cmd
 	}
 	if ap.closed.Load() {
@@ -566,10 +581,29 @@ func (f AutoFuture) Wait() error {
 		if f.cmd != nil {
 			return f.cmd.Err()
 		}
-		return fmt.Errorf("redis: Wait on a zero AutoFuture")
+		return errZeroAutoFuture
 	}
 	<-f.batch.done
 	return f.cmd.Err()
+}
+
+// WaitContext is like Wait but stops waiting when ctx is done. The command
+// still executes and its result remains readable once its batch completes —
+// ctx abandons only this wait, it does not cancel the command (per-command
+// contexts are not honored after enqueue; see the AutoPipeliner doc).
+func (f AutoFuture) WaitContext(ctx context.Context) error {
+	if f.batch == nil {
+		if f.cmd != nil {
+			return f.cmd.Err()
+		}
+		return errZeroAutoFuture
+	}
+	select {
+	case <-f.batch.done:
+		return f.cmd.Err()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // Cmd returns the underlying command (call Wait first before reading results).
@@ -583,10 +617,10 @@ func (ap *AutoPipeliner) submit(ctx context.Context, cmd Cmder) AutoFuture {
 		// batched path, so mirror that here instead of running after Close().
 		if ap.closed.Load() {
 			cmd.SetErr(ErrClosed)
-			return AutoFuture{cmd: cmd, batch: closedBatch}
+			return AutoFuture{cmd: cmd, batch: completedBatch}
 		}
 		_ = ap.pipeliner.Process(ctx, cmd)
-		return AutoFuture{cmd: cmd, batch: closedBatch}
+		return AutoFuture{cmd: cmd, batch: completedBatch}
 	}
 	return AutoFuture{cmd: cmd, batch: ap.enqueue(cmd)}
 }
@@ -596,8 +630,14 @@ func (ap *AutoPipeliner) submit(ctx context.Context, cmd Cmder) AutoFuture {
 // but the blocking face stripes its enqueue queue on the strength of every
 // caller waiting per command, and a non-waiting window there can be reordered.
 // The deferred face (AsyncAutoPipeline) is built for exactly that usage.
-var errSubmitBlockingFace = fmt.Errorf(
+var errSubmitBlockingFace = errors.New(
 	"redis: Submit requires the deferred autopipeliner (AsyncAutoPipeline); on the blocking face use the typed methods or Do")
+
+// errZeroAutoFuture is returned by Wait/WaitContext on a zero AutoFuture.
+var errZeroAutoFuture = errors.New("redis: Wait on a zero AutoFuture")
+
+// errDoNoArgs is returned by Do when called without a command.
+var errDoNoArgs = errors.New("redis: AutoPipeliner.Do requires at least one argument")
 
 // Submit queues a command without blocking and returns an AutoFuture; Wait on
 // it when the result is needed. This is the explicit form for working with raw
@@ -609,7 +649,7 @@ var errSubmitBlockingFace = fmt.Errorf(
 func (ap *AutoPipeliner) Submit(ctx context.Context, cmd Cmder) AutoFuture {
 	if ap.blocking {
 		cmd.SetErr(errSubmitBlockingFace)
-		return AutoFuture{cmd: cmd, batch: closedBatch}
+		return AutoFuture{cmd: cmd, batch: completedBatch}
 	}
 	return ap.submit(ctx, cmd)
 }
@@ -638,9 +678,11 @@ func (ap *AutoPipeliner) processBlocking(ctx context.Context, cmd Cmder) error {
 	return ap.submit(ctx, cmd).Wait()
 }
 
-// closedBatch is a reusable already-completed batch for error cases, so a
-// caller that enqueues after Close returns immediately.
-var closedBatch = func() *apBatch {
+// completedBatch is a reusable already-completed batch: returned both for
+// commands that already executed directly (blocking commands, Submit-time
+// rejections) and for error cases like enqueue-after-Close, so Wait returns
+// immediately and the command's own error tells the story.
+var completedBatch = func() *apBatch {
 	b := newAPBatch()
 	close(b.done)
 	return b
@@ -652,7 +694,7 @@ var closedBatch = func() *apBatch {
 func (ap *AutoPipeliner) enqueue(cmd Cmder) *apBatch {
 	if ap.closed.Load() {
 		cmd.SetErr(ErrClosed)
-		return closedBatch
+		return completedBatch
 	}
 
 	// Pick a shard. With shardFn (cluster mode) route by command content so all
@@ -679,7 +721,7 @@ func (ap *AutoPipeliner) enqueue(cmd Cmder) *apBatch {
 	if ap.closed.Load() {
 		st.mu.Unlock()
 		cmd.SetErr(ErrClosed)
-		return closedBatch
+		return completedBatch
 	}
 	batch := st.curBatch
 	st.queue = append(st.queue, cmd)
@@ -698,10 +740,16 @@ func (s *apShard) wake() {
 	}
 }
 
-// process is the internal method that queues a command and returns its done channel.
-// func (ap *AutoPipeliner) process(ctx context.Context, cmd Cmder) <-chan struct{} {
-//  	return ap.processWithQueuedCmd(ctx, cmd).done
-// }
+// IsBlocking reports which face this autopipeliner is: true for the blocking
+// face (Client.AutoPipeline — calls wait for execution), false for the
+// deferred face (AsyncAutoPipeline — calls return immediately and result
+// accessors block). The two faces reject different usage (Submit is
+// blocking-face-rejected), so code handed an *AutoPipeliner can branch on
+// this instead of probing with errors.
+func (ap *AutoPipeliner) IsBlocking() bool { return ap.blocking }
+
+// Config returns a copy of the effective configuration (defaults filled in).
+func (ap *AutoPipeliner) Config() AutoPipelineConfig { return *ap.config }
 
 // IsClosed reports whether the AutoPipeliner has been closed, either by an
 // explicit Close or by closing the owning client. A closed AutoPipeliner
@@ -923,6 +971,16 @@ func (s *apShard) flushBatchSlice() {
 	total := 0
 	for i := range s.stripes {
 		st := &s.stripes[i]
+		// Skip provably-empty stripes without taking their mutex. Safe in
+		// THIS path only: an enqueue publishes queueLen under the stripe lock
+		// and wakes the flusher after unlocking, so a command that appears
+		// concurrently with this unlocked read is re-observed by the
+		// flusher's Len() loop or the buffered notify — the same protocol the
+		// flusher already relies on. The shutdown drain must keep locking
+		// unconditionally (see flushBatchSliceShutdown).
+		if st.queueLen.Load() == 0 {
+			continue
+		}
 		st.mu.Lock()
 		if len(st.queue) > 0 {
 			queues = append(queues, st.queue)
@@ -950,6 +1008,12 @@ func (s *apShard) flushBatchSlice() {
 	if !s.sem.TryAcquire() {
 		err := s.sem.Acquire(context.Background(), autoPipelinePermitBackstop, context.DeadlineExceeded)
 		if err != nil {
+			// A permit not freeing within the backstop means the in-flight
+			// batch is wedged well past any configured timeout — leave an
+			// operator breadcrumb before failing the drained commands.
+			internal.Logger.Printf(context.Background(),
+				"redis: autopipeline: no batch permit after %s; failing %d queued commands",
+				autoPipelinePermitBackstop, total)
 			batchErr := err
 			for i := range queues {
 				for _, qc := range queues[i] {
@@ -1063,6 +1127,11 @@ func (s *apShard) flushBatchSliceShutdown() {
 		acquired := s.sem.TryAcquire()
 		if !acquired {
 			acquired = s.sem.Acquire(context.Background(), autoPipelinePermitBackstop, context.DeadlineExceeded) == nil
+			if !acquired {
+				internal.Logger.Printf(context.Background(),
+					"redis: autopipeline: no batch permit after %s during shutdown; flushing unserialized",
+					autoPipelinePermitBackstop)
+			}
 		}
 
 		// Execute each batch in a func so close(batch.done) is deferred: a panic

--- a/autopipeline_coalesce_test.go
+++ b/autopipeline_coalesce_test.go
@@ -138,7 +138,7 @@ func TestSilenceGap(t *testing.T) {
 		{"loopback 100µs", 100 * time.Microsecond, silenceGapFloor},
 		{"fast lan 1ms", time.Millisecond, silenceGapFloor},
 		{"lan 4ms", 4 * time.Millisecond, 500 * time.Microsecond},
-		{"wan 24ms", 24 * time.Millisecond, 3 * time.Millisecond},
+		{"wan 12ms", 12 * time.Millisecond, 1500 * time.Microsecond},
 		{"slow wan 200ms (ceiling)", 200 * time.Millisecond, silenceGapCeil},
 	}
 	for _, c := range cases {

--- a/autopipeline_coalesce_test.go
+++ b/autopipeline_coalesce_test.go
@@ -9,7 +9,7 @@ import (
 // TestAutoPipelineLoneCallerFlushesImmediately verifies that with the default
 // config (no MaxFlushDelay / AdaptiveDelay) a lone caller's command flushes
 // without any coalescing wait: an idle autopipeliner (no batches in flight, no
-// resubmission debt) must dispatch in a single round trip. This pins the fix
+// expected arrivals) must dispatch in a single round trip. This pins the fix
 // for the low-concurrency latency tax — the engine used to arm a ~20µs
 // debounce timer per flush, which fires ~1ms late on an idle host and made a
 // lone caller ~5x slower than a plain client.
@@ -125,39 +125,39 @@ func TestObserveBatchExecEWMA(t *testing.T) {
 	}
 }
 
-// TestCohortGap pins the silence-fallback derivation: loopback round trips
+// TestSilenceGap pins the silence-fallback derivation: loopback round trips
 // clamp to the floor, slow links scale as exec/8, and the ceiling bounds how
-// long stale debt can delay a flush.
-func TestCohortGap(t *testing.T) {
+// long a stale expectation can delay a flush.
+func TestSilenceGap(t *testing.T) {
 	cases := []struct {
 		name string
 		ewma time.Duration
 		want time.Duration
 	}{
-		{"no sample yet", 0, coalesceGapFloor},
-		{"loopback 100µs", 100 * time.Microsecond, coalesceGapFloor},
-		{"fast lan 1ms", time.Millisecond, coalesceGapFloor},
+		{"no sample yet", 0, silenceGapFloor},
+		{"loopback 100µs", 100 * time.Microsecond, silenceGapFloor},
+		{"fast lan 1ms", time.Millisecond, silenceGapFloor},
 		{"lan 4ms", 4 * time.Millisecond, 500 * time.Microsecond},
 		{"wan 24ms", 24 * time.Millisecond, 3 * time.Millisecond},
-		{"slow wan 200ms (ceiling)", 200 * time.Millisecond, coalesceGapCeil},
+		{"slow wan 200ms (ceiling)", 200 * time.Millisecond, silenceGapCeil},
 	}
 	for _, c := range cases {
 		ap := &AutoPipeliner{}
 		if c.ewma > 0 {
 			ap.execEWMA.Store(int64(c.ewma))
 		}
-		if got := ap.cohortGap(); got != c.want {
-			t.Errorf("%s: cohortGap() with ewma %v = %v, want %v", c.name, c.ewma, got, c.want)
+		if got := ap.silenceGap(); got != c.want {
+			t.Errorf("%s: silenceGap() with ewma %v = %v, want %v", c.name, c.ewma, got, c.want)
 		}
 	}
 }
 
-// TestAutoPipelineHerdCoalesces verifies the load path: concurrent blocking
+// TestAutoPipelineWaveCoalesces verifies the load path: concurrent blocking
 // callers cycling against the pipeliner make sustained progress and their
 // commands all execute. (The depth of the batches is a performance property
-// covered by benchmarks; this guards liveness of the debt/in-flight wait
-// machinery under a closed-loop herd.)
-func TestAutoPipelineHerdCoalesces(t *testing.T) {
+// covered by benchmarks; this guards liveness of the expected-arrivals /
+// in-flight wait machinery under a closed-loop wave.)
+func TestAutoPipelineWaveCoalesces(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(&Options{Addr: ":6379"})
 	defer client.Close()
@@ -177,7 +177,7 @@ func TestAutoPipelineHerdCoalesces(t *testing.T) {
 		go func() {
 			var err error
 			for i := 0; i < iters; i++ {
-				if e := ap.Incr(ctx, "herd-ctr").Err(); e != nil {
+				if e := ap.Incr(ctx, "wave-ctr").Err(); e != nil {
 					err = e
 					break
 				}
@@ -193,10 +193,10 @@ func TestAutoPipelineHerdCoalesces(t *testing.T) {
 				t.Fatalf("worker error: %v", err)
 			}
 		case <-deadline:
-			t.Fatalf("herd stalled: coalescing wait is not making progress")
+			t.Fatalf("wave stalled: coalescing wait is not making progress")
 		}
 	}
-	n, err := client.Get(ctx, "herd-ctr").Int()
+	n, err := client.Get(ctx, "wave-ctr").Int()
 	if err != nil || n != workers*iters {
 		t.Fatalf("herd-ctr = %d, %v; want %d", n, err, workers*iters)
 	}

--- a/autopipeline_coalesce_test.go
+++ b/autopipeline_coalesce_test.go
@@ -13,9 +13,6 @@ import (
 // for the low-concurrency latency tax — the engine used to arm a ~20µs
 // debounce timer per flush, which fires ~1ms late on an idle host and made a
 // lone caller ~5x slower than a plain client.
-//
-// The config is passed as an argument to AutoPipeline (the honored path;
-// Options.AutoPipelineConfig is not consulted by the blocking face).
 func TestAutoPipelineLoneCallerFlushesImmediately(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(&Options{Addr: ":6379"})

--- a/autopipeline_coalesce_test.go
+++ b/autopipeline_coalesce_test.go
@@ -1,0 +1,206 @@
+package redis
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestAutoPipelineLoneCallerFlushesImmediately verifies that with the default
+// config (no MaxFlushDelay / AdaptiveDelay) a lone caller's command flushes
+// without any coalescing wait: an idle autopipeliner (no batches in flight, no
+// resubmission debt) must dispatch in a single round trip. This pins the fix
+// for the low-concurrency latency tax — the engine used to arm a ~20µs
+// debounce timer per flush, which fires ~1ms late on an idle host and made a
+// lone caller ~5x slower than a plain client.
+//
+// The config is passed as an argument to AutoPipeline (the honored path;
+// Options.AutoPipelineConfig is not consulted by the blocking face).
+func TestAutoPipelineLoneCallerFlushesImmediately(t *testing.T) {
+	ctx := context.Background()
+	client := NewClient(&Options{Addr: ":6379"})
+	defer client.Close()
+
+	if err := client.FlushDB(ctx).Err(); err != nil {
+		t.Fatalf("flushdb: %v", err)
+	}
+	ap, err := newAutoPipeliner(client, &AutoPipelineConfig{
+		MaxBatchSize:         300,
+		MaxFlushDelay:        0, // default: no coalescing wait when idle
+		AdaptiveDelay:        false,
+		MaxConcurrentBatches: 5,
+		Unordered:            true,
+	}, true)
+	if err != nil {
+		t.Fatalf("newAutoPipeliner: %v", err)
+	}
+	defer ap.Close()
+
+	// Warm the connection, then time a lone command. Generous ceiling so CI
+	// jitter cannot flake it while a reintroduced per-flush wait (millisecond
+	// scale on idle hosts, per command) would still fail loudly across the
+	// sample of commands below.
+	if err := ap.Set(ctx, "lc-warm", "v", 0).Err(); err != nil {
+		t.Fatalf("warm set: %v", err)
+	}
+	const n = 20
+	start := time.Now()
+	for i := 0; i < n; i++ {
+		if err := ap.Set(ctx, "lc-key", "v", 0).Err(); err != nil {
+			t.Fatalf("set: %v", err)
+		}
+	}
+	perCmd := time.Since(start) / n
+
+	if perCmd > 50*time.Millisecond {
+		t.Fatalf("lone caller averaged %v per command; the idle path must flush "+
+			"immediately (no coalescing timer)", perCmd)
+	}
+
+	if v, err := client.Get(ctx, "lc-key").Result(); err != nil || v != "v" {
+		t.Fatalf("get lc-key = %q, %v; want \"v\", nil", v, err)
+	}
+}
+
+// TestAutoPipelineExplicitDelayWaitsFullWindow guards the gating: an explicit
+// MaxFlushDelay is an intentional accumulation window and must still be waited
+// in full (the idle fast path must NOT short-circuit it), so a later change
+// can't silently turn every explicit-delay command into an immediate flush.
+func TestAutoPipelineExplicitDelayWaitsFullWindow(t *testing.T) {
+	const delay = 100 * time.Millisecond
+
+	ctx := context.Background()
+	client := NewClient(&Options{Addr: ":6379"})
+	defer client.Close()
+
+	if err := client.FlushDB(ctx).Err(); err != nil {
+		t.Fatalf("flushdb: %v", err)
+	}
+	ap, err := newAutoPipeliner(client, &AutoPipelineConfig{
+		MaxBatchSize:         10000, // large: only the timer flushes
+		MaxFlushDelay:        delay,
+		AdaptiveDelay:        false,
+		MaxConcurrentBatches: 5,
+		Unordered:            true,
+	}, true)
+	if err != nil {
+		t.Fatalf("newAutoPipeliner: %v", err)
+	}
+	defer ap.Close()
+
+	start := time.Now()
+	// Typed call: goes through the engine (Do bypasses the pipeline entirely).
+	cmd := ap.Set(ctx, "ed-key", "v", 0)
+	if err := cmd.Err(); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	// It should wait roughly the full delay (not flush early on a stalled queue).
+	if elapsed < delay/2 {
+		t.Fatalf("single command flushed in %v; explicit MaxFlushDelay=%v was not "+
+			"honored (the idle fast path must not apply to an explicit window)", elapsed, delay)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("single command took %v; timer flush appears broken", elapsed)
+	}
+
+	if v, err := client.Get(ctx, "ed-key").Result(); err != nil || v != "v" {
+		t.Fatalf("get ed-key = %q, %v; want \"v\", nil", v, err)
+	}
+}
+
+// TestObserveBatchExecEWMA pins the round-trip smoothing behavior.
+func TestObserveBatchExecEWMA(t *testing.T) {
+	ap := &AutoPipeliner{}
+	ap.observeBatchExec(0) // ignored
+	if got := ap.execEWMA.Load(); got != 0 {
+		t.Fatalf("zero sample stored: %d", got)
+	}
+	ap.observeBatchExec(80 * time.Millisecond) // first sample: stored as-is
+	if got := ap.execEWMA.Load(); got != int64(80*time.Millisecond) {
+		t.Fatalf("first sample = %d", got)
+	}
+	ap.observeBatchExec(160 * time.Millisecond) // ewma += (sample-ewma)/8
+	want := int64(80*time.Millisecond) + int64(80*time.Millisecond)/8
+	if got := ap.execEWMA.Load(); got != want {
+		t.Fatalf("ewma after second sample = %d, want %d", got, want)
+	}
+}
+
+// TestCohortGap pins the silence-fallback derivation: loopback round trips
+// clamp to the floor, slow links scale as exec/8, and the ceiling bounds how
+// long stale debt can delay a flush.
+func TestCohortGap(t *testing.T) {
+	cases := []struct {
+		name string
+		ewma time.Duration
+		want time.Duration
+	}{
+		{"no sample yet", 0, coalesceGapFloor},
+		{"loopback 100µs", 100 * time.Microsecond, coalesceGapFloor},
+		{"fast lan 1ms", time.Millisecond, coalesceGapFloor},
+		{"lan 4ms", 4 * time.Millisecond, 500 * time.Microsecond},
+		{"wan 24ms", 24 * time.Millisecond, 3 * time.Millisecond},
+		{"slow wan 200ms (ceiling)", 200 * time.Millisecond, coalesceGapCeil},
+	}
+	for _, c := range cases {
+		ap := &AutoPipeliner{}
+		if c.ewma > 0 {
+			ap.execEWMA.Store(int64(c.ewma))
+		}
+		if got := ap.cohortGap(); got != c.want {
+			t.Errorf("%s: cohortGap() with ewma %v = %v, want %v", c.name, c.ewma, got, c.want)
+		}
+	}
+}
+
+// TestAutoPipelineHerdCoalesces verifies the load path: concurrent blocking
+// callers cycling against the pipeliner make sustained progress and their
+// commands all execute. (The depth of the batches is a performance property
+// covered by benchmarks; this guards liveness of the debt/in-flight wait
+// machinery under a closed-loop herd.)
+func TestAutoPipelineHerdCoalesces(t *testing.T) {
+	ctx := context.Background()
+	client := NewClient(&Options{Addr: ":6379"})
+	defer client.Close()
+
+	if err := client.FlushDB(ctx).Err(); err != nil {
+		t.Fatalf("flushdb: %v", err)
+	}
+	ap, err := newAutoPipeliner(client, nil, true) // defaults: ordered, no delay
+	if err != nil {
+		t.Fatalf("newAutoPipeliner: %v", err)
+	}
+	defer ap.Close()
+
+	const workers, iters = 16, 50
+	errCh := make(chan error, workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			var err error
+			for i := 0; i < iters; i++ {
+				if e := ap.Incr(ctx, "herd-ctr").Err(); e != nil {
+					err = e
+					break
+				}
+			}
+			errCh <- err
+		}()
+	}
+	deadline := time.After(30 * time.Second)
+	for w := 0; w < workers; w++ {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatalf("worker error: %v", err)
+			}
+		case <-deadline:
+			t.Fatalf("herd stalled: coalescing wait is not making progress")
+		}
+	}
+	n, err := client.Get(ctx, "herd-ctr").Int()
+	if err != nil || n != workers*iters {
+		t.Fatalf("herd-ctr = %d, %v; want %d", n, err, workers*iters)
+	}
+}

--- a/example/cluster-mget/go.mod
+++ b/example/cluster-mget/go.mod
@@ -9,4 +9,5 @@ require github.com/redis/go-redis/v9 v9.21.0
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/example/del-keys-without-ttl/go.mod
+++ b/example/del-keys-without-ttl/go.mod
@@ -13,4 +13,5 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/example/disable-maintnotifications/go.mod
+++ b/example/disable-maintnotifications/go.mod
@@ -9,4 +9,5 @@ require github.com/redis/go-redis/v9 v9.21.0
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/example/hll/go.mod
+++ b/example/hll/go.mod
@@ -9,4 +9,5 @@ require github.com/redis/go-redis/v9 v9.21.0
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/example/hset-struct/go.mod
+++ b/example/hset-struct/go.mod
@@ -12,4 +12,5 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/example/lua-scripting/go.mod
+++ b/example/lua-scripting/go.mod
@@ -9,4 +9,5 @@ require github.com/redis/go-redis/v9 v9.21.0
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/example/maintnotifiations-pubsub/go.mod
+++ b/example/maintnotifiations-pubsub/go.mod
@@ -9,4 +9,5 @@ require github.com/redis/go-redis/v9 v9.21.0
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/example/redis-bloom/go.mod
+++ b/example/redis-bloom/go.mod
@@ -9,4 +9,5 @@ require github.com/redis/go-redis/v9 v9.21.0
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/example/scan-struct/go.mod
+++ b/example/scan-struct/go.mod
@@ -12,4 +12,5 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/example/search-aggregate-steps/go.mod
+++ b/example/search-aggregate-steps/go.mod
@@ -9,4 +9,5 @@ require github.com/redis/go-redis/v9 v9.21.0
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/example/tls-cert-auth/go.mod
+++ b/example/tls-cert-auth/go.mod
@@ -9,4 +9,5 @@ require github.com/redis/go-redis/v9 v9.21.0
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/example/tls-connection/go.mod
+++ b/example/tls-connection/go.mod
@@ -9,4 +9,5 @@ require github.com/redis/go-redis/v9 v9.21.0
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/example/zerocopy-buffer/go.mod
+++ b/example/zerocopy-buffer/go.mod
@@ -9,4 +9,5 @@ require github.com/redis/go-redis/v9 v9.20.0
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )

--- a/extra/rediscensus/go.mod
+++ b/extra/rediscensus/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )
 
 retract (

--- a/extra/rediscmd/go.mod
+++ b/extra/rediscmd/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 )
 
 retract (

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,10 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/zeebo/xxh3 v1.1.0
 	go.uber.org/atomic v1.11.0
+	golang.org/x/sys v0.30.0
 )
 
-require (
-	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
-	golang.org/x/sys v0.30.0 // indirect
-)
+require github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 
 retract (
 	v9.15.1 // This version is used to retract v9.15.0

--- a/internal/otel/metrics.go
+++ b/internal/otel/metrics.go
@@ -266,8 +266,10 @@ func (noopRecorder) RecordStreamLag(context.Context, time.Duration, *pool.Conn, 
 func (noopRecorder) RecordConnectionCount(context.Context, int, *pool.Conn, string, bool) {}
 func (noopRecorder) RecordPendingRequests(context.Context, int, *pool.Conn, string)       {}
 
-// RegisterPools registers connection pools with the global recorder.
-func RegisterPools(connPool pool.Pooler, pubSubPool PubSubPooler, addr string) {
+// RegisterPools registers connection pools with the global recorder. pipelinePool
+// is the optional dedicated pipeline connection pool (nil when not configured);
+// it is registered as a regular pool under a "_pipeline" name suffix.
+func RegisterPools(connPool pool.Pooler, pubSubPool PubSubPooler, pipelinePool pool.Pooler, addr string) {
 	// Check if the global recorder implements PoolRegistrar
 	if registrar, ok := globalRecorder.(PoolRegistrar); ok {
 		// Generate a unique ID for this client's pools
@@ -281,11 +283,16 @@ func RegisterPools(connPool pool.Pooler, pubSubPool PubSubPooler, addr string) {
 			poolName := addr + "_" + uniqueID + "_pubsub"
 			registrar.RegisterPubSubPool(poolName, pubSubPool)
 		}
+		if pipelinePool != nil {
+			poolName := addr + "_" + uniqueID + "_pipeline"
+			registrar.RegisterPool(poolName, pipelinePool)
+		}
 	}
 }
 
-// UnregisterPools removes connection pools from the global recorder
-func UnregisterPools(connPool pool.Pooler, pubSubPool PubSubPooler) {
+// UnregisterPools removes connection pools from the global recorder. pipelinePool
+// is the optional dedicated pipeline connection pool (nil when not configured).
+func UnregisterPools(connPool pool.Pooler, pubSubPool PubSubPooler, pipelinePool pool.Pooler) {
 	// Check if the global recorder implements PoolRegistrar
 	if registrar, ok := globalRecorder.(PoolRegistrar); ok {
 		if connPool != nil {
@@ -293,6 +300,9 @@ func UnregisterPools(connPool pool.Pooler, pubSubPool PubSubPooler) {
 		}
 		if pubSubPool != nil {
 			registrar.UnregisterPubSubPool(pubSubPool)
+		}
+		if pipelinePool != nil {
+			registrar.UnregisterPool(pipelinePool)
 		}
 	}
 }

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -321,6 +321,11 @@ type Stats struct {
 	PendingRequests uint32 // number of pending requests waiting for a connection
 
 	PubSubStats PubSubStats
+
+	// PipelineStats holds the stats of the separate pipeline connection pool
+	// when one is configured (PipelineReadBufferSize/PipelineWriteBufferSize).
+	// nil when pipelines share the main pool.
+	PipelineStats *Stats
 }
 
 type ConnRetirer interface {

--- a/internal/semaphore.go
+++ b/internal/semaphore.go
@@ -171,23 +171,7 @@ func (s *FIFOSemaphore) Acquire(ctx context.Context, timeout time.Duration, time
 	}
 }
 
-// AcquireBlocking acquires a token, blocking indefinitely until one is available.
-func (s *FIFOSemaphore) AcquireBlocking() {
-	<-s.tokens
-}
-
 // Release releases a token back to the semaphore.
 func (s *FIFOSemaphore) Release() {
 	s.tokens <- struct{}{}
-}
-
-// Close closes the semaphore, unblocking all waiting goroutines.
-// After close, all Acquire calls will receive a closed channel signal.
-func (s *FIFOSemaphore) Close() {
-	close(s.tokens)
-}
-
-// Len returns the current number of acquired tokens.
-func (s *FIFOSemaphore) Len() int32 {
-	return s.max - int32(len(s.tokens))
 }

--- a/maintnotifications/additional_pool_hook_test.go
+++ b/maintnotifications/additional_pool_hook_test.go
@@ -1,0 +1,80 @@
+package maintnotifications
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/redis/go-redis/v9/internal/pool"
+)
+
+// countingPool records how many pool hooks were added and removed so a test can
+// assert a maintnotifications hook is attached to (and detached from) a pool.
+type countingPool struct {
+	pool.Pooler
+	added   int
+	removed int
+}
+
+func (p *countingPool) AddPoolHook(pool.PoolHook)    { p.added++ }
+func (p *countingPool) RemovePoolHook(pool.PoolHook) { p.removed++ }
+
+// TestInitPoolHookForPool verifies that a dedicated pool (e.g. a client's
+// pipeline connection pool) receives an independent maintnotifications pool hook,
+// and that the hook is detached on Close. This guards the regression where the
+// dedicated pipeline pool never got the MOVING/MIGRATING handoff hook, so
+// autopipelined/pipelined commands ran on connections without handoff handling.
+func TestInitPoolHookForPool(t *testing.T) {
+	client := &MockClient{options: &MockOptions{}}
+	primary := &countingPool{}
+	pipelinePool := &countingPool{}
+
+	manager, err := NewManager(client, primary, DefaultConfig())
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+	dialer := func(context.Context, string, string) (net.Conn, error) { return nil, nil }
+
+	manager.InitPoolHook(dialer)
+	manager.InitPoolHookForPool(pipelinePool, dialer)
+
+	if primary.added != 1 {
+		t.Fatalf("primary pool: expected 1 hook added, got %d", primary.added)
+	}
+	if pipelinePool.added != 1 {
+		t.Fatalf("pipeline pool: expected 1 hook added, got %d", pipelinePool.added)
+	}
+
+	// The additional hook must be a distinct instance bound to its own pool, so
+	// failed-handoff removals target the pipeline pool, not the primary pool.
+	if len(manager.additionalPoolHooks) != 1 {
+		t.Fatalf("expected 1 additional pool hook tracked, got %d", len(manager.additionalPoolHooks))
+	}
+	if manager.additionalPoolHooks[0].hook == manager.poolHooksRef {
+		t.Fatal("additional pool hook must be a separate instance from the primary hook")
+	}
+	if manager.additionalPoolHooks[0].pool != pipelinePool {
+		t.Fatal("additional pool hook bound to the wrong pool")
+	}
+
+	if err := manager.Close(); err != nil {
+		t.Fatalf("manager close failed: %v", err)
+	}
+	if pipelinePool.removed != 1 {
+		t.Fatalf("pipeline pool: expected hook removed on Close, got %d removals", pipelinePool.removed)
+	}
+}
+
+// TestInitPoolHookForPoolNil is a no-op guard: a nil pool must not panic or
+// register a hook.
+func TestInitPoolHookForPoolNil(t *testing.T) {
+	client := &MockClient{options: &MockOptions{}}
+	manager, err := NewManager(client, &countingPool{}, DefaultConfig())
+	if err != nil {
+		t.Fatalf("failed to create manager: %v", err)
+	}
+	manager.InitPoolHookForPool(nil, func(context.Context, string, string) (net.Conn, error) { return nil, nil })
+	if len(manager.additionalPoolHooks) != 0 {
+		t.Fatal("nil pool must not register an additional hook")
+	}
+}

--- a/maintnotifications/manager.go
+++ b/maintnotifications/manager.go
@@ -168,20 +168,21 @@ func (hm *Manager) InitPoolHookForPool(p pool.Pooler, baseDialer func(context.Co
 	}
 	hook := NewPoolHookWithPoolSize(baseDialer, network, hm.config, hm, poolSize)
 	hook.SetPool(p)
-	// The closed check and the append must be atomic with respect to Close's
-	// snapshot: under the same lock, either Close runs first (closed==true here,
-	// so we don't register and the hook is never attached) or we register first
-	// (Close's snapshot then includes this hook and tears it down). Without the
-	// lock around the check, a hook could be appended after Close snapshotted,
-	// leaking it (never shut down, never removed from the pool). In practice this
-	// only runs at construction, but the lock makes it correct regardless.
+	// The closed check, the append, AND the AddPoolHook must all be atomic with
+	// respect to Close's snapshot: hold the lock across all three so either Close
+	// runs first (closed==true here, so we neither register nor attach) or we
+	// register+attach first (Close's snapshot then includes this hook and tears
+	// it down). Attaching outside the lock left a window where Close could
+	// snapshot/tear-down between the append and the attach, then AddPoolHook
+	// would re-attach to a closed manager's pool — leaking an active hook.
+	// p.AddPoolHook is lock-free (atomic swap on the pool's own hook manager) and
+	// never calls back into this manager, so holding hooksMu across it is safe.
 	hm.hooksMu.Lock()
+	defer hm.hooksMu.Unlock()
 	if hm.closed.Load() {
-		hm.hooksMu.Unlock()
 		return
 	}
 	hm.additionalPoolHooks = append(hm.additionalPoolHooks, additionalPoolHook{pool: p, hook: hook})
-	hm.hooksMu.Unlock()
 	p.AddPoolHook(hook)
 }
 

--- a/maintnotifications/manager.go
+++ b/maintnotifications/manager.go
@@ -82,6 +82,14 @@ type Manager struct {
 	hooksMu      sync.RWMutex // Protects hooks slice
 	poolHooksRef *PoolHook
 
+	// additionalPoolHooks are pool hooks bound to pools other than the primary
+	// one (e.g. a dedicated pipeline connection pool). Each is an independent
+	// *PoolHook bound to its own pool because the hook's failed-handoff removal
+	// target (HandoffRequest.Pool) is taken from the hook's single pool field,
+	// so one hook cannot safely serve two pools. They share this Manager as
+	// their operations manager, keeping MOVING/MIGRATING tracking centralized.
+	additionalPoolHooks []additionalPoolHook
+
 	// Connections that successfully enabled maintnotifications. These need to be
 	// retired before the pool-level listeners are removed.
 	maintNotificationsConns sync.Map // connID -> *pool.Conn
@@ -132,6 +140,49 @@ func NewManager(client interfaces.ClientInterface, pool pool.Pooler, config *Con
 func (hm *Manager) InitPoolHook(baseDialer func(context.Context, string, string) (net.Conn, error)) {
 	poolHook := hm.createPoolHook(baseDialer)
 	hm.pool.AddPoolHook(poolHook)
+}
+
+// additionalPoolHook pairs a pool hook with the pool it was attached to so the
+// manager can shut it down and detach it on Close.
+type additionalPoolHook struct {
+	pool pool.Pooler
+	hook *PoolHook
+}
+
+// InitPoolHookForPool attaches a maintnotifications pool hook to an additional
+// pool (e.g. a client's dedicated pipeline connection pool). A fresh, independent
+// *PoolHook is created and bound to the given pool so that connections which fail
+// handoff are removed from the correct pool — the hook's removal target is its own
+// single pool field, so the primary hook cannot be reused for a second pool. The
+// new hook shares this Manager as its operations manager, so MOVING/MIGRATING
+// tracking and notification handling stay centralized across both pools.
+func (hm *Manager) InitPoolHookForPool(p pool.Pooler, baseDialer func(context.Context, string, string) (net.Conn, error)) {
+	if p == nil {
+		return
+	}
+	poolSize := 0
+	network := ""
+	if hm.options != nil {
+		poolSize = hm.options.GetPoolSize()
+		network = hm.options.GetNetwork()
+	}
+	hook := NewPoolHookWithPoolSize(baseDialer, network, hm.config, hm, poolSize)
+	hook.SetPool(p)
+	// The closed check and the append must be atomic with respect to Close's
+	// snapshot: under the same lock, either Close runs first (closed==true here,
+	// so we don't register and the hook is never attached) or we register first
+	// (Close's snapshot then includes this hook and tears it down). Without the
+	// lock around the check, a hook could be appended after Close snapshotted,
+	// leaking it (never shut down, never removed from the pool). In practice this
+	// only runs at construction, but the lock makes it correct regardless.
+	hm.hooksMu.Lock()
+	if hm.closed.Load() {
+		hm.hooksMu.Unlock()
+		return
+	}
+	hm.additionalPoolHooks = append(hm.additionalPoolHooks, additionalPoolHook{pool: p, hook: hook})
+	hm.hooksMu.Unlock()
+	p.AddPoolHook(hook)
 }
 
 // setupPushNotifications sets up push notification handling by registering with the client's processor.
@@ -324,6 +375,28 @@ func (hm *Manager) Close() error {
 		// Remove the pool hook from the pool
 		if hm.pool != nil {
 			hm.pool.RemovePoolHook(hm.poolHooksRef)
+		}
+	}
+
+	// Shutdown and detach any hooks bound to additional pools (e.g. a dedicated
+	// pipeline pool). Snapshot under the lock so we don't iterate concurrently
+	// with a registering InitPoolHookForPool; Shutdown itself runs unlocked.
+	hm.hooksMu.Lock()
+	additional := hm.additionalPoolHooks
+	hm.additionalPoolHooks = nil
+	hm.hooksMu.Unlock()
+	for _, ah := range additional {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		err := ah.hook.Shutdown(shutdownCtx)
+		cancel()
+		if err != nil {
+			// Could not cleanly shut down an additional hook; stay open so the
+			// caller can retry Close, matching the primary-hook behavior above.
+			hm.closed.Store(false)
+			return err
+		}
+		if ah.pool != nil {
+			ah.pool.RemovePoolHook(ah.hook)
 		}
 	}
 

--- a/maintnotifications/manager.go
+++ b/maintnotifications/manager.go
@@ -336,17 +336,38 @@ func (hm *Manager) maintNotificationsConnSnapshot() []*pool.Conn {
 
 func (hm *Manager) retireMaintNotificationsConns(ctx context.Context) {
 	conns := hm.maintNotificationsConnSnapshot()
-	if len(conns) == 0 || hm.pool == nil {
+	if len(conns) == 0 {
 		return
 	}
 
-	if retirer, ok := hm.pool.(pool.ConnRetirer); ok {
-		retirer.RetireConns(ctx, conns, pool.CloseReasonMaintNotificationsDisabled)
-		return
+	// Tracked connections can live in the primary pool OR in any additional
+	// pool this manager attached a hook to (e.g. a client's dedicated pipeline
+	// connection pool — its conns run initConn and are tracked exactly like
+	// primary ones). Retire through every pool: RetireConns skips connections
+	// a pool does not own, so offering the full snapshot to each pool is safe.
+	// Missing the additional pools left pipeline connections in service with
+	// maintnotifications enabled but no hook attached after a runtime
+	// downgrade — pushes on them were silently dropped.
+	pools := make([]pool.Pooler, 0, 1+len(hm.additionalPoolHooks))
+	if hm.pool != nil {
+		pools = append(pools, hm.pool)
 	}
+	hm.hooksMu.RLock()
+	for _, ah := range hm.additionalPoolHooks {
+		if ah.pool != nil {
+			pools = append(pools, ah.pool)
+		}
+	}
+	hm.hooksMu.RUnlock()
 
-	for _, cn := range conns {
-		_ = hm.pool.CloseConn(ctx, cn, pool.CloseReasonMaintNotificationsDisabled, pool.MetricStateIdle)
+	for _, pl := range pools {
+		if retirer, ok := pl.(pool.ConnRetirer); ok {
+			retirer.RetireConns(ctx, conns, pool.CloseReasonMaintNotificationsDisabled)
+			continue
+		}
+		for _, cn := range conns {
+			_ = pl.CloseConn(ctx, cn, pool.CloseReasonMaintNotificationsDisabled, pool.MetricStateIdle)
+		}
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -187,6 +187,60 @@ type Options struct {
 	// default: 32KiB (32768 bytes)
 	WriteBufferSize int
 
+	// PipelineReadBufferSize is the size of the bufio.Reader buffer for pipeline connections.
+	// If set to a value > 0, a separate connection pool will be created specifically for
+	// pipelining operations (Pipeline() and AutoPipeline()) with this buffer size.
+	//
+	// This allows you to use large buffers for pipelining (to reduce syscalls and improve
+	// throughput) while keeping regular command buffers small (to save memory).
+	//
+	// If not set (0), pipeline operations will use the regular connection pool with
+	// ReadBufferSize buffers.
+	//
+	// Recommended: 512 KiB for high-throughput pipelining workloads.
+	//
+	// Example:
+	//   client := redis.NewClient(&redis.Options{
+	//       Addr:                    "localhost:6379",
+	//       ReadBufferSize:          64 * 1024,   // 64 KiB for regular commands
+	//       PipelineReadBufferSize:  512 * 1024,  // 512 KiB for pipelining
+	//       PipelineWriteBufferSize: 512 * 1024,
+	//   })
+	//
+	// Memory impact: With PoolSize=100 and PipelinePoolSize=10:
+	//   - Without pipeline pool: 100 conns × 1 MiB = 100 MB (if all use 512 KiB buffers)
+	//   - With pipeline pool: (100 × 128 KiB) + (10 × 1 MiB) = 22.8 MB (77% savings)
+	//
+	// default: 0 (use ReadBufferSize)
+	PipelineReadBufferSize int
+
+	// PipelineWriteBufferSize is the size of the bufio.Writer buffer for pipeline connections.
+	// If set to a value > 0, a separate connection pool will be created specifically for
+	// pipelining operations (Pipeline() and AutoPipeline()) with this buffer size.
+	//
+	// This allows you to use large buffers for pipelining (to reduce syscalls and improve
+	// throughput) while keeping regular command buffers small (to save memory).
+	//
+	// If not set (0), pipeline operations will use the regular connection pool with
+	// WriteBufferSize buffers.
+	//
+	// Recommended: 512 KiB for high-throughput pipelining workloads.
+	//
+	// default: 0 (use WriteBufferSize)
+	PipelineWriteBufferSize int
+
+	// PipelinePoolSize is the pool size for the separate pipeline connection pool.
+	// Only used if PipelineReadBufferSize or PipelineWriteBufferSize is set.
+	//
+	// Pipelining typically needs fewer connections than regular operations because
+	// batching reduces connection contention. A smaller pool saves memory while
+	// maintaining high throughput.
+	//
+	// If not set (0), defaults to 10 connections.
+	//
+	// default: 10
+	PipelinePoolSize int
+
 	// PoolFIFO type of connection pool.
 	//
 	//	- true for FIFO pool

--- a/options.go
+++ b/options.go
@@ -197,19 +197,25 @@ type Options struct {
 	// If not set (0), pipeline operations will use the regular connection pool with
 	// ReadBufferSize buffers.
 	//
-	// Recommended: 512 KiB for high-throughput pipelining workloads.
+	// Recommended: 64–128 KiB for high-throughput pipelining. The only benefit is
+	// making the buffer large enough to hold a typical batch's wire bytes, so the
+	// batch flushes in one syscall instead of overflowing mid-write. Size it to
+	// roughly MaxBatchSize × average-command-bytes, rounded up. Benchmarks show
+	// throughput climbs from the 32 KiB default up to ~64 KiB and then plateaus;
+	// going beyond ~128 KiB gives no further gain and very large buffers (≥512 KiB)
+	// can regress throughput and waste memory. Bigger is not better.
 	//
 	// Example:
 	//   client := redis.NewClient(&redis.Options{
 	//       Addr:                    "localhost:6379",
-	//       ReadBufferSize:          64 * 1024,   // 64 KiB for regular commands
-	//       PipelineReadBufferSize:  512 * 1024,  // 512 KiB for pipelining
-	//       PipelineWriteBufferSize: 512 * 1024,
+	//       ReadBufferSize:          32 * 1024,   // 32 KiB for regular commands
+	//       PipelineReadBufferSize:  128 * 1024,  // 128 KiB for pipelining
+	//       PipelineWriteBufferSize: 128 * 1024,
 	//   })
 	//
 	// Memory impact: With PoolSize=100 and PipelinePoolSize=10:
-	//   - Without pipeline pool: 100 conns × 1 MiB = 100 MB (if all use 512 KiB buffers)
-	//   - With pipeline pool: (100 × 128 KiB) + (10 × 1 MiB) = 22.8 MB (77% savings)
+	//   - Without pipeline pool: 100 conns × 128 KiB = 12.8 MB (if all use 128 KiB buffers)
+	//   - With pipeline pool: (100 × 32 KiB) + (10 × 128 KiB) = 4.5 MB (~65% savings)
 	//
 	// default: 0 (use ReadBufferSize)
 	PipelineReadBufferSize int
@@ -224,7 +230,10 @@ type Options struct {
 	// If not set (0), pipeline operations will use the regular connection pool with
 	// WriteBufferSize buffers.
 	//
-	// Recommended: 512 KiB for high-throughput pipelining workloads.
+	// Recommended: 64–128 KiB for high-throughput pipelining (size to roughly
+	// MaxBatchSize × average-command-bytes). Throughput plateaus past ~64 KiB and
+	// gains nothing beyond ~128 KiB; very large buffers (≥512 KiB) can regress it.
+	// See PipelineReadBufferSize for the full rationale.
 	//
 	// default: 0 (use WriteBufferSize)
 	PipelineWriteBufferSize int

--- a/osscluster.go
+++ b/osscluster.go
@@ -142,6 +142,14 @@ type ClusterOptions struct {
 	// default: 32KiB (32768 bytes)
 	WriteBufferSize int
 
+	// PipelineReadBufferSize, PipelineWriteBufferSize and PipelinePoolSize
+	// configure an optional separate connection pool used for pipelining on
+	// each node, with its own (typically larger) buffers. See the same-named
+	// fields on Options for details. Zero values disable the separate pool.
+	PipelineReadBufferSize  int
+	PipelineWriteBufferSize int
+	PipelinePoolSize        int
+
 	TLSConfig *tls.Config
 
 	// DisableRoutingPolicies disables the request/response policy routing system.
@@ -455,11 +463,15 @@ func (opt *ClusterOptions) clientOptions() *Options {
 		ConnMaxLifetimeJitter: opt.ConnMaxLifetimeJitter,
 		ReadBufferSize:        opt.ReadBufferSize,
 		WriteBufferSize:       opt.WriteBufferSize,
-		DisableIdentity:       opt.DisableIdentity,
-		DisableIndentity:      opt.DisableIdentity,
-		IdentitySuffix:        opt.IdentitySuffix,
-		FailingTimeoutSeconds: opt.FailingTimeoutSeconds,
-		TLSConfig:             opt.TLSConfig,
+
+		PipelineReadBufferSize:  opt.PipelineReadBufferSize,
+		PipelineWriteBufferSize: opt.PipelineWriteBufferSize,
+		PipelinePoolSize:        opt.PipelinePoolSize,
+		DisableIdentity:         opt.DisableIdentity,
+		DisableIndentity:        opt.DisableIdentity,
+		IdentitySuffix:          opt.IdentitySuffix,
+		FailingTimeoutSeconds:   opt.FailingTimeoutSeconds,
+		TLSConfig:               opt.TLSConfig,
 		// If ClusterSlots is populated, then we probably have an artificial
 		// cluster whose nodes are not in clustering mode (otherwise there isn't
 		// much use for ClusterSlots config).  This means we cannot execute the

--- a/pipeline_buffer_test.go
+++ b/pipeline_buffer_test.go
@@ -7,7 +7,9 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// TestPipelineBufferSizes verifies that pipeline pool is created with custom buffer sizes
+// TestPipelineBufferSizes verifies that enabling the pipeline buffer options keeps
+// pipelining working end-to-end. It does not assert the actual socket buffer sizes
+// (not observable here) - only that the configured client still runs pipelines.
 func TestPipelineBufferSizes(t *testing.T) {
 	ctx := context.Background()
 

--- a/pipeline_buffer_test.go
+++ b/pipeline_buffer_test.go
@@ -13,7 +13,7 @@ func TestPipelineBufferSizes(t *testing.T) {
 
 	// Create client with custom pipeline buffer sizes
 	client := redis.NewClient(&redis.Options{
-		Addr:                    "localhost:6379",
+		Addr:                    redisAddr,
 		ReadBufferSize:          64 * 1024,  // 64 KiB for regular connections
 		WriteBufferSize:         64 * 1024,  // 64 KiB for regular connections
 		PipelineReadBufferSize:  512 * 1024, // 512 KiB for pipeline connections
@@ -69,7 +69,7 @@ func TestNoPipelinePool(t *testing.T) {
 
 	// Create client WITHOUT custom pipeline buffer sizes
 	client := redis.NewClient(&redis.Options{
-		Addr:            "localhost:6379",
+		Addr:            redisAddr,
 		ReadBufferSize:  64 * 1024, // 64 KiB for all connections
 		WriteBufferSize: 64 * 1024, // 64 KiB for all connections
 		// No PipelineReadBufferSize or PipelineWriteBufferSize
@@ -109,7 +109,7 @@ func TestPipelinePoolStats(t *testing.T) {
 
 	// Create client with custom pipeline buffer sizes
 	client := redis.NewClient(&redis.Options{
-		Addr:                    "localhost:6379",
+		Addr:                    redisAddr,
 		ReadBufferSize:          64 * 1024,  // 64 KiB for regular connections
 		WriteBufferSize:         64 * 1024,  // 64 KiB for regular connections
 		PipelineReadBufferSize:  512 * 1024, // 512 KiB for pipeline connections
@@ -159,7 +159,7 @@ func TestNoPipelinePoolStats(t *testing.T) {
 
 	// Create client WITHOUT custom pipeline buffer sizes
 	client := redis.NewClient(&redis.Options{
-		Addr:            "localhost:6379",
+		Addr:            redisAddr,
 		ReadBufferSize:  64 * 1024, // 64 KiB for all connections
 		WriteBufferSize: 64 * 1024, // 64 KiB for all connections
 	})

--- a/pipeline_buffer_test.go
+++ b/pipeline_buffer_test.go
@@ -1,0 +1,189 @@
+package redis_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// TestPipelineBufferSizes verifies that pipeline pool is created with custom buffer sizes
+func TestPipelineBufferSizes(t *testing.T) {
+	ctx := context.Background()
+
+	// Create client with custom pipeline buffer sizes
+	client := redis.NewClient(&redis.Options{
+		Addr:                    "localhost:6379",
+		ReadBufferSize:          64 * 1024,  // 64 KiB for regular connections
+		WriteBufferSize:         64 * 1024,  // 64 KiB for regular connections
+		PipelineReadBufferSize:  512 * 1024, // 512 KiB for pipeline connections
+		PipelineWriteBufferSize: 512 * 1024, // 512 KiB for pipeline connections
+		PipelinePoolSize:        5,          // Small pool for pipelining
+	})
+	defer client.Close()
+
+	// Test that regular commands work
+	err := client.Set(ctx, "test_key", "test_value", 0).Err()
+	if err != nil {
+		t.Fatalf("Failed to set key: %v", err)
+	}
+
+	val, err := client.Get(ctx, "test_key").Result()
+	if err != nil {
+		t.Fatalf("Failed to get key: %v", err)
+	}
+	if val != "test_value" {
+		t.Fatalf("Expected 'test_value', got '%s'", val)
+	}
+
+	// Test that pipeline works
+	pipe := client.Pipeline()
+	pipe.Set(ctx, "pipe_key1", "value1", 0)
+	pipe.Set(ctx, "pipe_key2", "value2", 0)
+	pipe.Get(ctx, "pipe_key1")
+	pipe.Get(ctx, "pipe_key2")
+
+	cmds, err := pipe.Exec(ctx)
+	if err != nil {
+		t.Fatalf("Pipeline execution failed: %v", err)
+	}
+
+	if len(cmds) != 4 {
+		t.Fatalf("Expected 4 commands, got %d", len(cmds))
+	}
+
+	// Verify results
+	if cmds[2].(*redis.StringCmd).Val() != "value1" {
+		t.Fatalf("Expected 'value1', got '%s'", cmds[2].(*redis.StringCmd).Val())
+	}
+	if cmds[3].(*redis.StringCmd).Val() != "value2" {
+		t.Fatalf("Expected 'value2', got '%s'", cmds[3].(*redis.StringCmd).Val())
+	}
+
+	t.Log("Pipeline with custom buffer sizes works correctly")
+}
+
+// TestNoPipelinePool verifies that client works without pipeline pool (backward compatibility)
+func TestNoPipelinePool(t *testing.T) {
+	ctx := context.Background()
+
+	// Create client WITHOUT custom pipeline buffer sizes
+	client := redis.NewClient(&redis.Options{
+		Addr:            "localhost:6379",
+		ReadBufferSize:  64 * 1024, // 64 KiB for all connections
+		WriteBufferSize: 64 * 1024, // 64 KiB for all connections
+		// No PipelineReadBufferSize or PipelineWriteBufferSize
+	})
+	defer client.Close()
+
+	// Test that pipeline still works (using regular pool)
+	pipe := client.Pipeline()
+	pipe.Set(ctx, "no_pipe_pool_key1", "value1", 0)
+	pipe.Set(ctx, "no_pipe_pool_key2", "value2", 0)
+	pipe.Get(ctx, "no_pipe_pool_key1")
+	pipe.Get(ctx, "no_pipe_pool_key2")
+
+	cmds, err := pipe.Exec(ctx)
+	if err != nil {
+		t.Fatalf("Pipeline execution failed: %v", err)
+	}
+
+	if len(cmds) != 4 {
+		t.Fatalf("Expected 4 commands, got %d", len(cmds))
+	}
+
+	// Verify results
+	if cmds[2].(*redis.StringCmd).Val() != "value1" {
+		t.Fatalf("Expected 'value1', got '%s'", cmds[2].(*redis.StringCmd).Val())
+	}
+	if cmds[3].(*redis.StringCmd).Val() != "value2" {
+		t.Fatalf("Expected 'value2', got '%s'", cmds[3].(*redis.StringCmd).Val())
+	}
+
+	t.Log("Pipeline without custom buffer sizes (backward compatibility) works correctly")
+}
+
+// TestPipelinePoolStats verifies that PoolStats includes pipeline pool stats
+func TestPipelinePoolStats(t *testing.T) {
+	ctx := context.Background()
+
+	// Create client with custom pipeline buffer sizes
+	client := redis.NewClient(&redis.Options{
+		Addr:                    "localhost:6379",
+		ReadBufferSize:          64 * 1024,  // 64 KiB for regular connections
+		WriteBufferSize:         64 * 1024,  // 64 KiB for regular connections
+		PipelineReadBufferSize:  512 * 1024, // 512 KiB for pipeline connections
+		PipelineWriteBufferSize: 512 * 1024, // 512 KiB for pipeline connections
+		PipelinePoolSize:        5,          // Small pool for pipelining
+	})
+	defer client.Close()
+
+	// Execute some pipeline commands
+	pipe := client.Pipeline()
+	for i := 0; i < 10; i++ {
+		pipe.Set(ctx, "stats_key", "value", 0)
+	}
+	_, err := pipe.Exec(ctx)
+	if err != nil {
+		t.Fatalf("Pipeline execution failed: %v", err)
+	}
+
+	// Get pool stats
+	stats := client.PoolStats()
+	if stats == nil {
+		t.Fatal("PoolStats returned nil")
+	}
+
+	// Verify pipeline stats are included
+	if stats.PipelineStats == nil {
+		t.Fatal("PipelineStats is nil - pipeline pool stats not included")
+	}
+
+	t.Logf("Regular pool stats: TotalConns=%d, IdleConns=%d, Hits=%d, Misses=%d",
+		stats.TotalConns, stats.IdleConns, stats.Hits, stats.Misses)
+	t.Logf("Pipeline pool stats: TotalConns=%d, IdleConns=%d, Hits=%d, Misses=%d",
+		stats.PipelineStats.TotalConns, stats.PipelineStats.IdleConns,
+		stats.PipelineStats.Hits, stats.PipelineStats.Misses)
+
+	// Verify pipeline pool has connections
+	if stats.PipelineStats.TotalConns == 0 {
+		t.Error("Pipeline pool has no connections")
+	}
+
+	t.Log("PoolStats includes pipeline pool stats correctly")
+}
+
+// TestNoPipelinePoolStats verifies that PoolStats works without pipeline pool
+func TestNoPipelinePoolStats(t *testing.T) {
+	ctx := context.Background()
+
+	// Create client WITHOUT custom pipeline buffer sizes
+	client := redis.NewClient(&redis.Options{
+		Addr:            "localhost:6379",
+		ReadBufferSize:  64 * 1024, // 64 KiB for all connections
+		WriteBufferSize: 64 * 1024, // 64 KiB for all connections
+	})
+	defer client.Close()
+
+	// Execute some commands
+	err := client.Set(ctx, "test_key", "test_value", 0).Err()
+	if err != nil {
+		t.Fatalf("Failed to set key: %v", err)
+	}
+
+	// Get pool stats
+	stats := client.PoolStats()
+	if stats == nil {
+		t.Fatal("PoolStats returned nil")
+	}
+
+	// Verify pipeline stats are nil (no pipeline pool)
+	if stats.PipelineStats != nil {
+		t.Error("PipelineStats should be nil when no pipeline pool is configured")
+	}
+
+	t.Logf("Regular pool stats: TotalConns=%d, IdleConns=%d, Hits=%d, Misses=%d",
+		stats.TotalConns, stats.IdleConns, stats.Hits, stats.Misses)
+
+	t.Log("PoolStats works correctly without pipeline pool")
+}

--- a/redis.go
+++ b/redis.go
@@ -318,6 +318,11 @@ type baseClient struct {
 	optLock    sync.RWMutex
 	connPool   pool.Pooler
 	pubSubPool *pool.PubSubPool
+	// pipelinePool is an optional separate connection pool for pipelining
+	// operations, used when PipelineReadBufferSize/PipelineWriteBufferSize is
+	// set so pipelines can use large buffers without bloating the main pool.
+	// nil means pipelines use connPool.
+	pipelinePool pool.Pooler
 	hooksMixin
 
 	// onClose holds named callbacks invoked when the client is closed.
@@ -830,6 +835,61 @@ func (c *baseClient) withConn(
 	return fnErr
 }
 
+// withPipelineConn executes fn with a connection from the pipeline pool when
+// one is configured (PipelineReadBufferSize/PipelineWriteBufferSize set),
+// otherwise it falls back to the regular pool via withConn.
+func (c *baseClient) withPipelineConn(
+	ctx context.Context, fn func(context.Context, *pool.Conn) error,
+) error {
+	// Use pipeline pool if available, otherwise fall back to regular pool.
+	if c.pipelinePool == nil {
+		return c.withConn(ctx, fn)
+	}
+
+	cn, err := c.pipelinePool.Get(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Initialize connection if needed.
+	if !cn.IsInited() {
+		if err := c.initConn(ctx, cn); err != nil {
+			c.pipelinePool.Remove(ctx, cn, err)
+			if unwrapped := errors.Unwrap(err); unwrapped != nil {
+				return unwrapped
+			}
+			return err
+		}
+
+		// initConn transitions the connection to IDLE, so re-acquire it.
+		if !cn.TryAcquire() {
+			// Couldn't re-acquire: remove the connection so it isn't leaked from
+			// the pipeline pool's accounting (the deferred Put/Remove below only
+			// runs once fnErr is set, which it isn't on this early return).
+			err := fmt.Errorf("redis: connection is not usable")
+			c.pipelinePool.Remove(ctx, cn, err)
+			return err
+		}
+	}
+
+	var fnErr error
+	defer func() {
+		if isBadConn(fnErr, false, c.opt.Addr) {
+			c.pipelinePool.Remove(ctx, cn, fnErr)
+		} else {
+			// Process any pending push notifications before returning the
+			// connection to the pool.
+			if err := c.processPushNotifications(ctx, cn); err != nil {
+				internal.Logger.Printf(ctx, "push: error processing pending notifications before releasing connection: %v", err)
+			}
+			c.pipelinePool.Put(ctx, cn)
+		}
+	}()
+
+	fnErr = fn(ctx, cn)
+	return fnErr
+}
+
 func (c *baseClient) dial(ctx context.Context, network, addr string) (net.Conn, error) {
 	return c.opt.Dialer(ctx, network, addr)
 }
@@ -1065,6 +1125,13 @@ func (c *baseClient) enableMaintNotificationsUpgrades() error {
 
 	// Initialize pool hook (safe to call without lock since manager is now set)
 	manager.InitPoolHook(c.dialHook)
+	// If a dedicated pipeline connection pool is in use, attach an independent
+	// maintnotifications hook to it as well. Otherwise autopipelined/pipelined
+	// commands run on pipeline-pool connections that never receive MOVING/
+	// MIGRATING handoff handling.
+	if c.pipelinePool != nil {
+		manager.InitPoolHookForPool(c.pipelinePool, c.dialHook)
+	}
 	return nil
 }
 
@@ -1105,6 +1172,11 @@ func (c *baseClient) Close() error {
 
 	if c.connPool != nil {
 		if err := c.connPool.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if c.pipelinePool != nil {
+		if err := c.pipelinePool.Close(); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
@@ -1164,7 +1236,9 @@ func (c *baseClient) generalProcessPipeline(
 
 		// Enable retries by default to retry dial errors returned by withConn.
 		canRetry := true
-		lastErr = c.withConn(ctx, func(ctx context.Context, cn *pool.Conn) error {
+		// Route pipelines through the dedicated pipeline pool when configured;
+		// withPipelineConn falls back to the regular pool when it is not.
+		lastErr = c.withPipelineConn(ctx, func(ctx context.Context, cn *pool.Conn) error {
 			lastConn = cn
 			// Process any pending push notifications before executing the pipeline
 			if err := c.processPushNotifications(ctx, cn); err != nil {
@@ -1388,9 +1462,35 @@ func NewClient(opt *Options) *Client {
 		panic(fmt.Errorf("redis: failed to create pubsub pool: %w", err))
 	}
 
+	// Optionally create a separate connection pool for pipelining, with its own
+	// (typically larger) buffers, so pipelines can use big buffers without
+	// bloating the main pool. Enabled when either pipeline buffer size is set.
+	if opt.PipelineReadBufferSize > 0 || opt.PipelineWriteBufferSize > 0 {
+		pipelineOpt := opt.clone()
+		if opt.PipelineReadBufferSize > 0 {
+			pipelineOpt.ReadBufferSize = opt.PipelineReadBufferSize
+		}
+		if opt.PipelineWriteBufferSize > 0 {
+			pipelineOpt.WriteBufferSize = opt.PipelineWriteBufferSize
+		}
+		if opt.PipelinePoolSize > 0 {
+			pipelineOpt.PoolSize = opt.PipelinePoolSize
+		} else {
+			pipelineOpt.PoolSize = 10 // default smaller pool for pipelining
+		}
+		pipelinePoolName := opt.Addr + "_" + uniqueID + "_pipeline"
+		c.pipelinePool, err = newConnPool(pipelineOpt, c.dialHook, pipelinePoolName)
+		if err != nil {
+			panic(fmt.Errorf("redis: failed to create pipeline connection pool: %w", err))
+		}
+	}
+
 	if opt.StreamingCredentialsProvider != nil {
 		c.streamingCredentialsManager = streaming.NewManager(c.connPool, c.opt.PoolTimeout)
 		c.connPool.AddPoolHook(c.streamingCredentialsManager.PoolHook())
+		if c.pipelinePool != nil {
+			c.pipelinePool.AddPoolHook(c.streamingCredentialsManager.PoolHook())
+		}
 	}
 
 	// Initialize maintnotifications first if enabled and protocol is RESP3
@@ -1509,6 +1609,9 @@ type PoolStats pool.Stats
 func (c *Client) PoolStats() *PoolStats {
 	stats := c.connPool.Stats()
 	stats.PubSubStats = *c.pubSubPool.Stats()
+	if c.pipelinePool != nil {
+		stats.PipelineStats = c.pipelinePool.Stats()
+	}
 	return (*PoolStats)(stats)
 }
 

--- a/redis.go
+++ b/redis.go
@@ -1168,7 +1168,7 @@ func (c *baseClient) Close() error {
 	}
 
 	// Unregister pools from OTel before closing them
-	otel.UnregisterPools(c.connPool, c.pubSubPool)
+	otel.UnregisterPools(c.connPool, c.pubSubPool, c.pipelinePool)
 
 	if c.connPool != nil {
 		if err := c.connPool.Close(); err != nil && firstErr == nil {
@@ -1516,7 +1516,7 @@ func NewClient(opt *Options) *Client {
 
 	// Register pools with OTel recorder if it supports pool registration
 	// This allows async gauge metrics to pull stats from pools periodically
-	otel.RegisterPools(c.connPool, c.pubSubPool, opt.Addr)
+	otel.RegisterPools(c.connPool, c.pubSubPool, c.pipelinePool, opt.Addr)
 
 	return &c
 }

--- a/redis.go
+++ b/redis.go
@@ -352,6 +352,7 @@ func (c *baseClient) clone() *baseClient {
 	clone := &baseClient{
 		opt:                         c.opt,
 		connPool:                    c.connPool,
+		pipelinePool:                c.pipelinePool,
 		pubSubPool:                  c.pubSubPool,
 		onClose:                     c.onClose,
 		pushProcessor:               c.pushProcessor,

--- a/redis.go
+++ b/redis.go
@@ -840,10 +840,22 @@ func (c *baseClient) withConn(
 // otherwise it falls back to the regular pool via withConn.
 func (c *baseClient) withPipelineConn(
 	ctx context.Context, fn func(context.Context, *pool.Conn) error,
-) error {
+) (retErr error) {
 	// Use pipeline pool if available, otherwise fall back to regular pool.
 	if c.pipelinePool == nil {
 		return c.withConn(ctx, fn)
+	}
+
+	// Honor the Limiter on the dedicated pipeline-pool path too, mirroring
+	// getConn/releaseConn: Allow() before acquiring and ReportResult() on every
+	// exit (including the early init/re-acquire failures below). Without this,
+	// enabling the pipeline pool would silently bypass throttling and failure
+	// reporting for callers that set a Limiter.
+	if c.opt.Limiter != nil {
+		if err := c.opt.Limiter.Allow(); err != nil {
+			return err
+		}
+		defer func() { c.opt.Limiter.ReportResult(retErr) }()
 	}
 
 	cn, err := c.pipelinePool.Get(ctx)
@@ -874,6 +886,7 @@ func (c *baseClient) withPipelineConn(
 
 	var fnErr error
 	defer func() {
+		retErr = fnErr
 		if isBadConn(fnErr, false, c.opt.Addr) {
 			c.pipelinePool.Remove(ctx, cn, fnErr)
 		} else {

--- a/ring.go
+++ b/ring.go
@@ -143,6 +143,14 @@ type RingOptions struct {
 	// default: 32KiB (32768 bytes)
 	WriteBufferSize int
 
+	// PipelineReadBufferSize, PipelineWriteBufferSize and PipelinePoolSize
+	// configure an optional separate connection pool used for pipelining on
+	// each shard, with its own (typically larger) buffers. See the same-named
+	// fields on Options for details. Zero values disable the separate pool.
+	PipelineReadBufferSize  int
+	PipelineWriteBufferSize int
+	PipelinePoolSize        int
+
 	TLSConfig *tls.Config
 	Limiter   Limiter
 
@@ -246,6 +254,10 @@ func (opt *RingOptions) clientOptions() *Options {
 		ConnMaxLifetimeJitter: opt.ConnMaxLifetimeJitter,
 		ReadBufferSize:        opt.ReadBufferSize,
 		WriteBufferSize:       opt.WriteBufferSize,
+
+		PipelineReadBufferSize:  opt.PipelineReadBufferSize,
+		PipelineWriteBufferSize: opt.PipelineWriteBufferSize,
+		PipelinePoolSize:        opt.PipelinePoolSize,
 
 		TLSConfig: opt.TLSConfig,
 		Limiter:   opt.Limiter,

--- a/sentinel.go
+++ b/sentinel.go
@@ -607,6 +607,13 @@ func NewFailoverClient(failoverOpt *FailoverOptions) *Client {
 				return cn.RemoteAddr().String() != addr
 			})
 		}
+		// Drop stale pipeline-pool connections dialed to the demoted master too;
+		// otherwise pipelined traffic keeps using the old address after failover.
+		if pipelinePool, ok := rdb.pipelinePool.(*pool.ConnPool); ok {
+			_ = pipelinePool.Filter(func(cn *pool.Conn) bool {
+				return cn.RemoteAddr().String() != addr
+			})
+		}
 	}
 	failover.mu.Unlock()
 

--- a/sentinel.go
+++ b/sentinel.go
@@ -123,6 +123,14 @@ type FailoverOptions struct {
 	// default: 32KiB (32768 bytes)
 	WriteBufferSize int
 
+	// PipelineReadBufferSize, PipelineWriteBufferSize and PipelinePoolSize
+	// configure an optional separate connection pool used for pipelining, with
+	// its own (typically larger) buffers. See the same-named fields on Options
+	// for details. Zero values disable the separate pool.
+	PipelineReadBufferSize  int
+	PipelineWriteBufferSize int
+	PipelinePoolSize        int
+
 	PoolFIFO bool
 
 	PoolSize int
@@ -176,7 +184,7 @@ type FailoverOptions struct {
 	// seamlessly. Requires Protocol: 3 (RESP3) for push notifications.
 	// If nil, maintnotifications upgrades are disabled.
 	// (however if Mode is nil, it defaults to "auto" - enable if server supports it)
-	//MaintNotificationsConfig *maintnotifications.Config
+	// MaintNotificationsConfig *maintnotifications.Config
 }
 
 func (opt *FailoverOptions) clientOptions() *Options {
@@ -201,6 +209,10 @@ func (opt *FailoverOptions) clientOptions() *Options {
 
 		ReadBufferSize:  opt.ReadBufferSize,
 		WriteBufferSize: opt.WriteBufferSize,
+
+		PipelineReadBufferSize:  opt.PipelineReadBufferSize,
+		PipelineWriteBufferSize: opt.PipelineWriteBufferSize,
+		PipelinePoolSize:        opt.PipelinePoolSize,
 
 		DialTimeout:        opt.DialTimeout,
 		DialerRetries:      opt.DialerRetries,
@@ -317,6 +329,10 @@ func (opt *FailoverOptions) clusterOptions() *ClusterOptions {
 
 		ReadBufferSize:  opt.ReadBufferSize,
 		WriteBufferSize: opt.WriteBufferSize,
+
+		PipelineReadBufferSize:  opt.PipelineReadBufferSize,
+		PipelineWriteBufferSize: opt.PipelineWriteBufferSize,
+		PipelinePoolSize:        opt.PipelinePoolSize,
 
 		DialTimeout:        opt.DialTimeout,
 		DialerRetries:      opt.DialerRetries,
@@ -559,6 +575,27 @@ func NewFailoverClient(failoverOpt *FailoverOptions) *Client {
 	rdb.pubSubPool, err = newPubSubPool(opt, rdb.dialHook, pubsubPoolName)
 	if err != nil {
 		panic(fmt.Errorf("redis: failed to create pubsub pool: %w", err))
+	}
+
+	// Optionally create a separate connection pool for pipelining, with its own
+	// (typically larger) buffers. Enabled when either pipeline buffer size is set.
+	if opt.PipelineReadBufferSize > 0 || opt.PipelineWriteBufferSize > 0 {
+		pipelineOpt := opt.clone()
+		if opt.PipelineReadBufferSize > 0 {
+			pipelineOpt.ReadBufferSize = opt.PipelineReadBufferSize
+		}
+		if opt.PipelineWriteBufferSize > 0 {
+			pipelineOpt.WriteBufferSize = opt.PipelineWriteBufferSize
+		}
+		if opt.PipelinePoolSize > 0 {
+			pipelineOpt.PoolSize = opt.PipelinePoolSize
+		} else {
+			pipelineOpt.PoolSize = 10 // default smaller pool for pipelining
+		}
+		rdb.pipelinePool, err = newConnPool(pipelineOpt, rdb.dialHook, mainPoolName+"_pipeline")
+		if err != nil {
+			panic(fmt.Errorf("redis: failed to create pipeline connection pool: %w", err))
+		}
 	}
 
 	rdb.onClose.register(onCloseHookIDSentinelFailover, failover.Close)


### PR DESCRIPTION
Adds an **optional dedicated connection pool tuned for pipelining** — a small
pool of large-buffer connections. Independent of autopipelining: it also speeds
up manual `Pipeline()` / `TxPipelined()`, so it ships value on its own.

Pipelines benefit from large read/write buffers, but sizing the *whole* pool
that big wastes memory. A small dedicated pool of big-buffer connections gives
the win at much lower memory cost. Zero/unset options = current behavior (no
separate pool created; falls back to the main pool).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core connection pooling, pipeline execution, maintnotifications/failover, and large autopipeline semantic changes (defaults, `Do`, ordering/coalescing) that can affect latency, throughput, and ordering for existing users.
> 
> **Overview**
> Adds an **opt-in dedicated pipeline connection pool** via `PipelineReadBufferSize`, `PipelineWriteBufferSize`, and `PipelinePoolSize` on `Options` (and cluster/ring/sentinel option structs). When enabled, `processPipeline` and related paths use `withPipelineConn` so manual `Pipeline()` / autopipeline batches can use larger buffers and a smaller pool without sizing the whole client pool that way; unset options keep today’s behavior (main pool only). `PoolStats` gains optional `PipelineStats`, OTel pool registration includes the pipeline pool, and maintnotifications attaches a separate pool hook to that pool (with failover filtering stale pipeline connections).
> 
> **Autopipeline** is heavily reworked alongside this: default blocking config goes back to **one ordered batch stream** (`MaxConcurrentBatches: 1`, no forced `Unordered`); standalone clients default to **one shard** with optional `NumShards` and stricter ordering rules on the async face. Coalescing drops the fixed default accumulate window in favor of **expected-arrival / in-flight backpressure** (`awaitExpectedArrivals`, RTT-scaled silence gap), **8-way enqueue striping** where reordering is safe, merged multi-stripe flushes, and safer shutdown/permit waits on `context.Background`. **`Do`** no longer batches—it runs on a normal connection; **`Submit`** is rejected on the blocking face; **`AutoFuture.WaitContext`**, `IsBlocking`, and `Config()` are added. Tests cover coalescing behavior and the pipeline pool; CI pins Go **1.26.5**; `golang.org/x/sys` is a direct dep for stripe cache-line padding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da2f94fbda482de691ed959b9970707df63a3250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->