### PR TITLE
feat(autopipeline): #4 tests and benchmarks

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -80,5 +80,5 @@ runs:
         # script) so the input value cannot inject shell commands.
         MAKE_TARGET: ${{ inputs.make-target }}
       run: |
-        make "${MAKE_TARGET:?make-target must not be empty}"
+        make -- "${MAKE_TARGET:?make-target must not be empty}"
       shell: bash

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -16,6 +16,10 @@ inputs:
   client-libs-test-image-tag:
     description: 'Client libs test image tag'
     required: false
+  make-target:
+    description: 'Makefile target to run for the test step'
+    required: false
+    default: 'test.ci'
 runs:
   using: "composite"
   steps:
@@ -72,6 +76,9 @@ runs:
       env:
         RCE_DOCKER: "true"
         RE_CLUSTER: "false"
+        # Passed through the environment (not ${{ }}-interpolated into the
+        # script) so the input value cannot inject shell commands.
+        MAKE_TARGET: ${{ inputs.make-target }}
       run: |
-        make test.ci
+        make "${MAKE_TARGET:?make-target must not be empty}"
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,3 +105,27 @@ jobs:
           files: coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  test-autopipeline-subjects:
+    name: test-autopipeline-subjects
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        redis-version:
+          - "8.10.x" # Redis CE 8.10
+        go-version:
+          - "stable"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # Replay the command integration suite through the AutoPipeliner Cmdable
+      # faces (blocking + async) so every command is verified to behave the same
+      # batched as on a plain client.
+      - name: Run command suite through AutoPipeliner faces
+        uses: ./.github/actions/run-tests
+        with:
+          go-version: ${{ matrix.go-version }}
+          redis-version: ${{ matrix.redis-version }}
+          make-target: test.autopipeline-subjects
+

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ test.ci.skip-vectorsets:
 # newUniversalSubject in main_test.go). Requires the docker env
 # (make docker.start).
 #
-# The focus lists every parametrized suite explicitly (Describe names differ
-# in case). Skipped on purpose: DDL Commands (needs the cluster topology the
+# The focus covers every parametrized suite (some via the Commands/BitCount
+# substrings — Describe names differ in case). Skipped on purpose: DDL Commands (needs the cluster topology the
 # lightweight BeforeSuite doesn't build), HotKeys Commands (same), and
 # AutoPipeline Blocking Commands (the AP suite itself — running it through an
 # AP subject would nest engines).

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,35 @@ test.ci.skip-vectorsets:
 	cd internal/customvet && go build .
 	go vet -vettool ./internal/customvet/customvet
 
+# Replay the parametrized command integration suites through the AutoPipeliner
+# Cmdable faces (blocking + async) to prove the commands behave the same
+# batched as on a plain client. Selected via GOREDIS_TEST_SUBJECT (see
+# newUniversalSubject in main_test.go). Requires the docker env
+# (make docker.start).
+#
+# The focus lists every parametrized suite explicitly (Describe names differ
+# in case). Skipped on purpose: DDL Commands (needs the cluster topology the
+# lightweight BeforeSuite doesn't build), HotKeys Commands (same), and
+# AutoPipeline Blocking Commands (the AP suite itself — running it through an
+# AP subject would nest engines).
+test.autopipeline-subjects:
+	# RE_CLUSTER=true forces the lightweight BeforeSuite (no sentinel/ring/cluster
+	# setup): the command suite only needs the standalone Redis, and running the
+	# full stateful BeforeSuite twice (once per subject) against the same server
+	# corrupts replication state and fails the second run. Both faces then run
+	# cleanly against the same env. The explicit -timeout keeps a hang from
+	# eating go test's 10m default per subject.
+	set -e; for subj in ap-blocking ap-async; do \
+	  echo "=== command suite via GOREDIS_TEST_SUBJECT=$$subj ==="; \
+	  (export RE_CLUSTER=true && \
+	   export RCE_DOCKER=$(RCE_DOCKER) && \
+	   export REDIS_VERSION=$(REDIS_VERSION) && \
+	   export GOREDIS_TEST_SUBJECT=$$subj && \
+	   go test -v . -race -skip Example -run TestGinkgoSuite -timeout 8m \
+	     -ginkgo.focus='Commands|RediSearch commands|Probabilistic commands|RedisTimeseries commands|Redis VectorSet commands|BitCount|ScanIterator|Advanced JSON' \
+	     -ginkgo.skip='AutoPipeline Blocking Commands|DDL Commands|HotKeys Commands'); \
+	done
+
 bench:
 	export RE_CLUSTER=$(RE_CLUSTER) && \
 	export RCE_DOCKER=$(RCE_DOCKER) && \
@@ -101,7 +130,7 @@ test.e2e.logic:
 		go test -v -run "TestCreateTestFaultInjectorLogic|TestFaultInjectorClientCreation" ./maintnotifications/e2e/
 	@echo "Logic tests completed!"
 
-.PHONY: all test test.ci test.ci.skip-vectorsets bench fmt test.e2e test.e2e.logic docker.e2e.start docker.e2e.stop
+.PHONY: all test test.ci test.ci.skip-vectorsets test.autopipeline-subjects bench fmt test.e2e test.e2e.logic docker.e2e.start docker.e2e.stop
 
 build:
 	export RE_CLUSTER=$(RE_CLUSTER) && \

--- a/README.md
+++ b/README.md
@@ -407,9 +407,10 @@ comes in two faces:
   executes and returns its own value/error, exactly like a normal client, so
   existing code keeps working unchanged. Under concurrency the engine coalesces
   commands from all goroutines into deep, back-to-back pipelines (a single
-  ordered batch stream by default), reaching roughly an order of magnitude
-  more executed commands per second than a plain client in the same
-  environment. Per-goroutine ordering is preserved.
+  ordered batch stream by default), reaching several times a plain client's
+  executed commands per second in the same environment — roughly an order of
+  magnitude with a parallel-batch config (MaxConcurrentBatches > 1 with
+  Unordered). Per-goroutine ordering is preserved.
 - **`AsyncAutoPipeline()` — deferred, highest throughput.** Command calls return
   immediately; you submit a window of commands and read their results afterward,
   which keeps each pipeline deep — tens of times a plain client's throughput.

--- a/README.md
+++ b/README.md
@@ -409,8 +409,8 @@ comes in two faces:
   commands from all goroutines into deep, back-to-back pipelines (a single
   ordered batch stream by default), reaching several times a plain client's
   executed commands per second in the same environment — roughly an order of
-  magnitude with a parallel-batch config (MaxConcurrentBatches > 1 with
-  Unordered). Per-goroutine ordering is preserved.
+  magnitude with a parallel-batch config (`MaxConcurrentBatches` > 1 with
+  `Unordered`). Per-goroutine ordering is preserved.
 - **`AsyncAutoPipeline()` — deferred, highest throughput.** Command calls return
   immediately; you submit a window of commands and read their results afterward,
   which keeps each pipeline deep — tens of times a plain client's throughput.

--- a/README.md
+++ b/README.md
@@ -407,12 +407,15 @@ comes in two faces:
   executes and returns its own value/error, exactly like a normal client, so
   existing code keeps working unchanged. Under concurrency the engine coalesces
   commands from all goroutines into deep, back-to-back pipelines (a single
-  ordered batch stream by default), reaching ~1M+ SET/sec vs ~100k for a plain
-  client (measured locally over loopback; indicative, not a spec).
-  Per-goroutine ordering is preserved.
+  ordered batch stream by default), reaching roughly an order of magnitude
+  more executed commands per second than a plain client in the same
+  environment. Per-goroutine ordering is preserved.
 - **`AsyncAutoPipeline()` — deferred, highest throughput.** Command calls return
   immediately; you submit a window of commands and read their results afterward,
-  which keeps each pipeline deep (~2-3M SET/sec). Ordered by default.
+  which keeps each pipeline deep — tens of times a plain client's throughput.
+  Ordered by default. Absolute numbers depend heavily on the machine, network
+  path and server; see `autopipeline_bench_README.md` for the benchmark
+  methodology and multipliers.
 
 ```go
 rdb := redis.NewClient(&redis.Options{Addr: "localhost:6379"})

--- a/array_commands_test.go
+++ b/array_commands_test.go
@@ -14,16 +14,19 @@ import (
 
 var _ = Describe("Array Commands", Label("array"), func() {
 	ctx := context.TODO()
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 
 	BeforeEach(func() {
 		SkipBeforeRedisVersion("8.8", "Redis 8.8.0 introduces support for Array")
-		client = redis.NewClient(redisOptions())
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		rawClient = redis.NewClient(redisOptions())
+		client, closeSubject = newUniversalSubject(rawClient)
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	Describe("ARSet and ARGet", func() {

--- a/autopipeline_bench_README.md
+++ b/autopipeline_bench_README.md
@@ -1,0 +1,128 @@
+# Autopipelining benchmarks
+
+These benchmarks validate the goal of autopipelining: batching concurrent
+commands into pipelines cuts network round-trips and raises throughput, without
+callers writing pipeline code.
+
+Two measurement rules keep every number honest:
+
+- **Throughput is measured on executed commands** — a command is counted only
+  after its result has been read (`.Result()` / `.Err()`), never when it is
+  merely queued. On the deferred face `ap.Set` returns immediately, so counting
+  calls would measure enqueue speed, not throughput.
+- **Rates divide by the timed region, not the nominal window.** The
+  fixed-duration drivers keep draining whatever was in flight when the deadline
+  hit; that drain is part of the timed region, so `ops/sec` cannot be inflated
+  by work that finished after the window closed.
+
+## Running
+
+The benchmarks talk to a real Redis on `:6379` (they skip when none answers).
+Start one first:
+
+```sh
+make docker.start            # or: docker run --rm -p 6379:6379 redis
+
+# the headline three-way throughput comparison:
+go test -run '^$' -bench BenchmarkAutoPipelineThroughput -benchtime=1x .
+
+# everything:
+go test -run '^$' -bench Benchmark -benchmem -benchtime=1x .
+```
+
+The throughput benchmarks run for a fixed wall-clock duration (~3s each) and
+report `ops/sec`, so `-benchtime=1x` (one iteration) is correct for them.
+**Do not pass a time-based `-benchtime`** (e.g. `-benchtime=5s`): the
+fixed-duration drivers ignore `b.N`, so Go's framework would re-run the full
+window geometrically trying to fill the time budget.
+
+The per-operation benchmarks (`BenchmarkDispatchPath`,
+`BenchmarkAutoPipelineZeroCopy`) are the opposite: their ns/op and allocs/op
+are only meaningful at the **default** `-benchtime` — at `-benchtime=1x` the
+workers still issue a minimum window each, all billed to a single iteration.
+(The "everything" command above also sweeps the repo's other root-package
+benchmarks; that is harmless, just broader than this file.)
+
+## The headline benchmark: BenchmarkAutoPipelineThroughput
+
+Three ways to issue the same workload (2000 goroutines), each counting only
+executed commands:
+
+1. **Normal** — a plain client; each `Set` is a blocking round-trip. Bounded by
+   Redis's non-pipelined ceiling (like `redis-benchmark` without `-P`).
+2. **AutoPipelineBlocking** — the blocking face with a parallel-batch config:
+   `ap.Set(...)` blocks until executed, the same call shape as a normal client.
+   Only one command per caller is in flight, but the flusher batches across the
+   2000 callers into deep pipelines.
+3. **AutoPipelineWindowed** — the deferred face: each caller submits a window of
+   200 commands, then reads the results. Keeps pipelines deepest.
+
+The `WindowedGET` variant repeats (3) with GET instead of SET: SET throughput is
+server-bound (Redis's write processing), GET is cheaper on the server, so the
+GET number shows the client machinery itself is not the limit.
+
+**Absolute numbers are machine- and load-dependent and vary a lot** — CPU
+count, Redis's own ceiling, network path (loopback vs docker veth vs real
+network), and noisy neighbors all move them by integer factors. The signal is
+the WITHIN-RUN multiplier against the `Normal` baseline measured in the same
+environment, plus `allocs/op` (which is exact and stable everywhere):
+
+| variant                 | vs Normal (same run)   |
+| ----------------------- | ---------------------- |
+| Normal                  | 1x (the baseline)      |
+| AutoPipelineBlocking    | ~10x                   |
+| AutoPipelineWindowed    | ~25-30x                |
+| AutoPipelineWindowedGET | above Windowed (reads) |
+
+As one concrete example: an Apple Silicon laptop with a loopback Redis puts
+`Normal` around 80k ops/sec (so ~800k blocking, ~2.5M windowed); a 4-vCPU CI
+runner with dockerized Redis lands near half that on the CPU-bound variants —
+different absolutes, same multipliers and ordering.
+
+The autopipeline variants use an explicit parallel-batch config
+(`MaxBatchSize: 300, MaxConcurrentBatches: 80, Unordered: true`) — **not the
+ordered default**. The default (`MaxConcurrentBatches: 1`,
+`DefaultAutoPipelineOptions` / `DefaultBlockingAutoPipelineOptions`) serializes
+batch execution: blocking usage lands at roughly half the parallel-batch
+multiplier, while windowed submission stays well into the tens-of-x even
+ordered.
+
+## The other benchmarks
+
+- **BenchmarkIndividualCommands** — plain-client baseline: one blocking
+  round-trip per command across GOMAXPROCS workers. Its ns/op is your
+  environment's RTT floor; every other number is best read against it.
+- **BenchmarkManualPipeline** — hand-built 100-deep `Pipeline().Exec()`,
+  sequential: the per-command cost of explicit pipelining (roughly a tenth
+  of a round-trip per command). The ceiling autopipelining approaches
+  without anyone writing pipeline code.
+- **BenchmarkDispatchPath** — the engine's per-command dispatch cost with
+  honest `b.N` accounting: ns/op and allocs/op per executed command
+  (4 allocs/cmd on the submit path; unordered dispatch roughly halves the
+  ordered ns/op), plus the lone-command blocking fast path (~1 RTT).
+- **BenchmarkFutureFace** — the typed future face on the ordered default
+  config: per-command reads (`InOrder`) vs windowed reads (`Window200`,
+  roughly 2x InOrder).
+- **BenchmarkAutoPipelineSubmit** — the non-blocking `Submit` entry point,
+  windowed, on the ordered default; lands in the same band as
+  `FutureFace/Window200`.
+- **BenchmarkAutoPipelineZeroCopy** — `GetToBuffer`/`SetFromBuffer` vs regular
+  `Get`/`Set` (Set+Get pairs): B/op drops ~10x at 4KiB and ~90x at 64KiB
+  (payloads decode into the caller's buffer instead of fresh strings), with
+  throughput at parity or better; allocs/op 10 vs 11. The B/op and allocs/op
+  ratios are environment-independent.
+- **BenchmarkClusterAutoPipelineThroughput** — the same blocking/windowed
+  drivers against a local 3-master cluster (slot-routed shard batches keep
+  per-node pipelines deep; scales past the standalone numbers in the same
+  environment, with a wide run-order-dependent spread). Skips when no
+  cluster answers on `:16600-16602`.
+
+## What was deliberately removed
+
+Earlier revisions carried "tuning sweep" benchmarks (batch sizes, flush
+delays, buffer sizes) whose numbers were dominated by the configured
+`MaxFlushDelay` timer at low parallelism — every swept value reported the same
+timer readout, which could only mislead someone tuning from them. They were
+removed rather than fixed: `BenchmarkDispatchPath` and the throughput drivers
+cover the engine's real knobs. Tune with your own workload shape; the engine's
+defaults need no tuning to hit the numbers above.

--- a/autopipeline_bench_test.go
+++ b/autopipeline_bench_test.go
@@ -324,10 +324,11 @@ func benchWindowed(b *testing.B, cfg *redis.AutoPipelineOptions, goroutines, win
 		b.Fatal(err)
 	}
 
-	per := b.N / goroutines
-	if per == 0 {
-		per = 1
-	}
+	// Exact b.N partitioning: the first b.N%goroutines workers run one extra
+	// command, so the total is b.N and ns/op / allocs/op are per command at
+	// any -benchtime (a floor-and-min-1 split would over-run for small b.N
+	// and drop the remainder for large).
+	base, extra := b.N/goroutines, b.N%goroutines
 	b.ReportAllocs()
 	b.ResetTimer()
 	var wg sync.WaitGroup
@@ -335,6 +336,10 @@ func benchWindowed(b *testing.B, cfg *redis.AutoPipelineOptions, goroutines, win
 	for g := 0; g < goroutines; g++ {
 		go func(id int) {
 			defer wg.Done()
+			per := base
+			if id < extra {
+				per++
+			}
 			futs := make([]redis.AutoFuture, 0, window)
 			cmds := 0
 			for cmds < per {
@@ -415,6 +420,12 @@ func BenchmarkAutoPipelineZeroCopy(b *testing.B) {
 				c := redis.NewClient(&redis.Options{
 					Addr:     benchAddr,
 					PoolSize: 10,
+					// Generous deadlines: at 64KiB payloads a slow CI runner
+					// pushes gigabytes through few conns; the default 3s
+					// write deadline trips under that load and the bench
+					// (correctly) fails on the surfaced error.
+					ReadTimeout:  30 * time.Second,
+					WriteTimeout: 30 * time.Second,
 					AutoPipelineOptions: &redis.AutoPipelineOptions{
 						MaxBatchSize:         300,
 						MaxConcurrentBatches: 80,
@@ -435,11 +446,16 @@ func BenchmarkAutoPipelineZeroCopy(b *testing.B) {
 				}
 				pstr := string(payload)
 
-				const goroutines = 500
-				per := b.N / goroutines
-				if per == 0 {
-					per = 1
+				// Fewer workers at large payloads: 500 goroutines x 64KiB
+				// saturates a CI runner's socket budget and only measures
+				// queueing on the write deadline.
+				goroutines := 500
+				if sz >= 65536 {
+					goroutines = 100
 				}
+				// Exact b.N partitioning (see benchWindowed): each unit is
+				// one Set+Get pair.
+				base, extra := b.N/goroutines, b.N%goroutines
 				var count int64
 
 				// Allocate cap >= sz+2 so GetToBuffer takes the fast path that
@@ -458,6 +474,10 @@ func BenchmarkAutoPipelineZeroCopy(b *testing.B) {
 				for g := 0; g < goroutines; g++ {
 					go func(id int) {
 						defer wg.Done()
+						per := base
+						if id < extra {
+							per++
+						}
 						rbuf := rbufs[id]
 						for i := 0; i < per; i++ {
 							key := fmt.Sprintf("zc:%d:%d", id, i)

--- a/autopipeline_bench_test.go
+++ b/autopipeline_bench_test.go
@@ -1,0 +1,658 @@
+package redis_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// benchAddr is the standalone server the benchmarks run against — the same
+// server the docker-compose env exposes in CI (and `redis-benchmark`'s
+// default), so numbers are comparable with the reference bands in
+// autopipeline_bench_README.md.
+const benchAddr = ":6379"
+
+// skipWithoutBenchServer skips the benchmark when no server answers, instead
+// of "passing" while measuring dial-failure latency.
+func skipWithoutBenchServer(b *testing.B) {
+	b.Helper()
+	probe := redis.NewClient(&redis.Options{Addr: benchAddr})
+	defer probe.Close()
+	if err := probe.Ping(context.Background()).Err(); err != nil {
+		b.Skipf("no redis at %s: %v", benchAddr, err)
+	}
+}
+
+// BenchmarkIndividualCommands is the plain-client baseline: one blocking
+// round-trip per command across GOMAXPROCS workers.
+func BenchmarkIndividualCommands(b *testing.B) {
+	skipWithoutBenchServer(b)
+	ctx := context.Background()
+	client := redis.NewClient(&redis.Options{
+		Addr: benchAddr,
+	})
+	defer client.Close()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			key := fmt.Sprintf("key%d", i)
+			if err := client.Set(ctx, key, i, 0).Err(); err != nil {
+				b.Error(err)
+				return
+			}
+			i++
+		}
+	})
+}
+
+// BenchmarkManualPipeline benchmarks using manual pipelining. Deliberately
+// sequential (one goroutine, one pipeline at a time): it isolates the
+// per-batch cost of an explicit Pipeline().Exec() round-trip, so its numbers
+// are not directly comparable to the parallel BenchmarkIndividualCommands
+// above. For a like-for-like concurrent comparison of the client faces see
+// BenchmarkAutoPipelineThroughput, whose variants all share one harness.
+func BenchmarkManualPipeline(b *testing.B) {
+	skipWithoutBenchServer(b)
+	ctx := context.Background()
+	client := redis.NewClient(&redis.Options{
+		Addr: benchAddr,
+	})
+	defer client.Close()
+
+	const batchSize = 100
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i += batchSize {
+		pipe := client.Pipeline()
+
+		end := i + batchSize
+		if end > b.N {
+			end = b.N
+		}
+
+		for j := i; j < end; j++ {
+			key := fmt.Sprintf("key%d", j)
+			pipe.Set(ctx, key, j, 0)
+		}
+
+		if _, err := pipe.Exec(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkFutureFace measures the uniform typed future face two ways:
+//   - InOrder: fap.Set(...).Err() per command (blocking-like ergonomics).
+//   - Window: submit a window of typed commands, then read them (max throughput).
+//
+// Both use the same fap.Set typed method; only when the result is read differs.
+// Fixed-duration driver: goroutines issue commands until the deadline and the
+// metric divides by the TIMED region (which includes draining the windows
+// already in flight at the deadline), so the reported ops/sec is honest.
+// NOTE: fixed-duration drivers ignore b.N — run them with the default
+// -benchtime or -benchtime=1x, not a time-based value (which would re-run the
+// full window geometrically).
+func BenchmarkFutureFace(b *testing.B) {
+	run := func(b *testing.B, window int) {
+		skipWithoutBenchServer(b)
+		ctx := context.Background()
+		c := redis.NewClient(&redis.Options{Addr: benchAddr, PoolSize: 250})
+		defer c.Close()
+		fap, err := c.AsyncAutoPipeline() // windowed submit-then-read is the deferred pattern
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer fap.Close()
+
+		const duration = 3 * time.Second
+		goroutines := 2000
+		if window > 1 {
+			goroutines = 500
+		}
+		var count int64
+		deadline := time.Now().Add(duration)
+
+		b.ResetTimer()
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for g := 0; g < goroutines; g++ {
+			go func(id int) {
+				defer wg.Done()
+				key := "k" + strconv.Itoa(id)
+				cs := make([]*redis.StatusCmd, 0, window)
+				for time.Now().Before(deadline) {
+					cs = cs[:0]
+					for j := 0; j < window; j++ {
+						cs = append(cs, fap.Set(ctx, key, j, 0))
+					}
+					for _, cc := range cs {
+						if err := cc.Err(); err != nil {
+							b.Error(err)
+							return
+						}
+					}
+					atomic.AddInt64(&count, int64(window))
+				}
+			}(g)
+		}
+		wg.Wait()
+		b.StopTimer()
+		b.ReportMetric(float64(count)/b.Elapsed().Seconds(), "ops/sec")
+	}
+
+	b.Run("InOrder", func(b *testing.B) { run(b, 1) })
+	b.Run("Window200", func(b *testing.B) { run(b, 200) })
+}
+
+// BenchmarkAutoPipelineSubmit measures the non-blocking Submit path. Each
+// goroutine submits a window of commands without blocking, then waits on them,
+// so it pays one park/unpark round-trip per window instead of per command.
+// Fixed-duration driver; see the BenchmarkFutureFace note about -benchtime.
+func BenchmarkAutoPipelineSubmit(b *testing.B) {
+	skipWithoutBenchServer(b)
+	ctx := context.Background()
+	client := redis.NewClient(&redis.Options{Addr: benchAddr, PoolSize: 250})
+	defer client.Close()
+	ap, err := client.AsyncAutoPipeline() // Submit is only allowed on the deferred face
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer ap.Close()
+
+	const (
+		duration   = 3 * time.Second
+		goroutines = 500
+		window     = 200
+	)
+	var count int64
+	deadline := time.Now().Add(duration)
+
+	b.ResetTimer()
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			futs := make([]redis.AutoFuture, 0, window)
+			key := fmt.Sprintf("submit:%d", id)
+			for time.Now().Before(deadline) {
+				futs = futs[:0]
+				for j := 0; j < window; j++ {
+					futs = append(futs, ap.Submit(ctx, redis.NewStatusCmd(ctx, "set", key, j)))
+				}
+				for i := range futs {
+					if err := futs[i].Wait(); err != nil {
+						b.Error(err)
+						return
+					}
+				}
+				atomic.AddInt64(&count, window)
+			}
+		}(g)
+	}
+	wg.Wait()
+	b.StopTimer()
+	b.ReportMetric(float64(count)/b.Elapsed().Seconds(), "ops/sec")
+}
+
+// clusterBenchAddrs is the local osscluster (docker-compose `cluster` profile,
+// formed with `redis-cli --cluster create ... --cluster-replicas 1`).
+var clusterBenchAddrs = []string{"127.0.0.1:16600", "127.0.0.1:16601", "127.0.0.1:16602"}
+
+func newClusterBenchClient(b *testing.B) *redis.ClusterClient {
+	b.Helper()
+	c := redis.NewClusterClient(&redis.ClusterOptions{Addrs: clusterBenchAddrs, PoolSize: 500})
+	if err := c.Ping(context.Background()).Err(); err != nil {
+		c.Close()
+		b.Skipf("cluster not reachable on %v: %v", clusterBenchAddrs, err)
+	}
+	return c
+}
+
+// BenchmarkClusterAutoPipelineThroughput measures executed throughput against a
+// 3-master cluster. ClusterClient.AutoPipeline routes commands to shards by slot
+// so each shard's batch stays on one node (keeping per-node pipelines deep), which
+// is what lets a cluster scale past a single instance. As with the standalone
+// benchmark, a command is counted only after its result is read, and the metric
+// divides by the timed region (including the post-deadline drain of windows
+// already in flight), so the reported ops/sec is honest.
+// Fixed-duration driver; see the BenchmarkFutureFace note about -benchtime.
+func BenchmarkClusterAutoPipelineThroughput(b *testing.B) {
+	const duration = 3 * time.Second
+
+	b.Run("Blocking", func(b *testing.B) {
+		c := newClusterBenchClient(b)
+		defer c.Close()
+		ap, err := c.AutoPipelineWithOptions(&redis.AutoPipelineOptions{MaxBatchSize: 512, MaxConcurrentBatches: 200, Unordered: true})
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer ap.Close()
+		const G = 2000
+		var count int64
+		dl := time.Now().Add(duration)
+		ctx := context.Background()
+		b.ResetTimer()
+		var wg sync.WaitGroup
+		wg.Add(G)
+		for g := 0; g < G; g++ {
+			go func(id int) {
+				defer wg.Done()
+				i, key := 0, fmt.Sprintf("b:%d", id)
+				for time.Now().Before(dl) {
+					const run = 50
+					for r := 0; r < run; r++ {
+						i++
+						if err := ap.Set(ctx, key, i, 0).Err(); err != nil {
+							b.Error(err)
+							return
+						}
+					}
+					atomic.AddInt64(&count, run)
+				}
+			}(g)
+		}
+		wg.Wait()
+		b.StopTimer()
+		b.ReportMetric(float64(count)/b.Elapsed().Seconds(), "ops/sec")
+	})
+
+	b.Run("Windowed", func(b *testing.B) {
+		c := newClusterBenchClient(b)
+		defer c.Close()
+		ap, err := c.AsyncAutoPipelineWithOptions(&redis.AutoPipelineOptions{MaxBatchSize: 300, MaxConcurrentBatches: 96, Unordered: true})
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer ap.Close()
+		const G, W = 1000, 300
+		var count int64
+		dl := time.Now().Add(duration)
+		ctx := context.Background()
+		b.ResetTimer()
+		var wg sync.WaitGroup
+		wg.Add(G)
+		for g := 0; g < G; g++ {
+			go func(id int) {
+				defer wg.Done()
+				cmds := make([]*redis.StatusCmd, 0, W)
+				for time.Now().Before(dl) {
+					cmds = cmds[:0]
+					for j := 0; j < W; j++ {
+						cmds = append(cmds, ap.Set(ctx, fmt.Sprintf("w:%d:%d", id, j), j, 0))
+					}
+					for _, cm := range cmds {
+						if err := cm.Err(); err != nil {
+							b.Error(err)
+							return
+						}
+					}
+					atomic.AddInt64(&count, int64(W))
+				}
+			}(g)
+		}
+		wg.Wait()
+		b.StopTimer()
+		b.ReportMetric(float64(count)/b.Elapsed().Seconds(), "ops/sec")
+	})
+}
+
+// benchWindowed measures the per-command dispatch cost of the deferred face
+// with honest b.N accounting: ns/op and allocs/op are per executed command.
+func benchWindowed(b *testing.B, cfg *redis.AutoPipelineOptions, goroutines, window int) {
+	skipWithoutBenchServer(b)
+	ctx := context.Background()
+	client := redis.NewClient(&redis.Options{Addr: benchAddr, PoolSize: 100})
+	defer client.Close()
+	ap, err := client.AsyncAutoPipelineWithOptions(cfg)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer ap.Close()
+
+	// one warmup command so pools/conns exist
+	if err := ap.Set(ctx, "dispatch:warm", 1, 0).Err(); err != nil {
+		b.Fatal(err)
+	}
+
+	per := b.N / goroutines
+	if per == 0 {
+		per = 1
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			futs := make([]redis.AutoFuture, 0, window)
+			cmds := 0
+			for cmds < per {
+				futs = futs[:0]
+				n := window
+				if rem := per - cmds; rem < n {
+					n = rem
+				}
+				for k := 0; k < n; k++ {
+					futs = append(futs, ap.Submit(ctx, redis.NewCmd(ctx, "set", "dispatch:k", k)))
+				}
+				for i := range futs {
+					if err := futs[i].Wait(); err != nil {
+						b.Error(err)
+					}
+				}
+				cmds += n
+			}
+		}(g)
+	}
+	wg.Wait()
+	b.StopTimer()
+}
+
+func BenchmarkDispatchPath(b *testing.B) {
+	b.Run("ordered/g64_w100", func(b *testing.B) {
+		benchWindowed(b, &redis.AutoPipelineOptions{MaxBatchSize: 300}, 64, 100)
+	})
+	b.Run("unordered/g64_w100", func(b *testing.B) {
+		benchWindowed(b, &redis.AutoPipelineOptions{
+			MaxBatchSize: 300, MaxConcurrentBatches: 8, Unordered: true,
+		}, 64, 100)
+	})
+	b.Run("solo/blocking", func(b *testing.B) {
+		skipWithoutBenchServer(b)
+		ctx := context.Background()
+		client := redis.NewClient(&redis.Options{Addr: benchAddr})
+		defer client.Close()
+		ap, err := client.AutoPipeline()
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer ap.Close()
+		if err := ap.Set(ctx, "dispatch:warm", 1, 0).Err(); err != nil {
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = ap.Set(ctx, "dispatch:k", i, 0).Err()
+		}
+		b.StopTimer()
+	})
+}
+
+// BenchmarkAutoPipelineZeroCopy compares regular Get/Set against the zero-copy
+// GetToBuffer/SetFromBuffer commands, both issued through the autopipeliner.
+// Each iteration is a Set+Get pair (so throughput mixes both directions).
+//
+// What zero-copy buys, per this benchmark's own output: B/op drops ~10x at
+// 4KiB and ~90x at 64KiB (the payload is decoded into the caller's buffer
+// instead of a freshly allocated string; allocs/op only goes 11 -> 10), with
+// throughput at parity (the fast path reads payload+CRLF in a single socket
+// read when the buffer has cap >= n+2, as allocated here). The per-goroutine
+// read buffers are allocated OUTSIDE the timed region so B/op reflects the
+// command path, not the harness.
+func BenchmarkAutoPipelineZeroCopy(b *testing.B) {
+	sizes := []int{64, 4096, 65536}
+	for _, sz := range sizes {
+		for _, zc := range []bool{false, true} {
+			name := fmt.Sprintf("size=%d/regular", sz)
+			if zc {
+				name = fmt.Sprintf("size=%d/zerocopy", sz)
+			}
+			b.Run(name, func(b *testing.B) {
+				skipWithoutBenchServer(b)
+				ctx := context.Background()
+				c := redis.NewClient(&redis.Options{
+					Addr:     benchAddr,
+					PoolSize: 10,
+					AutoPipelineOptions: &redis.AutoPipelineOptions{
+						MaxBatchSize:         300,
+						MaxConcurrentBatches: 80,
+						Unordered:            true,
+					},
+				})
+				defer c.Close()
+				c.FlushDB(ctx)
+				ap, err := c.AutoPipeline()
+				if err != nil {
+					b.Fatal(err)
+				}
+				defer ap.Close()
+
+				payload := make([]byte, sz)
+				for i := range payload {
+					payload[i] = 'x'
+				}
+				pstr := string(payload)
+
+				const goroutines = 500
+				per := b.N / goroutines
+				if per == 0 {
+					per = 1
+				}
+				var count int64
+
+				// Allocate cap >= sz+2 so GetToBuffer takes the fast path that
+				// reads payload+CRLF in a single socket read. The slice handed
+				// to GetToBuffer is still len==sz. Allocated before ResetTimer
+				// so the harness buffers don't pollute B/op.
+				rbufs := make([][]byte, goroutines)
+				for i := range rbufs {
+					rbufs[i] = make([]byte, sz, sz+2)
+				}
+
+				b.ResetTimer()
+				b.ReportAllocs()
+				var wg sync.WaitGroup
+				wg.Add(goroutines)
+				for g := 0; g < goroutines; g++ {
+					go func(id int) {
+						defer wg.Done()
+						rbuf := rbufs[id]
+						for i := 0; i < per; i++ {
+							key := fmt.Sprintf("zc:%d:%d", id, i)
+							if zc {
+								if err := ap.SetFromBuffer(ctx, key, payload).Err(); err != nil {
+									b.Error(err)
+									return
+								}
+								if err := ap.GetToBuffer(ctx, key, rbuf).Err(); err != nil {
+									b.Error(err)
+									return
+								}
+							} else {
+								if err := ap.Set(ctx, key, pstr, 0).Err(); err != nil {
+									b.Error(err)
+									return
+								}
+								if err := ap.Get(ctx, key).Err(); err != nil {
+									b.Error(err)
+									return
+								}
+							}
+							atomic.AddInt64(&count, 2)
+						}
+					}(g)
+				}
+				wg.Wait()
+				b.StopTimer()
+				b.ReportMetric(float64(count)/b.Elapsed().Seconds(), "ops/sec")
+			})
+		}
+	}
+}
+
+// BenchmarkAutoPipelineThroughput compares executed-command throughput three
+// ways. In every variant a command is counted ONLY after its result has been
+// read (the command actually executed on the server) — there is no counting of
+// merely-queued commands — and the metric divides by the TIMED region, which
+// includes draining whatever was in flight at the deadline, so the reported
+// ops/sec is real throughput.
+//
+//  1. Normal — a plain client. Each Set is a blocking round-trip; throughput is
+//     bounded by the connection pool and Redis's non-pipelined ceiling
+//     (matching redis-benchmark without -P).
+//  2. AutoPipelineBlocking — ap.Set(...).Err() read immediately, the way the
+//     normal client is used (drop-in, one command in flight per caller). The
+//     flusher batches across the many concurrent callers into deep pipelines.
+//  3. AutoPipelineWindowed — submit a window of commands per caller, then read
+//     their results. Keeps each pipeline deepest; the high-throughput usage.
+//
+// The autopipeline variants use a parallel-batch config (MaxConcurrentBatches>1,
+// Unordered) — NOT the ordered default. The default (MaxConcurrentBatches=1)
+// serializes batch execution and reaches roughly half the blocking number;
+// windowed submission stays in the millions even ordered.
+//
+// Fixed-duration drivers; see the BenchmarkFutureFace note about -benchtime.
+// Run: go test -run '^$' -bench BenchmarkAutoPipelineThroughput -benchtime=1x
+func BenchmarkAutoPipelineThroughput(b *testing.B) {
+	const (
+		duration   = 3 * time.Second
+		goroutines = 2000
+		window     = 200 // commands submitted before reading results (windowed variant)
+	)
+
+	// apConfig is a parallel-batch config: many batches execute concurrently so
+	// blocking callers don't serialize behind a single flusher. Unordered is
+	// required for MaxConcurrentBatches>1.
+	apConfig := func() *redis.AutoPipelineOptions {
+		return &redis.AutoPipelineOptions{MaxBatchSize: 300, MaxConcurrentBatches: 80, Unordered: true}
+	}
+
+	// drive runs `fn` on `goroutines` goroutines until the deadline and reports
+	// executed ops/sec over the timed region. fn returns how many executed
+	// commands it performed in one iteration (after reading their results); it
+	// must not count un-read commands.
+	drive := func(b *testing.B, fn func(id int) int) {
+		var count int64
+		deadline := time.Now().Add(duration)
+		b.ResetTimer()
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for g := 0; g < goroutines; g++ {
+			go func(id int) {
+				defer wg.Done()
+				for time.Now().Before(deadline) {
+					atomic.AddInt64(&count, int64(fn(id)))
+				}
+			}(g)
+		}
+		wg.Wait()
+		b.StopTimer()
+		// Divide by the timed region, not the nominal window: goroutines check
+		// the deadline once per run/window, so real elapsed exceeds `duration`
+		// and dividing by the constant would inflate the number.
+		b.ReportMetric(float64(count)/b.Elapsed().Seconds(), "ops/sec")
+	}
+
+	ctx := context.Background()
+
+	b.Run("Normal", func(b *testing.B) {
+		skipWithoutBenchServer(b)
+		c := redis.NewClient(&redis.Options{Addr: benchAddr, PoolSize: 100})
+		defer c.Close()
+		drive(b, func(id int) int {
+			// k is only the SET payload; a counter shared across drive's
+			// goroutines would race.
+			const run = 50 // amortize the harness per-step cost; each Set still blocks
+			for k := 0; k < run; k++ {
+				if err := c.Set(ctx, fmt.Sprintf("n:%d", id), k, 0).Err(); err != nil {
+					b.Error(err)
+				}
+			}
+			return run
+		})
+	})
+
+	b.Run("AutoPipelineBlocking", func(b *testing.B) {
+		skipWithoutBenchServer(b)
+		c := redis.NewClient(&redis.Options{Addr: benchAddr})
+		defer c.Close()
+		ap, err := c.AutoPipelineWithOptions(apConfig()) // blocking face, parallel batches
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer ap.Close()
+		drive(b, func(id int) int {
+			// Each command call blocks until executed (drop-in shape, no .Result()
+			// needed). We issue a small run per drive() step so the harness's
+			// per-step atomic/closure cost is amortized and doesn't understate the
+			// command rate — every command here still fully executes and is counted.
+			// k is only the SET payload; a shared counter would race.
+			const run = 50
+			for k := 0; k < run; k++ {
+				if err := ap.Set(ctx, fmt.Sprintf("b:%d", id), k, 0).Err(); err != nil {
+					b.Error(err)
+				}
+			}
+			return run
+		})
+	})
+
+	b.Run("AutoPipelineWindowed", func(b *testing.B) {
+		skipWithoutBenchServer(b)
+		c := redis.NewClient(&redis.Options{Addr: benchAddr})
+		defer c.Close()
+		ap, err := c.AsyncAutoPipelineWithOptions(apConfig()) // deferred face: submit a window, read later
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer ap.Close()
+		drive(b, func(id int) int {
+			cmds := make([]*redis.StatusCmd, 0, window)
+			for j := 0; j < window; j++ {
+				cmds = append(cmds, ap.Set(ctx, fmt.Sprintf("w:%d", id), j, 0)) // does not block
+			}
+			n := 0
+			for _, cmd := range cmds {
+				if _, err := cmd.Result(); err != nil { // read result = executed
+					b.Error(err)
+				}
+				n++
+			}
+			return n // only commands whose result was read
+		})
+	})
+
+	// Windowed GET: same windowed-async pattern but read-only. SET throughput is
+	// capped by Redis's write processing, so the SET variants above are
+	// server-bound, not client-bound. GET is cheaper on the server; this variant
+	// shows the client machinery itself is not the limit for the SET numbers.
+	b.Run("AutoPipelineWindowedGET", func(b *testing.B) {
+		skipWithoutBenchServer(b)
+		c := redis.NewClient(&redis.Options{Addr: benchAddr})
+		defer c.Close()
+		if err := c.Set(ctx, "bench:get", "v", 0).Err(); err != nil {
+			b.Fatal(err)
+		}
+		ap, err := c.AsyncAutoPipelineWithOptions(apConfig())
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer ap.Close()
+		drive(b, func(id int) int {
+			cmds := make([]*redis.StringCmd, 0, window)
+			for j := 0; j < window; j++ {
+				cmds = append(cmds, ap.Get(ctx, "bench:get"))
+			}
+			n := 0
+			for _, cmd := range cmds {
+				if _, err := cmd.Result(); err != nil {
+					b.Error(err)
+				}
+				n++
+			}
+			return n
+		})
+	})
+}

--- a/autopipeline_test.go
+++ b/autopipeline_test.go
@@ -4209,3 +4209,46 @@ func TestClusterNodeHookPostNextError(t *testing.T) {
 		}
 	})
 }
+
+// Regression: ScanIterator on the deferred (async) face. Next() used to read
+// the command's page/cursor fields without awaiting execution — the fetch
+// only enqueues on this face — so it spun re-issuing SCANs with a stale
+// cursor forever, flooding the engine with an unbounded batch and hanging
+// the caller. Next() now awaits the fetch before reading.
+func TestAsyncAutoPipelineScanIterator(t *testing.T) {
+	ctx := context.Background()
+	client := redis.NewClient(&redis.Options{Addr: apTestAddr()})
+	defer client.Close()
+	if err := client.Ping(ctx).Err(); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
+	if err := client.FlushDB(ctx).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	ap, err := client.AsyncAutoPipeline()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const n = 33
+	for i := 0; i < n; i++ {
+		if err := ap.Set(ctx, fmt.Sprintf("apiter:%d", i), i, 0).Err(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	runWithWatchdog(t, 30*time.Second, func() {
+		var got int
+		iter := ap.Scan(ctx, 0, "apiter:*", 5).Iterator()
+		for iter.Next(ctx) {
+			got++
+		}
+		if err := iter.Err(); err != nil {
+			t.Fatalf("iterator: %v", err)
+		}
+		if got != n {
+			t.Fatalf("scanned %d keys, want %d", got, n)
+		}
+	})
+}

--- a/autopipeline_test.go
+++ b/autopipeline_test.go
@@ -4230,6 +4230,7 @@ func TestAsyncAutoPipelineScanIterator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ap.Close()
 
 	const n = 33
 	for i := 0; i < n; i++ {

--- a/bitmap_commands_test.go
+++ b/bitmap_commands_test.go
@@ -13,12 +13,16 @@ type bitCountExpected struct {
 }
 
 var _ = Describe("BitCountBite", func() {
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 	key := "bit_count_test"
 
 	BeforeEach(func() {
-		client = redis.NewClient(redisOptions())
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		rawClient = redis.NewClient(redisOptions())
+		// Subject/closer before the first Expect (see commands_test.go).
+		client, closeSubject = newUniversalSubject(rawClient)
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 		values := []int{0, 1, 0, 0, 1, 0, 1, 0, 1, 1}
 		for i, v := range values {
 			cmd := client.SetBit(ctx, key, int64(i), v)
@@ -27,7 +31,7 @@ var _ = Describe("BitCountBite", func() {
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	It("bit count bite", func() {
@@ -53,12 +57,16 @@ var _ = Describe("BitCountBite", func() {
 })
 
 var _ = Describe("BitCountByte", func() {
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 	key := "bit_count_test"
 
 	BeforeEach(func() {
-		client = redis.NewClient(redisOptions())
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		rawClient = redis.NewClient(redisOptions())
+		// Subject/closer before the first Expect (see commands_test.go).
+		client, closeSubject = newUniversalSubject(rawClient)
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 		values := []int{0, 0, 0, 0, 0, 0, 0, 1, 1, 1}
 		for i, v := range values {
 			cmd := client.SetBit(ctx, key, int64(i), v)
@@ -67,7 +75,7 @@ var _ = Describe("BitCountByte", func() {
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	It("bit count byte", func() {

--- a/commands_test.go
+++ b/commands_test.go
@@ -31,15 +31,26 @@ func (t *TimeValue) ScanRedis(s string) (err error) {
 
 var _ = Describe("Commands", func() {
 	ctx := context.TODO()
-	var client *redis.Client
+	// client is the UniversalClient under test (the raw client or an
+	// autopipeliner, per GOREDIS_TEST_SUBJECT — see newUniversalSubject).
+	// rawClient is always the underlying *redis.Client, used for setup/teardown
+	// and the admin/connection-only calls (FlushDB, Config*, Ping, PoolStats,
+	// Conn, ...) that are not part of the UniversalClient interface.
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 
 	BeforeEach(func() {
-		client = redis.NewClient(redisOptions())
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		rawClient = redis.NewClient(redisOptions())
+		// Build the subject (and its closer) BEFORE any assertion: if the
+		// FlushDB Expect fails, AfterEach still runs and must have a valid
+		// closer for THIS spec's clients, not nil or the previous spec's.
+		client, closeSubject = newUniversalSubject(rawClient)
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	Describe("server", func() {
@@ -71,7 +82,7 @@ var _ = Describe("Commands", func() {
 			Expect(err.Error()).To(authErr)
 			Expect(cmds[0].Err().Error()).To(authErr)
 
-			stats := client.PoolStats()
+			stats := rawClient.PoolStats()
 			Expect(stats.Hits).To(Equal(uint32(2)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
@@ -101,13 +112,13 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should Ping", func() {
-			ping := client.Ping(ctx)
+			ping := rawClient.Ping(ctx)
 			Expect(ping.Err()).NotTo(HaveOccurred())
 			Expect(ping.Val()).To(Equal("PONG"))
 		})
 
 		It("should Ping with Do method", func() {
-			result := client.Conn().Do(ctx, "PING")
+			result := rawClient.Conn().Do(ctx, "PING")
 			Expect(result.Err()).NotTo(HaveOccurred())
 			Expect(result.Val()).To(Equal("PONG"))
 		})
@@ -117,7 +128,7 @@ var _ = Describe("Commands", func() {
 
 			// assume testing on single redis instance
 			start := time.Now()
-			val, err := client.Wait(ctx, 1, wait).Result()
+			val, err := rawClient.Wait(ctx, 1, wait).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(Equal(int64(0)))
 			Expect(time.Now()).To(BeTemporally("~", start.Add(wait), 3*time.Second))
@@ -129,7 +140,7 @@ var _ = Describe("Commands", func() {
 			// No replicas here, so WAITAOF blocks until timeout and returns
 			// the two counts [numlocal, numreplicas]. numLocal=0 skips AOF.
 			start := time.Now()
-			val, err := client.WaitAOF(ctx, 0, 1, waitAOF).Result()
+			val, err := rawClient.WaitAOF(ctx, 0, 1, waitAOF).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(HaveLen(2))
 			Expect(val[1]).To(Equal(int64(0)))
@@ -159,7 +170,7 @@ var _ = Describe("Commands", func() {
 		It("should BgRewriteAOF", func() {
 			Skip("flaky test")
 
-			val, err := client.BgRewriteAOF(ctx).Result()
+			val, err := rawClient.BgRewriteAOF(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(ContainSubstring("Background append only file rewriting"))
 		})
@@ -169,30 +180,30 @@ var _ = Describe("Commands", func() {
 
 			// workaround for "ERR Can't BGSAVE while AOF log rewriting is in progress"
 			Eventually(func() string {
-				return client.BgSave(ctx).Val()
+				return rawClient.BgSave(ctx).Val()
 			}, "30s").Should(Equal("Background saving started"))
 		})
 
 		It("Should CommandGetKeys", func() {
-			keys, err := client.CommandGetKeys(ctx, "MSET", "a", "b", "c", "d", "e", "f").Result()
+			keys, err := rawClient.CommandGetKeys(ctx, "MSET", "a", "b", "c", "d", "e", "f").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(keys).To(Equal([]string{"a", "c", "e"}))
 
-			keys, err = client.CommandGetKeys(ctx, "EVAL", "not consulted", "3", "key1", "key2", "key3", "arg1", "arg2", "arg3", "argN").Result()
+			keys, err = rawClient.CommandGetKeys(ctx, "EVAL", "not consulted", "3", "key1", "key2", "key3", "arg1", "arg2", "arg3", "argN").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(keys).To(Equal([]string{"key1", "key2", "key3"}))
 
-			keys, err = client.CommandGetKeys(ctx, "SORT", "mylist", "ALPHA", "STORE", "outlist").Result()
+			keys, err = rawClient.CommandGetKeys(ctx, "SORT", "mylist", "ALPHA", "STORE", "outlist").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(keys).To(Equal([]string{"mylist", "outlist"}))
 
-			_, err = client.CommandGetKeys(ctx, "FAKECOMMAND", "arg1", "arg2").Result()
+			_, err = rawClient.CommandGetKeys(ctx, "FAKECOMMAND", "arg1", "arg2").Result()
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("ERR Invalid command specified"))
 		})
 
 		It("should CommandGetKeysAndFlags", func() {
-			keysAndFlags, err := client.CommandGetKeysAndFlags(ctx, "LMOVE", "mylist1", "mylist2", "left", "left").Result()
+			keysAndFlags, err := rawClient.CommandGetKeysAndFlags(ctx, "LMOVE", "mylist1", "mylist2", "left", "left").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(keysAndFlags).To(Equal([]redis.KeyFlags{
 				{
@@ -205,19 +216,19 @@ var _ = Describe("Commands", func() {
 				},
 			}))
 
-			_, err = client.CommandGetKeysAndFlags(ctx, "FAKECOMMAND", "arg1", "arg2").Result()
+			_, err = rawClient.CommandGetKeysAndFlags(ctx, "FAKECOMMAND", "arg1", "arg2").Result()
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("ERR Invalid command specified"))
 		})
 
 		It("should ClientKill", func() {
-			r := client.ClientKill(ctx, "1.1.1.1:1111")
+			r := rawClient.ClientKill(ctx, "1.1.1.1:1111")
 			Expect(r.Err()).To(MatchError("ERR No such client"))
 			Expect(r.Val()).To(Equal(""))
 		})
 
 		It("should ClientKillByFilter", func() {
-			r := client.ClientKillByFilter(ctx, "TYPE", "test")
+			r := rawClient.ClientKillByFilter(ctx, "TYPE", "test")
 			Expect(r.Err()).To(MatchError("ERR Unknown client type 'test'"))
 			Expect(r.Val()).To(Equal(int64(0)))
 		})
@@ -231,16 +242,16 @@ var _ = Describe("Commands", func() {
 			defer func() {
 				Expect(db.Close()).NotTo(HaveOccurred())
 			}()
-			val, err := client.ClientList(ctx).Result()
+			val, err := rawClient.ClientList(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).Should(ContainSubstring("name=killmyid"))
 
 			myid := db.ClientID(ctx).Val()
-			killed := client.ClientKillByFilter(ctx, "ID", strconv.FormatInt(myid, 10))
+			killed := rawClient.ClientKillByFilter(ctx, "ID", strconv.FormatInt(myid, 10))
 			Expect(killed.Err()).NotTo(HaveOccurred())
 			Expect(killed.Val()).To(BeNumerically("==", 1))
 
-			val, err = client.ClientList(ctx).Result()
+			val, err = rawClient.ClientList(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).ShouldNot(ContainSubstring("name=killmyid"))
 		})
@@ -268,7 +279,7 @@ var _ = Describe("Commands", func() {
 				// ok
 			}
 
-			killed := client.ClientKillByFilter(ctx, "MAXAGE", "1")
+			killed := rawClient.ClientKillByFilter(ctx, "MAXAGE", "1")
 			Expect(killed.Err()).NotTo(HaveOccurred())
 			Expect(killed.Val()).To(BeNumerically(">=", 1))
 
@@ -281,21 +292,21 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ClientID", func() {
-			err := client.ClientID(ctx).Err()
+			err := rawClient.ClientID(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(client.ClientID(ctx).Val()).To(BeNumerically(">=", 0))
+			Expect(rawClient.ClientID(ctx).Val()).To(BeNumerically(">=", 0))
 		})
 
 		It("should ClientUnblock", func() {
-			id := client.ClientID(ctx).Val()
-			r, err := client.ClientUnblock(ctx, id).Result()
+			id := rawClient.ClientID(ctx).Val()
+			r, err := rawClient.ClientUnblock(ctx, id).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(r).To(Equal(int64(0)))
 		})
 
 		It("should ClientUnblockWithError", func() {
-			id := client.ClientID(ctx).Val()
-			r, err := client.ClientUnblockWithError(ctx, id).Result()
+			id := rawClient.ClientID(ctx).Val()
+			r, err := rawClient.ClientUnblockWithError(ctx, id).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(r).To(Equal(int64(0)))
 		})
@@ -303,17 +314,17 @@ var _ = Describe("Commands", func() {
 		// NonRedisEnterprise: Redis Enterprise CLIENT INFO advertises an extra
 		// connection flag ("m") that the OSS client-info parser does not recognize.
 		It("should ClientInfo", Label("NonRedisEnterprise"), func() {
-			info, err := client.ClientInfo(ctx).Result()
+			info, err := rawClient.ClientInfo(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(info).NotTo(BeNil())
 		})
 
 		It("should ClientPause", Label("NonRedisEnterprise"), func() {
-			err := client.ClientPause(ctx, time.Second).Err()
+			err := rawClient.ClientPause(ctx, time.Second).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			start := time.Now()
-			err = client.Ping(ctx).Err()
+			err = rawClient.Ping(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(time.Now()).To(BeTemporally("~", start.Add(time.Second), 800*time.Millisecond))
 		})
@@ -383,7 +394,7 @@ var _ = Describe("Commands", func() {
 				pipe.ClientSetInfo(ctx, libInfo)
 			}).To(Panic())
 			// Test setting the default options for libName, libName suffix and libVer
-			clientInfo := client.ClientInfo(ctx).Val()
+			clientInfo := rawClient.ClientInfo(ctx).Val()
 			Expect(clientInfo.LibName).To(ContainSubstring("go-redis(go-redis,"))
 			// Test setting the libName suffix in options
 			opt := redisOptions()
@@ -395,9 +406,9 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ClientTracking ON/OFF", func() {
-			skipIfClientTrackingUnavailable(ctx, client)
+			skipIfClientTrackingUnavailable(ctx, rawClient)
 
-			conn := client.Conn()
+			conn := rawClient.Conn()
 			defer conn.Close()
 
 			status, err := conn.ClientTrackingOn(ctx, nil).Result()
@@ -418,9 +429,9 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ClientTracking with BCAST and NOLOOP", func() {
-			skipIfClientTrackingUnavailable(ctx, client)
+			skipIfClientTrackingUnavailable(ctx, rawClient)
 
-			conn := client.Conn()
+			conn := rawClient.Conn()
 			defer conn.Close()
 
 			status, err := conn.ClientTracking(ctx, true, &redis.ClientTrackingOptions{
@@ -461,7 +472,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ConfigGet", func() {
-			val, err := client.ConfigGet(ctx, "*").Result()
+			val, err := rawClient.ConfigGet(ctx, "*").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).NotTo(BeEmpty())
 		})
@@ -478,7 +489,7 @@ var _ = Describe("Commands", func() {
 			}
 
 			for prefix, lookup := range expected {
-				val, err := client.ConfigGet(ctx, prefix).Result()
+				val, err := rawClient.ConfigGet(ctx, prefix).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(val).NotTo(BeEmpty())
 				Expect(val[lookup]).NotTo(BeEmpty())
@@ -486,26 +497,26 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ConfigResetStat", Label("NonRedisEnterprise"), func() {
-			r := client.ConfigResetStat(ctx)
+			r := rawClient.ConfigResetStat(ctx)
 			Expect(r.Err()).NotTo(HaveOccurred())
 			Expect(r.Val()).To(Equal("OK"))
 		})
 
 		It("should ConfigSet", Label("NonRedisEnterprise"), func() {
-			configGet := client.ConfigGet(ctx, "maxmemory")
+			configGet := rawClient.ConfigGet(ctx, "maxmemory")
 			Expect(configGet.Err()).NotTo(HaveOccurred())
 			Expect(configGet.Val()).To(HaveLen(1))
 			_, ok := configGet.Val()["maxmemory"]
 			Expect(ok).To(BeTrue())
 
-			configSet := client.ConfigSet(ctx, "maxmemory", configGet.Val()["maxmemory"])
+			configSet := rawClient.ConfigSet(ctx, "maxmemory", configGet.Val()["maxmemory"])
 			Expect(configSet.Err()).NotTo(HaveOccurred())
 			Expect(configSet.Val()).To(Equal("OK"))
 		})
 
 		It("should ConfigGet with Modules", Label("NonRedisEnterprise"), func() {
 			SkipBeforeRedisVersion("8", "config get won't return modules configs before redis 8")
-			configGet := client.ConfigGet(ctx, "*")
+			configGet := rawClient.ConfigGet(ctx, "*")
 			Expect(configGet.Err()).NotTo(HaveOccurred())
 			Expect(configGet.Val()).To(HaveKey("maxmemory"))
 			Expect(configGet.Val()).To(HaveKey("search-timeout"))
@@ -518,11 +529,11 @@ var _ = Describe("Commands", func() {
 		// (superseded by CONFIG GET/SET in Redis 8), so this OSS-only path errors.
 		It("should ConfigSet FT DIALECT", Label("NonRedisEnterprise"), func() {
 			SkipBeforeRedisVersion("8", "config doesn't include modules before Redis 8")
-			defaultState, err := client.ConfigGet(ctx, "search-default-dialect").Result()
+			defaultState, err := rawClient.ConfigGet(ctx, "search-default-dialect").Result()
 			Expect(err).NotTo(HaveOccurred())
 
 			// set to 3
-			res, err := client.ConfigSet(ctx, "search-default-dialect", "3").Result()
+			res, err := rawClient.ConfigSet(ctx, "search-default-dialect", "3").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(BeEquivalentTo("OK"))
 
@@ -530,12 +541,12 @@ var _ = Describe("Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "3"}))
 
-			resGet, err := client.ConfigGet(ctx, "search-default-dialect").Result()
+			resGet, err := rawClient.ConfigGet(ctx, "search-default-dialect").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resGet).To(BeEquivalentTo(map[string]string{"search-default-dialect": "3"}))
 
 			// set to 2
-			res, err = client.ConfigSet(ctx, "search-default-dialect", "2").Result()
+			res, err = rawClient.ConfigSet(ctx, "search-default-dialect", "2").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(BeEquivalentTo("OK"))
 
@@ -544,7 +555,7 @@ var _ = Describe("Commands", func() {
 			Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "2"}))
 
 			// set to 1
-			res, err = client.ConfigSet(ctx, "search-default-dialect", "1").Result()
+			res, err = rawClient.ConfigSet(ctx, "search-default-dialect", "1").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(BeEquivalentTo("OK"))
 
@@ -552,19 +563,19 @@ var _ = Describe("Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(defDialect).To(BeEquivalentTo(map[string]interface{}{"DEFAULT_DIALECT": "1"}))
 
-			resGet, err = client.ConfigGet(ctx, "search-default-dialect").Result()
+			resGet, err = rawClient.ConfigGet(ctx, "search-default-dialect").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resGet).To(BeEquivalentTo(map[string]string{"search-default-dialect": "1"}))
 
 			// set to default
-			res, err = client.ConfigSet(ctx, "search-default-dialect", defaultState["search-default-dialect"]).Result()
+			res, err = rawClient.ConfigSet(ctx, "search-default-dialect", defaultState["search-default-dialect"]).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(res).To(BeEquivalentTo("OK"))
 		})
 
 		It("should ConfigSet fail for ReadOnly", func() {
 			SkipBeforeRedisVersion("8", "Config doesn't include modules before Redis 8")
-			_, err := client.ConfigSet(ctx, "search-max-doctablesize", "100000").Result()
+			_, err := rawClient.ConfigSet(ctx, "search-max-doctablesize", "100000").Result()
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -582,21 +593,21 @@ var _ = Describe("Commands", func() {
 
 			// read the defaults to set them back later
 			for setting := range expected {
-				val, err := client.ConfigGet(ctx, setting).Result()
+				val, err := rawClient.ConfigGet(ctx, setting).Result()
 				Expect(err).NotTo(HaveOccurred())
 				defaults[setting] = val[setting]
 			}
 
 			// check if new values can be set
 			for setting, value := range expected {
-				val, err := client.ConfigSet(ctx, setting, value).Result()
+				val, err := rawClient.ConfigSet(ctx, setting, value).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(val).NotTo(BeEmpty())
 				Expect(val).To(Equal("OK"))
 			}
 
 			for setting, value := range expected {
-				val, err := client.ConfigGet(ctx, setting).Result()
+				val, err := rawClient.ConfigGet(ctx, setting).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(val).NotTo(BeEmpty())
 				Expect(val[setting]).To(Equal(value))
@@ -604,7 +615,7 @@ var _ = Describe("Commands", func() {
 
 			// set back to the defaults
 			for setting, value := range defaults {
-				val, err := client.ConfigSet(ctx, setting, value).Result()
+				val, err := rawClient.ConfigSet(ctx, setting, value).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(val).NotTo(BeEmpty())
 				Expect(val).To(Equal("OK"))
@@ -621,7 +632,7 @@ var _ = Describe("Commands", func() {
 			}
 
 			for setting, value := range expected {
-				val, err := client.ConfigSet(ctx, setting, value).Result()
+				val, err := rawClient.ConfigSet(ctx, setting, value).Result()
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(ContainSubstring(setting)))
 				Expect(val).To(BeEmpty())
@@ -629,33 +640,33 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ConfigRewrite", Label("NonRedisEnterprise"), func() {
-			configRewrite := client.ConfigRewrite(ctx)
+			configRewrite := rawClient.ConfigRewrite(ctx)
 			Expect(configRewrite.Err()).NotTo(HaveOccurred())
 			Expect(configRewrite.Val()).To(Equal("OK"))
 		})
 
 		It("should DBSize", func() {
-			size, err := client.DBSize(ctx).Result()
+			size, err := rawClient.DBSize(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(size).To(Equal(int64(0)))
 		})
 
 		It("should Info", func() {
-			info := client.Info(ctx)
+			info := rawClient.Info(ctx)
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(Equal(""))
 		})
 
 		It("should InfoMap", Label("redis.info"), func() {
-			info := client.InfoMap(ctx)
+			info := rawClient.InfoMap(ctx)
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(BeNil())
 
-			info = client.InfoMap(ctx, "dummy")
+			info = rawClient.InfoMap(ctx, "dummy")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).To(BeNil())
 
-			info = client.InfoMap(ctx, "server")
+			info = rawClient.InfoMap(ctx, "server")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).To(HaveLen(1))
 		})
@@ -664,22 +675,22 @@ var _ = Describe("Commands", func() {
 		// INFO shape, so the OSS module-name assertions do not hold.
 		It("should Info Modules", Label("redis.info", "NonRedisEnterprise"), func() {
 			SkipBeforeRedisVersion("8", "modules are included in info for Redis Version >= 8")
-			info := client.Info(ctx)
+			info := rawClient.Info(ctx)
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(BeNil())
 
-			info = client.Info(ctx, "search")
+			info = rawClient.Info(ctx, "search")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).To(ContainSubstring("search"))
 
-			info = client.Info(ctx, "modules")
+			info = rawClient.Info(ctx, "modules")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).To(ContainSubstring("search"))
 			Expect(info.Val()).To(ContainSubstring("ReJSON"))
 			Expect(info.Val()).To(ContainSubstring("timeseries"))
 			Expect(info.Val()).To(ContainSubstring("bf"))
 
-			info = client.Info(ctx, "everything")
+			info = rawClient.Info(ctx, "everything")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).To(ContainSubstring("search"))
 			Expect(info.Val()).To(ContainSubstring("ReJSON"))
@@ -691,16 +702,16 @@ var _ = Describe("Commands", func() {
 		// different INFO layout from OSS, so the parsed module map is empty here.
 		It("should InfoMap Modules", Label("redis.info", "NonRedisEnterprise"), func() {
 			SkipBeforeRedisVersion("8", "modules are included in info for Redis Version >= 8")
-			info := client.InfoMap(ctx)
+			info := rawClient.InfoMap(ctx)
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(BeNil())
 
-			info = client.InfoMap(ctx, "search")
+			info = rawClient.InfoMap(ctx, "search")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(len(info.Val())).To(BeNumerically(">=", 2))
 			Expect(info.Val()["search_version"]).ToNot(BeNil())
 
-			info = client.InfoMap(ctx, "modules")
+			info = rawClient.InfoMap(ctx, "modules")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			val := info.Val()
 			modules, ok := val["Modules"]
@@ -712,20 +723,20 @@ var _ = Describe("Commands", func() {
 			Expect(modules["timeseries"]).ToNot(BeNil())
 			Expect(modules["bf"]).ToNot(BeNil())
 
-			info = client.InfoMap(ctx, "everything")
+			info = rawClient.InfoMap(ctx, "everything")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(len(info.Val())).To(BeNumerically(">=", 10))
 		})
 
 		It("should Info cpu", func() {
-			info := client.Info(ctx, "cpu")
+			info := rawClient.Info(ctx, "cpu")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(Equal(""))
 			Expect(info.Val()).To(ContainSubstring(`used_cpu_sys`))
 		})
 
 		It("should Info cpu and memory", func() {
-			info := client.Info(ctx, "cpu", "memory")
+			info := rawClient.Info(ctx, "cpu", "memory")
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(Equal(""))
 			Expect(info.Val()).To(ContainSubstring(`used_cpu_sys`))
@@ -733,7 +744,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should LastSave", Label("NonRedisEnterprise"), func() {
-			lastSave := client.LastSave(ctx)
+			lastSave := rawClient.LastSave(ctx)
 			Expect(lastSave.Err()).NotTo(HaveOccurred())
 			Expect(lastSave.Val()).NotTo(Equal(0))
 		})
@@ -741,38 +752,38 @@ var _ = Describe("Commands", func() {
 		It("should Save", Label("NonRedisEnterprise"), func() {
 			// workaround for "ERR Background save already in progress"
 			Eventually(func() string {
-				return client.Save(ctx).Val()
+				return rawClient.Save(ctx).Val()
 			}, "10s").Should(Equal("OK"))
 		})
 
 		It("should SlaveOf", Label("NonRedisEnterprise"), func() {
-			slaveOf := client.SlaveOf(ctx, "localhost", "8888")
+			slaveOf := rawClient.SlaveOf(ctx, "localhost", "8888")
 			Expect(slaveOf.Err()).NotTo(HaveOccurred())
 			Expect(slaveOf.Val()).To(Equal("OK"))
 
-			slaveOf = client.SlaveOf(ctx, "NO", "ONE")
+			slaveOf = rawClient.SlaveOf(ctx, "NO", "ONE")
 			Expect(slaveOf.Err()).NotTo(HaveOccurred())
 			Expect(slaveOf.Val()).To(Equal("OK"))
 		})
 
 		It("should ReplicaOf", Label("NonRedisEnterprise"), func() {
-			replicaOf := client.ReplicaOf(ctx, "localhost", "8888")
+			replicaOf := rawClient.ReplicaOf(ctx, "localhost", "8888")
 			Expect(replicaOf.Err()).NotTo(HaveOccurred())
 			Expect(replicaOf.Val()).To(Equal("OK"))
 
-			replicaOf = client.ReplicaOf(ctx, "NO", "ONE")
+			replicaOf = rawClient.ReplicaOf(ctx, "NO", "ONE")
 			Expect(replicaOf.Err()).NotTo(HaveOccurred())
 			Expect(replicaOf.Val()).To(Equal("OK"))
 		})
 
 		It("should Time", func() {
-			tm, err := client.Time(ctx).Result()
+			tm, err := rawClient.Time(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(tm).To(BeTemporally("~", time.Now(), 3*time.Second))
 		})
 
 		It("should Command", Label("NonRedisEnterprise"), func() {
-			cmds, err := client.Command(ctx).Result()
+			cmds, err := rawClient.Command(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 
 			cmd := cmds["mget"]
@@ -794,7 +805,7 @@ var _ = Describe("Commands", func() {
 
 		It("should Command Tips", Label("NonRedisEnterprise"), func() {
 			SkipAfterRedisVersion("7.9", "Redis 8 changed the COMMAND reply format")
-			cmds, err := client.Command(ctx).Result()
+			cmds, err := rawClient.Command(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 
 			cmd := cmds["touch"]
@@ -809,7 +820,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should return all command names", func() {
-			cmdList := client.CommandList(ctx, nil)
+			cmdList := rawClient.CommandList(ctx, nil)
 			Expect(cmdList.Err()).NotTo(HaveOccurred())
 			cmdNames := cmdList.Val()
 
@@ -825,7 +836,7 @@ var _ = Describe("Commands", func() {
 			filter := &redis.FilterBy{
 				Module: "JSON",
 			}
-			cmdList := client.CommandList(ctx, filter)
+			cmdList := rawClient.CommandList(ctx, filter)
 			Expect(cmdList.Err()).NotTo(HaveOccurred())
 			Expect(cmdList.Val()).To(HaveLen(0))
 		})
@@ -835,7 +846,7 @@ var _ = Describe("Commands", func() {
 				ACLCat: "admin",
 			}
 
-			cmdList := client.CommandList(ctx, filter)
+			cmdList := rawClient.CommandList(ctx, filter)
 			Expect(cmdList.Err()).NotTo(HaveOccurred())
 			cmdNames := cmdList.Val()
 
@@ -847,7 +858,7 @@ var _ = Describe("Commands", func() {
 			filter := &redis.FilterBy{
 				Pattern: "*GET*",
 			}
-			cmdList := client.CommandList(ctx, filter)
+			cmdList := rawClient.CommandList(ctx, filter)
 			Expect(cmdList.Err()).NotTo(HaveOccurred())
 			cmdNames := cmdList.Val()
 
@@ -861,33 +872,33 @@ var _ = Describe("Commands", func() {
 
 	Describe("debugging", Label("NonRedisEnterprise"), func() {
 		It("should DebugObject", func() {
-			err := client.DebugObject(ctx, "foo").Err()
+			err := rawClient.DebugObject(ctx, "foo").Err()
 			Expect(err).To(MatchError("ERR no such key"))
 
 			err = client.Set(ctx, "foo", "bar", 0).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			s, err := client.DebugObject(ctx, "foo").Result()
+			s, err := rawClient.DebugObject(ctx, "foo").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s).To(ContainSubstring("serializedlength:4"))
 		})
 
 		It("should MemoryUsage", func() {
-			err := client.MemoryUsage(ctx, "foo").Err()
+			err := rawClient.MemoryUsage(ctx, "foo").Err()
 			Expect(err).To(Equal(redis.Nil))
 
 			err = client.Set(ctx, "foo", "bar", 0).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			n, err := client.MemoryUsage(ctx, "foo").Result()
+			n, err := rawClient.MemoryUsage(ctx, "foo").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(n).NotTo(BeZero())
 
-			n, err = client.MemoryUsage(ctx, "foo", 0).Result()
+			n, err = rawClient.MemoryUsage(ctx, "foo", 0).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(n).NotTo(BeZero())
 
-			_, err = client.MemoryUsage(ctx, "foo", 0, 1).Result()
+			_, err = rawClient.MemoryUsage(ctx, "foo", 0, 1).Result()
 			Expect(err).Should(MatchError("MemoryUsage expects single sample count"))
 		})
 	})
@@ -1071,10 +1082,10 @@ var _ = Describe("Commands", func() {
 			Expect(refCount.Err()).NotTo(HaveOccurred())
 			Expect(refCount.Val()).To(Equal(int64(1)))
 
-			client.ConfigSet(ctx, "maxmemory-policy", "volatile-lfu")
+			rawClient.ConfigSet(ctx, "maxmemory-policy", "volatile-lfu")
 			freq := client.ObjectFreq(ctx, "key")
 			Expect(freq.Err()).NotTo(HaveOccurred())
-			client.ConfigSet(ctx, "maxmemory-policy", "noeviction") // default
+			rawClient.ConfigSet(ctx, "maxmemory-policy", "noeviction") // default
 
 			err := client.ObjectEncoding(ctx, "key").Err()
 			Expect(err).NotTo(HaveOccurred())
@@ -1986,7 +1997,7 @@ var _ = Describe("Commands", func() {
 			Expect(string(orig.Bytes())).To(Equal("value"))
 
 			clone := orig.Clone()
-			Expect(client.Process(ctx, clone)).To(MatchError(ContainSubstring("cannot be cloned")))
+			Expect(rawClient.Process(ctx, clone)).To(MatchError(ContainSubstring("cannot be cloned")))
 
 			// Follow-up call on the same client must work: the clone's
 			// readReply drained the network reply so the connection
@@ -3472,7 +3483,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should fail module loadex", Label("NonRedisEnterprise"), func() {
-			dryRun := client.ModuleLoadex(ctx, &redis.ModuleLoadexConfig{
+			dryRun := rawClient.ModuleLoadex(ctx, &redis.ModuleLoadexConfig{
 				Path: "/path/to/non-existent-library.so",
 				Conf: map[string]interface{}{
 					"param1": "value1",
@@ -4344,9 +4355,9 @@ var _ = Describe("Commands", func() {
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(BeNil())
 
-			Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+			Expect(rawClient.Ping(ctx).Err()).NotTo(HaveOccurred())
 
-			stats := client.PoolStats()
+			stats := rawClient.PoolStats()
 			Expect(stats.Hits).To(Equal(uint32(2)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
@@ -4626,9 +4637,9 @@ var _ = Describe("Commands", func() {
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(BeNil())
 
-			Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+			Expect(rawClient.Ping(ctx).Err()).NotTo(HaveOccurred())
 
-			stats := client.PoolStats()
+			stats := rawClient.PoolStats()
 			Expect(stats.Hits).To(Equal(uint32(2)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
@@ -5149,9 +5160,9 @@ var _ = Describe("Commands", func() {
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(BeNil())
 
-			Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+			Expect(rawClient.Ping(ctx).Err()).NotTo(HaveOccurred())
 
-			stats := client.PoolStats()
+			stats := rawClient.PoolStats()
 			Expect(stats.Hits).To(Equal(uint32(2)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
@@ -5652,9 +5663,9 @@ var _ = Describe("Commands", func() {
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(BeNil())
 
-			Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+			Expect(rawClient.Ping(ctx).Err()).NotTo(HaveOccurred())
 
-			stats := client.PoolStats()
+			stats := rawClient.PoolStats()
 			Expect(stats.Hits).To(Equal(uint32(2)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
@@ -5734,9 +5745,9 @@ var _ = Describe("Commands", func() {
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(BeNil())
 
-			Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+			Expect(rawClient.Ping(ctx).Err()).NotTo(HaveOccurred())
 
-			stats := client.PoolStats()
+			stats := rawClient.PoolStats()
 			Expect(stats.Hits).To(Equal(uint32(2)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
@@ -6472,9 +6483,9 @@ var _ = Describe("Commands", func() {
 			Expect(err).To(Equal(redis.Nil))
 			Expect(val).To(BeNil())
 
-			Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
+			Expect(rawClient.Ping(ctx).Err()).NotTo(HaveOccurred())
 
-			stats := client.PoolStats()
+			stats := rawClient.PoolStats()
 			Expect(stats.Hits).To(Equal(uint32(2)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
@@ -9986,44 +9997,46 @@ var _ = Describe("Commands", func() {
 		It("returns slow query result", func() {
 			const key = "slowlog-log-slower-than"
 
-			old := client.ConfigGet(ctx, key).Val()
-			client.ConfigSet(ctx, key, "0")
-			defer client.ConfigSet(ctx, key, old[key])
+			old := rawClient.ConfigGet(ctx, key).Val()
+			rawClient.ConfigSet(ctx, key, "0")
+			defer rawClient.ConfigSet(ctx, key, old[key])
 
-			err := client.Do(ctx, "slowlog", "reset").Err()
+			err := rawClient.Do(ctx, "slowlog", "reset").Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			client.Set(ctx, "test", "true", 0)
+			Expect(client.Set(ctx, "test", "true", 0).Err()).NotTo(HaveOccurred())
 
-			result, err := client.SlowLogGet(ctx, -1).Result()
+			result, err := rawClient.SlowLogGet(ctx, -1).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).NotTo(BeZero())
 		})
 
 		It("returns the number of slow queries", Label("NonRedisEnterprise"), func() {
 			// Reset slowlog
-			err := client.SlowLogReset(ctx).Err()
+			err := rawClient.SlowLogReset(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			const key = "slowlog-log-slower-than"
 
-			old := client.ConfigGet(ctx, key).Val()
+			old := rawClient.ConfigGet(ctx, key).Val()
 			// first slowlog entry is the config set command itself
-			client.ConfigSet(ctx, key, "0")
-			defer client.ConfigSet(ctx, key, old[key])
+			rawClient.ConfigSet(ctx, key, "0")
+			defer rawClient.ConfigSet(ctx, key, old[key])
 
-			// Set a key to trigger a slow query, and this is the second slowlog entry
-			client.Set(ctx, "test", "true", 0)
-			result, err := client.SlowLogLen(ctx).Result()
+			// Set a key to trigger a slow query, and this is the second slowlog entry.
+			// Read the result so the command has actually executed before we count
+			// (required on the deferred autopipeline face, harmless otherwise).
+			Expect(client.Set(ctx, "test", "true", 0).Err()).NotTo(HaveOccurred())
+			result, err := rawClient.SlowLogLen(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).Should(Equal(int64(2)))
 
 			// Reset slowlog
-			err = client.SlowLogReset(ctx).Err()
+			err = rawClient.SlowLogReset(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			// Check if slowlog is empty, this is the first slowlog entry after reset
-			result, err = client.SlowLogLen(ctx).Result()
+			result, err = rawClient.SlowLogLen(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).Should(Equal(int64(1)))
 		})
@@ -10031,16 +10044,21 @@ var _ = Describe("Commands", func() {
 		It("returns the command argument count", Label("NonRedisEnterprise"), func() {
 			SkipBeforeRedisVersion("8.10", "SLOWLOG GET reports the command argument count since Redis 8.10")
 
+			// Config*/SlowLog/Do stay on the raw client: on the deferred
+			// autopipeline face a Do runs outside the pipeline and could
+			// execute before a just-enqueued unread ConfigSet flushes.
 			const key = "slowlog-log-slower-than"
-			old := client.ConfigGet(ctx, key).Val()
-			client.ConfigSet(ctx, key, "0")
-			defer client.ConfigSet(ctx, key, old[key])
+			old := rawClient.ConfigGet(ctx, key).Val()
+			rawClient.ConfigSet(ctx, key, "0")
+			defer rawClient.ConfigSet(ctx, key, old[key])
 
 			// A short command: CommandArgc matches the number of stored Args.
-			Expect(client.Do(ctx, "slowlog", "reset").Err()).NotTo(HaveOccurred())
-			client.Set(ctx, "test", "true", 0)
+			Expect(rawClient.Do(ctx, "slowlog", "reset").Err()).NotTo(HaveOccurred())
+			// The measured command goes through the subject; assert the write
+			// so the deferred face has executed it before SlowLogGet reads.
+			Expect(client.Set(ctx, "test", "true", 0).Err()).NotTo(HaveOccurred())
 
-			result, err := client.SlowLogGet(ctx, -1).Result()
+			result, err := rawClient.SlowLogGet(ctx, -1).Result()
 			Expect(err).NotTo(HaveOccurred())
 			var setEntry *redis.SlowLog
 			for i := range result {
@@ -10053,18 +10071,18 @@ var _ = Describe("Commands", func() {
 
 			// A long command: Redis truncates the stored Args at slowlog-max-argc,
 			// but CommandArgc still reports the full original argument count.
-			maxArgc := client.ConfigGet(ctx, "slowlog-max-argc").Val()["slowlog-max-argc"]
-			client.ConfigSet(ctx, "slowlog-max-argc", "32")
-			defer client.ConfigSet(ctx, "slowlog-max-argc", maxArgc)
-			Expect(client.Do(ctx, "slowlog", "reset").Err()).NotTo(HaveOccurred())
+			maxArgc := rawClient.ConfigGet(ctx, "slowlog-max-argc").Val()["slowlog-max-argc"]
+			rawClient.ConfigSet(ctx, "slowlog-max-argc", "32")
+			defer rawClient.ConfigSet(ctx, "slowlog-max-argc", maxArgc)
+			Expect(rawClient.Do(ctx, "slowlog", "reset").Err()).NotTo(HaveOccurred())
 
 			args := []interface{}{"rpush", "slowlog-big-list"}
 			for i := 0; i < 50; i++ {
 				args = append(args, fmt.Sprintf("v%d", i))
 			}
-			Expect(client.Do(ctx, args...).Err()).NotTo(HaveOccurred())
+			Expect(rawClient.Do(ctx, args...).Err()).NotTo(HaveOccurred())
 
-			result, err = client.SlowLogGet(ctx, -1).Result()
+			result, err = rawClient.SlowLogGet(ctx, -1).Result()
 			Expect(err).NotTo(HaveOccurred())
 			var pushEntry *redis.SlowLog
 			for i := range result {
@@ -10085,17 +10103,17 @@ var _ = Describe("Commands", func() {
 			const key = "latency-monitor-threshold"
 
 			// reset all latencies first to ensure clean state
-			err := client.LatencyReset(ctx).Err()
+			err := rawClient.LatencyReset(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			old := client.ConfigGet(ctx, key).Val()
-			client.ConfigSet(ctx, key, "1")
-			defer client.ConfigSet(ctx, key, old[key])
+			old := rawClient.ConfigGet(ctx, key).Val()
+			rawClient.ConfigSet(ctx, key, "1")
+			defer rawClient.ConfigSet(ctx, key, old[key])
 
-			err = client.Do(ctx, "DEBUG", "SLEEP", 0.01).Err()
+			err = rawClient.Do(ctx, "DEBUG", "SLEEP", 0.01).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			result, err := client.Latency(ctx).Result()
+			result, err := rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).NotTo(BeZero())
 		})
@@ -10104,39 +10122,39 @@ var _ = Describe("Commands", func() {
 			const key = "latency-monitor-threshold"
 
 			// reset all latencies
-			err := client.LatencyReset(ctx).Err()
+			err := rawClient.LatencyReset(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			old := client.ConfigGet(ctx, key).Val()
+			old := rawClient.ConfigGet(ctx, key).Val()
 			// Use a higher threshold (100ms) to avoid capturing normal operations
 			// that could cause flakiness due to timing variations on busy CI runners.
-			client.ConfigSet(ctx, key, "100")
-			defer client.ConfigSet(ctx, key, old[key])
+			rawClient.ConfigSet(ctx, key, "100")
+			defer rawClient.ConfigSet(ctx, key, old[key])
 
 			// get latency after reset
-			result, err := client.Latency(ctx).Result()
+			result, err := rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).Should(Equal(0))
 
 			// create a new latency event by sleeping past the threshold
-			err = client.Do(ctx, "DEBUG", "SLEEP", 0.15).Err()
+			err = rawClient.Do(ctx, "DEBUG", "SLEEP", 0.15).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			// get latency after create a new latency
-			result, err = client.Latency(ctx).Result()
+			result, err = rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).Should(BeNumerically(">=", 1))
 			triggered := result[0].Name
 
 			// reset all latencies again
-			err = client.LatencyReset(ctx).Err()
+			err = rawClient.LatencyReset(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			// get latency after reset again. Don't assert total length is 0:
 			// other operations on the connection may briefly land in the
 			// latency log on a slow CI runner. Instead verify the specific
 			// event we triggered is gone.
-			result, err = client.Latency(ctx).Result()
+			result, err = rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			for _, event := range result {
 				if event.Name == triggered {
@@ -10149,35 +10167,35 @@ var _ = Describe("Commands", func() {
 			const key = "latency-monitor-threshold"
 
 			// reset all latencies first to ensure clean state
-			err := client.LatencyReset(ctx).Err()
+			err := rawClient.LatencyReset(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			old := client.ConfigGet(ctx, key).Val()
+			old := rawClient.ConfigGet(ctx, key).Val()
 			// Use a higher threshold (100ms) to avoid capturing normal operations
 			// that could cause flakiness due to timing variations
-			client.ConfigSet(ctx, key, "100")
-			defer client.ConfigSet(ctx, key, old[key])
+			rawClient.ConfigSet(ctx, key, "100")
+			defer rawClient.ConfigSet(ctx, key, old[key])
 
-			result, err := client.Latency(ctx).Result()
+			result, err := rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).Should(Equal(0))
 
 			// Use a longer sleep (150ms) to ensure it exceeds the 100ms threshold
-			err = client.Do(ctx, "DEBUG", "SLEEP", 0.15).Err()
+			err = rawClient.Do(ctx, "DEBUG", "SLEEP", 0.15).Err()
 			Expect(err).NotTo(HaveOccurred())
 
-			result, err = client.Latency(ctx).Result()
+			result, err = rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(result)).Should(BeNumerically(">=", 1))
 
 			// reset latency by event name
 			eventName := result[0].Name
-			err = client.LatencyReset(ctx, eventName).Err()
+			err = rawClient.LatencyReset(ctx, eventName).Err()
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify the specific event was reset (not that all events are gone)
 			// This avoids flakiness from other operations triggering latency events
-			result, err = client.Latency(ctx).Result()
+			result, err = rawClient.Latency(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			for _, event := range result {
 				if event.Name == eventName {

--- a/iterator.go
+++ b/iterator.go
@@ -46,6 +46,14 @@ func (it *ScanIterator) Next(ctx context.Context) bool {
 		if err != nil {
 			return false
 		}
+		// Await the fetch before reading page/cursor: on the deferred
+		// autopipeline face process() only enqueues, and reading the raw
+		// fields of a not-yet-executed command would spin re-issuing SCANs
+		// with a stale cursor forever. Err() blocks until executed there and
+		// is a no-op read everywhere else.
+		if err := it.cmd.Err(); err != nil {
+			return false
+		}
 
 		it.pos = 1
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 var _ = Describe("ScanIterator", func() {
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 
 	seed := func(n int) error {
 		pipe := client.Pipeline()
@@ -44,12 +46,13 @@ var _ = Describe("ScanIterator", func() {
 	}
 
 	BeforeEach(func() {
-		client = redis.NewClient(redisOptions())
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		rawClient = redis.NewClient(redisOptions())
+		client, closeSubject = newUniversalSubject(rawClient)
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	It("should scan across empty DBs", func() {

--- a/json_test.go
+++ b/json_test.go
@@ -18,7 +18,9 @@ type JSONGetTestStruct struct {
 
 var _ = Describe("JSON Commands", Label("json"), func() {
 	ctx := context.TODO()
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 
 	setupRedisClient := func(protocolVersion int) *redis.Client {
 		opt := &redis.Options{
@@ -33,16 +35,17 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 
 	AfterEach(func() {
 		if client != nil {
-			client.FlushDB(ctx)
-			client.Close()
+			rawClient.FlushDB(ctx)
+			closeSubject()
 		}
 	})
 
 	protocols := []int{2, 3}
 	for _, protocol := range protocols {
 		BeforeEach(func() {
-			client = setupRedisClient(protocol)
-			Expect(client.FlushAll(ctx).Err()).NotTo(HaveOccurred())
+			rawClient = setupRedisClient(protocol)
+			client, closeSubject = newUniversalSubject(rawClient)
+			Expect(rawClient.FlushAll(ctx).Err()).NotTo(HaveOccurred())
 		})
 
 		Describe("arrays", Label("arrays"), func() {
@@ -785,7 +788,9 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 })
 
 var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 	var ctx = context.Background()
 
 	setupRedisClient := func(protocolVersion int) *redis.Client {
@@ -801,8 +806,8 @@ var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
 
 	AfterEach(func() {
 		if client != nil {
-			client.FlushDB(ctx)
-			client.Close()
+			rawClient.FlushDB(ctx)
+			closeSubject()
 		}
 	})
 
@@ -812,7 +817,8 @@ var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
 		for _, protocol := range protocols {
 			When("using protocol version", func() {
 				BeforeEach(func() {
-					client = setupRedisClient(protocol)
+					rawClient = setupRedisClient(protocol)
+					client, closeSubject = newUniversalSubject(rawClient)
 				})
 
 				It("should perform complex JSON and RediSearch operations", func() {

--- a/main_test.go
+++ b/main_test.go
@@ -612,3 +612,51 @@ func initializeTLSCluster(ctx context.Context) error {
 func cleanupTLSCluster() {
 	// TLS cluster is auto-managed by the container, no cleanup needed
 }
+
+// newUniversalSubject returns the redis.UniversalClient that a parametrized
+// command suite runs against, selected by the GOREDIS_TEST_SUBJECT env var so a
+// whole suite can be replayed through the autopipeliner without touching each
+// spec:
+//
+//	(unset)|client -> the *redis.Client itself (default; unchanged behavior)
+//	ap-blocking     -> client.AutoPipeline()      (synchronous drop-in face)
+//	ap-async        -> client.AsyncAutoPipeline()  (deferred face; result reads block)
+//
+// It returns the subject plus a single closer that closes the autopipeliner (if
+// any) and then the underlying *redis.Client — so callers just defer/AfterEach
+// one call. Admin/connection-only calls not on UniversalClient (FlushDB,
+// Config*, Ping, Info, Conn, ...) should use the underlying client directly.
+func newUniversalSubject(c *redis.Client) (redis.UniversalClient, func() error) {
+	// closeWith closes the optional autopipeliner then the underlying client,
+	// returning the first error.
+	closeWith := func(ap *redis.AutoPipeliner) func() error {
+		return func() error {
+			var firstErr error
+			if ap != nil {
+				if err := ap.Close(); err != nil {
+					firstErr = err
+				}
+			}
+			if err := c.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+			return firstErr
+		}
+	}
+	switch os.Getenv("GOREDIS_TEST_SUBJECT") {
+	case "ap-blocking":
+		ap, err := c.AutoPipelineWithOptions(&redis.AutoPipelineOptions{MaxBatchSize: 300})
+		if err != nil {
+			panic(err)
+		}
+		return ap, closeWith(ap)
+	case "ap-async":
+		ap, err := c.AsyncAutoPipelineWithOptions(&redis.AutoPipelineOptions{MaxBatchSize: 300})
+		if err != nil {
+			panic(err)
+		}
+		return ap, closeWith(ap)
+	default:
+		return c, closeWith(nil)
+	}
+}

--- a/maintnotifications/manager.go
+++ b/maintnotifications/manager.go
@@ -410,13 +410,21 @@ func (hm *Manager) Close() error {
 	additional := hm.additionalPoolHooks
 	hm.additionalPoolHooks = nil
 	hm.hooksMu.Unlock()
-	for _, ah := range additional {
+	for i, ah := range additional {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		err := ah.hook.Shutdown(shutdownCtx)
 		cancel()
 		if err != nil {
-			// Could not cleanly shut down an additional hook; stay open so the
-			// caller can retry Close, matching the primary-hook behavior above.
+			// Could not cleanly shut down this hook. Put it and the ones not
+			// yet processed back so a retried Close still sees them, then stay
+			// open so the caller can retry, matching the primary-hook behavior
+			// above. Hooks before i already shut down and detached.
+			hm.hooksMu.Lock()
+			remaining := make([]additionalPoolHook, 0, len(additional)-i+len(hm.additionalPoolHooks))
+			remaining = append(remaining, additional[i:]...)
+			remaining = append(remaining, hm.additionalPoolHooks...)
+			hm.additionalPoolHooks = remaining
+			hm.hooksMu.Unlock()
 			hm.closed.Store(false)
 			return err
 		}

--- a/pipeline_buffer_test.go
+++ b/pipeline_buffer_test.go
@@ -7,9 +7,22 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// TestPipelineBufferSizes verifies that enabling the pipeline buffer options keeps
-// pipelining working end-to-end. It does not assert the actual socket buffer sizes
-// (not observable here) - only that the configured client still runs pipelines.
+// skipWithoutRedis skips the test when no server answers at redisAddr, so a
+// unit-only run doesn't turn missing integration infrastructure into a
+// failure. It probes with a DEFAULT-options client, not the test's configured
+// one: probing with the client under test would convert a regression in the
+// very options being exercised (buffer sizes, pipeline pool) into a silent
+// skip while the server is up.
+func skipWithoutRedis(t *testing.T, ctx context.Context, _ *redis.Client) {
+	t.Helper()
+	probe := redis.NewClient(&redis.Options{Addr: redisAddr})
+	defer probe.Close()
+	if err := probe.Ping(ctx).Err(); err != nil {
+		t.Skipf("no redis at %s: %v", redisAddr, err)
+	}
+}
+
+// TestPipelineBufferSizes verifies that pipeline pool is created with custom buffer sizes
 func TestPipelineBufferSizes(t *testing.T) {
 	ctx := context.Background()
 
@@ -23,6 +36,7 @@ func TestPipelineBufferSizes(t *testing.T) {
 		PipelinePoolSize:        5,          // Small pool for pipelining
 	})
 	defer client.Close()
+	skipWithoutRedis(t, ctx, client)
 
 	// Test that regular commands work
 	err := client.Set(ctx, "test_key", "test_value", 0).Err()
@@ -77,6 +91,7 @@ func TestNoPipelinePool(t *testing.T) {
 		// No PipelineReadBufferSize or PipelineWriteBufferSize
 	})
 	defer client.Close()
+	skipWithoutRedis(t, ctx, client)
 
 	// Test that pipeline still works (using regular pool)
 	pipe := client.Pipeline()
@@ -119,6 +134,7 @@ func TestPipelinePoolStats(t *testing.T) {
 		PipelinePoolSize:        5,          // Small pool for pipelining
 	})
 	defer client.Close()
+	skipWithoutRedis(t, ctx, client)
 
 	// Execute some pipeline commands
 	pipe := client.Pipeline()
@@ -166,6 +182,7 @@ func TestNoPipelinePoolStats(t *testing.T) {
 		WriteBufferSize: 64 * 1024, // 64 KiB for all connections
 	})
 	defer client.Close()
+	skipWithoutRedis(t, ctx, client)
 
 	// Execute some commands
 	err := client.Set(ctx, "test_key", "test_value", 0).Err()

--- a/pipeline_buffer_test.go
+++ b/pipeline_buffer_test.go
@@ -22,7 +22,9 @@ func skipWithoutRedis(t *testing.T, ctx context.Context, _ *redis.Client) {
 	}
 }
 
-// TestPipelineBufferSizes verifies that pipeline pool is created with custom buffer sizes
+// TestPipelineBufferSizes verifies that enabling the pipeline buffer options keeps
+// pipelining working end-to-end. It does not assert the actual socket buffer sizes
+// (not observable here) - only that the configured client still runs pipelines.
 func TestPipelineBufferSizes(t *testing.T) {
 	ctx := context.Background()
 

--- a/probabilistic_test.go
+++ b/probabilistic_test.go
@@ -29,17 +29,20 @@ var _ = Describe("Probabilistic commands", Label("probabilistic"), func() {
 		protocol := protocol // capture loop variable for each context
 
 		Context(fmt.Sprintf("with protocol version %d", protocol), func() {
-			var client *redis.Client
+			var client redis.UniversalClient
+			var rawClient *redis.Client
+			var closeSubject func() error
 
 			BeforeEach(func() {
-				client = setupRedisClient(protocol)
-				Expect(client.FlushAll(ctx).Err()).NotTo(HaveOccurred())
+				rawClient = setupRedisClient(protocol)
+				client, closeSubject = newUniversalSubject(rawClient)
+				Expect(rawClient.FlushAll(ctx).Err()).NotTo(HaveOccurred())
 			})
 
 			AfterEach(func() {
 				if client != nil {
-					client.FlushDB(ctx)
-					client.Close()
+					rawClient.FlushDB(ctx)
+					closeSubject()
 				}
 			})
 
@@ -243,7 +246,11 @@ var _ = Describe("Probabilistic commands", Label("probabilistic"), func() {
 						client.BFLoadChunk(ctx, "testbfsd1", e.Iter, e.Data)
 					}
 					infAfter := client.BFInfoSize(ctx, "testbfsd1")
-					Expect(infBefore).To(BeEquivalentTo(infAfter))
+					// Compare values, not command structs: on the async
+					// autopipeline face each command carries its own batch
+					// pointer, so struct equality is always false there (and
+					// Val() awaits the result).
+					Expect(infBefore.Val()).To(BeEquivalentTo(infAfter.Val()))
 				})
 
 				It("should BFReserveWithArgs", Label("bloom", "bfreserveargs"), func() {
@@ -368,7 +375,8 @@ var _ = Describe("Probabilistic commands", Label("probabilistic"), func() {
 						client.CFLoadChunk(ctx, "testcfsd1", e.Iter, e.Data)
 					}
 					infAfter := client.CFInfo(ctx, "testcfsd1")
-					Expect(infBefore).To(BeEquivalentTo(infAfter))
+					// Compare values, not command structs (see BFScanDump above).
+					Expect(infBefore.Val()).To(BeEquivalentTo(infAfter.Val()))
 				})
 
 				It("should CFInfo and CFReserveWithArgs", Label("cuckoo", "cfinfo", "cfreserveargs"), func() {

--- a/search_test.go
+++ b/search_test.go
@@ -56,22 +56,25 @@ func encodeFloat16Vector(vec []float32) []byte {
 
 var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	ctx := context.TODO()
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 
 	BeforeEach(func() {
-		client = reNewClient(2, false)
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		rawClient = reNewClient(2, false)
+		client, closeSubject = newUniversalSubject(rawClient)
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	It("should FTCreate and FTSearch WithScores", Label("search", "ftcreate", "ftsearch"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		client.HSet(ctx, "doc1", "txt", "foo baz")
 		client.HSet(ctx, "doc2", "txt", "foo bar")
 		res, err := client.FTSearchWithArgs(ctx, "txt", "foo ~bar", &redis.FTSearchOptions{WithScores: true}).Result()
@@ -88,7 +91,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{StopWords: []interface{}{"foo", "bar", "baz"}}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		client.HSet(ctx, "doc1", "txt", "foo baz")
 		client.HSet(ctx, "doc2", "txt", "hello world")
 		res1, err := client.FTSearchWithArgs(ctx, "txt", "foo bar", &redis.FTSearchOptions{NoContent: true}).Result()
@@ -103,7 +106,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}, &redis.FieldSchema{FieldName: "num", FieldType: redis.SearchFieldTypeNumeric}, &redis.FieldSchema{FieldName: "loc", FieldType: redis.SearchFieldTypeGeo}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		client.HSet(ctx, "doc1", "txt", "foo bar", "num", 3.141, "loc", "-0.441,51.458")
 		client.HSet(ctx, "doc2", "txt", "foo baz", "num", 2, "loc", "-0.1,51.2")
 		res1, err := client.FTSearchWithArgs(ctx, "txt", "foo", &redis.FTSearchOptions{Filters: []redis.FTSearchFilter{{FieldName: "num", Min: 0, Max: 2}}, NoContent: true}).Result()
@@ -134,7 +137,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "num", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}, &redis.FieldSchema{FieldName: "num", FieldType: redis.SearchFieldTypeNumeric, Sortable: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "num")
+		WaitForIndexing(rawClient, "num")
 		client.HSet(ctx, "doc1", "txt", "foo bar", "num", 1)
 		client.HSet(ctx, "doc2", "txt", "foo baz", "num", 2)
 		client.HSet(ctx, "doc3", "txt", "foo qux", "num", 3)
@@ -168,7 +171,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "title", FieldType: redis.SearchFieldTypeText, Weight: 5}, &redis.FieldSchema{FieldName: "body", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		client.HSet(ctx, "doc1", "title", "RediSearch", "body", "Redisearch implements a search engine on top of redis")
 		res1, err := client.FTSearchWithArgs(ctx, "txt", "search engine", &redis.FTSearchOptions{NoContent: true, Verbatim: true, LimitOffset: 0, Limit: 5}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -185,7 +188,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx", &redis.FTCreateOptions{}, text1, text2, num, geo, tag).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx")
+		WaitForIndexing(rawClient, "idx")
 		client.HSet(ctx, "doc1", "field", "aaa", "text", "1", "numeric", 1, "geo", "1,1", "tag", "1")
 		client.HSet(ctx, "doc2", "field", "aab", "text", "2", "numeric", 2, "geo", "2,2", "tag", "2")
 		res1, err := client.FTSearch(ctx, "idx", "@text:aa*").Result()
@@ -221,7 +224,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{}, text1, text2, text3).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		res1, err := client.FTExplain(ctx, "txt", "@f3:f3_val @f2:f2_val @f1:f1_val").Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res1).ToNot(BeEmpty())
@@ -234,11 +237,11 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val1, err := client.FTCreate(ctx, "testAlias", &redis.FTCreateOptions{Prefix: []interface{}{"index1:"}}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val1).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "testAlias")
+		WaitForIndexing(rawClient, "testAlias")
 		val2, err := client.FTCreate(ctx, "testAlias2", &redis.FTCreateOptions{Prefix: []interface{}{"index2:"}}, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val2).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "testAlias2")
+		WaitForIndexing(rawClient, "testAlias2")
 
 		client.HSet(ctx, "index1:lonestar", "name", "lonestar")
 		client.HSet(ctx, "index2:yogurt", "name", "yogurt")
@@ -273,7 +276,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText, Sortable: true, NoStem: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		resInfo, err := client.FTInfo(ctx, "idx1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -286,7 +289,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		resAlter, err := client.FTAlter(ctx, "idx1", false, []interface{}{"body", redis.SearchFieldTypeText.String()}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -307,7 +310,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "f1", "some valid content", "f2", "this is sample text")
 		client.HSet(ctx, "doc2", "f1", "very important", "f2", "lorem ipsum")
@@ -354,7 +357,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		resDictAdd, err := client.FTDictAdd(ctx, "custom_dict", "item1", "item2", "item3").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -378,7 +381,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "name", "Jon")
 		client.HSet(ctx, "doc2", "name", "John")
@@ -388,12 +391,12 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		Expect(res1.Total).To(BeEquivalentTo(int64(1)))
 		Expect(res1.Docs[0].Fields["name"]).To(BeEquivalentTo("Jon"))
 
-		client.FlushDB(ctx)
+		rawClient.FlushDB(ctx)
 		text2 := &redis.FieldSchema{FieldName: "name", FieldType: redis.SearchFieldTypeText, PhoneticMatcher: "dm:en"}
 		val2, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val2).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "name", "Jon")
 		client.HSet(ctx, "doc2", "name", "John")
@@ -415,7 +418,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "description", "The quick brown fox jumps over the lazy dog")
 		client.HSet(ctx, "doc2", "description", "Quick alice was beginning to get very tired of sitting by her quick sister on the bank, and of having nothing to do.")
@@ -457,7 +460,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "description", "The quick brown fox jumps over the lazy dog")
 		client.HSet(ctx, "doc2", "description", "Quick alice was beginning to get very tired of sitting by her quick sister on the bank, and of having nothing to do.")
@@ -514,7 +517,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, text2, text3, num).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "search", "title", "RediSearch",
 			"body", "Redisearch implements a search engine on top of redis",
@@ -618,7 +621,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "t1", "a", "t2", "b")
 		client.HSet(ctx, "doc2", "t1", "b", "t2", "a")
@@ -659,7 +662,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "t1", "hello", "t2", "world")
 
@@ -701,7 +704,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnHash: true, Prefix: []interface{}{"product:"}}, title, description).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "product:1", "title", "New Gaming Laptop", "description", "this is not a desktop")
 		client.HSet(ctx, "product:2", "title", "Super Old Not Gaming Laptop", "description", "this laptop is not a new laptop but it is a laptop")
@@ -757,7 +760,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		// 6 feb
 		client.HSet(ctx, "doc1", "PrimaryKey", "9::362330", "CreatedDateTimeUTC", "1738823999")
@@ -794,7 +797,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "PrimaryKey", "9::362330", "CreatedDateTimeUTC", "637387878524969984")
 		client.HSet(ctx, "doc2", "PrimaryKey", "9::362329", "CreatedDateTimeUTC", "637387875859270016")
@@ -813,7 +816,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "name", "bar", "age", "25")
 		client.HSet(ctx, "doc2", "name", "foo", "age", "19")
@@ -1065,7 +1068,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{SkipInitialScan: true}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		res, err := client.FTSearch(ctx, "idx1", "@foo:bar").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1078,7 +1081,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []interface{}{"king:"}}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.JSONSet(ctx, "king:1", "$", `{"name": "henry"}`)
 		client.JSONSet(ctx, "king:2", "$", `{"name": "james"}`)
@@ -1097,7 +1100,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.JSONSet(ctx, "doc:1", "$", `{"name": "Jon", "age": 25}`)
 
@@ -1115,7 +1118,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, tag1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "1", "t", "HELLO")
 		client.HSet(ctx, "2", "t", "hello")
@@ -1134,7 +1137,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err = client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, tag2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		res, err = client.FTSearch(ctx, "idx1", "@t:{HELLO}").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1153,7 +1156,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		res, err := client.FTSearchWithArgs(ctx, "idx1", "*", &redis.FTSearchOptions{Return: []redis.FTSearchReturn{{FieldName: "$.t", As: "txt"}}}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1175,7 +1178,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnHash: true}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		resSynUpdate, err := client.FTSynUpdateWithArgs(ctx, "idx1", "id1", &redis.FTSynUpdateOptions{SkipInitialScan: true}, []interface{}{"boy", "child", "offspring"}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1201,7 +1204,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnHash: true}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		resSynUpdate, err := client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"boy", "child", "offspring"}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1239,7 +1242,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []interface{}{"king:"}}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.JSONSet(ctx, "king:1", "$", `{"name": "henry", "num": 42}`)
 		client.JSONSet(ctx, "king:2", "$", `{"name": "james", "num": 3.14}`)
@@ -1263,7 +1266,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true, Prefix: []interface{}{"king:"}}, tag1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.JSONSet(ctx, "king:1", "$", `{"name": "henry", "country": {"name": "england"}}`)
 
@@ -1281,7 +1284,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnJSON: true}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.JSONSet(ctx, "doc:1", "$", `{"prod:name": "RediSearch"}`)
 
@@ -1310,7 +1313,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{HNSWOptions: hnswOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "a", "v", "aaaaaaaa")
 		client.HSet(ctx, "b", "v", "aaaabaaa")
@@ -1335,7 +1338,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{HNSWOptions: hnswOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "a", "v", "aaaaaaaa")
 		client.HSet(ctx, "b", "v", "aaaabaaa")
@@ -1360,7 +1363,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{HNSWOptions: hnswOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "a", "v", "aaaaaaaa")
 		client.HSet(ctx, "b", "v", "aaaabaaa")
@@ -1381,7 +1384,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "name", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "name", "Alice")
 		client.HSet(ctx, "doc2", "name", "Bob")
@@ -1399,7 +1402,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "numval", FieldType: redis.SearchFieldTypeNumeric}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "numval", 101)
 		client.HSet(ctx, "doc2", "numval", 102)
@@ -1417,7 +1420,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "g", FieldType: redis.SearchFieldTypeGeo}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "g", "29.69465, 34.95126")
 		client.HSet(ctx, "doc2", "g", "29.69350, 34.94737")
@@ -1472,7 +1475,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		res, err := client.FTInfo(ctx, "idx1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1486,7 +1489,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err = client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText, WithSuffixtrie: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		res, err = client.FTInfo(ctx, "idx1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1500,7 +1503,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err = client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "t", FieldType: redis.SearchFieldTypeTag, WithSuffixtrie: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		res, err = client.FTInfo(ctx, "idx1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -1586,7 +1589,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err = client.FTCreate(ctx, "idx_hash", ftCreateOptions, schema...).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(Equal("OK"))
-		WaitForIndexing(client, "idx_hash")
+		WaitForIndexing(rawClient, "idx_hash")
 
 		ftSearchOptions := &redis.FTSearchOptions{
 			DialectVersion: 4,
@@ -1617,7 +1620,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "geom", FieldType: redis.SearchFieldTypeGeoShape, GeoShapeFieldType: "FLAT"}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "small", "geom", "POLYGON((1 1, 1 100, 100 100, 100 1, 1 1))")
 		client.HSet(ctx, "large", "geom", "POLYGON((1 1, 1 200, 200 200, 200 1, 1 1))")
@@ -1648,7 +1651,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "index")
+		WaitForIndexing(rawClient, "index")
 	})
 
 	It("should test geoshapes query intersects and disjoint", Label("NonRedisEnterprise"), func() {
@@ -1728,7 +1731,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText, IndexMissing: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "property:1", map[string]interface{}{
 			"title":       "Luxury Villa in Malibu",
@@ -1773,7 +1776,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText, IndexEmpty: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "property:1", map[string]interface{}{
 			"title":       "Luxury Villa in Malibu",
@@ -1837,7 +1840,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		// Insert vectors in int8 and uint8 format
 		client.HSet(ctx, "doc1", "int8_vector", "\x01\x02", "uint8_vector", "\x01\x02")
@@ -1880,7 +1883,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FTCreateOptions{OnHash: true, Prefix: []interface{}{"doc:"}},
 			&redis.FieldSchema{FieldName: "vector", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{FlatOptions: vecField}}).Result()
 		Expect(err).NotTo(HaveOccurred())
-		WaitForIndexing(client, "idx_vec")
+		WaitForIndexing(rawClient, "idx_vec")
 
 		bigPos := []float32{1e38, 1e38}
 		bigNeg := []float32{-1e38, -1e38}
@@ -1930,7 +1933,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "a", "v", "aaaaaaaa")
 		client.HSet(ctx, "b", "v", "aaaabaaa")
@@ -1962,7 +1965,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 	})
 
 	It("should FTCreate VECTOR with VAMANA algorithm - advanced parameters", Label("search", "ftcreate"), func() {
@@ -1983,7 +1986,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 	})
 
 	It("should fail FTCreate VECTOR with VAMANA - missing required parameters", Label("search", "ftcreate"), func() {
@@ -2052,7 +2055,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		// L2 distance test vectors
 		vectors := [][]float32{
@@ -2091,7 +2094,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := [][]float32{
 			{1.0, 0.0, 0.0},
@@ -2129,7 +2132,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := [][]float32{
 			{1.0, 2.0, 3.0},
@@ -2167,7 +2170,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := [][]float32{
 			{1.0, 2.0, 3.0, 4.0},
@@ -2205,7 +2208,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := [][]float32{
 			{1.5, 2.5, 3.5, 4.5},
@@ -2240,7 +2243,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := [][]float32{
 			{1.0, 2.0, 3.0, 4.0},
@@ -2275,7 +2278,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "a", "v", "aaaaaaaa")
 		client.HSet(ctx, "b", "v", "aaaabaaa")
@@ -2305,7 +2308,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 20)
 		for i := 0; i < 20; i++ {
@@ -2344,7 +2347,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v16", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions16}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx16")
+		WaitForIndexing(rawClient, "idx16")
 
 		// Test FLOAT32 with LVQ8
 		vamanaOptions32 := &redis.FTVamanaOptions{
@@ -2359,7 +2362,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v32", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions32}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx32")
+		WaitForIndexing(rawClient, "idx32")
 
 		// Add data to both indices
 		for i := 0; i < 15; i++ {
@@ -2407,7 +2410,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 20)
 		for i := 0; i < 20; i++ {
@@ -2443,7 +2446,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 25)
 		for i := 0; i < 25; i++ {
@@ -2479,7 +2482,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 30)
 		for i := 0; i < 30; i++ {
@@ -2520,7 +2523,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 15)
 		for i := 0; i < 15; i++ {
@@ -2551,7 +2554,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "testIdx")
+		WaitForIndexing(rawClient, "testIdx")
 
 		client.HSet(ctx, "doc1", "txt", "hello world")
 
@@ -2571,7 +2574,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txns")
+		WaitForIndexing(rawClient, "txns")
 
 		client.HSet(ctx, "doc1", "dummy", "dummy")
 
@@ -2595,7 +2598,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx")
+		WaitForIndexing(rawClient, "idx")
 
 		client.HSet(ctx, "doc1", "n", 0)
 
@@ -2618,7 +2621,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestAvg")
+		WaitForIndexing(rawClient, "aggTestAvg")
 
 		client.HSet(ctx, "doc1", "grp", "g1")
 
@@ -2644,7 +2647,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestCount")
+		WaitForIndexing(rawClient, "aggTestCount")
 
 		client.HSet(ctx, "doc1", "grp", "g1")
 
@@ -2670,7 +2673,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestSum")
+		WaitForIndexing(rawClient, "aggTestSum")
 
 		client.HSet(ctx, "doc1", "grp", "g1")
 
@@ -2695,7 +2698,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggExpired")
+		WaitForIndexing(rawClient, "aggExpired")
 
 		for i := 1; i <= 15; i++ {
 			key := fmt.Sprintf("doc%d", i)
@@ -2731,7 +2734,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTimeoutHeavy")
+		WaitForIndexing(rawClient, "aggTimeoutHeavy")
 
 		const totalDocs = 100000
 		for i := 0; i < totalDocs; i++ {
@@ -2740,7 +2743,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			Expect(err).NotTo(HaveOccurred())
 		}
 		// default behaviour was changed in 8.0.1, set to fail to validate the timeout was triggered
-		err = client.ConfigSet(ctx, "search-on-timeout", "fail").Err()
+		err = rawClient.ConfigSet(ctx, "search-on-timeout", "fail").Err()
 		Expect(err).NotTo(HaveOccurred())
 
 		options := &redis.FTAggregateOptions{
@@ -2762,7 +2765,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestCountDistinct")
+		WaitForIndexing(rawClient, "aggTestCountDistinct")
 
 		client.HSet(ctx, "doc1", "grp", "g1")
 
@@ -2788,7 +2791,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestCountDistinctIsh")
+		WaitForIndexing(rawClient, "aggTestCountDistinctIsh")
 
 		_, err = client.HSet(ctx, "doc1", "grp", "g1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2813,7 +2816,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "scoringTest")
+		WaitForIndexing(rawClient, "scoringTest")
 
 		_, err = client.HSet(ctx, "doc1", "description", "red apple").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2840,7 +2843,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestStddev")
+		WaitForIndexing(rawClient, "aggTestStddev")
 
 		_, err = client.HSet(ctx, "doc1", "grp", "g1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2867,7 +2870,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestQuantile")
+		WaitForIndexing(rawClient, "aggTestQuantile")
 
 		_, err = client.HSet(ctx, "doc1", "grp", "g1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2893,7 +2896,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestFirstValue")
+		WaitForIndexing(rawClient, "aggTestFirstValue")
 
 		_, err = client.HSet(ctx, "doc1", "grp", "g1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -2918,14 +2921,14 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		val, err = client.FTCreate(ctx, "idx2", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "name", FieldType: redis.SearchFieldTypeText},
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx2")
+		WaitForIndexing(rawClient, "idx2")
 
 		_, err = client.FTAliasAdd(ctx, "idx2", "idx1").Result()
 		Expect(err).To(HaveOccurred())
@@ -2938,7 +2941,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txtIndex")
+		WaitForIndexing(rawClient, "txtIndex")
 
 		_, err = client.HSet(ctx, "doc1", "txt", "hello world").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -3024,7 +3027,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			Expect(err).To(HaveOccurred())
 		}
 
-		val, err := client.ConfigGet(ctx, "*").Result()
+		val, err := rawClient.ConfigGet(ctx, "*").Result()
 		Expect(err).NotTo(HaveOccurred())
 		// Since FT.CONFIG is deprecated since redis 8, use CONFIG instead with new search parameters.
 		keys := make([]string, 0, len(val))
@@ -3042,7 +3045,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "aggTestMinMax")
+		WaitForIndexing(rawClient, "aggTestMinMax")
 
 		_, err = client.HSet(ctx, "doc1", "grp", "g1").Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -3077,7 +3080,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 20)
 		for i := 0; i < 20; i++ {
@@ -3116,7 +3119,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 20)
 		for i := 0; i < 20; i++ {
@@ -3165,7 +3168,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 				&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(BeEquivalentTo("OK"))
-			WaitForIndexing(client, indexName)
+			WaitForIndexing(rawClient, indexName)
 
 			for i := 0; i < 15; i++ {
 				vec := make([]float32, 8)
@@ -3212,7 +3215,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 				&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(BeEquivalentTo("OK"))
-			WaitForIndexing(client, indexName)
+			WaitForIndexing(rawClient, indexName)
 
 			for i := 0; i < 15; i++ {
 				vec := make([]float32, 8)
@@ -3261,7 +3264,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 					&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(val).To(BeEquivalentTo("OK"))
-				WaitForIndexing(client, indexName)
+				WaitForIndexing(rawClient, indexName)
 
 				for i := 0; i < 10; i++ {
 					vec := make([]float32, 8)
@@ -3313,7 +3316,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 				&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(BeEquivalentTo("OK"))
-			WaitForIndexing(client, indexName)
+			WaitForIndexing(rawClient, indexName)
 
 			for i := 0; i < 15; i++ {
 				vec := make([]float32, 8)
@@ -3365,7 +3368,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 20)
 		for i := 0; i < 20; i++ {
@@ -3404,7 +3407,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 			&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		vectors := make([][]float32, 20)
 		for i := 0; i < 20; i++ {
@@ -3453,7 +3456,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 				&redis.FieldSchema{FieldName: "v", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{VamanaOptions: vamanaOptions}}).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(BeEquivalentTo("OK"))
-			WaitForIndexing(client, indexName)
+			WaitForIndexing(rawClient, indexName)
 
 			// Add test data
 			for i := 0; i < 15; i++ {
@@ -3503,7 +3506,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx_vector")
+		WaitForIndexing(rawClient, "idx_vector")
 
 		// Get FT.INFO
 		resInfo, err := client.FTInfo(ctx, "idx_vector").Result()
@@ -3609,10 +3612,13 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 // Hybrid Search Tests
 var _ = Describe("FT.HYBRID Commands", func() {
 	ctx := context.TODO()
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 
 	BeforeEach(func() {
-		client = reNewClient(2, false)
+		rawClient = reNewClient(2, false)
+		client, closeSubject = newUniversalSubject(rawClient)
 		// Create index with text, numeric, tag fields and vector fields
 		err := client.FTCreate(ctx, "hybrid_idx", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText},
@@ -3643,7 +3649,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 				},
 			}).Err()
 		Expect(err).NotTo(HaveOccurred())
-		WaitForIndexing(client, "hybrid_idx")
+		WaitForIndexing(rawClient, "hybrid_idx")
 
 		// Add test data
 		items := []struct {
@@ -3678,6 +3684,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	AfterEach(func() {
 		err := client.FTDropIndex(ctx, "hybrid_idx").Err()
 		Expect(err).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	It("should perform basic hybrid search", Label("search", "fthybrid"), func() {
@@ -4381,17 +4388,20 @@ var _ = Describe("RediSearch FT.Config with Resp2 and Resp3", Label("search", "N
 
 var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 	ctx := context.TODO()
-	var client *redis.Client
+	var client redis.UniversalClient
+	var rawClient *redis.Client
+	var closeSubject func() error
 	var client2 *redis.Client
 
 	BeforeEach(func() {
-		client = reNewClient(3, true)
+		rawClient = reNewClient(3, true)
+		client, closeSubject = newUniversalSubject(rawClient)
 		client2 = reNewClient(3, false)
-		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
+		Expect(rawClient.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		Expect(client.Close()).NotTo(HaveOccurred())
+		Expect(closeSubject()).NotTo(HaveOccurred())
 	})
 
 	It("should handle FTAggregate with RESP3", Label("search", "ftcreate", "ftaggregate"), func() {
@@ -4400,11 +4410,11 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, num1).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "PrimaryKey", "9::362330", "CreatedDateTimeUTC", "637387878524969984")
 		client.HSet(ctx, "doc2", "PrimaryKey", "9::362329", "CreatedDateTimeUTC", "637387875859270016")
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		options := &redis.FTAggregateOptions{Apply: []redis.FTAggregateApply{{Field: "@CreatedDateTimeUTC * 10", As: "CreatedDateTimeUTC"}}}
 
@@ -4440,7 +4450,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText, Sortable: true, NoStem: true}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		// Test with UnstableResp3 true - both RawResult and Result should work
 		resInfo, err := client.FTInfo(ctx, "idx1").RawResult()
@@ -4475,7 +4485,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		client.HSet(ctx, "doc1", "f1", "some valid content", "f2", "this is sample text")
 		client.HSet(ctx, "doc2", "f1", "very important", "f2", "lorem ipsum")
@@ -4511,7 +4521,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{StopWords: []interface{}{"foo", "bar", "baz"}}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		client.HSet(ctx, "doc1", "txt", "foo baz")
 		client.HSet(ctx, "doc2", "txt", "hello world")
 
@@ -4555,7 +4565,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnHash: true}, text1, text2).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "idx1")
+		WaitForIndexing(rawClient, "idx1")
 
 		resSynUpdate, err := client.FTSynUpdate(ctx, "idx1", "id1", []interface{}{"boy", "child", "offspring"}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -4612,7 +4622,7 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{}, text1, text2, text3).Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(val).To(BeEquivalentTo("OK"))
-		WaitForIndexing(client, "txt")
+		WaitForIndexing(rawClient, "txt")
 		res1, err := client.FTExplain(ctx, "txt", "@f3:f3_val @f2:f2_val @f1:f1_val").Result()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res1).ToNot(BeEmpty())

--- a/search_test.go
+++ b/search_test.go
@@ -4402,6 +4402,9 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 
 	AfterEach(func() {
 		Expect(closeSubject()).NotTo(HaveOccurred())
+		// client2 is spec-local like the subject; leaking it across specs
+		// accumulates pools and goroutines over the suite.
+		Expect(client2.Close()).NotTo(HaveOccurred())
 	})
 
 	It("should handle FTAggregate with RESP3", Label("search", "ftcreate", "ftaggregate"), func() {

--- a/timeseries_commands_test.go
+++ b/timeseries_commands_test.go
@@ -33,17 +33,20 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 		protocol := protocol // capture loop variable for each context
 
 		Context(fmt.Sprintf("with protocol version %d", protocol), func() {
-			var client *redis.Client
+			var client redis.UniversalClient
+			var rawClient *redis.Client
+			var closeSubject func() error
 
 			BeforeEach(func() {
-				client = setupRedisClient(protocol)
-				Expect(client.FlushAll(ctx).Err()).NotTo(HaveOccurred())
+				rawClient = setupRedisClient(protocol)
+				client, closeSubject = newUniversalSubject(rawClient)
+				Expect(rawClient.FlushAll(ctx).Err()).NotTo(HaveOccurred())
 			})
 
 			AfterEach(func() {
 				if client != nil {
-					client.FlushDB(ctx)
-					client.Close()
+					rawClient.FlushDB(ctx)
+					closeSubject()
 				}
 			})
 
@@ -67,7 +70,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(result).To(BeEquivalentTo("OK"))
 				resultInfo, err := client.TSInfo(ctx, "4").Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(resultInfo["labels"].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"Time", "Series"}))
 				} else {
 					Expect(resultInfo["labels"].(map[interface{}]interface{})["Time"]).To(BeEquivalentTo("Series"))
@@ -164,7 +167,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(result).To(BeEquivalentTo(4))
 				resultInfo, err := client.TSInfo(ctx, "4").Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(resultInfo["labels"].([]interface{})).To(ContainElement([]interface{}{"Time", "Series"}))
 				} else {
 					Expect(resultInfo["labels"].(map[interface{}]interface{})["Time"]).To(BeEquivalentTo("Series"))
@@ -258,7 +261,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 
 				resultInfo, err = client.TSInfo(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(resultInfo["labels"]).To(BeEquivalentTo([]interface{}{}))
 				} else {
 					Expect(resultInfo["labels"]).To(BeEquivalentTo(map[interface{}]interface{}{}))
@@ -271,7 +274,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 
 				resultInfo, err = client.TSInfo(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(resultInfo["labels"].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"Time", "Series"}))
 					Expect(resultInfo["retentionTime"]).To(BeEquivalentTo(10))
 					if redisVersionAtLeast("8") {
@@ -361,7 +364,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(resultDeleteRule).To(BeEquivalentTo("OK"))
 				resultInfo, err := client.TSInfo(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(resultInfo["rules"]).To(BeEquivalentTo([]interface{}{}))
 				} else {
 					Expect(resultInfo["rules"]).To(BeEquivalentTo(map[interface{}]interface{}{}))
@@ -563,7 +566,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 
 				result, err := client.TSMGet(ctx, []string{"Test=This"}).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1].([]interface{})[1]).To(BeEquivalentTo("15"))
 					Expect(result["b"][1].([]interface{})[1]).To(BeEquivalentTo("25"))
 				} else {
@@ -573,7 +576,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mgetOpt := &redis.TSMGetOptions{WithLabels: true}
 				result, err = client.TSMGetWithArgs(ctx, []string{"Test=This"}, mgetOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["b"][0]).To(ConsistOf([]interface{}{"Test", "This"}, []interface{}{"Taste", "That"}))
 				} else {
 					Expect(result["b"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"Test": "This", "Taste": "That"}))
@@ -599,7 +602,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(err).NotTo(HaveOccurred())
 				result, err = client.TSMGet(ctx, []string{"is_compaction=true"}).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(0), "4"}))
 				} else {
 					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(0), 4.0}))
@@ -607,7 +610,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mgetOpt = &redis.TSMGetOptions{Latest: true}
 				result, err = client.TSMGetWithArgs(ctx, []string{"is_compaction=true"}, mgetOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(10), "8"}))
 				} else {
 					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{int64(10), 8.0}))
@@ -990,7 +993,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err := client.TSMRange(ctx, 0, 200, []string{"Test=This"}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(100))
 				} else {
 					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(100))
@@ -999,7 +1002,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt := &redis.TSMRangeOptions{Count: 10}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(10))
 				} else {
 					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(10))
@@ -1013,13 +1016,13 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMRangeWithArgs(ctx, 0, 500, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(20))
 				} else {
 					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(20))
 				}
 				// Test WithLabels
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][0]).To(BeEquivalentTo([]interface{}{}))
 				} else {
 					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{}))
@@ -1027,7 +1030,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{WithLabels: true}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][0]).To(ConsistOf([]interface{}{[]interface{}{"Test", "This"}, []interface{}{"team", "ny"}}))
 				} else {
 					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"Test": "This", "team": "ny"}))
@@ -1036,7 +1039,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{SelectedLabels: []interface{}{"team"}}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "ny"}))
 					Expect(result["b"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "sf"}))
 				} else {
@@ -1051,7 +1054,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{FilterByTS: fts, FilterByValue: []int{1, 2}}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1].([]interface{})).To(BeEquivalentTo([]interface{}{[]interface{}{int64(15), "1"}, []interface{}{int64(16), "2"}}))
 				} else {
 					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(15), 1.0}, []interface{}{int64(16), 2.0}}))
@@ -1060,7 +1063,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{GroupByLabel: "Test", Reducer: "sum"}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "2"}, []interface{}{int64(2), "4"}, []interface{}{int64(3), "6"}}))
 				} else {
 					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 0.0}, []interface{}{int64(1), 2.0}, []interface{}{int64(2), 4.0}, []interface{}{int64(3), 6.0}}))
@@ -1068,7 +1071,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{GroupByLabel: "Test", Reducer: "max"}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "1"}, []interface{}{int64(2), "2"}, []interface{}{int64(3), "3"}}))
 				} else {
 					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 0.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(3), 3.0}}))
@@ -1078,7 +1081,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["team=ny"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "1"}, []interface{}{int64(2), "2"}, []interface{}{int64(3), "3"}}))
 					Expect(result["team=sf"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "0"}, []interface{}{int64(1), "1"}, []interface{}{int64(2), "2"}, []interface{}{int64(3), "3"}}))
 				} else {
@@ -1089,7 +1092,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: "-"}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "10"}, []interface{}{int64(10), "1"}}))
 				} else {
 					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 10.0}, []interface{}{int64(10), 1.0}}))
@@ -1098,7 +1101,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: 5}
 				result, err = client.TSMRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), "5"}, []interface{}{int64(5), "6"}}))
 				} else {
 					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(0), 5.0}, []interface{}{int64(5), 6.0}}))
@@ -1149,7 +1152,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt := &redis.TSMRangeOptions{Latest: true}
 				result, err := client.TSMRangeWithArgs(ctx, 0, 10, []string{"is_compaction=true"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["b"][1]).To(ConsistOf([]interface{}{int64(0), "4"}, []interface{}{int64(10), "8"}))
 					Expect(result["d"][1]).To(ConsistOf([]interface{}{int64(0), "4"}, []interface{}{int64(10), "8"}))
 				} else {
@@ -1188,7 +1191,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(Equal(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["multi-mrange-a"][1]).To(Equal([]interface{}{
 						[]interface{}{int64(1000), "10", "20"},
 						[]interface{}{int64(1020), "30", "40"},
@@ -1235,7 +1238,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err := client.TSMRevRange(ctx, 0, 200, []string{"Test=This"}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(100))
 				} else {
 					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(100))
@@ -1244,7 +1247,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt := &redis.TSMRevRangeOptions{Count: 10}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(10))
 				} else {
 					Expect(len(result["a"][2].([]interface{}))).To(BeEquivalentTo(10))
@@ -1258,7 +1261,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 500, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(len(result["a"][1].([]interface{}))).To(BeEquivalentTo(20))
 					Expect(result["a"][0]).To(BeEquivalentTo([]interface{}{}))
 				} else {
@@ -1268,7 +1271,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{WithLabels: true}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][0]).To(ConsistOf([]interface{}{[]interface{}{"Test", "This"}, []interface{}{"team", "ny"}}))
 				} else {
 					Expect(result["a"][0]).To(BeEquivalentTo(map[interface{}]interface{}{"Test": "This", "team": "ny"}))
@@ -1277,7 +1280,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{SelectedLabels: []interface{}{"team"}}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "ny"}))
 					Expect(result["b"][0].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"team", "sf"}))
 				} else {
@@ -1292,7 +1295,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{FilterByTS: fts, FilterByValue: []int{1, 2}}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 200, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1].([]interface{})).To(ConsistOf([]interface{}{int64(16), "2"}, []interface{}{int64(15), "1"}))
 				} else {
 					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(16), 2.0}, []interface{}{int64(15), 1.0}}))
@@ -1301,7 +1304,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{GroupByLabel: "Test", Reducer: "sum"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "6"}, []interface{}{int64(2), "4"}, []interface{}{int64(1), "2"}, []interface{}{int64(0), "0"}}))
 				} else {
 					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), 6.0}, []interface{}{int64(2), 4.0}, []interface{}{int64(1), 2.0}, []interface{}{int64(0), 0.0}}))
@@ -1309,7 +1312,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{GroupByLabel: "Test", Reducer: "max"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["Test=This"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "3"}, []interface{}{int64(2), "2"}, []interface{}{int64(1), "1"}, []interface{}{int64(0), "0"}}))
 				} else {
 					Expect(result["Test=This"][3]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), 3.0}, []interface{}{int64(2), 2.0}, []interface{}{int64(1), 1.0}, []interface{}{int64(0), 0.0}}))
@@ -1318,7 +1321,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 3, []string{"Test=This"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(BeEquivalentTo(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["team=ny"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "3"}, []interface{}{int64(2), "2"}, []interface{}{int64(1), "1"}, []interface{}{int64(0), "0"}}))
 					Expect(result["team=sf"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(3), "3"}, []interface{}{int64(2), "2"}, []interface{}{int64(1), "1"}, []interface{}{int64(0), "0"}}))
 				} else {
@@ -1329,7 +1332,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: "-"}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), "1"}, []interface{}{int64(0), "10"}}))
 				} else {
 					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), 1.0}, []interface{}{int64(0), 10.0}}))
@@ -1337,7 +1340,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt = &redis.TSMRevRangeOptions{Aggregator: redis.Count, BucketDuration: 10, Align: 1}
 				result, err = client.TSMRevRangeWithArgs(ctx, 0, 10, []string{"team=ny"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["a"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(1), "10"}, []interface{}{int64(0), "1"}}))
 				} else {
 					Expect(result["a"][2]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(1), 10.0}, []interface{}{int64(0), 1.0}}))
@@ -1375,7 +1378,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				}).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(result)).To(Equal(2))
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["multi-mrevrange-a"][1]).To(Equal([]interface{}{
 						[]interface{}{int64(1020), "30", "40"},
 						[]interface{}{int64(1000), "10", "20"},
@@ -1521,7 +1524,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				mrangeOpt := &redis.TSMRevRangeOptions{Latest: true}
 				result, err := client.TSMRevRangeWithArgs(ctx, 0, 10, []string{"is_compaction=true"}, mrangeOpt).Result()
 				Expect(err).NotTo(HaveOccurred())
-				if client.Options().Protocol == 2 {
+				if rawClient.Options().Protocol == 2 {
 					Expect(result["b"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), "8"}, []interface{}{int64(0), "4"}}))
 					Expect(result["d"][1]).To(BeEquivalentTo([]interface{}{[]interface{}{int64(10), "8"}, []interface{}{int64(0), "4"}}))
 				} else {

--- a/vectorset_commands_integration_test.go
+++ b/vectorset_commands_integration_test.go
@@ -50,17 +50,20 @@ var _ = Describe("Redis VectorSet commands", Label("vectorset"), func() {
 		protocol := protocol
 
 		Context(fmt.Sprintf("with protocol version %d", protocol), func() {
-			var client *redis.Client
+			var client redis.UniversalClient
+			var rawClient *redis.Client
+			var closeSubject func() error
 
 			BeforeEach(func() {
-				client = setupRedisClient(protocol)
-				Expect(client.FlushAll(ctx).Err()).NotTo(HaveOccurred())
+				rawClient = setupRedisClient(protocol)
+				client, closeSubject = newUniversalSubject(rawClient)
+				Expect(rawClient.FlushAll(ctx).Err()).NotTo(HaveOccurred())
 			})
 
 			AfterEach(func() {
 				if client != nil {
-					client.FlushDB(ctx)
-					client.Close()
+					rawClient.FlushDB(ctx)
+					closeSubject()
 				}
 			})
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> The iterator change affects all SCAN-style iteration on the async autopipeline face (correctness fix with regression tests); maintnotifications Close retry semantics change only on failed additional-hook shutdown.
> 
> **Overview**
> Adds **end-to-end verification** that major Ginkgo command suites behave the same through **blocking and async AutoPipeline** faces: `newUniversalSubject` selects the client via `GOREDIS_TEST_SUBJECT`, suites use `client` for commands and `rawClient` for admin-only APIs, and CI runs `make test.autopipeline-subjects` through a parameterized `run-tests` **`make-target`** (passed via env to avoid shell injection).
> 
> Fixes a **production bug** on the deferred face: **`ScanIterator.Next`** now calls **`Err()`** after `process()` so SCAN pages are not read before execution (avoids infinite re-SCAN / hang); covered by `TestAsyncAutoPipelineScanIterator` and parametrized iterator tests.
> 
> Adds **autopipeline throughput benchmarks** (`autopipeline_bench_test.go`, `autopipeline_bench_README.md`) and softens README throughput claims to relative multipliers. Minor fixes: **HookManager** restores unprocessed additional pool hooks on partial shutdown failure; pipeline buffer tests **skip** when Redis is absent; probabilistic dump/restore tests compare **`.Val()`** instead of command structs on async AP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b30454c8566b3809ac845c6ea3a8b0d00a7d0aa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->