### PR TITLE
fix(maintnotifications): data race on clusterStateReloadCallback

### DIFF
--- a/maintnotifications/cluster_state_callback_race_test.go
+++ b/maintnotifications/cluster_state_callback_race_test.go
@@ -1,0 +1,56 @@
+package maintnotifications
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// clusterStateReloadCallback is set from the OnNewNode hook while a node client
+// is being created (GetOrCreateWithNodeAddress) and read from
+// TriggerClusterStateReload, which runs when a SMIGRATED push notification is
+// handled on one of that node's connections (handleSMigrated). With
+// MinIdleConns>0 the node's background dial goroutines process push frames
+// during initConn, so a SMIGRATED can reach TriggerClusterStateReload while the
+// OnNewNode hook is still setting the callback. Run with -race against the
+// pre-fix tree to see the report at manager.go (read in TriggerClusterStateReload
+// vs write in SetClusterStateReloadCallback).
+func TestManagerClusterStateReloadCallbackConcurrent(t *testing.T) {
+	hm := &Manager{}
+
+	const (
+		workers    = 4
+		iterations = 2000
+	)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	// Setters, as the OnNewNode hook does when node clients are created.
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cb := func(context.Context, string, []string) {}
+			<-start
+			for j := 0; j < iterations; j++ {
+				hm.SetClusterStateReloadCallback(cb)
+			}
+		}()
+	}
+
+	// Triggers, as the SMIGRATED push handler does.
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < iterations; j++ {
+				hm.TriggerClusterStateReload(context.Background(), "127.0.0.1:6379", nil)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}

--- a/maintnotifications/manager.go
+++ b/maintnotifications/manager.go
@@ -86,8 +86,11 @@ type Manager struct {
 	// retired before the pool-level listeners are removed.
 	maintNotificationsConns sync.Map // connID -> *pool.Conn
 
-	// Cluster state reload callback for SMIGRATED notifications
-	clusterStateReloadCallback ClusterStateReloadCallback
+	// Cluster state reload callback for SMIGRATED notifications.
+	// Stored atomically because it is set from the OnNewNode hook while a node
+	// client is being created and read from the SMIGRATED push handler on that
+	// node's connections, which can overlap during connection init.
+	clusterStateReloadCallback atomic.Pointer[ClusterStateReloadCallback]
 }
 
 // MovingOperation tracks an active MOVING operation.
@@ -401,13 +404,13 @@ func (hm *Manager) AddNotificationHook(notificationHook NotificationHook) {
 // SetClusterStateReloadCallback sets the callback function that will be called when a SMIGRATED notification is received.
 // This allows node clients to notify their parent ClusterClient to reload cluster state.
 func (hm *Manager) SetClusterStateReloadCallback(callback ClusterStateReloadCallback) {
-	hm.clusterStateReloadCallback = callback
+	hm.clusterStateReloadCallback.Store(&callback)
 }
 
 // TriggerClusterStateReload calls the cluster state reload callback if it's set.
 // This is called when a SMIGRATED notification is received.
 func (hm *Manager) TriggerClusterStateReload(ctx context.Context, hostPort string, slotRanges []string) {
-	if hm.clusterStateReloadCallback != nil {
-		hm.clusterStateReloadCallback(ctx, hostPort, slotRanges)
+	if cb := hm.clusterStateReloadCallback.Load(); cb != nil {
+		(*cb)(ctx, hostPort, slotRanges)
 	}
 }


### PR DESCRIPTION
The maintenance-notifications Manager holds a cluster-state reload callback that a SMIGRATED push notification invokes to reload cluster state. On a ClusterClient with maintenance notifications enabled it is installed from the OnNewNode hook while a node client is being created, and it is read and called from the SMIGRATED handler on that node's connections. Every other field on Manager is a sync.Map or an atomic, but this one was a plain func value guarded on neither the write nor the read. When MinIdleConns is above zero the new node client starts background dialers during creation, and those connections process push frames while they initialize, so a SMIGRATED arriving in that window reads the callback at the same moment the OnNewNode hook writes it. go test -race reports the read in TriggerClusterStateReload against the write in SetClusterStateReloadCallback. Moving the field to an atomic pointer so the setter stores and the trigger loads closes it, matching the atomic-pointer handling already used for the hook chain in redis.go.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small concurrency fix using atomic load/store on one callback field; behavior unchanged aside from eliminating the race.
> 
> **Overview**
> Fixes a **data race** on the maintenance `Manager`’s cluster-state reload callback used when **SMIGRATED** push notifications arrive.
> 
> The callback was a plain field written from **OnNewNode** during node client creation and read from **TriggerClusterStateReload** on connection push handling; with **MinIdleConns > 0**, those paths can overlap during connection init. The field is now an **`atomic.Pointer`**, with **Store** on set and **Load** on trigger, consistent with other lock-free fields in this package.
> 
> Adds **`TestManagerClusterStateReloadCallbackConcurrent`** to exercise concurrent set/trigger (intended for **`-race`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a02514d25349dbb29c2fdc8ad8bc7e30a0de89b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->