### PR TITLE
fix(proto): encode nil *uint8 as "0" like other numeric pointers

### DIFF
--- a/internal/proto/writer.go
+++ b/internal/proto/writer.go
@@ -118,7 +118,7 @@ func (w *Writer) WriteArg(v interface{}) error {
 		return w.uint(uint64(v))
 	case *uint8:
 		if v == nil {
-			return w.string("")
+			return w.uint(0)
 		}
 		return w.uint(uint64(*v))
 	case uint16:

--- a/internal/proto/writer_test.go
+++ b/internal/proto/writer_test.go
@@ -137,7 +137,7 @@ var _ = Describe("WriteArg", func() {
 		(*uint)(nil):                           "$1\r\n0\r\n",
 		uint8(10):                              "$2\r\n10\r\n",
 		util.ToPtr(uint8(10)):                  "$2\r\n10\r\n",
-		(*uint8)(nil):                          "$0\r\n\r\n",
+		(*uint8)(nil):                          "$1\r\n0\r\n",
 		uint16(10):                             "$2\r\n10\r\n",
 		util.ToPtr(uint16(10)):                 "$2\r\n10\r\n",
 		(*uint16)(nil):                         "$1\r\n0\r\n",


### PR DESCRIPTION
`WriteArg` encodes a nil pointer to a numeric type as its zero value. Every nil `*int`, `*int8`, `*int16`, `*int32`, `*int64`, `*uint`, `*uint16`, `*uint32`, `*uint64`, `*float32`, `*float64`, `*bool` and `*time.Duration` encodes as `"0"`. The `*uint8` case returned an empty string instead.

It is also inconsistent with the non-nil `*uint8` path, which writes the number through `w.uint`. The table test already asserts `uint8(10)` and `*uint8(10)` both encode as `"10"`, so `uint8` is treated as a number here, not a byte.

In practice `var p *uint8; rdb.Set(ctx, key, p, 0)` sent `""` while every other nil numeric pointer sent `"0"`.

The empty-string branch came in with the other nil-pointer guards in #3271; it looks like the one case that was missed rather than intended behavior.

Note this is a wire-output change for the nil `*uint8` case: it now sends `"0"` (`$1\r\n0\r\n`) instead of an empty bulk string (`$0\r\n\r\n`).

Changed the nil branch to `w.uint(0)` and updated the `(*uint8)(nil)` expectation in the writer table test.

Tested:

```
go test ./internal/proto/
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-branch serialization fix in the proto writer with a narrow wire-output change for nil `*uint8` only.
> 
> **Overview**
> **`WriteArg`** now encodes a nil **`*uint8`** as **`"0"`** via **`w.uint(0)`**, matching every other nil numeric pointer type instead of an empty bulk string.
> 
> This is a **wire-format change** for that case only: Redis commands that pass a nil **`*uint8`** (e.g. **`Set`** with a nil pointer value) will send **`$1\r\n0\r\n`** instead of **`$0\r\n\r\n`**. The writer table test expectation for **`(*uint8)(nil)`** was updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 081addbce39e0983fd232d433a4cbd5577f23d82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->