### PR TITLE
fix(proto): don't over-read nil replies in Reader.Discard

### DIFF
--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -738,7 +738,15 @@ func (r *Reader) Discard(line []byte) (err error) {
 	}
 
 	n, err := replyLen(line)
-	if err != nil && err != Nil {
+	if err != nil {
+		if err == Nil {
+			// A nil reply ($-1, =-1, !-1, *-1, %-1) carries no payload; the
+			// header line was already consumed by readLine, so there is
+			// nothing to discard. Falling through would Discard(n+2)==2 bytes
+			// that belong to the next reply and desync the stream, matching
+			// how readRawReplyBuf/readRawReplyWriteTo already treat Nil.
+			return nil
+		}
 		return err
 	}
 

--- a/internal/proto/reader_test.go
+++ b/internal/proto/reader_test.go
@@ -347,6 +347,44 @@ func TestReader_ReadStringInto_BufferTooSmall(t *testing.T) {
 	}
 }
 
+func TestReader_Discard_NilReplies(t *testing.T) {
+	// Discard must consume only the header line of a nil reply, leaving the
+	// following reply byte-aligned. A nil bulk string ($-1), verbatim (=-1)
+	// and blob error (!-1) each have no payload; discarding an extra 2 bytes
+	// (the phantom payload CRLF) eats into the next reply and desyncs a
+	// pooled connection so one command's data bleeds into another's.
+	nilHeaders := []string{"$-1", "=-1", "!-1", "*-1", "%-1"}
+	for _, h := range nilHeaders {
+		src := h + "\r\n$5\r\nhello\r\n"
+		r := proto.NewReader(bytes.NewReader([]byte(src)))
+		if err := r.DiscardNext(); err != nil {
+			t.Fatalf("%s: DiscardNext: %v", h, err)
+		}
+		s, err := r.ReadString()
+		if err != nil {
+			t.Fatalf("%s: follow-up ReadString: %v (stream left misaligned by Discard)", h, err)
+		}
+		if s != "hello" {
+			t.Fatalf("%s: follow-up got %q, want \"hello\"", h, s)
+		}
+	}
+}
+
+func TestReader_Discard_AttributeWithNilValue(t *testing.T) {
+	// A RESP3 attribute carrying a nil bulk value is skipped via Discard on
+	// the read path (ReadLine -> RespAttr -> Discard). The real reply that
+	// follows the attribute must parse unchanged.
+	src := "|1\r\n$3\r\nttl\r\n$-1\r\n$6\r\nsecond\r\n"
+	r := proto.NewReader(bytes.NewReader([]byte(src)))
+	s, err := r.ReadString()
+	if err != nil {
+		t.Fatalf("ReadString after nil-valued attribute: %v", err)
+	}
+	if s != "second" {
+		t.Fatalf("got %q, want \"second\"", s)
+	}
+}
+
 func TestReader_ReadStringInto_Large(t *testing.T) {
 	// Payload deliberately larger than the default bufio buffer (32 KiB)
 	// so we exercise the path where bufio.Reader drains its internal


### PR DESCRIPTION
Reader.Discard on a nil bulk string, feeding the reply after it:

    $-1\r\n$5\r\nhello\r\n  ->  DiscardNext() then ReadString()
    redis: invalid reply: "\r\n"   // want "hello"

replyLen returns (0, Nil) for $-1/=-1/!-1, but the guard is `err != nil && err != Nil`, so Nil falls through to the string branch and runs Discard(n+2)=Discard(2). A nil reply is only its header line (already consumed by readLine), so those 2 bytes come out of the next reply and desync the connection. On a pooled conn that means one command reads bytes belonging to another.

Reached on the read path when a RESP3 attribute frame is skipped (ReadLine -> RespAttr -> Discard/DiscardNext) and one of its values is a nil bulk string. readRawReplyBuf and readRawReplyWriteTo already early-return on err==Nil; Discard was the only consumer that did not. Fix matches them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level RESP stream alignment in the shared proto reader; incorrect behavior could corrupt pooled connections, but the change is narrow and covered by new regression tests.
> 
> **Overview**
> **`Reader.Discard`** no longer treats nil-length RESP headers (`$-1`, `=-1`, `!-1`, `*-1`, `%-1`) as bulk payloads. When `replyLen` returns `Nil`, it returns immediately instead of calling `Discard(2)`, which was stealing bytes from the next reply and desyncing pooled connections.
> 
> This aligns **`Discard`** with **`readRawReplyBuf`** / **`readRawReplyWriteTo`**, which already handled `Nil` correctly. The bug showed up when skipping RESP3 attributes whose values are nil bulk strings (`ReadLine` → `RespAttr` → `Discard`).
> 
> Tests cover discarding each nil header type followed by a bulk string, and reading through an attribute with a nil value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb3a513284088b954984ca7bc7f5068c1a6d4e26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->