### PR TITLE
fix(command): WaitAOF should return *IntSliceCmd, not *IntCmd

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -296,8 +296,8 @@ func (c cmdable) Wait(ctx context.Context, numSlaves int, timeout time.Duration)
 	return cmd
 }
 
-func (c cmdable) WaitAOF(ctx context.Context, numLocal, numSlaves int, timeout time.Duration) *IntCmd {
-	cmd := NewIntCmd(ctx, "waitAOF", numLocal, numSlaves, int(timeout/time.Millisecond))
+func (c cmdable) WaitAOF(ctx context.Context, numLocal, numSlaves int, timeout time.Duration) *IntSliceCmd {
+	cmd := NewIntSliceCmd(ctx, "waitAOF", numLocal, numSlaves, int(timeout/time.Millisecond))
 	cmd.setReadTimeout(timeout)
 	_ = c(ctx, cmd)
 	return cmd

--- a/commands_test.go
+++ b/commands_test.go
@@ -108,13 +108,14 @@ var _ = Describe("Commands", func() {
 
 		It("should WaitAOF", func() {
 			const waitAOF = 3 * time.Second
-			Skip("flaky test")
 
-			// assuming that the redis instance doesn't have AOF enabled
+			// No replicas here, so WAITAOF blocks until timeout and returns
+			// the two counts [numlocal, numreplicas]. numLocal=0 skips AOF.
 			start := time.Now()
-			val, err := client.WaitAOF(ctx, 1, 1, waitAOF).Result()
+			val, err := client.WaitAOF(ctx, 0, 1, waitAOF).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(val).NotTo(ContainSubstring("ERR WAITAOF cannot be used when numlocal is set but appendonly is disabled"))
+			Expect(val).To(HaveLen(2))
+			Expect(val[1]).To(Equal(int64(0)))
 			Expect(time.Now()).To(BeTemporally("~", start.Add(waitAOF), 3*time.Second))
 		})
 


### PR DESCRIPTION
### Problem

`WaitAOF` returns `*IntCmd`, but WAITAOF replies with a two-element array `[numlocal, numreplicas]`. So `Result()` always fails with `redis: can't parse int reply: "*2"`, and the command is unusable.

### Fix

Returns `*IntSliceCmd` so both counts are parsed. 

Also un-skips the WaitAOF test. Earlier it was skipped and its assertions did not match its own comment. Now it checks the reply parses into a two-element slice.

Fixes [#3887](https://github.com/redis/go-redis/issues/3887)

**BREAKING CHANGE:** `WaitAOF` now returns `*IntSliceCmd` instead of `*IntCmd`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to WaitAOF’s return type affects any caller using *IntCmd; behavior is otherwise a narrow command-wrapper fix with low runtime risk.
> 
> **Overview**
> **`WaitAOF`** now returns **`*IntSliceCmd`** instead of **`*IntCmd`**, matching Redis’s WAITAOF reply `[numlocal, numreplicas]` so `Result()` parses both counts instead of failing on a multi-bulk reply.
> 
> The integration test is re-enabled: it calls WAITAOF with **`numLocal=0`** (avoids AOF-disabled errors on a standalone instance), expects a **two-element** slice, and checks the replica count is **0** when no replicas are present, along with the timeout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03baf7cbe6481957971ed6ed73a0f2d337a62fd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->