### PR TITLE
Add TS.READ command

### DIFF
--- a/timeseries_commands.go
+++ b/timeseries_commands.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/redis/go-redis/v9/internal/proto"
 	"github.com/redis/go-redis/v9/internal/util"
@@ -40,6 +41,23 @@ type TimeseriesCmdable interface {
 	TSMRevRangeWithArgs(ctx context.Context, fromTimestamp int, toTimestamp int, filterExpr []string, options *TSMRevRangeOptions) *MapStringSliceInterfaceCmd
 	TSMGet(ctx context.Context, filters []string) *MapStringSliceInterfaceCmd
 	TSMGetWithArgs(ctx context.Context, filters []string, options *TSMGetOptions) *MapStringSliceInterfaceCmd
+	TSRead(ctx context.Context, key string, timestamp interface{}) *TSTimestampValueSliceCmd
+	TSReadWithArgs(ctx context.Context, key string, timestamp interface{}, options *TSReadOptions) *TSTimestampValueSliceCmd
+}
+
+// TS.READ timestamp cursor sentinels.
+const (
+	TSReadEarliest = "-" // read from the earliest sample
+	TSReadLatest   = "+" // latest sample, inclusive
+	TSReadNew      = "$" // only samples added after the call
+)
+
+// TSReadOptions holds the optional TS.READ arguments.
+type TSReadOptions struct {
+	Block    bool          // wait for samples (emits the BLOCK group)
+	Timeout  time.Duration // max wait; 0 blocks indefinitely
+	MinCount int           // unblock threshold; defaults to 1
+	MaxCount int           // reply cap; 0 is unlimited
 }
 
 type TSOptions struct {
@@ -786,6 +804,47 @@ func (c cmdable) TSRangeWithArgs(ctx context.Context, key string, fromTimestamp 
 		}
 	}
 	cmd := newTSTimestampValueSliceCmd(ctx, args...)
+	_ = c(ctx, cmd)
+	return cmd
+}
+
+// TSRead - Returns samples at or after timestamp, in ascending order.
+// timestamp is a non-negative Unix-ms integer or a sentinel (TSReadEarliest,
+// TSReadLatest, TSReadNew).
+// For more information - https://redis.io/commands/ts.read/
+func (c cmdable) TSRead(ctx context.Context, key string, timestamp interface{}) *TSTimestampValueSliceCmd {
+	args := []interface{}{"TS.READ", key, timestamp}
+	cmd := newTSTimestampValueSliceCmd(ctx, args...)
+	_ = c(ctx, cmd)
+	return cmd
+}
+
+// TSReadWithArgs - TS.READ with the optional BLOCK and MAX_COUNT groups.
+// When options.Block is set it waits for options.MinCount samples or until
+// options.Timeout elapses. Blocking calls must not be used in a pipeline or MULTI.
+// For more information - https://redis.io/commands/ts.read/
+func (c cmdable) TSReadWithArgs(ctx context.Context, key string, timestamp interface{}, options *TSReadOptions) *TSTimestampValueSliceCmd {
+	args := []interface{}{"TS.READ", key, timestamp}
+	blocking := false
+	var blockTimeout time.Duration
+	if options != nil {
+		if options.Block {
+			blocking = true
+			blockTimeout = options.Timeout
+			minCount := options.MinCount
+			if minCount <= 0 {
+				minCount = 1
+			}
+			args = append(args, "BLOCK", formatMs(ctx, options.Timeout), minCount)
+		}
+		if options.MaxCount != 0 {
+			args = append(args, "MAX_COUNT", options.MaxCount)
+		}
+	}
+	cmd := newTSTimestampValueSliceCmd(ctx, args...)
+	if blocking {
+		cmd.setReadTimeout(blockTimeout)
+	}
 	_ = c(ctx, cmd)
 	return cmd
 }

--- a/timeseries_commands_test.go
+++ b/timeseries_commands_test.go
@@ -1819,12 +1819,8 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should TSRead and TSReadWithArgs", Label("timeseries", "tsread", "tsreadWithArgs", "NonRedisEnterprise"), func() {
-				// Skip unless the server knows TS.READ (added in 8.10, which can't be
-				// expressed as a float64 for SkipBeforeRedisVersion).
-				if err := client.TSRead(ctx, "tsread-probe", 0).Err(); err != nil &&
-					strings.Contains(strings.ToLower(err.Error()), "unknown command") {
-					Skip("TS.READ is not supported by this server")
-				}
+				// TS.READ was added in Redis 8.10.
+				SkipBeforeRedisVersion("8.10", "TS.READ was added in Redis 8.10")
 
 				_, err := client.TSCreate(ctx, "tsread:1").Result()
 				Expect(err).NotTo(HaveOccurred())

--- a/timeseries_commands_test.go
+++ b/timeseries_commands_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"
@@ -1815,6 +1816,101 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(redis.Avg.String()).To(Equal("AVG"))
 				Expect(redis.Sum.String()).To(Equal("SUM"))
 				Expect(redis.Count.String()).To(Equal("COUNT"))
+			})
+
+			It("should TSRead and TSReadWithArgs", Label("timeseries", "tsread", "tsreadWithArgs", "NonRedisEnterprise"), func() {
+				// Skip unless the server knows TS.READ (added in 8.10, which can't be
+				// expressed as a float64 for SkipBeforeRedisVersion).
+				if err := client.TSRead(ctx, "tsread-probe", 0).Err(); err != nil &&
+					strings.Contains(strings.ToLower(err.Error()), "unknown command") {
+					Skip("TS.READ is not supported by this server")
+				}
+
+				_, err := client.TSCreate(ctx, "tsread:1").Result()
+				Expect(err).NotTo(HaveOccurred())
+				for _, s := range []redis.TSTimestampValue{
+					{Timestamp: 100, Value: 1.0},
+					{Timestamp: 200, Value: 2.0},
+					{Timestamp: 300, Value: 3.0},
+				} {
+					_, err := client.TSAdd(ctx, "tsread:1", s.Timestamp, s.Value).Result()
+					Expect(err).NotTo(HaveOccurred())
+				}
+
+				// Read everything at or after the cursor.
+				samples, err := client.TSRead(ctx, "tsread:1", 0).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(samples).To(Equal([]redis.TSTimestampValue{
+					{Timestamp: 100, Value: 1.0},
+					{Timestamp: 200, Value: 2.0},
+					{Timestamp: 300, Value: 3.0},
+				}))
+
+				// Page in bounded batches, advancing the cursor to lastTimestamp + 1.
+				page, err := client.TSReadWithArgs(ctx, "tsread:1", redis.TSReadEarliest, &redis.TSReadOptions{MaxCount: 2}).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(page).To(Equal([]redis.TSTimestampValue{
+					{Timestamp: 100, Value: 1.0},
+					{Timestamp: 200, Value: 2.0},
+				}))
+				next := page[len(page)-1].Timestamp + 1
+				page, err = client.TSReadWithArgs(ctx, "tsread:1", next, &redis.TSReadOptions{MaxCount: 2}).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(page).To(Equal([]redis.TSTimestampValue{
+					{Timestamp: 300, Value: 3.0},
+				}))
+
+				// Past the newest sample, or a missing key, returns empty.
+				empty, err := client.TSRead(ctx, "tsread:1", 301).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(empty).To(BeEmpty())
+				empty, err = client.TSRead(ctx, "tsread-missing", 0).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(empty).To(BeEmpty())
+
+				// "+" returns the latest sample, inclusive, even without BLOCK.
+				latest, err := client.TSRead(ctx, "tsread:1", redis.TSReadLatest).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(latest).To(Equal([]redis.TSTimestampValue{{Timestamp: 300, Value: 3.0}}))
+
+				// "$" without BLOCK always returns empty.
+				fresh, err := client.TSRead(ctx, "tsread:1", redis.TSReadNew).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fresh).To(BeEmpty())
+
+				// Timeout flush: MinCount can't be reached, so the samples >= 101
+				// are returned after the timeout.
+				flush, err := client.TSReadWithArgs(ctx, "tsread:1", 101, &redis.TSReadOptions{
+					Block:    true,
+					Timeout:  500 * time.Millisecond,
+					MinCount: 10,
+				}).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(flush).To(Equal([]redis.TSTimestampValue{
+					{Timestamp: 200, Value: 2.0},
+					{Timestamp: 300, Value: 3.0},
+				}))
+
+				// Wake-up: a concurrent append unblocks a "$" tail read.
+				producer := setupRedisClient(protocol)
+				done := make(chan struct{})
+				// Defers run LIFO: join the producer before closing its client.
+				defer producer.Close()
+				defer func() { <-done }()
+				go func() {
+					defer GinkgoRecover()
+					defer close(done)
+					time.Sleep(200 * time.Millisecond)
+					_, addErr := producer.TSAdd(ctx, "tsread:1", 400, 4.0).Result()
+					Expect(addErr).NotTo(HaveOccurred())
+				}()
+				tail, err := client.TSReadWithArgs(ctx, "tsread:1", redis.TSReadNew, &redis.TSReadOptions{
+					Block:    true,
+					Timeout:  5 * time.Second,
+					MinCount: 1,
+				}).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tail).To(Equal([]redis.TSTimestampValue{{Timestamp: 400, Value: 4.0}}))
 			})
 		})
 	}


### PR DESCRIPTION
TS.READ is a read-only, single-key command that returns a batch of time series samples with timestamps at or after a cursor, in ascending timestamp order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and tests only; blocking behavior follows existing client patterns with documented pipeline/MULTI restrictions.
> 
> **Overview**
> Adds **Redis Time Series `TS.READ`** to go-redis so clients can fetch samples at or after a cursor in ascending time order (Redis 8.10+).
> 
> **`TSRead` / `TSReadWithArgs`** are wired into `TimeseriesCmdable` and reuse `TSTimestampValueSliceCmd`. Cursor sentinels **`TSReadEarliest` (`-`)**, **`TSReadLatest` (`+`)**, and **`TSReadNew` (`$`)** are exposed as constants. **`TSReadOptions`** supports **`MAX_COUNT`** paging and a **`BLOCK`** group with timeout, min count (default 1), and **`setReadTimeout`** on the command when blocking (same idea as other blocking Redis commands).
> 
> Integration tests cover full reads, paginated reads, empty/missing-key behavior, sentinel cursors, block timeout flush, and a concurrent append unblocking a blocking `$` read.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36ee894a612371921de35f8bd24562bdf3bc6b42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->