### PR TITLE
DOC-6806 remove duplicate example step

### DIFF
--- a/doctests/timeseries_tut_test.go
+++ b/doctests/timeseries_tut_test.go
@@ -669,7 +669,9 @@ func ExampleClient_timeseries_aggregation() {
 	// >>> [{0 1.9500000000000002} {2 2.0999999999999996} {4 1.78}]
 	// STEP_END
 
-	// STEP_START agg_multi
+	// This example uses multiple aggregators in a single range query but is
+	// not a documented tutorial step (see the "agg_multi" step below for the
+	// cross-series aggregation example that the docs reference).
 	res33, err := rdb.TSRangeWithArgs(
 		ctx,
 		"rg:2",
@@ -686,7 +688,6 @@ func ExampleClient_timeseries_aggregation() {
 
 	fmt.Println(res33)
 	// >>> [{0 [1.8 2.1]} {2 [1.9 2.3]} {4 [1.78 1.78]}]
-	// STEP_END
 
 	// Output:
 	// [{0 1.9500000000000002} {2 2.0999999999999996} {4 1.78}]

--- a/doctests/timeseries_tut_test.go
+++ b/doctests/timeseries_tut_test.go
@@ -669,9 +669,7 @@ func ExampleClient_timeseries_aggregation() {
 	// >>> [{0 1.9500000000000002} {2 2.0999999999999996} {4 1.78}]
 	// STEP_END
 
-	// This example uses multiple aggregators in a single range query but is
-	// not a documented tutorial step (see the "agg_multi" step below for the
-	// cross-series aggregation example that the docs reference).
+	// STEP_START agg_multi
 	res33, err := rdb.TSRangeWithArgs(
 		ctx,
 		"rg:2",
@@ -688,6 +686,7 @@ func ExampleClient_timeseries_aggregation() {
 
 	fmt.Println(res33)
 	// >>> [{0 [1.8 2.1]} {2 [1.9 2.3]} {4 [1.78 1.78]}]
+	// STEP_END
 
 	// Output:
 	// [{0 1.9500000000000002} {2 2.0999999999999996} {4 1.78}]


### PR DESCRIPTION
There were two example steps called `agg_multi` in the time series example. This caused doc build errors and displayed incorrectly on the doc page. Fixed with this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and doctest marker changes only; no runtime or API behavior changes.
> 
> **Overview**
> Fixes duplicate **`agg_multi`** tutorial step markers in the time series doctest that were breaking doc builds and mis-rendering on the docs page.
> 
> In **`ExampleClient_timeseries_aggregation`**, the multi-aggregator **`TSRangeWithArgs`** sample is no longer wrapped in **`STEP_START` / `STEP_END agg_multi`**. It stays in the example for test output, with comments clarifying it is not a published tutorial step and that the documented **`agg_multi`** content is the cross-series aggregation example in **`ExampleClient_timeseries_aggmulti`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51dc6e098b0902403551653b256ca2df83d8670c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->