### PR TITLE
fix: reject unhashable keys in RESP3 map parsing

### DIFF
--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -452,6 +452,12 @@ func (r *Reader) readMap(line []byte) (map[interface{}]interface{}, error) {
 			}
 			return nil, err
 		}
+
+		switch k.(type) {
+		case []interface{}, map[interface{}]interface{}:
+    		return nil, fmt.Errorf("redis: RESP3 map key must be a scalar type, got %T", k)
+		}
+
 		m[k] = v
 	}
 	return m, nil

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -440,6 +440,16 @@ func (r *Reader) readMap(line []byte) (map[interface{}]interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		// Reject unhashable keys (arrays/maps) before they are used as a map
+		// key, which would otherwise panic. This check must run before the
+		// value is read so it also guards the Nil and RedisError paths below,
+		// which write the key into the map and continue.
+		switch k.(type) {
+		case []interface{}, map[interface{}]interface{}:
+			return nil, fmt.Errorf("redis: RESP3 map key must be a scalar type, got %T", k)
+		}
+
 		v, err := r.ReadReply()
 		if err != nil {
 			if err == Nil {
@@ -451,11 +461,6 @@ func (r *Reader) readMap(line []byte) (map[interface{}]interface{}, error) {
 				continue
 			}
 			return nil, err
-		}
-
-		switch k.(type) {
-		case []interface{}, map[interface{}]interface{}:
-    		return nil, fmt.Errorf("redis: RESP3 map key must be a scalar type, got %T", k)
 		}
 
 		m[k] = v

--- a/internal/proto/reader_fuzz_test.go
+++ b/internal/proto/reader_fuzz_test.go
@@ -1,37 +1,61 @@
 package proto
 
 import (
-    "bytes"
-    "testing"
+	"bytes"
+	"strings"
+	"testing"
 )
 
 func FuzzReadReply(f *testing.F) {
-    // Seed corpus with valid RESP3 replies
-    for _, s := range []string{
-        "+OK\r\n", ":123\r\n", "-ERR x\r\n",
-        "$5\r\nhello\r\n", "*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n",
-        "_\r\n", "#t\r\n", ",3.14\r\n",
-        "%1\r\n+k\r\n+v\r\n", "~2\r\n+a\r\n+b\r\n",
-        ">2\r\n+pub\r\n+msg\r\n",
-    } {
-        f.Add([]byte(s))
-    }
-    f.Fuzz(func(t *testing.T, data []byte) {
-        r := NewReader(bytes.NewReader(data))
-        _, _ = r.ReadReply()
-    })
+	// Seed corpus with valid RESP3 replies plus unhashable-key maps so the
+	// fuzzer exercises every readMap write site (value ok / Nil / error).
+	for _, s := range []string{
+		"+OK\r\n", ":123\r\n", "-ERR x\r\n",
+		"$5\r\nhello\r\n", "*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n",
+		"_\r\n", "#t\r\n", ",3.14\r\n",
+		"%1\r\n+k\r\n+v\r\n", "~2\r\n+a\r\n+b\r\n",
+		">2\r\n+pub\r\n+msg\r\n",
+		"%1\r\n*0\r\n+v\r\n",     // array key, value ok
+		"%1\r\n*0\r\n_\r\n",      // array key, Nil value
+		"%1\r\n*0\r\n-ERR x\r\n", // array key, RedisError value
+		"%1\r\n%0\r\n+v\r\n",     // map key, value ok
+	} {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		r := NewReader(bytes.NewReader(data))
+		_, _ = r.ReadReply()
+	})
 }
 
-// Explicit test for the unhashable key fix
+// TestReadMapRejectsUnhashableKey verifies that an aggregate (array or map)
+// used as a RESP3 map key is rejected with a parse error instead of causing a
+// runtime "hash of unhashable type" panic. The key is written into the result
+// map at three sites in readMap — on a successful value read, on a Nil value,
+// and on a RedisError value — so each is covered here.
 func TestReadMapRejectsUnhashableKey(t *testing.T) {
-    // RESP3 map with unhashable key (nested map)
-    data := []byte("%1\r\n%0\r\n+\r\n")
-    r := NewReader(bytes.NewReader(data))
-    _, err := r.ReadReply()
-    if err == nil {
-        t.Fatal("expected error for unhashable map key, got nil")
-    }
-    if !strings.Contains(err.Error(), "scalar type") {
-        t.Fatalf("expected 'scalar type' in error, got: %v", err)
-    }
+	cases := []struct {
+		name string
+		data string
+	}{
+		{"array key, value ok", "%1\r\n*0\r\n+v\r\n"},
+		{"array key, Nil value", "%1\r\n*0\r\n_\r\n"},
+		{"array key, RedisError value", "%1\r\n*0\r\n-ERR boom\r\n"},
+		{"map key, value ok", "%1\r\n%0\r\n+v\r\n"},
+		{"map key, Nil value", "%1\r\n%0\r\n_\r\n"},
+		{"map key, RedisError value", "%1\r\n%0\r\n-ERR boom\r\n"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := NewReader(bytes.NewReader([]byte(tc.data)))
+			_, err := r.ReadReply()
+			if err == nil {
+				t.Fatal("expected error for unhashable map key, got nil")
+			}
+			if !strings.Contains(err.Error(), "scalar type") {
+				t.Fatalf("expected 'scalar type' in error, got: %v", err)
+			}
+		})
+	}
 }

--- a/internal/proto/reader_fuzz_test.go
+++ b/internal/proto/reader_fuzz_test.go
@@ -1,0 +1,37 @@
+package proto
+
+import (
+    "bytes"
+    "testing"
+)
+
+func FuzzReadReply(f *testing.F) {
+    // Seed corpus with valid RESP3 replies
+    for _, s := range []string{
+        "+OK\r\n", ":123\r\n", "-ERR x\r\n",
+        "$5\r\nhello\r\n", "*2\r\n$3\r\nfoo\r\n$3\r\nbar\r\n",
+        "_\r\n", "#t\r\n", ",3.14\r\n",
+        "%1\r\n+k\r\n+v\r\n", "~2\r\n+a\r\n+b\r\n",
+        ">2\r\n+pub\r\n+msg\r\n",
+    } {
+        f.Add([]byte(s))
+    }
+    f.Fuzz(func(t *testing.T, data []byte) {
+        r := NewReader(bytes.NewReader(data))
+        _, _ = r.ReadReply()
+    })
+}
+
+// Explicit test for the unhashable key fix
+func TestReadMapRejectsUnhashableKey(t *testing.T) {
+    // RESP3 map with unhashable key (nested map)
+    data := []byte("%1\r\n%0\r\n+\r\n")
+    r := NewReader(bytes.NewReader(data))
+    _, err := r.ReadReply()
+    if err == nil {
+        t.Fatal("expected error for unhashable map key, got nil")
+    }
+    if !strings.Contains(err.Error(), "scalar type") {
+        t.Fatalf("expected 'scalar type' in error, got: %v", err)
+    }
+}


### PR DESCRIPTION
## Description
Fixes a panic in RESP3 map reply parsing when the map key is an 
unhashable type (map or array).

## Changes
- Add type validation in readMap() to reject unhashable keys
- Return a clear parse error instead of panicking
- Add regression test for the panic condition

## Why
While this requires an already-compromised connection to trigger, 
defensive parsing improves robustness. Parsers shouldn't panic on 
malformed input.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized defensive change in the protocol reader; malformed map keys now surface as errors without altering normal scalar-key behavior.
> 
> **Overview**
> **RESP3 map parsing** no longer panics when a map key is an array or nested map. `readMap` validates each key after it is read and returns a parse error (`scalar type`) before assigning into the Go map, including on Nil and RedisError value paths.
> 
> Adds **`FuzzReadReply`** (seeded with valid replies and unhashable-key maps) and **`TestReadMapRejectsUnhashableKey`** for array/map keys across normal, nil, and error values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 169636be37ff4dcd9568a11360fe5f69b698d6c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->