### PR TITLE
fix(maintnotif): tight race condition windown on handoff

### DIFF
--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -774,8 +774,13 @@ func (cn *Conn) MarkQueuedForHandoff() error {
 			// Already unusable - this is fine, keep the new handoff state
 			return nil
 		}
-		// Restore the original state if transition fails for other reasons
-		cn.handoffStateAtomic.Store(currentState)
+		// Restore the original handoff state only if nothing else changed it
+		// since our CAS above. A concurrent handoff worker may have completed
+		// the handoff and run ClearHandoffState in this window; a plain Store
+		// would clobber that, resurrecting ShouldHandoff=true and wedging the
+		// connection so it can never be acquired again. The CAS leaves the
+		// worker's state intact when it has taken over.
+		cn.handoffStateAtomic.CompareAndSwap(newState, currentState)
 		return fmt.Errorf("failed to mark connection as unusable: %w", err)
 	}
 	return nil

--- a/internal/pool/conn_handoff_race_test.go
+++ b/internal/pool/conn_handoff_race_test.go
@@ -20,7 +20,10 @@ import (
 // the previous plain-Store rollback a resurrected ShouldHandoff is observed
 // within these iterations; with the CAS rollback it never is.
 func TestMarkQueuedForHandoffRollbackDoesNotResurrectClearedState(t *testing.T) {
-	const iterations = 20000
+	iterations := 20000
+	if testing.Short() {
+		iterations = 2000
+	}
 
 	for i := 0; i < iterations; i++ {
 		cn := NewConn(nil)

--- a/internal/pool/conn_handoff_race_test.go
+++ b/internal/pool/conn_handoff_race_test.go
@@ -1,0 +1,59 @@
+package pool
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestMarkQueuedForHandoffRollbackDoesNotResurrectClearedState is a regression
+// test for the handoff CAS-rollback race.
+//
+// When MarkQueuedForHandoff cannot transition the connection to UNUSABLE it
+// rolls back the handoff metadata it just CAS'd. A concurrent handoff worker
+// may have completed the handoff and run ClearHandoffState in that exact
+// window. The rollback must NOT clobber the worker's cleared state by
+// resurrecting ShouldHandoff=true — doing so wedges the connection forever,
+// because OnGet rejects any connection reporting ShouldHandoff.
+//
+// The offending interleaving (the clear landing between the metadata CAS and
+// the rollback store) is timing-dependent, so this hammers it many times. With
+// the previous plain-Store rollback a resurrected ShouldHandoff is observed
+// within these iterations; with the CAS rollback it never is.
+func TestMarkQueuedForHandoffRollbackDoesNotResurrectClearedState(t *testing.T) {
+	const iterations = 20000
+
+	for i := 0; i < iterations; i++ {
+		cn := NewConn(nil)
+		if err := cn.MarkForHandoff("new-endpoint:6379", int64(i+1)); err != nil {
+			t.Fatalf("iter %d: MarkForHandoff: %v", i, err)
+		}
+		// Force MarkQueuedForHandoff down its rollback path: StateClosed is not a
+		// valid source for the UNUSABLE transition, so TryTransition fails and the
+		// metadata rollback runs.
+		cn.GetStateMachine().Transition(StateClosed)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = cn.MarkQueuedForHandoff()
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			// Represents a worker that finished the handoff and cleared state.
+			cn.ClearHandoffState()
+		}()
+		close(start)
+		wg.Wait()
+
+		// ClearHandoffState always runs, so the connection's final handoff state
+		// must be cleared. A resurrected ShouldHandoff means the rollback
+		// clobbered the worker's clear.
+		if cn.ShouldHandoff() {
+			t.Fatalf("iter %d: ShouldHandoff resurrected after ClearHandoffState — rollback clobbered the cleared state", i)
+		}
+	}
+}

--- a/maintnotifications/pool_hook.go
+++ b/maintnotifications/pool_hook.go
@@ -164,13 +164,18 @@ func (ph *PoolHook) OnPut(ctx context.Context, conn *pool.Conn) (shouldPool bool
 	}
 
 	if err := conn.MarkQueuedForHandoff(); err != nil {
-		// The handoff was already queued successfully above, so a worker owns
-		// this connection. MarkQueuedForHandoff only fails when that worker has
-		// concurrently advanced the connection's state (handoff in progress or
-		// already completed). Removing the connection here would discard a
-		// healthy connection that is being handed off; pool it instead and let
-		// the worker remove it itself if the handoff ultimately fails.
-		return true, false, nil
+		// Marking can fail if a worker advanced the connection's state between
+		// our queueHandoff above and here. Re-check ShouldHandoff: with the CAS
+		// rollback in Conn.MarkQueuedForHandoff, a worker that already cleared
+		// the handoff state is no longer misreported as ShouldHandoff=true, so a
+		// cleared connection is reliably detected and pooled here.
+		if !conn.ShouldHandoff() {
+			// Handoff was processed - this is normal, pool the connection.
+			return true, false, nil
+		}
+		// Still marked for handoff in an ambiguous state — remove it rather than
+		// returning a connection a queued worker may still close or replace.
+		return false, true, nil
 	}
 	internal.Logger.Printf(ctx, logs.MarkedForHandoff(conn.GetID()))
 	return true, false, nil

--- a/maintnotifications/pool_hook.go
+++ b/maintnotifications/pool_hook.go
@@ -164,13 +164,13 @@ func (ph *PoolHook) OnPut(ctx context.Context, conn *pool.Conn) (shouldPool bool
 	}
 
 	if err := conn.MarkQueuedForHandoff(); err != nil {
-		// If marking fails, check if handoff was processed in the meantime
-		if !conn.ShouldHandoff() {
-			// Handoff was processed - this is normal, pool the connection
-			return true, false, nil
-		}
-		// Other error - remove the connection
-		return false, true, nil
+		// The handoff was already queued successfully above, so a worker owns
+		// this connection. MarkQueuedForHandoff only fails when that worker has
+		// concurrently advanced the connection's state (handoff in progress or
+		// already completed). Removing the connection here would discard a
+		// healthy connection that is being handed off; pool it instead and let
+		// the worker remove it itself if the handoff ultimately fails.
+		return true, false, nil
 	}
 	internal.Logger.Printf(ctx, logs.MarkedForHandoff(conn.GetID()))
 	return true, false, nil

--- a/maintnotifications/pool_hook_test.go
+++ b/maintnotifications/pool_hook_test.go
@@ -1007,3 +1007,100 @@ func TestConnectionHook(t *testing.T) {
 		t.Logf("HandoffTimeout configuration test completed successfully")
 	})
 }
+
+// TestPoolHookNeverReturnsConnectionMarkedForHandoff verifies the core
+// guarantee that the pool hook never hands a connection back to a caller while
+// it is marked for (or undergoing) handoff, and that OnPut pools — never
+// removes — such a connection (the handoff worker owns it once queued).
+//
+// Both OnGet guard layers are exercised:
+//   - ShouldHandoff(): connection marked for handoff but not yet queued
+//   - !IsUsable():     connection queued / handoff in progress
+func TestPoolHookNeverReturnsConnectionMarkedForHandoff(t *testing.T) {
+	baseDialer := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return &mockNetConn{addr: addr}, nil
+	}
+	ctx := context.Background()
+
+	t.Run("OnGet refuses a connection marked or queued for handoff", func(t *testing.T) {
+		processor := NewPoolHook(baseDialer, "tcp", nil, nil)
+		defer processor.Shutdown(ctx)
+
+		conn := createMockPoolConnection()
+
+		// Healthy, usable connection: accepted.
+		if accept, err := processor.OnGet(ctx, conn, false); !accept || err != nil {
+			t.Fatalf("OnGet should accept a healthy connection: accept=%v err=%v", accept, err)
+		}
+
+		// Marked for handoff (ShouldHandoff()==true, still usable): refused via
+		// the ShouldHandoff guard.
+		if err := conn.MarkForHandoff("new-endpoint:6379", 1); err != nil {
+			t.Fatalf("MarkForHandoff: %v", err)
+		}
+		if !conn.ShouldHandoff() {
+			t.Fatal("connection should be marked for handoff")
+		}
+		if accept, err := processor.OnGet(ctx, conn, false); accept || err != ErrConnectionMarkedForHandoffWithState {
+			t.Fatalf("OnGet must refuse a connection marked for handoff: accept=%v err=%v", accept, err)
+		}
+
+		// Queued for handoff: MarkQueuedForHandoff clears ShouldHandoff and makes
+		// the connection UNUSABLE, so it is now refused via the usable guard.
+		if err := conn.MarkQueuedForHandoff(); err != nil {
+			t.Fatalf("MarkQueuedForHandoff: %v", err)
+		}
+		if conn.ShouldHandoff() {
+			t.Fatal("queued connection should have ShouldHandoff()==false")
+		}
+		if conn.IsUsable() {
+			t.Fatal("queued connection should be unusable")
+		}
+		if accept, err := processor.OnGet(ctx, conn, false); accept || err != ErrConnectionMarkedForHandoff {
+			t.Fatalf("OnGet must refuse a connection queued for handoff: accept=%v err=%v", accept, err)
+		}
+	})
+
+	t.Run("OnPut pools (never removes) a connection being handed off", func(t *testing.T) {
+		config := &Config{
+			Mode:              ModeAuto,
+			EndpointType:      EndpointTypeAuto,
+			MaxWorkers:        1,
+			HandoffQueueSize:  10,
+			MaxHandoffRetries: 3,
+		}
+		processor := NewPoolHook(baseDialer, "tcp", config, nil)
+		defer processor.Shutdown(ctx)
+
+		conn := createMockPoolConnection()
+		conn.SetInitConnFunc(func(ctx context.Context, cn *pool.Conn) error { return nil })
+		if err := conn.MarkForHandoff("new-endpoint:6379", 1); err != nil {
+			t.Fatalf("MarkForHandoff: %v", err)
+		}
+
+		// Returning a marked connection queues the async handoff. The worker now
+		// owns it, so OnPut must pool it, never remove it.
+		shouldPool, shouldRemove, err := processor.OnPut(ctx, conn)
+		if err != nil {
+			t.Fatalf("OnPut should not error: %v", err)
+		}
+		if !shouldPool || shouldRemove {
+			t.Fatalf("a connection being handed off must be pooled, not removed (shouldPool=%v, shouldRemove=%v)", shouldPool, shouldRemove)
+		}
+
+		// Once the handoff completes the connection is healthy and acceptable again.
+		deadline := time.Now().Add(5 * time.Second)
+		for time.Now().Before(deadline) {
+			if conn.IsUsable() && !processor.IsHandoffPending(conn) {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		if !conn.IsUsable() || processor.IsHandoffPending(conn) {
+			t.Fatalf("handoff did not complete (IsUsable=%v, pending=%v)", conn.IsUsable(), processor.IsHandoffPending(conn))
+		}
+		if accept, err := processor.OnGet(ctx, conn, false); !accept || err != nil {
+			t.Fatalf("OnGet should accept the connection after handoff completes: accept=%v err=%v", accept, err)
+		}
+	})
+}


### PR DESCRIPTION
a flaky test caught a tight race condition window, this should address it by making sure the connection handoff state is correct if a worker acquired it while we were marking it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches atomic handoff state and pool acquire/reject paths during maintenance handoffs; fix is narrow but incorrect rollback could still wedge connections in production.
> 
> **Overview**
> Fixes a **race between `MarkQueuedForHandoff` rollback and a handoff worker** that could permanently wedge pool connections.
> 
> When queuing for handoff fails the UNUSABLE transition, the code rolls back the handoff metadata CAS. A plain **`Store` of the old state could run after the worker’s `ClearHandoffState`**, resurrecting `ShouldHandoff=true` so **`OnGet` forever rejects** the connection. Rollback now uses **`CompareAndSwap(newState, currentState)`** so a worker that already cleared state is not overwritten.
> 
> **`maintnotifications` `OnPut`** comments clarify that after this fix, re-checking `ShouldHandoff` when marking fails reliably detects a completed handoff and pools the connection; if still marked in an ambiguous state, the hook still removes rather than returning a conn the worker may close.
> 
> Adds a **stress regression test** for the rollback vs. `ClearHandoffState` interleaving and **pool hook tests** that `OnGet` refuses marked/queued handoff conns and `OnPut` pools (does not remove) connections under handoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304dbd2fa098eb761975672db2fc9a194b2165ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->