### PR TITLE
test(autopipeline): parametrize the command suite over the Client and…

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -16,6 +16,10 @@ inputs:
   client-libs-test-image-tag:
     description: 'Client libs test image tag'
     required: false
+  make-target:
+    description: 'Makefile target to run for the test step'
+    required: false
+    default: 'test.ci'
 runs:
   using: "composite"
   steps:
@@ -73,5 +77,5 @@ runs:
         RCE_DOCKER: "true"
         RE_CLUSTER: "false"
       run: |
-        make test.ci
+        make ${{ inputs.make-target }}
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,3 +105,27 @@ jobs:
           files: coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  test-autopipeline-subjects:
+    name: test-autopipeline-subjects
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        redis-version:
+          - "8.8.x" # Redis CE 8.8
+        go-version:
+          - "stable"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # Replay the command integration suite through the AutoPipeliner Cmdable
+      # faces (blocking + async) so every command is verified to behave the same
+      # batched as on a plain client.
+      - name: Run command suite through AutoPipeliner faces
+        uses: ./.github/actions/run-tests
+        with:
+          go-version: ${{ matrix.go-version }}
+          redis-version: ${{ matrix.redis-version }}
+          make-target: test.autopipeline-subjects
+

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,27 @@ test.ci.skip-vectorsets:
 	cd internal/customvet && go build .
 	go vet -vettool ./internal/customvet/customvet
 
+# Replay the command integration suite through the AutoPipeliner Cmdable faces
+# (blocking + async) to prove every command behaves identically when batched as
+# on a plain client. Selected via GOREDIS_TEST_SUBJECT (see newCommandSubject in
+# commands_test.go). Requires the docker env (make docker.start).
+test.autopipeline-subjects:
+	# RE_CLUSTER=true forces the lightweight BeforeSuite (no sentinel/ring/cluster
+	# setup): the command suite only needs the standalone Redis, and running the
+	# full stateful BeforeSuite twice (once per subject) against the same server
+	# corrupts replication state and fails the second run. Both faces then run
+	# cleanly against the same env.
+	set -e; for subj in ap-blocking ap-async; do \
+	  echo "=== command suite via GOREDIS_TEST_SUBJECT=$$subj ==="; \
+	  (export RE_CLUSTER=true && \
+	   export RCE_DOCKER=$(RCE_DOCKER) && \
+	   export REDIS_VERSION=$(REDIS_VERSION) && \
+	   export GOREDIS_TEST_SUBJECT=$$subj && \
+	   go test -v . -race -skip Example -run TestGinkgoSuite \
+	     -ginkgo.focus='Commands' \
+	     -ginkgo.skip='Array Commands|AutoPipeline Blocking Commands|DDL Commands|FT.HYBRID Commands|HotKeys Commands|JSON Commands'); \
+	done
+
 bench:
 	export RE_CLUSTER=$(RE_CLUSTER) && \
 	export RCE_DOCKER=$(RCE_DOCKER) && \
@@ -101,7 +122,7 @@ test.e2e.logic:
 		go test -v -run "TestCreateTestFaultInjectorLogic|TestFaultInjectorClientCreation" ./maintnotifications/e2e/
 	@echo "Logic tests completed!"
 
-.PHONY: all test test.ci test.ci.skip-vectorsets bench fmt test.e2e test.e2e.logic docker.e2e.start docker.e2e.stop
+.PHONY: all test test.ci test.ci.skip-vectorsets test.autopipeline-subjects bench fmt test.e2e test.e2e.logic docker.e2e.start docker.e2e.stop
 
 build:
 	export RE_CLUSTER=$(RE_CLUSTER) && \

--- a/array_commands_test.go
+++ b/array_commands_test.go
@@ -14,16 +14,19 @@ import (
 
 var _ = Describe("Array Commands", Label("array"), func() {
 	ctx := context.TODO()
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 
 	BeforeEach(func() {
 		SkipBeforeRedisVersion(8.8, "Redis 8.8.0 introduces support for Array")
-		client = redis.NewClient(redisOptions())
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		rawClient = redis.NewClient(redisOptions())
+		client, closeSubject = newUniversalSubject(rawClient)
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	Describe("ARSet and ARGet", func() {

--- a/bitmap_commands_test.go
+++ b/bitmap_commands_test.go
@@ -13,12 +13,15 @@ type bitCountExpected struct {
 }
 
 var _ = Describe("BitCountBite", func() {
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 	key := "bit_count_test"
 
 	BeforeEach(func() {
-		client = redis.NewClient(redisOptions())
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		rawClient = redis.NewClient(redisOptions())
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		client, closeSubject = newUniversalSubject(rawClient)
 		values := []int{0, 1, 0, 0, 1, 0, 1, 0, 1, 1}
 		for i, v := range values {
 			cmd := client.SetBit(ctx, key, int64(i), v)
@@ -27,7 +30,7 @@ var _ = Describe("BitCountBite", func() {
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	It("bit count bite", func() {
@@ -53,12 +56,15 @@ var _ = Describe("BitCountBite", func() {
 })
 
 var _ = Describe("BitCountByte", func() {
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 	key := "bit_count_test"
 
 	BeforeEach(func() {
-		client = redis.NewClient(redisOptions())
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		rawClient = redis.NewClient(redisOptions())
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		client, closeSubject = newUniversalSubject(rawClient)
 		values := []int{0, 0, 0, 0, 0, 0, 0, 1, 1, 1}
 		for i, v := range values {
 			cmd := client.SetBit(ctx, key, int64(i), v)
@@ -67,7 +73,7 @@ var _ = Describe("BitCountByte", func() {
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	It("bit count byte", func() {

--- a/commands_test.go
+++ b/commands_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"os"
 	"reflect"
 	"strconv"
 	"time"
@@ -29,17 +30,51 @@ func (t *TimeValue) ScanRedis(s string) (err error) {
 	return
 }
 
+// newCommandSubject returns the Cmdable that the command specs run against,
+// selected by the GOREDIS_TEST_SUBJECT env var so the whole suite can be
+// replayed through the autopipeliner without touching each spec:
+//
+//	(unset)|client -> the *redis.Client itself (default; unchanged behavior)
+//	ap-blocking     -> client.AutoPipeline()      (synchronous drop-in face)
+//	ap-async        -> client.AsyncAutoPipeline()  (deferred face; result reads block)
+//
+// It returns the subject plus an optional closer for the autopipeliner.
+func newCommandSubject(c *redis.Client) (redis.Cmdable, func() error) {
+	switch os.Getenv("GOREDIS_TEST_SUBJECT") {
+	case "ap-blocking":
+		ap, err := c.AutoPipeline(&redis.AutoPipelineConfig{MaxBatchSize: 300})
+		Expect(err).NotTo(HaveOccurred())
+		return ap, ap.Close
+	case "ap-async":
+		ap, err := c.AsyncAutoPipeline(&redis.AutoPipelineConfig{MaxBatchSize: 300})
+		Expect(err).NotTo(HaveOccurred())
+		return ap, ap.Close
+	default:
+		return c, nil
+	}
+}
+
 var _ = Describe("Commands", func() {
 	ctx := context.TODO()
-	var client *redis.Client
+	// client is the Cmdable under test (may be the raw client or an
+	// autopipeliner, per GOREDIS_TEST_SUBJECT). rawClient is always the
+	// underlying *redis.Client, used for setup/teardown and the few
+	// client-only calls (PoolStats, Conn) that are not part of Cmdable.
+	var client redis.Cmdable
+	var rawClient *redis.Client
+	var apCloser func() error
 
 	BeforeEach(func() {
-		client = redis.NewClient(redisOptions())
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		rawClient = redis.NewClient(redisOptions())
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		client, apCloser = newCommandSubject(rawClient)
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		if apCloser != nil {
+			Expect(apCloser()).NotTo(HaveOccurred())
+		}
+		Expect(rawClient.Close()).NotTo(HaveOccurred())
 	})
 
 	Describe("server", func() {
@@ -54,7 +89,7 @@ var _ = Describe("Commands", func() {
 			Expect(cmds[0].Err().Error()).To(ContainSubstring("ERR AUTH"))
 			Expect(cmds[1].Err().Error()).To(ContainSubstring("ERR AUTH"))
 
-			stats := client.PoolStats()
+			stats := rawClient.PoolStats()
 			Expect(stats.Hits).To(Equal(uint32(1)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
@@ -84,13 +119,13 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should Ping", func() {
-			ping := client.Ping(ctx)
+			ping := rawClient.Ping(ctx)
 			Expect(ping.Err()).NotTo(HaveOccurred())
 			Expect(ping.Val()).To(Equal("PONG"))
 		})
 
 		It("should Ping with Do method", func() {
-			result := client.Conn().Do(ctx, "PING")
+			result := rawClient.Conn().Do(ctx, "PING")
 			Expect(result.Err()).NotTo(HaveOccurred())
 			Expect(result.Val()).To(Equal("PONG"))
 		})
@@ -100,7 +135,7 @@ var _ = Describe("Commands", func() {
 
 			// assume testing on single redis instance
 			start := time.Now()
-			val, err := client.Wait(ctx, 1, wait).Result()
+			val, err := rawClient.Wait(ctx, 1, wait).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(Equal(int64(0)))
 			Expect(time.Now()).To(BeTemporally("~", start.Add(wait), 3*time.Second))
@@ -112,7 +147,7 @@ var _ = Describe("Commands", func() {
 
 			// assuming that the redis instance doesn't have AOF enabled
 			start := time.Now()
-			val, err := client.WaitAOF(ctx, 1, 1, waitAOF).Result()
+			val, err := rawClient.WaitAOF(ctx, 1, 1, waitAOF).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).NotTo(ContainSubstring("ERR WAITAOF cannot be used when numlocal is set but appendonly is disabled"))
 			Expect(time.Now()).To(BeTemporally("~", start.Add(waitAOF), 3*time.Second))
@@ -141,7 +176,7 @@ var _ = Describe("Commands", func() {
 		It("should BgRewriteAOF", func() {
 			Skip("flaky test")
 
-			val, err := client.BgRewriteAOF(ctx).Result()
+			val, err := rawClient.BgRewriteAOF(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(ContainSubstring("Background append only file rewriting"))
 		})
@@ -151,30 +186,30 @@ var _ = Describe("Commands", func() {
 
 			// workaround for "ERR Can't BGSAVE while AOF log rewriting is in progress"
 			Eventually(func() string {
-				return client.BgSave(ctx).Val()
+				return rawClient.BgSave(ctx).Val()
 			}, "30s").Should(Equal("Background saving started"))
 		})
 
 		It("Should CommandGetKeys", func() {
-			keys, err := client.CommandGetKeys(ctx, "MSET", "a", "b", "c", "d", "e", "f").Result()
+			keys, err := rawClient.CommandGetKeys(ctx, "MSET", "a", "b", "c", "d", "e", "f").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(keys).To(Equal([]string{"a", "c", "e"}))
 
-			keys, err = client.CommandGetKeys(ctx, "EVAL", "not consulted", "3", "key1", "key2", "key3", "arg1", "arg2", "arg3", "argN").Result()
+			keys, err = rawClient.CommandGetKeys(ctx, "EVAL", "not consulted", "3", "key1", "key2", "key3", "arg1", "arg2", "arg3", "argN").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(keys).To(Equal([]string{"key1", "key2", "key3"}))
 
-			keys, err = client.CommandGetKeys(ctx, "SORT", "mylist", "ALPHA", "STORE", "outlist").Result()
+			keys, err = rawClient.CommandGetKeys(ctx, "SORT", "mylist", "ALPHA", "STORE", "outlist").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(keys).To(Equal([]string{"mylist", "outlist"}))
 
-			_, err = client.CommandGetKeys(ctx, "FAKECOMMAND", "arg1", "arg2").Result()
+			_, err = rawClient.CommandGetKeys(ctx, "FAKECOMMAND", "arg1", "arg2").Result()
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("ERR Invalid command specified"))
 		})
 
 		It("should CommandGetKeysAndFlags", func() {
-			keysAndFlags, err := client.CommandGetKeysAndFlags(ctx, "LMOVE", "mylist1", "mylist2", "left", "left").Result()
+			keysAndFlags, err := rawClient.CommandGetKeysAndFlags(ctx, "LMOVE", "mylist1", "mylist2", "left", "left").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(keysAndFlags).To(Equal([]redis.KeyFlags{
 				{
@@ -187,19 +222,19 @@ var _ = Describe("Commands", func() {
 				},
 			}))
 
-			_, err = client.CommandGetKeysAndFlags(ctx, "FAKECOMMAND", "arg1", "arg2").Result()
+			_, err = rawClient.CommandGetKeysAndFlags(ctx, "FAKECOMMAND", "arg1", "arg2").Result()
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("ERR Invalid command specified"))
 		})
 
 		It("should ClientKill", func() {
-			r := client.ClientKill(ctx, "1.1.1.1:1111")
+			r := rawClient.ClientKill(ctx, "1.1.1.1:1111")
 			Expect(r.Err()).To(MatchError("ERR No such client"))
 			Expect(r.Val()).To(Equal(""))
 		})
 
 		It("should ClientKillByFilter", func() {
-			r := client.ClientKillByFilter(ctx, "TYPE", "test")
+			r := rawClient.ClientKillByFilter(ctx, "TYPE", "test")
 			Expect(r.Err()).To(MatchError("ERR Unknown client type 'test'"))
 			Expect(r.Val()).To(Equal(int64(0)))
 		})
@@ -213,16 +248,16 @@ var _ = Describe("Commands", func() {
 			defer func() {
 				Expect(db.Close()).NotTo(HaveOccurred())
 			}()
-			val, err := client.ClientList(ctx).Result()
+			val, err := rawClient.ClientList(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).Should(ContainSubstring("name=killmyid"))
 
 			myid := db.ClientID(ctx).Val()
-			killed := client.ClientKillByFilter(ctx, "ID", strconv.FormatInt(myid, 10))
+			killed := rawClient.ClientKillByFilter(ctx, "ID", strconv.FormatInt(myid, 10))
 			Expect(killed.Err()).NotTo(HaveOccurred())
 			Expect(killed.Val()).To(BeNumerically("==", 1))
 
-			val, err = client.ClientList(ctx).Result()
+			val, err = rawClient.ClientList(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).ShouldNot(ContainSubstring("name=killmyid"))
 		})
@@ -250,7 +285,7 @@ var _ = Describe("Commands", func() {
 				// ok
 			}
 
-			killed := client.ClientKillByFilter(ctx, "MAXAGE", "1")
+			killed := rawClient.ClientKillByFilter(ctx, "MAXAGE", "1")
 			Expect(killed.Err()).NotTo(HaveOccurred())
 			Expect(killed.Val()).To(BeNumerically(">=", 1))
 
@@ -263,37 +298,37 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ClientID", func() {
-			err := client.ClientID(ctx).Err()
+			err := rawClient.ClientID(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(client.ClientID(ctx).Val()).To(BeNumerically(">=", 0))
+			Expect(rawClient.ClientID(ctx).Val()).To(BeNumerically(">=", 0))
 		})
 
 		It("should ClientUnblock", func() {
-			id := client.ClientID(ctx).Val()
-			r, err := client.ClientUnblock(ctx, id).Result()
+			id := rawClient.ClientID(ctx).Val()
+			r, err := rawClient.ClientUnblock(ctx, id).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(r).To(Equal(int64(0)))
 		})
 
 		It("should ClientUnblockWithError", func() {
-			id := client.ClientID(ctx).Val()
-			r, err := client.ClientUnblockWithError(ctx, id).Result()
+			id := rawClient.ClientID(ctx).Val()
+			r, err := rawClient.ClientUnblockWithError(ctx, id).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(r).To(Equal(int64(0)))
 		})
 
 		It("should ClientInfo", func() {
-			info, err := client.ClientInfo(ctx).Result()
+			info, err := rawClient.ClientInfo(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(info).NotTo(BeNil())
 		})
 
 		It("should ClientPause", Label("NonRedisEnterprise"), func() {
-			err := client.ClientPause(ctx, time.Second).Err()
+			err := rawClient.ClientPause(ctx, time.Second).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			start := time.Now()
-			err = client.Ping(ctx).Err()
+			err = rawClient.Ping(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(time.Now()).To(BeTemporally("~", start.Add(time.Second), 800*time.Millisecond))
 		})
@@ -361,7 +396,7 @@ var _ = Describe("Commands", func() {
 				pipe.ClientSetInfo(ctx, libInfo)
 			}).To(Panic())
 			// Test setting the default options for libName, libName suffix and libVer
-			clientInfo := client.ClientInfo(ctx).Val()
+			clientInfo := rawClient.ClientInfo(ctx).Val()
 			Expect(clientInfo.LibName).To(ContainSubstring("go-redis(go-redis,"))
 			// Test setting the libName suffix in options
 			opt := redisOptions()
@@ -373,7 +408,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ConfigGet", func() {
-			val, err := client.ConfigGet(ctx, "*").Result()
+			val, err := rawClient.ConfigGet(ctx, "*").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).NotTo(BeEmpty())
 		})
@@ -388,7 +423,7 @@ var _ = Describe("Commands", func() {
 			}
 
 			for prefix, lookup := range expected {
-				val, err := client.ConfigGet(ctx, prefix).Result()
+				val, err := rawClient.ConfigGet(ctx, prefix).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(val).NotTo(BeEmpty())
 				Expect(val[lookup]).NotTo(BeEmpty())
@@ -396,26 +431,26 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ConfigResetStat", Label("NonRedisEnterprise"), func() {
-			r := client.ConfigResetStat(ctx)
+			r := rawClient.ConfigResetStat(ctx)
 			Expect(r.Err()).NotTo(HaveOccurred())
 			Expect(r.Val()).To(Equal("OK"))
 		})
 
 		It("should ConfigSet", Label("NonRedisEnterprise"), func() {
-			configGet := client.ConfigGet(ctx, "maxmemory")
+			configGet := rawClient.ConfigGet(ctx, "maxmemory")
 			Expect(configGet.Err()).NotTo(HaveOccurred())
 			Expect(configGet.Val()).To(HaveLen(1))
 			_, ok := configGet.Val()["maxmemory"]
 			Expect(ok).To(BeTrue())
 
-			configSet := client.ConfigSet(ctx, "maxmemory", configGet.Val()["maxmemory"])
+			configSet := rawClient.ConfigSet(ctx, "maxmemory", configGet.Val()["maxmemory"])
 			Expect(configSet.Err()).NotTo(HaveOccurred())
 			Expect(configSet.Val()).To(Equal("OK"))
 		})
 
 		It("should ConfigGet with Modules", Label("NonRedisEnterprise"), func() {
 			SkipBeforeRedisVersion(8, "config get won't return modules configs before redis 8")
-			configGet := client.ConfigGet(ctx, "*")
+			configGet := rawClient.ConfigGet(ctx, "*")
 			Expect(configGet.Err()).NotTo(HaveOccurred())
 			Expect(configGet.Val()).To(HaveKey("maxmemory"))
 			Expect(configGet.Val()).To(HaveKey("search-timeout"))
@@ -426,11 +461,11 @@ var _ = Describe("Commands", func() {
 
 		It("should ConfigSet FT DIALECT", func() {
 			SkipBeforeRedisVersion(8, "config doesn't include modules before Redis 8")
-			defaultState, err := client.ConfigGet(ctx, "search-default-dialect").Result()
+			defaultState, err := rawClient.ConfigGet(ctx, "search-default-dialect").Result()
 			Expect(err).NotTo(HaveOccurred())
 
 			// set to 3
-			res, err := client.ConfigSet(ctx, "search-default-dialect", "3").Result()
+			res, err := rawClient.ConfigSet(ctx, "search-default-dialect", "3").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(BeEquivalentTo("OK"))
 
@@ -438,12 +473,12 @@ var _ = Describe("Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "3"}))
 
-			resGet, err := client.ConfigGet(ctx, "search-default-dialect").Result()
+			resGet, err := rawClient.ConfigGet(ctx, "search-default-dialect").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resGet).To(BeEquivalentTo(map[string]string{"search-default-dialect": "3"}))
 
 			// set to 2
-			res, err = client.ConfigSet(ctx, "search-default-dialect", "2").Result()
+			res, err = rawClient.ConfigSet(ctx, "search-default-dialect", "2").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(BeEquivalentTo("OK"))
 
@@ -452,7 +487,7 @@ var _ = Describe("Commands", func() {
 			Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "2"}))
 
 			// set to 1
-			res, err = client.ConfigSet(ctx, "search-default-dialect", "1").Result()
+			res, err = rawClient.ConfigSet(ctx, "search-default-dialect", "1").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(BeEquivalentTo("OK"))
 
@@ -460,19 +495,19 @@ var _ = Describe("Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "1"}))
 
-			resGet, err = client.ConfigGet(ctx, "search-default-dialect").Result()
+			resGet, err = rawClient.ConfigGet(ctx, "search-default-dialect").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resGet).To(BeEquivalentTo(map[string]string{"search-default-dialect": "1"}))
 
 			// set to default
-			res, err = client.ConfigSet(ctx, "search-default-dialect", defaultState["search-default-dialect"]).Result()
+			res, err = rawClient.ConfigSet(ctx, "search-default-dialect", defaultState["search-default-dialect"]).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(BeEquivalentTo("OK"))
 		})
 
 		It("should ConfigSet fail for ReadOnly", func() {
 			SkipBeforeRedisVersion(8, "Config doesn't include modules before Redis 8")
-			_, err := client.ConfigSet(ctx, "search-max-doctablesize", "100000").Result()
+			_, err := rawClient.ConfigSet(ctx, "search-max-doctablesize", "100000").Result()
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -488,21 +523,21 @@ var _ = Describe("Commands", func() {
 
 			// read the defaults to set them back later
 			for setting := range expected {
-				val, err := client.ConfigGet(ctx, setting).Result()
+				val, err := rawClient.ConfigGet(ctx, setting).Result()
 				Expect(err).NotTo(HaveOccurred())
 				defaults[setting] = val[setting]
 			}
 
 			// check if new values can be set
 			for setting, value := range expected {
-				val, err := client.ConfigSet(ctx, setting, value).Result()
+				val, err := rawClient.ConfigSet(ctx, setting, value).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(val).NotTo(BeEmpty())
 				Expect(val).To(Equal("OK"))
 			}
 
 			for setting, value := range expected {
-				val, err := client.ConfigGet(ctx, setting).Result()
+				val, err := rawClient.ConfigGet(ctx, setting).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(val).NotTo(BeEmpty())
 				Expect(val[setting]).To(Equal(value))
@@ -510,7 +545,7 @@ var _ = Describe("Commands", func() {
 
 			// set back to the defaults
 			for setting, value := range defaults {
-				val, err := client.ConfigSet(ctx, setting, value).Result()
+				val, err := rawClient.ConfigSet(ctx, setting, value).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(val).NotTo(BeEmpty())
 				Expect(val).To(Equal("OK"))
@@ -527,7 +562,7 @@ var _ = Describe("Commands", func() {
 			}
 
 			for setting, value := range expected {
-				val, err := client.ConfigSet(ctx, setting, value).Result()
+				val, err := rawClient.ConfigSet(ctx, setting, value).Result()
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(ContainSubstring(setting)))
 				Expect(val).To(BeEmpty())
@@ -535,55 +570,55 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ConfigRewrite", Label("NonRedisEnterprise"), func() {
-			configRewrite := client.ConfigRewrite(ctx)
+			configRewrite := rawClient.ConfigRewrite(ctx)
 			Expect(configRewrite.Err()).NotTo(HaveOccurred())
 			Expect(configRewrite.Val()).To(Equal("OK"))
 		})
 
 		It("should DBSize", func() {
-			size, err := client.DBSize(ctx).Result()
+			size, err := rawClient.DBSize(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(size).To(Equal(int64(0)))
 		})
 
 		It("should Info", func() {
-			info := client.Info(ctx)
+			info := rawClient.Info(ctx)
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(Equal(""))
 		})
 
 		It("should InfoMap", Label("redis.info"), func() {
-			info := client.InfoMap(ctx)
+			info := rawClient.InfoMap(ctx)
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(BeNil())
 
-			info = client.InfoMap(ctx, "dummy")
+			info = rawClient.InfoMap(ctx, "dummy")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).To(BeNil())
 
-			info = client.InfoMap(ctx, "server")
+			info = rawClient.InfoMap(ctx, "server")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).To(HaveLen(1))
 		})
 
 		It("should Info Modules", Label("redis.info"), func() {
 			SkipBeforeRedisVersion(8, "modules are included in info for Redis Version >= 8")
-			info := client.Info(ctx)
+			info := rawClient.Info(ctx)
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(BeNil())
 
-			info = client.Info(ctx, "search")
+			info = rawClient.Info(ctx, "search")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).To(ContainSubstring("search"))
 
-			info = client.Info(ctx, "modules")
+			info = rawClient.Info(ctx, "modules")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).To(ContainSubstring("search"))
 			Expect(info.Val()).To(ContainSubstring("ReJSON"))
 			Expect(info.Val()).To(ContainSubstring("timeseries"))
 			Expect(info.Val()).To(ContainSubstring("bf"))
 
-			info = client.Info(ctx, "everything")
+			info = rawClient.Info(ctx, "everything")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).To(ContainSubstring("search"))
 			Expect(info.Val()).To(ContainSubstring("ReJSON"))
@@ -593,16 +628,16 @@ var _ = Describe("Commands", func() {
 
 		It("should InfoMap Modules", Label("redis.info"), func() {
 			SkipBeforeRedisVersion(8, "modules are included in info for Redis Version >= 8")
-			info := client.InfoMap(ctx)
+			info := rawClient.InfoMap(ctx)
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(BeNil())
 
-			info = client.InfoMap(ctx, "search")
+			info = rawClient.InfoMap(ctx, "search")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(len(info.Val())).To(BeNumerically(">=", 2))
 			Expect(info.Val()["search_version"]).ToNot(BeNil())
 
-			info = client.InfoMap(ctx, "modules")
+			info = rawClient.InfoMap(ctx, "modules")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			val := info.Val()
 			modules, ok := val["Modules"]
@@ -614,20 +649,20 @@ var _ = Describe("Commands", func() {
 			Expect(modules["timeseries"]).ToNot(BeNil())
 			Expect(modules["bf"]).ToNot(BeNil())
 
-			info = client.InfoMap(ctx, "everything")
+			info = rawClient.InfoMap(ctx, "everything")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(len(info.Val())).To(BeNumerically(">=", 10))
 		})
 
 		It("should Info cpu", func() {
-			info := client.Info(ctx, "cpu")
+			info := rawClient.Info(ctx, "cpu")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(Equal(""))
 			Expect(info.Val()).To(ContainSubstring(`used_cpu_sys`))
 		})
 
 		It("should Info cpu and memory", func() {
-			info := client.Info(ctx, "cpu", "memory")
+			info := rawClient.Info(ctx, "cpu", "memory")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(Equal(""))
 			Expect(info.Val()).To(ContainSubstring(`used_cpu_sys`))
@@ -635,7 +670,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should LastSave", Label("NonRedisEnterprise"), func() {
-			lastSave := client.LastSave(ctx)
+			lastSave := rawClient.LastSave(ctx)
 			Expect(lastSave.Err()).NotTo(HaveOccurred())
 			Expect(lastSave.Val()).NotTo(Equal(0))
 		})
@@ -643,38 +678,38 @@ var _ = Describe("Commands", func() {
 		It("should Save", Label("NonRedisEnterprise"), func() {
 			// workaround for "ERR Background save already in progress"
 			Eventually(func() string {
-				return client.Save(ctx).Val()
+				return rawClient.Save(ctx).Val()
 			}, "10s").Should(Equal("OK"))
 		})
 
 		It("should SlaveOf", Label("NonRedisEnterprise"), func() {
-			slaveOf := client.SlaveOf(ctx, "localhost", "8888")
+			slaveOf := rawClient.SlaveOf(ctx, "localhost", "8888")
 			Expect(slaveOf.Err()).NotTo(HaveOccurred())
 			Expect(slaveOf.Val()).To(Equal("OK"))
 
-			slaveOf = client.SlaveOf(ctx, "NO", "ONE")
+			slaveOf = rawClient.SlaveOf(ctx, "NO", "ONE")
 			Expect(slaveOf.Err()).NotTo(HaveOccurred())
 			Expect(slaveOf.Val()).To(Equal("OK"))
 		})
 
 		It("should ReplicaOf", Label("NonRedisEnterprise"), func() {
-			replicaOf := client.ReplicaOf(ctx, "localhost", "8888")
+			replicaOf := rawClient.ReplicaOf(ctx, "localhost", "8888")
 			Expect(replicaOf.Err()).NotTo(HaveOccurred())
 			Expect(replicaOf.Val()).To(Equal("OK"))
 
-			replicaOf = client.ReplicaOf(ctx, "NO", "ONE")
+			replicaOf = rawClient.ReplicaOf(ctx, "NO", "ONE")
 			Expect(replicaOf.Err()).NotTo(HaveOccurred())
 			Expect(replicaOf.Val()).To(Equal("OK"))
 		})
 
 		It("should Time", func() {
-			tm, err := client.Time(ctx).Result()
+			tm, err := rawClient.Time(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(tm).To(BeTemporally("~", time.Now(), 3*time.Second))
 		})
 
 		It("should Command", Label("NonRedisEnterprise"), func() {
-			cmds, err := client.Command(ctx).Result()
+			cmds, err := rawClient.Command(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 
 			cmd := cmds["mget"]
@@ -696,7 +731,7 @@ var _ = Describe("Commands", func() {
 
 		It("should Command Tips", Label("NonRedisEnterprise"), func() {
 			SkipAfterRedisVersion(7.9, "Redis 8 changed the COMMAND reply format")
-			cmds, err := client.Command(ctx).Result()
+			cmds, err := rawClient.Command(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 
 			cmd := cmds["touch"]
@@ -711,7 +746,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should return all command names", func() {
-			cmdList := client.CommandList(ctx, nil)
+			cmdList := rawClient.CommandList(ctx, nil)
 			Expect(cmdList.Err()).NotTo(HaveOccurred())
 			cmdNames := cmdList.Val()
 
@@ -727,7 +762,7 @@ var _ = Describe("Commands", func() {
 			filter := &redis.FilterBy{
 				Module: "JSON",
 			}
-			cmdList := client.CommandList(ctx, filter)
+			cmdList := rawClient.CommandList(ctx, filter)
 			Expect(cmdList.Err()).NotTo(HaveOccurred())
 			Expect(cmdList.Val()).To(HaveLen(0))
 		})
@@ -737,7 +772,7 @@ var _ = Describe("Commands", func() {
 				ACLCat: "admin",
 			}
 
-			cmdList := client.CommandList(ctx, filter)
+			cmdList := rawClient.CommandList(ctx, filter)
 			Expect(cmdList.Err()).NotTo(HaveOccurred())
 			cmdNames := cmdList.Val()
 
@@ -749,7 +784,7 @@ var _ = Describe("Commands", func() {
 			filter := &redis.FilterBy{
 				Pattern: "*GET*",
 			}
-			cmdList := client.CommandList(ctx, filter)
+			cmdList := rawClient.CommandList(ctx, filter)
 			Expect(cmdList.Err()).NotTo(HaveOccurred())
 			cmdNames := cmdList.Val()
 
@@ -763,33 +798,33 @@ var _ = Describe("Commands", func() {
 
 	Describe("debugging", Label("NonRedisEnterprise"), func() {
 		It("should DebugObject", func() {
-			err := client.DebugObject(ctx, "foo").Err()
+			err := rawClient.DebugObject(ctx, "foo").Err()
 			Expect(err).To(MatchError("ERR no such key"))
 
 			err = client.Set(ctx, "foo", "bar", 0).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			s, err := client.DebugObject(ctx, "foo").Result()
+			s, err := rawClient.DebugObject(ctx, "foo").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s).To(ContainSubstring("serializedlength:4"))
 		})
 
 		It("should MemoryUsage", func() {
-			err := client.MemoryUsage(ctx, "foo").Err()
+			err := rawClient.MemoryUsage(ctx, "foo").Err()
 			Expect(err).To(Equal(redis.Nil))
 
 			err = client.Set(ctx, "foo", "bar", 0).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			n, err := client.MemoryUsage(ctx, "foo").Result()
+			n, err := rawClient.MemoryUsage(ctx, "foo").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(n).NotTo(BeZero())
 
-			n, err = client.MemoryUsage(ctx, "foo", 0).Result()
+			n, err = rawClient.MemoryUsage(ctx, "foo", 0).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(n).NotTo(BeZero())
 
-			_, err = client.MemoryUsage(ctx, "foo", 0, 1).Result()
+			_, err = rawClient.MemoryUsage(ctx, "foo", 0, 1).Result()
 			Expect(err).Should(MatchError("MemoryUsage expects single sample count"))
 		})
 	})
@@ -973,10 +1008,10 @@ var _ = Describe("Commands", func() {
 			Expect(refCount.Err()).NotTo(HaveOccurred())
 			Expect(refCount.Val()).To(Equal(int64(1)))
 
-			client.ConfigSet(ctx, "maxmemory-policy", "volatile-lfu")
+			rawClient.ConfigSet(ctx, "maxmemory-policy", "volatile-lfu")
 			freq := client.ObjectFreq(ctx, "key")
 			Expect(freq.Err()).NotTo(HaveOccurred())
-			client.ConfigSet(ctx, "maxmemory-policy", "noeviction") // default
+			rawClient.ConfigSet(ctx, "maxmemory-policy", "noeviction") // default
 
 			err := client.ObjectEncoding(ctx, "key").Err()
 			Expect(err).NotTo(HaveOccurred())
@@ -1884,7 +1919,7 @@ var _ = Describe("Commands", func() {
 			Expect(string(orig.Bytes())).To(Equal("value"))
 
 			clone := orig.Clone()
-			Expect(client.Process(ctx, clone)).To(MatchError(ContainSubstring("cannot be cloned")))
+			Expect(rawClient.Process(ctx, clone)).To(MatchError(ContainSubstring("cannot be cloned")))
 
 			// Follow-up call on the same client must work: the clone's
 			// readReply drained the network reply so the connection
@@ -3370,7 +3405,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should fail module loadex", Label("NonRedisEnterprise"), func() {
-			dryRun := client.ModuleLoadex(ctx, &redis.ModuleLoadexConfig{
+			dryRun := rawClient.ModuleLoadex(ctx, &redis.ModuleLoadexConfig{
 				Path: "/path/to/non-existent-library.so",
 				Conf: map[string]interface{}{
 					"param1": "value1",
@@ -4242,9 +4277,9 @@ var _ = Describe("Commands", func() {
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(BeNil())
 
-			Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+			Expect(rawClient.Ping(ctx).Err()).NotTo(HaveOccurred())
 
-			stats := client.PoolStats()
+			stats := rawClient.PoolStats()
 			Expect(stats.Hits).To(Equal(uint32(2)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
@@ -4524,9 +4559,9 @@ var _ = Describe("Commands", func() {
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(BeNil())
 
-			Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+			Expect(rawClient.Ping(ctx).Err()).NotTo(HaveOccurred())
 
-			stats := client.PoolStats()
+			stats := rawClient.PoolStats()
 			Expect(stats.Hits).To(Equal(uint32(2)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
@@ -5340,9 +5375,9 @@ var _ = Describe("Commands", func() {
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(BeNil())
 
-			Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+			Expect(rawClient.Ping(ctx).Err()).NotTo(HaveOccurred())
 
-			stats := client.PoolStats()
+			stats := rawClient.PoolStats()
 			Expect(stats.Hits).To(Equal(uint32(2)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
@@ -5422,9 +5457,9 @@ var _ = Describe("Commands", func() {
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(BeNil())
 
-			Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+			Expect(rawClient.Ping(ctx).Err()).NotTo(HaveOccurred())
 
-			stats := client.PoolStats()
+			stats := rawClient.PoolStats()
 			Expect(stats.Hits).To(Equal(uint32(2)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
@@ -6160,9 +6195,9 @@ var _ = Describe("Commands", func() {
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(BeNil())
 
-			Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+			Expect(rawClient.Ping(ctx).Err()).NotTo(HaveOccurred())
 
-			stats := client.PoolStats()
+			stats := rawClient.PoolStats()
 			Expect(stats.Hits).To(Equal(uint32(2)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
@@ -9735,44 +9770,46 @@ var _ = Describe("Commands", func() {
 		It("returns slow query result", func() {
 			const key = "slowlog-log-slower-than"
 
-			old := client.ConfigGet(ctx, key).Val()
-			client.ConfigSet(ctx, key, "0")
-			defer client.ConfigSet(ctx, key, old[key])
+			old := rawClient.ConfigGet(ctx, key).Val()
+			rawClient.ConfigSet(ctx, key, "0")
+			defer rawClient.ConfigSet(ctx, key, old[key])
 
-			err := client.Do(ctx, "slowlog", "reset").Err()
+			err := rawClient.Do(ctx, "slowlog", "reset").Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			client.Set(ctx, "test", "true", 0)
 
-			result, err := client.SlowLogGet(ctx, -1).Result()
+			result, err := rawClient.SlowLogGet(ctx, -1).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).NotTo(BeZero())
 		})
 
 		It("returns the number of slow queries", Label("NonRedisEnterprise"), func() {
 			// Reset slowlog
-			err := client.SlowLogReset(ctx).Err()
+			err := rawClient.SlowLogReset(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			const key = "slowlog-log-slower-than"
 
-			old := client.ConfigGet(ctx, key).Val()
+			old := rawClient.ConfigGet(ctx, key).Val()
 			// first slowlog entry is the config set command itself
-			client.ConfigSet(ctx, key, "0")
-			defer client.ConfigSet(ctx, key, old[key])
+			rawClient.ConfigSet(ctx, key, "0")
+			defer rawClient.ConfigSet(ctx, key, old[key])
 
-			// Set a key to trigger a slow query, and this is the second slowlog entry
-			client.Set(ctx, "test", "true", 0)
-			result, err := client.SlowLogLen(ctx).Result()
+			// Set a key to trigger a slow query, and this is the second slowlog entry.
+			// Read the result so the command has actually executed before we count
+			// (required on the deferred autopipeline face, harmless otherwise).
+			Expect(client.Set(ctx, "test", "true", 0).Err()).NotTo(HaveOccurred())
+			result, err := rawClient.SlowLogLen(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).Should(Equal(int64(2)))
 
 			// Reset slowlog
-			err = client.SlowLogReset(ctx).Err()
+			err = rawClient.SlowLogReset(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			// Check if slowlog is empty, this is the first slowlog entry after reset
-			result, err = client.SlowLogLen(ctx).Result()
+			result, err = rawClient.SlowLogLen(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).Should(Equal(int64(1)))
 		})
@@ -9783,17 +9820,17 @@ var _ = Describe("Commands", func() {
 			const key = "latency-monitor-threshold"
 
 			// reset all latencies first to ensure clean state
-			err := client.LatencyReset(ctx).Err()
+			err := rawClient.LatencyReset(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			old := client.ConfigGet(ctx, key).Val()
-			client.ConfigSet(ctx, key, "1")
-			defer client.ConfigSet(ctx, key, old[key])
+			old := rawClient.ConfigGet(ctx, key).Val()
+			rawClient.ConfigSet(ctx, key, "1")
+			defer rawClient.ConfigSet(ctx, key, old[key])
 
-			err = client.Do(ctx, "DEBUG", "SLEEP", 0.01).Err()
+			err = rawClient.Do(ctx, "DEBUG", "SLEEP", 0.01).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			result, err := client.Latency(ctx).Result()
+			result, err := rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).NotTo(BeZero())
 		})
@@ -9802,39 +9839,39 @@ var _ = Describe("Commands", func() {
 			const key = "latency-monitor-threshold"
 
 			// reset all latencies
-			err := client.LatencyReset(ctx).Err()
+			err := rawClient.LatencyReset(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			old := client.ConfigGet(ctx, key).Val()
+			old := rawClient.ConfigGet(ctx, key).Val()
 			// Use a higher threshold (100ms) to avoid capturing normal operations
 			// that could cause flakiness due to timing variations on busy CI runners.
-			client.ConfigSet(ctx, key, "100")
-			defer client.ConfigSet(ctx, key, old[key])
+			rawClient.ConfigSet(ctx, key, "100")
+			defer rawClient.ConfigSet(ctx, key, old[key])
 
 			// get latency after reset
-			result, err := client.Latency(ctx).Result()
+			result, err := rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).Should(Equal(0))
 
 			// create a new latency event by sleeping past the threshold
-			err = client.Do(ctx, "DEBUG", "SLEEP", 0.15).Err()
+			err = rawClient.Do(ctx, "DEBUG", "SLEEP", 0.15).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			// get latency after create a new latency
-			result, err = client.Latency(ctx).Result()
+			result, err = rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).Should(BeNumerically(">=", 1))
 			triggered := result[0].Name
 
 			// reset all latencies again
-			err = client.LatencyReset(ctx).Err()
+			err = rawClient.LatencyReset(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			// get latency after reset again. Don't assert total length is 0:
 			// other operations on the connection may briefly land in the
 			// latency log on a slow CI runner. Instead verify the specific
 			// event we triggered is gone.
-			result, err = client.Latency(ctx).Result()
+			result, err = rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			for _, event := range result {
 				if event.Name == triggered {
@@ -9847,35 +9884,35 @@ var _ = Describe("Commands", func() {
 			const key = "latency-monitor-threshold"
 
 			// reset all latencies first to ensure clean state
-			err := client.LatencyReset(ctx).Err()
+			err := rawClient.LatencyReset(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			old := client.ConfigGet(ctx, key).Val()
+			old := rawClient.ConfigGet(ctx, key).Val()
 			// Use a higher threshold (100ms) to avoid capturing normal operations
 			// that could cause flakiness due to timing variations
-			client.ConfigSet(ctx, key, "100")
-			defer client.ConfigSet(ctx, key, old[key])
+			rawClient.ConfigSet(ctx, key, "100")
+			defer rawClient.ConfigSet(ctx, key, old[key])
 
-			result, err := client.Latency(ctx).Result()
+			result, err := rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).Should(Equal(0))
 
 			// Use a longer sleep (150ms) to ensure it exceeds the 100ms threshold
-			err = client.Do(ctx, "DEBUG", "SLEEP", 0.15).Err()
+			err = rawClient.Do(ctx, "DEBUG", "SLEEP", 0.15).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			result, err = client.Latency(ctx).Result()
+			result, err = rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).Should(BeNumerically(">=", 1))
 
 			// reset latency by event name
 			eventName := result[0].Name
-			err = client.LatencyReset(ctx, eventName).Err()
+			err = rawClient.LatencyReset(ctx, eventName).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify the specific event was reset (not that all events are gone)
 			// This avoids flakiness from other operations triggering latency events
-			result, err = client.Latency(ctx).Result()
+			result, err = rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			for _, event := range result {
 				if event.Name == eventName {

--- a/commands_test.go
+++ b/commands_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"os"
 	"reflect"
 	"strconv"
 	"time"
@@ -30,51 +29,25 @@ func (t *TimeValue) ScanRedis(s string) (err error) {
 	return
 }
 
-// newCommandSubject returns the Cmdable that the command specs run against,
-// selected by the GOREDIS_TEST_SUBJECT env var so the whole suite can be
-// replayed through the autopipeliner without touching each spec:
-//
-//	(unset)|client -> the *redis.Client itself (default; unchanged behavior)
-//	ap-blocking     -> client.AutoPipeline()      (synchronous drop-in face)
-//	ap-async        -> client.AsyncAutoPipeline()  (deferred face; result reads block)
-//
-// It returns the subject plus an optional closer for the autopipeliner.
-func newCommandSubject(c *redis.Client) (redis.Cmdable, func() error) {
-	switch os.Getenv("GOREDIS_TEST_SUBJECT") {
-	case "ap-blocking":
-		ap, err := c.AutoPipeline(&redis.AutoPipelineConfig{MaxBatchSize: 300})
-		Expect(err).NotTo(HaveOccurred())
-		return ap, ap.Close
-	case "ap-async":
-		ap, err := c.AsyncAutoPipeline(&redis.AutoPipelineConfig{MaxBatchSize: 300})
-		Expect(err).NotTo(HaveOccurred())
-		return ap, ap.Close
-	default:
-		return c, nil
-	}
-}
-
 var _ = Describe("Commands", func() {
 	ctx := context.TODO()
-	// client is the Cmdable under test (may be the raw client or an
-	// autopipeliner, per GOREDIS_TEST_SUBJECT). rawClient is always the
-	// underlying *redis.Client, used for setup/teardown and the few
-	// client-only calls (PoolStats, Conn) that are not part of Cmdable.
-	var client redis.Cmdable
+	// client is the UniversalClient under test (the raw client or an
+	// autopipeliner, per GOREDIS_TEST_SUBJECT — see newUniversalSubject).
+	// rawClient is always the underlying *redis.Client, used for setup/teardown
+	// and the admin/connection-only calls (FlushDB, Config*, Ping, PoolStats,
+	// Conn, ...) that are not part of the UniversalClient interface.
+	var client redis.UniversalClient
 	var rawClient *redis.Client
-	var apCloser func() error
+	var closeSubject func() error
 
 	BeforeEach(func() {
 		rawClient = redis.NewClient(redisOptions())
 		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
-		client, apCloser = newCommandSubject(rawClient)
+		client, closeSubject = newUniversalSubject(rawClient)
 	})
 
 	AfterEach(func() {
-		if apCloser != nil {
-			Expect(apCloser()).NotTo(HaveOccurred())
-		}
-		Expect(rawClient.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	Describe("server", func() {

--- a/commands_test.go
+++ b/commands_test.go
@@ -9750,7 +9750,7 @@ var _ = Describe("Commands", func() {
 			err := rawClient.Do(ctx, "slowlog", "reset").Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			client.Set(ctx, "test", "true", 0)
+			Expect(client.Set(ctx, "test", "true", 0).Err()).NotTo(HaveOccurred())
 
 			result, err := rawClient.SlowLogGet(ctx, -1).Result()
 			Expect(err).NotTo(HaveOccurred())

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 var _ = Describe("ScanIterator", func() {
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 
 	seed := func(n int) error {
 		pipe := client.Pipeline()
@@ -44,12 +46,13 @@ var _ = Describe("ScanIterator", func() {
 	}
 
 	BeforeEach(func() {
-		client = redis.NewClient(redisOptions())
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		rawClient = redis.NewClient(redisOptions())
+		client, closeSubject = newUniversalSubject(rawClient)
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	It("should scan across empty DBs", func() {

--- a/json_test.go
+++ b/json_test.go
@@ -18,7 +18,9 @@ type JSONGetTestStruct struct {
 
 var _ = Describe("JSON Commands", Label("json"), func() {
 	ctx := context.TODO()
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 
 	setupRedisClient := func(protocolVersion int) *redis.Client {
 		return redis.NewClient(&redis.Options{
@@ -31,16 +33,17 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 
 	AfterEach(func() {
 		if client != nil {
-			client.FlushDB(ctx)
-			client.Close()
+			rawClient.FlushDB(ctx)
+			closeSubject()
 		}
 	})
 
 	protocols := []int{2, 3}
 	for _, protocol := range protocols {
 		BeforeEach(func() {
-			client = setupRedisClient(protocol)
-			Expect(client.FlushAll(ctx).Err()).NotTo(HaveOccurred())
+			rawClient = setupRedisClient(protocol)
+			client, closeSubject = newUniversalSubject(rawClient)
+			Expect(rawClient.FlushAll(ctx).Err()).NotTo(HaveOccurred())
 		})
 
 		Describe("arrays", Label("arrays"), func() {
@@ -783,7 +786,9 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 })
 
 var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 	var ctx = context.Background()
 
 	setupRedisClient := func(protocolVersion int) *redis.Client {
@@ -797,8 +802,8 @@ var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
 
 	AfterEach(func() {
 		if client != nil {
-			client.FlushDB(ctx)
-			client.Close()
+			rawClient.FlushDB(ctx)
+			closeSubject()
 		}
 	})
 
@@ -808,7 +813,8 @@ var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
 		for _, protocol := range protocols {
 			When("using protocol version", func() {
 				BeforeEach(func() {
-					client = setupRedisClient(protocol)
+					rawClient = setupRedisClient(protocol)
+					client, closeSubject = newUniversalSubject(rawClient)
 				})
 
 				It("should perform complex JSON and RediSearch operations", func() {

--- a/main_test.go
+++ b/main_test.go
@@ -490,3 +490,51 @@ func initializeTLSCluster(ctx context.Context) error {
 func cleanupTLSCluster() {
 	// TLS cluster is auto-managed by the container, no cleanup needed
 }
+
+// newUniversalSubject returns the redis.UniversalClient that a parametrized
+// command suite runs against, selected by the GOREDIS_TEST_SUBJECT env var so a
+// whole suite can be replayed through the autopipeliner without touching each
+// spec:
+//
+//	(unset)|client -> the *redis.Client itself (default; unchanged behavior)
+//	ap-blocking     -> client.AutoPipeline()      (synchronous drop-in face)
+//	ap-async        -> client.AsyncAutoPipeline()  (deferred face; result reads block)
+//
+// It returns the subject plus a single closer that closes the autopipeliner (if
+// any) and then the underlying *redis.Client — so callers just defer/AfterEach
+// one call. Admin/connection-only calls not on UniversalClient (FlushDB,
+// Config*, Ping, Info, Conn, ...) should use the underlying client directly.
+func newUniversalSubject(c *redis.Client) (redis.UniversalClient, func() error) {
+	// closeWith closes the optional autopipeliner then the underlying client,
+	// returning the first error.
+	closeWith := func(ap *redis.AutoPipeliner) func() error {
+		return func() error {
+			var firstErr error
+			if ap != nil {
+				if err := ap.Close(); err != nil {
+					firstErr = err
+				}
+			}
+			if err := c.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+			return firstErr
+		}
+	}
+	switch os.Getenv("GOREDIS_TEST_SUBJECT") {
+	case "ap-blocking":
+		ap, err := c.AutoPipeline(&redis.AutoPipelineConfig{MaxBatchSize: 300})
+		if err != nil {
+			panic(err)
+		}
+		return ap, closeWith(ap)
+	case "ap-async":
+		ap, err := c.AsyncAutoPipeline(&redis.AutoPipelineConfig{MaxBatchSize: 300})
+		if err != nil {
+			panic(err)
+		}
+		return ap, closeWith(ap)
+	default:
+		return c, closeWith(nil)
+	}
+}

--- a/probabilistic_test.go
+++ b/probabilistic_test.go
@@ -27,17 +27,20 @@ var _ = Describe("Probabilistic commands", Label("probabilistic"), func() {
 		protocol := protocol // capture loop variable for each context
 
 		Context(fmt.Sprintf("with protocol version %d", protocol), func() {
-			var client *redis.Client
+			var client redis.UniversalClient
+			var rawClient *redis.Client
+			var closeSubject func() error
 
 			BeforeEach(func() {
-				client = setupRedisClient(protocol)
-				Expect(client.FlushAll(ctx).Err()).NotTo(HaveOccurred())
+				rawClient = setupRedisClient(protocol)
+				client, closeSubject = newUniversalSubject(rawClient)
+				Expect(rawClient.FlushAll(ctx).Err()).NotTo(HaveOccurred())
 			})
 
 			AfterEach(func() {
 				if client != nil {
-					client.FlushDB(ctx)
-					client.Close()
+					rawClient.FlushDB(ctx)
+					closeSubject()
 				}
 			})
 

--- a/search_test.go
+++ b/search_test.go
@@ -56,22 +56,25 @@ func encodeFloat16Vector(vec []float32) []byte {
 
 var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	ctx := context.TODO()
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 
 	BeforeEach(func() {
-		client = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 2})
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		rawClient = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 2})
+		client, closeSubject = newUniversalSubject(rawClient)
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	It("should FTCreate and FTSearch WithScores", Label("search", "ftcreate", "ftsearch"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		client.HSet(ctx, "doc1", "txt", "foo baz")
 		client.HSet(ctx, "doc2", "txt", "foo bar")
 		res, err := client.FTSearchWithArgs(ctx, "txt", "foo ~bar", &redis.FTSearchOptions{WithScores: true}).Result()
@@ -88,7 +91,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{StopWords: []interface{}{"foo", "bar", "baz"}}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		client.HSet(ctx, "doc1", "txt", "foo baz")
 		client.HSet(ctx, "doc2", "txt", "hello world")
 		res1, err := client.FTSearchWithArgs(ctx, "txt", "foo bar", &redis.FTSearchOptions{NoContent: true}).Result()
@@ -103,7 +106,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}, &redis.FieldSchema{FieldName: "num", FieldType: redis.SearchFieldTypeNumeric}, &redis.FieldSchema{FieldName: "loc", FieldType: redis.SearchFieldTypeGeo}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		client.HSet(ctx, "doc1", "txt", "foo bar", "num", 3.141, "loc", "-0.441,51.458")
 		client.HSet(ctx, "doc2", "txt", "foo baz", "num", 2, "loc", "-0.1,51.2")
 		res1, err := client.FTSearchWithArgs(ctx, "txt", "foo", &redis.FTSearchOptions{Filters: []redis.FTSearchFilter{{FieldName: "num", Min: 0, Max: 2}}, NoContent: true}).Result()
@@ -134,7 +137,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "num", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}, &redis.FieldSchema{FieldName: "num", FieldType: redis.SearchFieldTypeNumeric, Sortable: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "num")
+		WaitForIndexing(rawClient, "num")
 		client.HSet(ctx, "doc1", "txt", "foo bar", "num", 1)
 		client.HSet(ctx, "doc2", "txt", "foo baz", "num", 2)
 		client.HSet(ctx, "doc3", "txt", "foo qux", "num", 3)
@@ -168,7 +171,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "title", FieldType: redis.SearchFieldTypeText, Weight: 5}, &redis.FieldSchema{FieldName: "body", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		client.HSet(ctx, "doc1", "title", "RediSearch", "body", "Redisearch implements a search engine on top of redis")
 		res1, err := client.FTSearchWithArgs(ctx, "txt", "search engine", &redis.FTSearchOptions{NoContent: true, Verbatim: true, LimitOffset: 0, Limit: 5}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -185,7 +188,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx", &redis.FTCreateOptions{}, text1, text2, num, geo, tag).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx")
+		WaitForIndexing(rawClient, "idx")
 		client.HSet(ctx, "doc1", "field", "aaa", "text", "1", "numeric", 1, "geo", "1,1", "tag", "1")
 		client.HSet(ctx, "doc2", "field", "aab", "text", "2", "numeric", 2, "geo", "2,2", "tag", "2")
 		res1, err := client.FTSearch(ctx, "idx", "@text:aa*").Result()
@@ -221,7 +224,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{}, text1, text2, text3).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		res1, err := client.FTExplain(ctx, "txt", "@f3:f3_val @f2:f2_val @f1:f1_val").Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res1).ToNot(BeEmpty())
@@ -234,11 +237,11 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val1, err := client.FTCreate(ctx, "testAlias", &redis.FTCreateOptions{Prefix: []interface{}{"index1:"}}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val1).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "testAlias")
+		WaitForIndexing(rawClient, "testAlias")
 		val2, err := client.FTCreate(ctx, "testAlias2", &redis.FTCreateOptions{Prefix: []interface{}{"index2:"}}, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val2).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "testAlias2")
+		WaitForIndexing(rawClient, "testAlias2")
 
 		client.HSet(ctx, "index1:lonestar", "name", "lonestar")
 		client.HSet(ctx, "index2:yogurt", "name", "yogurt")
@@ -273,7 +276,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText, Sortable: true, NoStem: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		resInfo, err := client.FTInfo(ctx, "idx1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -286,7 +289,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		resAlter, err := client.FTAlter(ctx, "idx1", false, []interface{}{"body", redis.SearchFieldTypeText.String()}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -307,7 +310,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "f1", "some valid content", "f2", "this is sample text")
 		client.HSet(ctx, "doc2", "f1", "very important", "f2", "lorem ipsum")
@@ -354,7 +357,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		resDictAdd, err := client.FTDictAdd(ctx, "custom_dict", "item1", "item2", "item3").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -378,7 +381,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "name", "Jon")
 		client.HSet(ctx, "doc2", "name", "John")
@@ -388,12 +391,12 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(res1.Total).To(BeEquivalentTo(int64(1)))
 		Expect(res1.Docs[0].Fields["name"]).To(BeEquivalentTo("Jon"))
 
-		client.FlushDB(ctx)
+		rawClient.FlushDB(ctx)
 		text2 := &redis.FieldSchema{FieldName: "name", FieldType: redis.SearchFieldTypeText, PhoneticMatcher: "dm:en"}
 		val2, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val2).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "name", "Jon")
 		client.HSet(ctx, "doc2", "name", "John")
@@ -415,7 +418,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "description", "The quick brown fox jumps over the lazy dog")
 		client.HSet(ctx, "doc2", "description", "Quick alice was beginning to get very tired of sitting by her quick sister on the bank, and of having nothing to do.")
@@ -457,7 +460,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "description", "The quick brown fox jumps over the lazy dog")
 		client.HSet(ctx, "doc2", "description", "Quick alice was beginning to get very tired of sitting by her quick sister on the bank, and of having nothing to do.")
@@ -514,7 +517,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, text2, text3, num).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "search", "title", "RediSearch",
 			"body", "Redisearch implements a search engine on top of redis",
@@ -618,7 +621,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "t1", "a", "t2", "b")
 		client.HSet(ctx, "doc2", "t1", "b", "t2", "a")
@@ -659,7 +662,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "t1", "hello", "t2", "world")
 
@@ -701,7 +704,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnHash: true, Prefix: []interface{}{"product:"}}, title, description).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "product:1", "title", "New Gaming Laptop", "description", "this is not a desktop")
 		client.HSet(ctx, "product:2", "title", "Super Old Not Gaming Laptop", "description", "this laptop is not a new laptop but it is a laptop")
@@ -757,7 +760,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		// 6 feb
 		client.HSet(ctx, "doc1", "PrimaryKey", "9::362330", "CreatedDateTimeUTC", "1738823999")
@@ -794,7 +797,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "PrimaryKey", "9::362330", "CreatedDateTimeUTC", "637387878524969984")
 		client.HSet(ctx, "doc2", "PrimaryKey", "9::362329", "CreatedDateTimeUTC", "637387875859270016")
@@ -813,7 +816,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "name", "bar", "age", "25")
 		client.HSet(ctx, "doc2", "name", "foo", "age", "19")
@@ -1065,7 +1068,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{SkipInitialScan: true}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		res, err := client.FTSearch(ctx, "idx1", "@foo:bar").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1078,7 +1081,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []interface{}{"king:"}}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.JSONSet(ctx, "king:1", "$", `{"name": "henry"}`)
 		client.JSONSet(ctx, "king:2", "$", `{"name": "james"}`)
@@ -1097,7 +1100,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.JSONSet(ctx, "doc:1", "$", `{"name": "Jon", "age": 25}`)
 
@@ -1115,7 +1118,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, tag1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "1", "t", "HELLO")
 		client.HSet(ctx, "2", "t", "hello")
@@ -1134,7 +1137,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err = client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, tag2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		res, err = client.FTSearch(ctx, "idx1", "@t:{HELLO}").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1153,7 +1156,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*", &redis.FTSearchOptions{Return: []redis.FTSearchReturn{{FieldName: "$.t", As: "txt"}}}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1175,7 +1178,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnHash: true}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		resSynUpdate, err := client.FTSynUpdateWithArgs(ctx, "idx1", "id1", &redis.FTSynUpdateOptions{SkipInitialScan: true}, []interface{}{"boy", "child", "offspring"}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1201,7 +1204,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnHash: true}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		resSynUpdate, err := client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"boy", "child", "offspring"}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1239,7 +1242,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []interface{}{"king:"}}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.JSONSet(ctx, "king:1", "$", `{"name": "henry", "num": 42}`)
 		client.JSONSet(ctx, "king:2", "$", `{"name": "james", "num": 3.14}`)
@@ -1263,7 +1266,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []interface{}{"king:"}}, tag1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.JSONSet(ctx, "king:1", "$", `{"name": "henry", "country": {"name": "england"}}`)
 
@@ -1281,7 +1284,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.JSONSet(ctx, "doc:1", "$", `{"prod:name": "RediSearch"}`)
 
@@ -1310,7 +1313,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{HNSWOptions: hnswOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "a", "v", "aaaaaaaa")
 		client.HSet(ctx, "b", "v", "aaaabaaa")
@@ -1335,7 +1338,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{HNSWOptions: hnswOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "a", "v", "aaaaaaaa")
 		client.HSet(ctx, "b", "v", "aaaabaaa")
@@ -1360,7 +1363,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{HNSWOptions: hnswOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "a", "v", "aaaaaaaa")
 		client.HSet(ctx, "b", "v", "aaaabaaa")
@@ -1381,7 +1384,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "name", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "name", "Alice")
 		client.HSet(ctx, "doc2", "name", "Bob")
@@ -1399,7 +1402,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "numval", FieldType: redis.SearchFieldTypeNumeric}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "numval", 101)
 		client.HSet(ctx, "doc2", "numval", 102)
@@ -1417,7 +1420,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "g", FieldType: redis.SearchFieldTypeGeo}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "g", "29.69465, 34.95126")
 		client.HSet(ctx, "doc2", "g", "29.69350, 34.94737")
@@ -1472,7 +1475,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		res, err := client.FTInfo(ctx, "idx1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1486,7 +1489,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err = client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText, WithSuffixtrie: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		res, err = client.FTInfo(ctx, "idx1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1500,7 +1503,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err = client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "t", FieldType: redis.SearchFieldTypeTag, WithSuffixtrie: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		res, err = client.FTInfo(ctx, "idx1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1586,7 +1589,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err = client.FTCreate(ctx, "idx_hash", ftCreateOptions, schema...).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(Equal("OK"))
-		WaitForIndexing(client, "idx_hash")
+		WaitForIndexing(rawClient, "idx_hash")
 
 		ftSearchOptions := &redis.FTSearchOptions{
 			DialectVersion: 4,
@@ -1617,7 +1620,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "geom", FieldType: redis.SearchFieldTypeGeoShape, GeoShapeFieldType: "FLAT"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "small", "geom", "POLYGON((1 1, 1 100, 100 100, 100 1, 1 1))")
 		client.HSet(ctx, "large", "geom", "POLYGON((1 1, 1 200, 200 200, 200 1, 1 1))")
@@ -1648,7 +1651,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "index")
+		WaitForIndexing(rawClient, "index")
 	})
 
 	It("should test geoshapes query intersects and disjoint", Label("NonRedisEnterprise"), func() {
@@ -1728,7 +1731,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText, IndexMissing: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "property:1", map[string]interface{}{
 			"title":       "Luxury Villa in Malibu",
@@ -1773,7 +1776,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText, IndexEmpty: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "property:1", map[string]interface{}{
 			"title":       "Luxury Villa in Malibu",
@@ -1837,7 +1840,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		// Insert vectors in int8 and uint8 format
 		client.HSet(ctx, "doc1", "int8_vector", "\x01\x02", "uint8_vector", "\x01\x02")
@@ -1880,7 +1883,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FTCreateOptions{OnHash: true, Prefix: []interface{}{"doc:"}},
 			&redis.FieldSchema{FieldName: "vector", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{FlatOptions: vecField}}).Result()
 		Expect(err).NotTo(HaveOccurred())
-		WaitForIndexing(client, "idx_vec")
+		WaitForIndexing(rawClient, "idx_vec")
 
 		bigPos := []float32{1e38, 1e38}
 		bigNeg := []float32{-1e38, -1e38}
@@ -1930,7 +1933,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "a", "v", "aaaaaaaa")
 		client.HSet(ctx, "b", "v", "aaaabaaa")
@@ -1962,7 +1965,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 	})
 
 	It("should FTCreate VECTOR with VAMANA algorithm - advanced parameters", Label("search", "ftcreate"), func() {
@@ -1983,7 +1986,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 	})
 
 	It("should fail FTCreate VECTOR with VAMANA - missing required parameters", Label("search", "ftcreate"), func() {
@@ -2052,7 +2055,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		// L2 distance test vectors
 		vectors := [][]float32{
@@ -2091,7 +2094,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := [][]float32{
 			{1.0, 0.0, 0.0},
@@ -2129,7 +2132,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := [][]float32{
 			{1.0, 2.0, 3.0},
@@ -2167,7 +2170,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := [][]float32{
 			{1.0, 2.0, 3.0, 4.0},
@@ -2205,7 +2208,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := [][]float32{
 			{1.5, 2.5, 3.5, 4.5},
@@ -2240,7 +2243,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := [][]float32{
 			{1.0, 2.0, 3.0, 4.0},
@@ -2275,7 +2278,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "a", "v", "aaaaaaaa")
 		client.HSet(ctx, "b", "v", "aaaabaaa")
@@ -2305,7 +2308,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 20)
 		for i := 0; i < 20; i++ {
@@ -2344,7 +2347,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v16", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions16}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx16")
+		WaitForIndexing(rawClient, "idx16")
 
 		// Test FLOAT32 with LVQ8
 		vamanaOptions32 := &redis.FTVamanaOptions{
@@ -2359,7 +2362,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v32", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions32}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx32")
+		WaitForIndexing(rawClient, "idx32")
 
 		// Add data to both indices
 		for i := 0; i < 15; i++ {
@@ -2407,7 +2410,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 20)
 		for i := 0; i < 20; i++ {
@@ -2443,7 +2446,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 25)
 		for i := 0; i < 25; i++ {
@@ -2479,7 +2482,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 30)
 		for i := 0; i < 30; i++ {
@@ -2520,7 +2523,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 15)
 		for i := 0; i < 15; i++ {
@@ -2551,7 +2554,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "testIdx")
+		WaitForIndexing(rawClient, "testIdx")
 
 		client.HSet(ctx, "doc1", "txt", "hello world")
 
@@ -2571,7 +2574,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txns")
+		WaitForIndexing(rawClient, "txns")
 
 		client.HSet(ctx, "doc1", "dummy", "dummy")
 
@@ -2595,7 +2598,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx")
+		WaitForIndexing(rawClient, "idx")
 
 		client.HSet(ctx, "doc1", "n", 0)
 
@@ -2618,7 +2621,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestAvg")
+		WaitForIndexing(rawClient, "aggTestAvg")
 
 		client.HSet(ctx, "doc1", "grp", "g1")
 
@@ -2644,7 +2647,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestCount")
+		WaitForIndexing(rawClient, "aggTestCount")
 
 		client.HSet(ctx, "doc1", "grp", "g1")
 
@@ -2670,7 +2673,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestSum")
+		WaitForIndexing(rawClient, "aggTestSum")
 
 		client.HSet(ctx, "doc1", "grp", "g1")
 
@@ -2695,7 +2698,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggExpired")
+		WaitForIndexing(rawClient, "aggExpired")
 
 		for i := 1; i <= 15; i++ {
 			key := fmt.Sprintf("doc%d", i)
@@ -2728,7 +2731,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTimeoutHeavy")
+		WaitForIndexing(rawClient, "aggTimeoutHeavy")
 
 		const totalDocs = 100000
 		for i := 0; i < totalDocs; i++ {
@@ -2737,7 +2740,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			Expect(err).NotTo(HaveOccurred())
 		}
 		// default behaviour was changed in 8.0.1, set to fail to validate the timeout was triggered
-		err = client.ConfigSet(ctx, "search-on-timeout", "fail").Err()
+		err = rawClient.ConfigSet(ctx, "search-on-timeout", "fail").Err()
 		Expect(err).NotTo(HaveOccurred())
 
 		options := &redis.FTAggregateOptions{
@@ -2759,7 +2762,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestCountDistinct")
+		WaitForIndexing(rawClient, "aggTestCountDistinct")
 
 		client.HSet(ctx, "doc1", "grp", "g1")
 
@@ -2785,7 +2788,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestCountDistinctIsh")
+		WaitForIndexing(rawClient, "aggTestCountDistinctIsh")
 
 		_, err = client.HSet(ctx, "doc1", "grp", "g1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2810,7 +2813,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "scoringTest")
+		WaitForIndexing(rawClient, "scoringTest")
 
 		_, err = client.HSet(ctx, "doc1", "description", "red apple").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2837,7 +2840,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestStddev")
+		WaitForIndexing(rawClient, "aggTestStddev")
 
 		_, err = client.HSet(ctx, "doc1", "grp", "g1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2864,7 +2867,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestQuantile")
+		WaitForIndexing(rawClient, "aggTestQuantile")
 
 		_, err = client.HSet(ctx, "doc1", "grp", "g1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2890,7 +2893,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestFirstValue")
+		WaitForIndexing(rawClient, "aggTestFirstValue")
 
 		_, err = client.HSet(ctx, "doc1", "grp", "g1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2915,14 +2918,14 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		val, err = client.FTCreate(ctx, "idx2", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "name", FieldType: redis.SearchFieldTypeText},
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx2")
+		WaitForIndexing(rawClient, "idx2")
 
 		_, err = client.FTAliasAdd(ctx, "idx2", "idx1").Result()
 		Expect(err).To(HaveOccurred())
@@ -2935,7 +2938,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txtIndex")
+		WaitForIndexing(rawClient, "txtIndex")
 
 		_, err = client.HSet(ctx, "doc1", "txt", "hello world").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -3021,7 +3024,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			Expect(err).To(HaveOccurred())
 		}
 
-		val, err := client.ConfigGet(ctx, "*").Result()
+		val, err := rawClient.ConfigGet(ctx, "*").Result()
 		Expect(err).NotTo(HaveOccurred())
 		// Since FT.CONFIG is deprecated since redis 8, use CONFIG instead with new search parameters.
 		keys := make([]string, 0, len(val))
@@ -3039,7 +3042,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestMinMax")
+		WaitForIndexing(rawClient, "aggTestMinMax")
 
 		_, err = client.HSet(ctx, "doc1", "grp", "g1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -3074,7 +3077,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 20)
 		for i := 0; i < 20; i++ {
@@ -3113,7 +3116,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 20)
 		for i := 0; i < 20; i++ {
@@ -3162,7 +3165,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 				&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(BeEquivalentTo("OK"))
-			WaitForIndexing(client, indexName)
+			WaitForIndexing(rawClient, indexName)
 
 			for i := 0; i < 15; i++ {
 				vec := make([]float32, 8)
@@ -3209,7 +3212,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 				&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(BeEquivalentTo("OK"))
-			WaitForIndexing(client, indexName)
+			WaitForIndexing(rawClient, indexName)
 
 			for i := 0; i < 15; i++ {
 				vec := make([]float32, 8)
@@ -3258,7 +3261,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 					&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(val).To(BeEquivalentTo("OK"))
-				WaitForIndexing(client, indexName)
+				WaitForIndexing(rawClient, indexName)
 
 				for i := 0; i < 10; i++ {
 					vec := make([]float32, 8)
@@ -3310,7 +3313,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 				&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(BeEquivalentTo("OK"))
-			WaitForIndexing(client, indexName)
+			WaitForIndexing(rawClient, indexName)
 
 			for i := 0; i < 15; i++ {
 				vec := make([]float32, 8)
@@ -3362,7 +3365,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 20)
 		for i := 0; i < 20; i++ {
@@ -3401,7 +3404,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 20)
 		for i := 0; i < 20; i++ {
@@ -3450,7 +3453,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 				&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(BeEquivalentTo("OK"))
-			WaitForIndexing(client, indexName)
+			WaitForIndexing(rawClient, indexName)
 
 			// Add test data
 			for i := 0; i < 15; i++ {
@@ -3500,7 +3503,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx_vector")
+		WaitForIndexing(rawClient, "idx_vector")
 
 		// Get FT.INFO
 		resInfo, err := client.FTInfo(ctx, "idx_vector").Result()
@@ -3606,10 +3609,13 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 // Hybrid Search Tests
 var _ = Describe("FT.HYBRID Commands", func() {
 	ctx := context.TODO()
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 
 	BeforeEach(func() {
-		client = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 2})
+		rawClient = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 2})
+		client, closeSubject = newUniversalSubject(rawClient)
 		// Create index with text, numeric, tag fields and vector fields
 		err := client.FTCreate(ctx, "hybrid_idx", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText},
@@ -3640,7 +3646,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 				},
 			}).Err()
 		Expect(err).NotTo(HaveOccurred())
-		WaitForIndexing(client, "hybrid_idx")
+		WaitForIndexing(rawClient, "hybrid_idx")
 
 		// Add test data
 		items := []struct {
@@ -3675,6 +3681,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	AfterEach(func() {
 		err := client.FTDropIndex(ctx, "hybrid_idx").Err()
 		Expect(err).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	It("should perform basic hybrid search", Label("search", "fthybrid"), func() {
@@ -4378,17 +4385,20 @@ var _ = Describe("RediSearch FT.Config with Resp2 and Resp3", Label("search", "N
 
 var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 	ctx := context.TODO()
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 	var client2 *redis.Client
 
 	BeforeEach(func() {
-		client = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 3, UnstableResp3: true})
+		rawClient = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 3, UnstableResp3: true})
+		client, closeSubject = newUniversalSubject(rawClient)
 		client2 = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 3})
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	It("should handle FTAggregate with RESP3", Label("search", "ftcreate", "ftaggregate"), func() {
@@ -4397,11 +4407,11 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "PrimaryKey", "9::362330", "CreatedDateTimeUTC", "637387878524969984")
 		client.HSet(ctx, "doc2", "PrimaryKey", "9::362329", "CreatedDateTimeUTC", "637387875859270016")
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		options := &redis.FTAggregateOptions{Apply: []redis.FTAggregateApply{{Field: "@CreatedDateTimeUTC * 10", As: "CreatedDateTimeUTC"}}}
 
@@ -4437,7 +4447,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText, Sortable: true, NoStem: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		// Test with UnstableResp3 true - both RawResult and Result should work
 		resInfo, err := client.FTInfo(ctx, "idx1").RawResult()
@@ -4472,7 +4482,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "f1", "some valid content", "f2", "this is sample text")
 		client.HSet(ctx, "doc2", "f1", "very important", "f2", "lorem ipsum")
@@ -4508,7 +4518,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{StopWords: []interface{}{"foo", "bar", "baz"}}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		client.HSet(ctx, "doc1", "txt", "foo baz")
 		client.HSet(ctx, "doc2", "txt", "hello world")
 
@@ -4552,7 +4562,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnHash: true}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		resSynUpdate, err := client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"boy", "child", "offspring"}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -4609,7 +4619,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{}, text1, text2, text3).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		res1, err := client.FTExplain(ctx, "txt", "@f3:f3_val @f2:f2_val @f1:f1_val").Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res1).ToNot(BeEmpty())

--- a/timeseries_commands_test.go
+++ b/timeseries_commands_test.go
@@ -30,17 +30,20 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 		protocol := protocol // capture loop variable for each context
 
 		Context(fmt.Sprintf("with protocol version %d", protocol), func() {
-			var client *redis.Client
+			var client redis.UniversalClient
+			var rawClient *redis.Client
+			var closeSubject func() error
 
 			BeforeEach(func() {
-				client = setupRedisClient(protocol)
-				Expect(client.FlushAll(ctx).Err()).NotTo(HaveOccurred())
+				rawClient = setupRedisClient(protocol)
+				client, closeSubject = newUniversalSubject(rawClient)
+				Expect(rawClient.FlushAll(ctx).Err()).NotTo(HaveOccurred())
 			})
 
 			AfterEach(func() {
 				if client != nil {
-					client.FlushDB(ctx)
-					client.Close()
+					rawClient.FlushDB(ctx)
+					closeSubject()
 				}
 			})
 
@@ -64,7 +67,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(result).To(BeEquivalentTo("OK"))
 				resultInfo, err := client.TSInfo(ctx, "4").Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(resultInfo["labels"].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"Time", "Series"}))
 				} else {
 					Expect(resultInfo["labels"].(map[interface{}]interface{})["Time"]).To(BeEquivalentTo("Series"))
@@ -161,7 +164,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(result).To(BeEquivalentTo(4))
 				resultInfo, err := client.TSInfo(ctx, "4").Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(resultInfo["labels"].([]interface{})).To(ContainElement([]interface{}{"Time", "Series"}))
 				} else {
 					Expect(resultInfo["labels"].(map[interface{}]interface{})["Time"]).To(BeEquivalentTo("Series"))
@@ -255,7 +258,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 
 				resultInfo, err = client.TSInfo(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(resultInfo["labels"]).To(BeEquivalentTo([]interface{}{}))
 				} else {
 					Expect(resultInfo["labels"]).To(BeEquivalentTo(map[interface{}]interface{}{}))
@@ -268,7 +271,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 
 				resultInfo, err = client.TSInfo(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(resultInfo["labels"].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"Time", "Series"}))
 					Expect(resultInfo["retentionTime"]).To(BeEquivalentTo(10))
 					if RedisVersion >= 8 {
@@ -356,7 +359,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(resultDeleteRule).To(BeEquivalentTo("OK"))
 				resultInfo, err := client.TSInfo(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(resultInfo["rules"]).To(BeEquivalentTo([]interface{}{}))
 				} else {
 					Expect(resultInfo["rules"]).To(BeEquivalentTo(map[interface{}]interface{}{}))
@@ -558,7 +561,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 
 				result, err := client.TSMGet(ctx, []string{"Test=This"}).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1].([]interface{})[1]).To(BeEquivalentTo("15"))
 					Expect(result["b"][1].([]interface{})[1]).To(BeEquivalentTo("25"))
 				} else {
@@ -568,7 +571,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mgetOpt := &redis.TSMGetOptions{WithLabels: true}
 				result, err = client.TSMGetWithArgs(ctx, []string{"Test=This"}, mgetOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["b"][0]).To(ConsistOf([]interface{}{"Test", "This"}, []interface{}{"Taste", "That"}))
 				} else {
 					Expect(result["b"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"Test": "This", "Taste": "That"}))
@@ -594,7 +597,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(err).NotTo(HaveOccurred())
 				result, err = client.TSMGet(ctx, []string{"is_compaction=true"}).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(0), "4"}))
 				} else {
 					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(0), 4.0}))
@@ -602,7 +605,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mgetOpt = &redis.TSMGetOptions{Latest: true}
 				result, err = client.TSMGetWithArgs(ctx, []string{"is_compaction=true"}, mgetOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(10), "8"}))
 				} else {
 					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(10), 8.0}))
@@ -985,7 +988,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err := client.TSMRange(ctx, 0, 200, []string{"Test=This"}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(100))
 				} else {
 					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(100))
@@ -994,7 +997,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt := &redis.TSMRangeOptions{Count: 10}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(10))
 				} else {
 					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(10))
@@ -1008,13 +1011,13 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMRangeWithArgs(ctx, 0, 500, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(20))
 				} else {
 					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(20))
 				}
 				// Test WithLabels
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][0]).To(BeEquivalentTo([]interface{}{}))
 				} else {
 					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{}))
@@ -1022,7 +1025,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{WithLabels: true}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][0]).To(ConsistOf([]interface{}{[]interface{}{"Test", "This"}, []interface{}{"team", "ny"}}))
 				} else {
 					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"Test": "This", "team": "ny"}))
@@ -1031,7 +1034,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{SelectedLabels: []interface{}{"team"}}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "ny"}))
 					Expect(result["b"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "sf"}))
 				} else {
@@ -1046,7 +1049,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{FilterByTS: fts, FilterByValue: []int{1, 2}}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1].([]interface{})).To(BeEquivalentTo([]interface{}{[]interface{}{int64(15), "1"}, []interface{}{int64(16), "2"}}))
 				} else {
 					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(15), 1.0}, []interface{}{int64(16), 2.0}}))
@@ -1055,7 +1058,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{GroupByLabel: "Test", Reducer: "sum"}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "2"}, []interface{}{int64(2), "4"}, []interface{}{int64(3), "6"}}))
 				} else {
 					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 0.0}, []interface{}{int64(1), 2.0}, []interface{}{int64(2), 4.0}, []interface{}{int64(3), 6.0}}))
@@ -1063,7 +1066,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{GroupByLabel: "Test", Reducer: "max"}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "1"}, []interface{}{int64(2), "2"}, []interface{}{int64(3), "3"}}))
 				} else {
 					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 0.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(3), 3.0}}))
@@ -1073,7 +1076,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["team=ny"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "1"}, []interface{}{int64(2), "2"}, []interface{}{int64(3), "3"}}))
 					Expect(result["team=sf"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "1"}, []interface{}{int64(2), "2"}, []interface{}{int64(3), "3"}}))
 				} else {
@@ -1084,7 +1087,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: "-"}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "10"}, []interface{}{int64(10), "1"}}))
 				} else {
 					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 10.0}, []interface{}{int64(10), 1.0}}))
@@ -1093,7 +1096,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: 5}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "5"}, []interface{}{int64(5), "6"}}))
 				} else {
 					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 5.0}, []interface{}{int64(5), 6.0}}))
@@ -1144,7 +1147,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt := &redis.TSMRangeOptions{Latest: true}
 				result, err := client.TSMRangeWithArgs(ctx, 0, 10, []string{"is_compaction=true"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["b"][1]).To(ConsistOf([]interface{}{int64(0), "4"}, []interface{}{int64(10), "8"}))
 					Expect(result["d"][1]).To(ConsistOf([]interface{}{int64(0), "4"}, []interface{}{int64(10), "8"}))
 				} else {
@@ -1183,7 +1186,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(Equal(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["multi-mrange-a"][1]).To(Equal([]interface{}{
 						[]interface{}{int64(1000), "10", "20"},
 						[]interface{}{int64(1020), "30", "40"},
@@ -1230,7 +1233,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err := client.TSMRevRange(ctx, 0, 200, []string{"Test=This"}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(100))
 				} else {
 					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(100))
@@ -1239,7 +1242,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt := &redis.TSMRevRangeOptions{Count: 10}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(10))
 				} else {
 					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(10))
@@ -1253,7 +1256,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 500, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(20))
 					Expect(result["a"][0]).To(BeEquivalentTo([]interface{}{}))
 				} else {
@@ -1263,7 +1266,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{WithLabels: true}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][0]).To(ConsistOf([]interface{}{[]interface{}{"Test", "This"}, []interface{}{"team", "ny"}}))
 				} else {
 					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"Test": "This", "team": "ny"}))
@@ -1272,7 +1275,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{SelectedLabels: []interface{}{"team"}}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "ny"}))
 					Expect(result["b"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "sf"}))
 				} else {
@@ -1287,7 +1290,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{FilterByTS: fts, FilterByValue: []int{1, 2}}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1].([]interface{})).To(ConsistOf([]interface{}{int64(16), "2"}, []interface{}{int64(15), "1"}))
 				} else {
 					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(16), 2.0}, []interface{}{int64(15), 1.0}}))
@@ -1296,7 +1299,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{GroupByLabel: "Test", Reducer: "sum"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "6"}, []interface{}{int64(2), "4"}, []interface{}{int64(1), "2"}, []interface{}{int64(0), "0"}}))
 				} else {
 					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), 6.0}, []interface{}{int64(2), 4.0}, []interface{}{int64(1), 2.0}, []interface{}{int64(0), 0.0}}))
@@ -1304,7 +1307,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{GroupByLabel: "Test", Reducer: "max"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "3"}, []interface{}{int64(2), "2"}, []interface{}{int64(1), "1"}, []interface{}{int64(0), "0"}}))
 				} else {
 					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), 3.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(0), 0.0}}))
@@ -1313,7 +1316,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["team=ny"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "3"}, []interface{}{int64(2), "2"}, []interface{}{int64(1), "1"}, []interface{}{int64(0), "0"}}))
 					Expect(result["team=sf"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "3"}, []interface{}{int64(2), "2"}, []interface{}{int64(1), "1"}, []interface{}{int64(0), "0"}}))
 				} else {
@@ -1324,7 +1327,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: "-"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), "1"}, []interface{}{int64(0), "10"}}))
 				} else {
 					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), 1.0}, []interface{}{int64(0), 10.0}}))
@@ -1332,7 +1335,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: 1}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(1), "10"}, []interface{}{int64(0), "1"}}))
 				} else {
 					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(1), 10.0}, []interface{}{int64(0), 1.0}}))
@@ -1370,7 +1373,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(Equal(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["multi-mrevrange-a"][1]).To(Equal([]interface{}{
 						[]interface{}{int64(1020), "30", "40"},
 						[]interface{}{int64(1000), "10", "20"},
@@ -1443,7 +1446,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt := &redis.TSMRevRangeOptions{Latest: true}
 				result, err := client.TSMRevRangeWithArgs(ctx, 0, 10, []string{"is_compaction=true"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["b"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), "8"}, []interface{}{int64(0), "4"}}))
 					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), "8"}, []interface{}{int64(0), "4"}}))
 				} else {

--- a/vectorset_commands_integration_test.go
+++ b/vectorset_commands_integration_test.go
@@ -48,17 +48,20 @@ var _ = Describe("Redis VectorSet commands", Label("vectorset"), func() {
 		protocol := protocol
 
 		Context(fmt.Sprintf("with protocol version %d", protocol), func() {
-			var client *redis.Client
+			var client redis.UniversalClient
+			var rawClient *redis.Client
+			var closeSubject func() error
 
 			BeforeEach(func() {
-				client = setupRedisClient(protocol)
-				Expect(client.FlushAll(ctx).Err()).NotTo(HaveOccurred())
+				rawClient = setupRedisClient(protocol)
+				client, closeSubject = newUniversalSubject(rawClient)
+				Expect(rawClient.FlushAll(ctx).Err()).NotTo(HaveOccurred())
 			})
 
 			AfterEach(func() {
 				if client != nil {
-					client.FlushDB(ctx)
-					client.Close()
+					rawClient.FlushDB(ctx)
+					closeSubject()
 				}
 			})
 


### PR DESCRIPTION
… AutoPipeline faces

Run the command integration suite (Describe("Commands")) against the plain client and both AutoPipeliner faces (blocking + async), selected by the GOREDIS_TEST_SUBJECT env var, to prove every command behaves the same when batched. The suite's data commands go through a redis.Cmdable subject; the few admin/non-Cmdable calls (PoolStats, Conn, Config*, Ping, Do, SlowLog*, ...) use the underlying *redis.Client.

Adds a Makefile target (test.autopipeline-subjects) and a CI job (test-autopipeline-subjects) that replay the suite through ap-blocking and ap-async, plus a make-target input on the run-tests action. Also fixes a fire-and-forget in the SlowLog spec that only surfaced on the deferred face: read the command result so it has executed before asserting the side effect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI infrastructure only; no production client behavior changes. Large diff is mostly mechanical test refactors.
> 
> **Overview**
> Adds **`newUniversalSubject`** in `main_test.go`, driven by **`GOREDIS_TEST_SUBJECT`**, so integration specs can run against the plain `*redis.Client`, **`AutoPipeline()`** (`ap-blocking`), or **`AsyncAutoPipeline()`** (`ap-async`) without duplicating suites. Command paths use a **`redis.UniversalClient`** subject; setup, teardown, and non-`Cmdable` APIs (**`FlushDB`**, **`Config*`**, **`Ping`**, **`PoolStats`**, **`Conn`**, slowlog/latency admin, etc.) stay on **`rawClient`**.
> 
> Refactors the main command and related Ginkgo suites (**`commands_test.go`**, bitmap/array/iterator/json/search/timeseries/vectorset, and others) to that **`client` / `rawClient` / `closeSubject`** pattern. **`test.autopipeline-subjects`** replays the focused **Commands** Ginkgo suite for both autopipeline faces (with **`RE_CLUSTER=true`** to avoid double cluster BeforeSuite corrupting shared Redis). CI adds **`test-autopipeline-subjects`**; **`run-tests`** accepts a configurable **`make-target`**.
> 
> Small spec fixes for the deferred face: assert **`Set`** results before slowlog side-effect checks; relax latency reset assertions when other ops pollute the log on slow CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5bf07fe30c5a31673be8768b94e2de65bd83a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->