### PR TITLE
fix(options): keep single brackets for IPv6 hosts without a port in ParseURL

### DIFF
--- a/options.go
+++ b/options.go
@@ -547,10 +547,12 @@ func setupTCPConn(u *url.URL) (*Options, error) {
 // a host and a port. If the host is missing, it defaults to localhost
 // and if the port is missing, it defaults to 6379.
 func getHostPortWithDefaults(u *url.URL) (string, string) {
-	host, port, err := net.SplitHostPort(u.Host)
-	if err != nil {
-		host = u.Host
-	}
+	// u.Hostname and u.Port strip the surrounding brackets from IPv6 literals
+	// (e.g. "[::1]" -> "::1") and handle the missing-port case, which
+	// net.SplitHostPort instead reports as an error. Relying on them avoids
+	// leaving the brackets on the host, which the caller's net.JoinHostPort
+	// would wrap again and turn "redis://[::1]" into "[[::1]]:6379".
+	host, port := u.Hostname(), u.Port()
 	if host == "" {
 		host = "localhost"
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -31,6 +31,18 @@ func TestParseURL(t *testing.T) {
 			url: "redis://12345",
 			o:   &Options{Addr: "12345:6379"},
 		}, {
+			// IPv6 literal without a port keeps a single pair of brackets
+			url: "redis://[::1]",
+			o:   &Options{Addr: "[::1]:6379"},
+		}, {
+			// IPv6 literal with a port
+			url: "redis://[::1]:6380",
+			o:   &Options{Addr: "[::1]:6380"},
+		}, {
+			// IPv6 literal without a port, with a db number
+			url: "redis://[2001:db8::1]/2",
+			o:   &Options{Addr: "[2001:db8::1]:6379", DB: 2},
+		}, {
 			url: "rediss://localhost:123",
 			o:   &Options{Addr: "localhost:123", TLSConfig: &tls.Config{ /* no deep comparison */ }},
 		}, {
@@ -162,6 +174,25 @@ func TestParseURL(t *testing.T) {
 			}
 			comprareOptions(t, actual, tc.o)
 		})
+	}
+}
+
+func TestParseURLIPv6TLSServerName(t *testing.T) {
+	// For rediss:// the TLS SNI ServerName must be the bare IPv6 host, not the
+	// bracketed form, otherwise the handshake is attempted with an invalid
+	// server name.
+	o, err := ParseURL("rediss://[2001:db8::1]")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if o.Addr != "[2001:db8::1]:6379" {
+		t.Errorf("Addr: got %q, want %q", o.Addr, "[2001:db8::1]:6379")
+	}
+	if o.TLSConfig == nil {
+		t.Fatal("expected a TLSConfig for the rediss scheme")
+	}
+	if got, want := o.TLSConfig.ServerName, "2001:db8::1"; got != want {
+		t.Errorf("TLSConfig.ServerName: got %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
`ParseURL` and `ParseClusterURL` mangle a bracketed IPv6 host when the URL omits the port.

`getHostPortWithDefaults` calls `net.SplitHostPort(u.Host)`, which fails with `missing port` for a literal such as `[::1]`. The error branch falls back to `host = u.Host`, keeping the brackets, and the caller then runs `net.JoinHostPort(host, "6379")`, which wraps the already-bracketed host a second time:

```go
ParseURL("redis://[::1]")         // Addr = "[[::1]]:6379"
ParseURL("redis://[2001:db8::1]") // Addr = "[[2001:db8::1]]:6379"
```

The double-bracketed address can't be dialed. For `rediss://` it also leaves the TLS `ServerName` bracketed (`[::1]` instead of `::1`), so the handshake uses an invalid server name. A host with an explicit port (`redis://[::1]:6379`) is unaffected, because there `SplitHostPort` succeeds.

## Fix

Use `u.Hostname()` / `u.Port()`. They strip the IPv6 brackets and report a missing port as an empty string, so the existing defaulting still applies and `JoinHostPort` adds exactly one pair of brackets. The result is identical to the old code for every non-IPv6 case.

## Tests

Added IPv6 rows to `TestParseURL` and a `TestParseURLIPv6TLSServerName` check for the SNI. Both fail before the change (`got "[[::1]]:6379", want "[::1]:6379"`) and pass after. `gofmt`, `go vet ./...` and `go build ./...` are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized URL parsing fix with targeted tests; behavior for non-IPv6 URLs is intended to stay the same.
> 
> **Overview**
> Fixes **broken dial addresses** for Redis URLs that use a bracketed IPv6 host **without** an explicit port (e.g. `redis://[::1]`). `getHostPortWithDefaults` now uses `url.URL.Hostname()` and `Port()` instead of `net.SplitHostPort`, so the host is unbracketed before `net.JoinHostPort` applies the default port `6379`. That stops double-bracket forms like `[[::1]]:6379` that could not be dialed.
> 
> The same helper is used by **cluster and sentinel URL parsing**, so those entry points get the same IPv6 behavior. For **`rediss://`**, TLS `ServerName` is set from the unbracketed host (e.g. `2001:db8::1` instead of `[2001:db8::1]`).
> 
> **Tests** add IPv6 cases to `TestParseURL` and `TestParseURLIPv6TLSServerName` for the SNI name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1991835d9ab09ff3e272fbed133a6a7203b526b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->