### PR TITLE
fix(redisotel): avoid data race on shared attrs during MinIdleConns warmup

### DIFF
--- a/extra/redisotel/metrics.go
+++ b/extra/redisotel/metrics.go
@@ -128,7 +128,13 @@ func registerClient(rdb *redis.Client, conf *config, state *metricsState) error 
 }
 
 func poolStatsAttrs(conf *config) (poolAttrs, idleAttrs, usedAttrs attribute.Set) {
-	poolAttrs = attribute.NewSet(conf.attrs...)
+	// attribute.NewSet sorts and de-duplicates its input slice in place.
+	// conf.attrs is shared with every metricsHook.attrs, which is read
+	// concurrently while MinIdleConns pre-warms connections in the background,
+	// so pass a copy to avoid mutating the shared backing array (issue #3880).
+	attrs := make([]attribute.KeyValue, len(conf.attrs))
+	copy(attrs, conf.attrs)
+	poolAttrs = attribute.NewSet(attrs...)
 	idleAttrs = attribute.NewSet(append(poolAttrs.ToSlice(), attribute.String("state", "idle"))...)
 	usedAttrs = attribute.NewSet(append(poolAttrs.ToSlice(), attribute.String("state", "used"))...)
 	return

--- a/extra/redisotel/metrics_test.go
+++ b/extra/redisotel/metrics_test.go
@@ -2,6 +2,7 @@ package redisotel
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -51,4 +52,45 @@ func Test_poolStatsAttrs(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test_poolStatsAttrs_race reproduces issue #3880: attribute.NewSet sorts and
+// de-duplicates its input slice in place, so poolStatsAttrs mutates the shared
+// conf.attrs backing array. That array is aliased by every metricsHook.attrs
+// and read concurrently while MinIdleConns pre-warms connections in the
+// background, producing a data race. Must be run with -race.
+func Test_poolStatsAttrs_race(t *testing.T) {
+	conf := newConfig()
+	conf.attrs = append(conf.attrs,
+		attribute.String("pool.name", "pool1"),
+		attribute.String("foo1", "bar1"),
+		attribute.String("foo2", "bar2"),
+	)
+
+	// A metricsHook aliases conf.attrs, mirroring addMetricsHook.
+	mh := &metricsHook{attrs: conf.attrs}
+
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(2 * n)
+
+	// Readers: mirror metricsHook.DialHook reading mh.attrs during a dial.
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			attrs := make([]attribute.KeyValue, 0, len(mh.attrs)+2)
+			attrs = append(attrs, mh.attrs...)
+			_ = attribute.NewSet(attrs...)
+		}()
+	}
+
+	// Writers: registerClient calling poolStatsAttrs for each cluster node.
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			poolStatsAttrs(conf)
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
## Problem

Fixes #3880 — a data race between redisotel's `metricsHook` and the connection pool's `MinIdleConns` warmup, reproducible under `-race` with a `ClusterClient` (or `Ring`) when `MinIdleConns > 0` and `InstrumentMetrics` is enabled.

## Root cause

`attribute.NewSet` **sorts and de-duplicates its input slice in place** (`slices.SortStableFunc` + swaps in `NewSetWithFiltered`). In `poolStatsAttrs` we spread `conf.attrs` directly into `NewSet(conf.attrs...)`, and a variadic spread of an existing slice passes the same backing array — so every call mutates the shared `conf.attrs`.

That same backing array is aliased by every `metricsHook.attrs` (the hook is created with `attrs: conf.attrs`) and read concurrently in the Dial/Process hooks via `append(..., mh.attrs...)`. With a `ClusterClient`/`Ring`, `conf` is shared across all nodes, so:

- one node's `registerClient` → `poolStatsAttrs` **sorts** the array, while
- another node's background `MinIdleConns` dial **reads** it via the metrics `DialHook`.

→ the data race in the report (write in `NewSetWithFiltered`'s sort vs. `runtime.slicecopy` in the dial hook).

## Fix

Copy `conf.attrs` before handing it to `NewSet` in `poolStatsAttrs`. This removes the only runtime writer to the shared array — all other writes to `conf.attrs` are setup-time and happen-before any dial — so the array is effectively immutable at runtime and the aliased reads become safe.

Lock-free by design: rather than serializing dials and stats around a mutex (as the reporter suggested), this removes the unnecessary shared mutation entirely.

## Test

`Test_poolStatsAttrs_race` models the race directly: readers mirror `metricsHook.DialHook`'s `append(..., mh.attrs...)`, writers call the real `poolStatsAttrs`. It reports `DATA RACE` before the fix and passes after. Full `go test -race ./extra/redisotel/` stays green (the fix is set-identical).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized concurrency fix in redisotel metrics; observable attribute sets stay the same, with a new race regression test.
> 
> **Overview**
> Fixes a **`-race`** failure when **`InstrumentMetrics`** is used on **`ClusterClient`** / **`Ring`** with **`MinIdleConns > 0`**.
> 
> **`poolStatsAttrs`** no longer passes the shared **`conf.attrs`** slice into **`attribute.NewSet`**, which sorts and de-duplicates that slice **in place**. The same backing array is aliased by every **`metricsHook.attrs`** and read during background dials, so concurrent **`registerClient`** / pool warmup could race. The fix **copies** **`conf.attrs`** before building pool metric attribute sets.
> 
> Adds **`Test_poolStatsAttrs_race`**, which runs concurrent readers (dial-hook style) and writers (**`poolStatsAttrs`**) to guard the race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bff480e535cfa45754c84ecefeb05ef749d691d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->