### PR TITLE
fix(proto): avoid int overflow skipping map/attr bodies on read

### DIFF
--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -763,8 +763,14 @@ func (r *Reader) Discard(line []byte) (err error) {
 		}
 		return nil
 	case RespMap, RespAttr:
-		// Read key & value.
-		for i := 0; i < n*2; i++ {
+		// Iterate over the n key/value pairs rather than n*2 elements: a count
+		// above MaxInt/2 makes n*2 overflow to a negative loop bound, which
+		// would skip the body entirely and return nil, leaving the map bytes in
+		// the stream for the next reply to consume (a silent desync).
+		for i := 0; i < n; i++ {
+			if err = r.DiscardNext(); err != nil {
+				return err
+			}
 			if err = r.DiscardNext(); err != nil {
 				return err
 			}
@@ -857,10 +863,12 @@ func (r *Reader) readRawReplyBuf(buf []byte) ([]byte, error) {
 			}
 			return buf, err
 		}
-		for i := 0; i < n*2; i++ {
-			buf, err = r.readRawReplyBuf(buf)
-			if err != nil {
-				return buf, err
+		for i := 0; i < n; i++ {
+			for pair := 0; pair < 2; pair++ {
+				buf, err = r.readRawReplyBuf(buf)
+				if err != nil {
+					return buf, err
+				}
 			}
 		}
 		return buf, nil
@@ -875,11 +883,15 @@ func (r *Reader) readRawReplyBuf(buf []byte) ([]byte, error) {
 			}
 			return buf, err
 		}
-		// Read the attribute key-value pairs
-		for i := 0; i < n*2; i++ {
-			buf, err = r.readRawReplyBuf(buf)
-			if err != nil {
-				return buf, err
+		// Read the attribute key-value pairs. Iterate over pairs rather than
+		// n*2 elements so a count above MaxInt/2 can't overflow int to a
+		// negative loop bound and skip the body.
+		for i := 0; i < n; i++ {
+			for pair := 0; pair < 2; pair++ {
+				buf, err = r.readRawReplyBuf(buf)
+				if err != nil {
+					return buf, err
+				}
 			}
 		}
 		// Read the command reply that follows the attribute
@@ -956,11 +968,13 @@ func (r *Reader) readRawReplyWriteTo(w io.Writer) (int64, error) {
 			}
 			return written, err
 		}
-		for i := 0; i < count*2; i++ {
-			n, err := r.readRawReplyWriteTo(w)
-			written += n
-			if err != nil {
-				return written, err
+		for i := 0; i < count; i++ {
+			for pair := 0; pair < 2; pair++ {
+				n, err := r.readRawReplyWriteTo(w)
+				written += n
+				if err != nil {
+					return written, err
+				}
 			}
 		}
 		return written, nil
@@ -975,12 +989,16 @@ func (r *Reader) readRawReplyWriteTo(w io.Writer) (int64, error) {
 			}
 			return written, err
 		}
-		// Read the attribute key-value pairs
-		for i := 0; i < count*2; i++ {
-			n, err := r.readRawReplyWriteTo(w)
-			written += n
-			if err != nil {
-				return written, err
+		// Read the attribute key-value pairs. Iterate over pairs rather than
+		// count*2 elements so a count above MaxInt/2 can't overflow int to a
+		// negative loop bound and skip the body.
+		for i := 0; i < count; i++ {
+			for pair := 0; pair < 2; pair++ {
+				n, err := r.readRawReplyWriteTo(w)
+				written += n
+				if err != nil {
+					return written, err
+				}
 			}
 		}
 		// Read the command reply that follows the attribute

--- a/internal/proto/reader_test.go
+++ b/internal/proto/reader_test.go
@@ -385,6 +385,31 @@ func TestReader_Discard_AttributeWithNilValue(t *testing.T) {
 	}
 }
 
+func TestReader_Discard_MapCountOverflow(t *testing.T) {
+	// A valid map is discarded pair-by-pair and leaves the next reply aligned.
+	src := "%2\r\n+a\r\n+1\r\n+b\r\n+2\r\n$5\r\nhello\r\n"
+	r := proto.NewReader(bytes.NewReader([]byte(src)))
+	if err := r.DiscardNext(); err != nil {
+		t.Fatalf("DiscardNext on valid map: %v", err)
+	}
+	if s, err := r.ReadString(); err != nil || s != "hello" {
+		t.Fatalf("follow-up ReadString = %q, %v; want \"hello\", nil", s, err)
+	}
+
+	// A map (and an attribute) advertising a count above MaxInt/2 used to make
+	// the n*2 element loop overflow int to a negative bound, skip the body and
+	// return nil, leaving the map bytes to be read as the next reply. Iterating
+	// over pairs instead means the oversized frame is rejected with an error
+	// rather than silently desyncing a pooled connection.
+	for _, h := range []string{"%4611686018427387904", "|4611686018427387904"} {
+		src := h + "\r\n+k\r\n+v\r\n:42\r\n"
+		r := proto.NewReader(bytes.NewReader([]byte(src)))
+		if err := r.DiscardNext(); err == nil {
+			t.Fatalf("%s: DiscardNext returned nil; oversized count was silently skipped", h)
+		}
+	}
+}
+
 func TestReader_ReadStringInto_Large(t *testing.T) {
 	// Payload deliberately larger than the default bufio buffer (32 KiB)
 	// so we exercise the path where bufio.Reader drains its internal


### PR DESCRIPTION
The RESP3 map and attribute branches of Discard, readRawReplyBuf and readRawReplyWriteTo read key/value pairs by looping over n*2 elements, where n is the element count taken straight from the reply header (replyLen only rejects n < -1). A server sending a count above MaxInt/2, e.g. %4611686018427387904, makes n*2 overflow to a negative number, so the loop bound is negative, the body is never read, and the call returns nil. The header line was already consumed but the map bytes stay in the buffer, and since no error comes back the connection goes back to the pool and the next command reads those leftover bytes as its own reply. I hit it while checking the aggregate paths after the nil-discard fix and reproduced it against a crafted reply. Iterating over n pairs and reading two elements each keeps valid replies identical while making an oversized count fail with a read error instead of silently desyncing. The change stays inside these three readers so nothing on the call path shifts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level RESP parsing on pooled connections where a prior bug could silently misalign streams; the change is narrow and preserves behavior for valid replies.
> 
> **Overview**
> Fixes a **RESP3 map/attribute parsing bug** where `Discard`, `readRawReplyBuf`, and `readRawReplyWriteTo` advanced through key/value data using an `n*2` loop bound. When the advertised pair count is above `MaxInt/2`, that product overflows to a negative bound, the body is skipped with **no error**, and leftover bytes corrupt the next reply on a pooled connection.
> 
> The three code paths now iterate **`n` pairs** (two nested reads per pair), matching how `readMap` already works, so valid frames behave the same while absurd counts fail during reads instead of silently desyncing.
> 
> Adds **`TestReader_Discard_MapCountOverflow`** to confirm normal map discard stays aligned and crafted `%4611686018427387904` / `|4611686018427387904` headers return an error from `DiscardNext`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c929164c0b52edcf86ba6c49843024b3b831814c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->