### PR TITLE
fix(pool): data race on conn reader in isHealthyConn during handoff

### DIFF
--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -876,6 +876,18 @@ func (cn *Conn) PeekReplyTypeSafe() (byte, error) {
 	return cn.rd.PeekReplyType()
 }
 
+// PeekReplyTypeForCheck peeks at the reply type while holding readerMu, so it is
+// safe against a concurrent SetNetConn resetting the reader during handoff.
+// Unlike PeekReplyTypeSafe it does not require the data to already be buffered:
+// the pool health check calls it after connCheck reports unexpected socket data,
+// and connCheck only MSG_PEEKs, so the byte still has to be pulled from the
+// socket into the reader here.
+func (cn *Conn) PeekReplyTypeForCheck() (byte, error) {
+	cn.readerMu.RLock()
+	defer cn.readerMu.RUnlock()
+	return cn.rd.PeekReplyType()
+}
+
 func (cn *Conn) Write(b []byte) (int, error) {
 	// Lock-free netConn access for better performance
 	if netConn := cn.getNetConn(); netConn != nil {

--- a/internal/pool/conn_healthcheck_race_test.go
+++ b/internal/pool/conn_healthcheck_race_test.go
@@ -1,0 +1,79 @@
+package pool
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestIsHealthyConnReaderRaceWithSetNetConn is a regression test for a data
+// race between isHealthyConn peeking the reply type on cn.rd and a concurrent
+// handoff replacing the underlying connection via SetNetConn.
+//
+// SetNetConn resets cn.rd under readerMu (conn.go). The push-notification peek
+// in isHealthyConn read cn.rd without that lock, so a connection popped by Get
+// (health-checked before the OnGet state check) races the handoff worker that
+// is resetting the same reader.
+func TestIsHealthyConnReaderRaceWithSetNetConn(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	// Keep the client socket full of RESP push bytes so connCheck always
+	// reports unexpected data and the peek always has a byte to read, which is
+	// what drives isHealthyConn into the cn.rd peek branch.
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		buf := make([]byte, 4096)
+		for i := range buf {
+			buf[i] = '>' // proto.RespPush
+		}
+		for {
+			if _, err := c.Write(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	cn := NewConn(client)
+	p := &ConnPool{cfg: &Options{PushNotificationsEnabled: true}}
+
+	iterations := 5000
+	if testing.Short() {
+		iterations = 1000
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			cn.SetNetConn(client)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		now := time.Now().UnixNano()
+		for i := 0; i < iterations; i++ {
+			p.isHealthyConn(cn, now)
+		}
+	}()
+	close(start)
+	wg.Wait()
+}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1738,8 +1738,11 @@ func (p *ConnPool) isHealthyConn(cn *Conn, nowNs int64) bool {
 	if err := connCheck(cn.getNetConn()); err != nil {
 		// If there's unexpected data, it might be push notifications (RESP3)
 		if p.cfg.PushNotificationsEnabled && err == errUnexpectedRead {
-			// Peek at the reply type to check if it's a push notification
-			if replyType, err := cn.rd.PeekReplyType(); err == nil && replyType == proto.RespPush {
+			// Peek at the reply type to check if it's a push notification.
+			// Use the readerMu-guarded peek: a concurrent handoff may be
+			// resetting cn.rd via SetNetConn on a connection popped by Get
+			// before the OnGet state check rejects it.
+			if replyType, err := cn.PeekReplyTypeForCheck(); err == nil && replyType == proto.RespPush {
 				// For RESP3 connections with push notifications, we allow some buffered data
 				// The client will process these notifications before using the connection
 				internal.Logger.Printf(


### PR DESCRIPTION
`go test -race`, connection health check racing a handoff:

    WARNING: DATA RACE
    Write at 0x... by goroutine 10:
      bufio.(*Reader).Peek -> proto.(*Reader).PeekReplyType
      pool.(*ConnPool).isHealthyConn  pool.go:1742
    Previous write at 0x... by goroutine 9:
      bufio.(*Reader).reset -> proto.(*Reader).Reset
      pool.(*Conn).SetNetConn  conn.go:660

isHealthyConn peeks `cn.rd` for a buffered push notification without `readerMu`, the lock `SetNetConn` holds while resetting the reader during a handoff. `Get()` health-checks a connection popped from idle before the `OnGet` hook rejects it, so a connection queued for handoff (still pooled, UNUSABLE) can be checked here while the handoff worker resets its reader. The `putConn` push-notification peek already goes through the `readerMu`-guarded `HasBufferedData`/`PeekReplyTypeSafe` accessors; `isHealthyConn` was the one that bypassed the lock.

Routed through a `readerMu`-guarded accessor. `connCheck` only `MSG_PEEK`s, so unlike `PeekReplyTypeSafe` it can't require the byte to be buffered yet. Regression test hammers `isHealthyConn` against `SetNetConn` over a real socket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection pool health checks and reader locking on a hot path; behavior change is narrowly scoped to RESP3 push peeking but incorrect locking could affect connection reuse during handoff.
> 
> **Overview**
> Fixes a **data race** when the pool health-checks an idle connection while a handoff worker calls **`SetNetConn`** and resets **`cn.rd`** under **`readerMu`**.
> 
> **`isHealthyConn`** used to peek RESP push type via **`cn.rd.PeekReplyType()`** without the reader lock (unlike **`putConn`**, which already uses **`PeekReplyTypeSafe`** / **`HasBufferedData`**). **`Get()`** can health-check a connection before hooks reject a handoff-queued **`UNUSABLE`** conn, so that peek could race **`SetNetConn`**.
> 
> The change adds **`PeekReplyTypeForCheck()`**, which peeks under **`readerMu`** and does not require the byte to already be in the bufio buffer ( **`connCheck`** only **`MSG_PEEK`**s). **`isHealthyConn`** now uses that helper for the push-notification branch.
> 
> A **race regression test** hammers **`isHealthyConn`** against concurrent **`SetNetConn`** over a TCP socket filled with push bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c368f0730b5d4c0ed1b4f1539463eb2634c6e08b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->