### PR TITLE
fix: Override the ring client Publish to write to the correct shard's topic

### DIFF
--- a/ring.go
+++ b/ring.go
@@ -698,6 +698,17 @@ func (c *Ring) SSubscribe(ctx context.Context, channels ...string) *PubSub {
 	return shard.Client.SSubscribe(ctx, channels...)
 }
 
+// Publish posts the message to the channel
+func (c *Ring) Publish(ctx context.Context, channel string, message interface{}) *IntCmd {
+	shard, err := c.sharding.GetByKey(channel)
+	if err != nil {
+		cmd := NewIntCmd(ctx, "publish", channel, message)
+		cmd.SetErr(err)
+		return cmd
+	}
+	return shard.Client.Publish(ctx, channel, message)
+}
+
 func (c *Ring) OnNewNode(fn func(rdb *Client)) {
 	c.sharding.OnNewNode(fn)
 }

--- a/ring_test.go
+++ b/ring_test.go
@@ -804,6 +804,49 @@ var _ = Describe("Ring Tx timeout", func() {
 	})
 })
 
+var _ = Describe("Ring Publish/Subscribe sharding", func() {
+	var ring *redis.Ring
+
+	BeforeEach(func() {
+		ring = redis.NewRing(redisRingOptions())
+	})
+
+	AfterEach(func() {
+		Expect(ring.Close()).NotTo(HaveOccurred())
+	})
+
+	It("routes Publish to the same shard as Subscribe for a given channel", func() {
+		// Use many channels to test to make sure there isn't flakiness in the case this would fail.
+		// Because the default sharding (Ring.sharding.Random) is determined by a random function,
+		// we want to make sure there isn't an inconsistency in the failure case
+		const numChannels = 20
+
+		for i := 0; i < numChannels; i++ {
+			channel := fmt.Sprintf("ring-pubsub-test-channel-%d", i)
+
+			pubsub := ring.Subscribe(ctx, channel)
+
+			_, err := pubsub.Receive(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			n, err := ring.Publish(ctx, channel, "hello").Result()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(1)), "channel %s: message should reach the subscriber's shard", channel)
+
+			Eventually(func() interface{} {
+				msg, _ := pubsub.ReceiveTimeout(ctx, time.Second)
+				m, _ := msg.(*redis.Message)
+				if m == nil {
+					return nil
+				}
+				return m.Payload
+			}, 5*time.Second).Should(Equal("hello"))
+
+			Expect(pubsub.Close()).NotTo(HaveOccurred())
+		}
+	})
+})
+
 var _ = Describe("Ring GetShardClients and GetShardClientForKey", func() {
 	var ring *redis.Ring
 


### PR DESCRIPTION
fixes #3889 
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes pub/sub routing behavior for `Ring` users who relied on the old generic publish path; fix is small but affects multi-shard messaging correctness.
> 
> **Overview**
> **Fixes ring pub/sub** where `Publish` could target a different shard than `Subscribe` for the same channel, so subscribers never saw messages.
> 
> Adds an explicit `Ring.Publish` that resolves the shard with `sharding.GetByKey(channel)` (same routing as `Subscribe` / `PSubscribe`) and delegates to that shard’s client. Shard lookup failures return an `IntCmd` with the error set instead of panicking.
> 
> Adds an integration test that exercises **20 channels** end-to-end: subscribe, publish, assert subscriber count `1`, and receive the payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0767349616367c600c4bdd800be6ebe1028f73c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->