### PR TITLE
fix(options): treat unit durations <= 0 as disabled in ParseURL

### DIFF
--- a/options.go
+++ b/options.go
@@ -627,6 +627,10 @@ func (o *queryOptions) duration(name string) time.Duration {
 	}
 	dur, err := time.ParseDuration(s)
 	if err == nil {
+		if dur <= 0 {
+			// disable timeouts
+			return -1
+		}
 		return dur
 	}
 	if o.err == nil {

--- a/options_test.go
+++ b/options_test.go
@@ -58,6 +58,14 @@ func TestParseURL(t *testing.T) {
 			url: "redis://localhost:123/?db=2&conn_max_idle_time=-1",
 			o:   &Options{Addr: "localhost:123", DB: 2, ConnMaxIdleTime: -1},
 		}, {
+			// a zero or negative duration written with a unit disables the timeout,
+			// the same as the plain "0" / "-1" forms above
+			url: "redis://localhost:123/?db=2&conn_max_idle_time=0s",
+			o:   &Options{Addr: "localhost:123", DB: 2, ConnMaxIdleTime: -1},
+		}, {
+			url: "redis://localhost:123/?db=2&conn_max_idle_time=-1s",
+			o:   &Options{Addr: "localhost:123", DB: 2, ConnMaxIdleTime: -1},
+		}, {
 			// absent timeout values will use defaults
 			url: "redis://localhost:123/?db=2&conn_max_idle_time=",
 			o:   &Options{Addr: "localhost:123", DB: 2, ConnMaxIdleTime: 0},


### PR DESCRIPTION
`ParseURL` documents that a duration query parameter is disabled with a value `<= 0`:

> to disable a duration field, use value less than or equal to 0; to use the default value, leave the value blank or remove the parameter

That only works for plain integers. `queryOptions.duration()` returns the `-1` disable sentinel in the integer branch, but a duration written with a unit goes through `time.ParseDuration` and is returned as-is, so a zero value with a unit is not disabled and falls through to the default:

    read_timeout=0          -> ReadTimeout=0   (disabled)
    read_timeout=0s         -> ReadTimeout=3s  (default)
    conn_max_idle_time=0    -> ConnMaxIdleTime=-1  (disabled)
    conn_max_idle_time=0s   -> ConnMaxIdleTime=0   (30m default after init)

(`ReadTimeout` values are shown after `init()`, which maps the `-1` sentinel to the runtime no-timeout value.)

The fix applies the same `<= 0` check in the `ParseDuration` branch so `0s` disables the field like `0` already does. Negative values with a unit (`-1s`) are normalized to the same `-1` sentinel for consistency; those already disabled at runtime since `deadline()` treats any `timeout <= 0` as no deadline, so that part is parse-level consistency rather than a behavior change.

Added two `conn_max_idle_time` cases (`0s`, `-1s`) to `TestParseURL`; both fail before the change and pass after. `go vet ./...`, `gofmt`, and `go build ./...` are clean. The server-backed suite needs Docker so I did not run it, but the change is confined to URL parsing and is covered by `TestParseURL`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to URL option parsing with new unit tests; no auth or connection logic changes beyond correct timeout disable semantics.
> 
> **Overview**
> **`ParseURL` duration query params** now treat values with units the same as plain integers when disabling timeouts: after `time.ParseDuration`, **`dur <= 0` returns the `-1` sentinel** instead of passing through `0` (which `Options.init()` would turn into library defaults).
> 
> This closes a doc/behavior gap where `conn_max_idle_time=0` disabled idle timeout but `conn_max_idle_time=0s` did not. The same logic applies to other duration URL fields (`read_timeout`, `dial_timeout`, etc.).
> 
> **Tests:** `TestParseURL` adds `conn_max_idle_time=0s` and `conn_max_idle_time=-1s` expecting `ConnMaxIdleTime: -1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b43405330297212e7fd71d63bbe596b1e4a9d16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->