### PR TITLE
Add SUnionCard and SDiffCard commands

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -5046,6 +5046,8 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SUnionCard", Label("NonRedisEnterprise"), func() {
+			SkipBeforeRedisVersion("8.10", "SUNIONCARD is available since Redis 8.10")
+
 			sAdd := client.SAdd(ctx, "set1", "a", "b", "c")
 			Expect(sAdd.Err()).NotTo(HaveOccurred())
 			sAdd = client.SAdd(ctx, "set2", "c", "d")
@@ -5073,6 +5075,8 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SDiffCard", Label("NonRedisEnterprise"), func() {
+			SkipBeforeRedisVersion("8.10", "SDIFFCARD is available since Redis 8.10")
+
 			sAdd := client.SAdd(ctx, "set0", "a", "b", "c", "d", "e")
 			Expect(sAdd.Err()).NotTo(HaveOccurred())
 			sAdd = client.SAdd(ctx, "set1", "c", "d", "x")

--- a/commands_test.go
+++ b/commands_test.go
@@ -5045,6 +5045,62 @@ var _ = Describe("Commands", func() {
 			Expect(sInterCard.Val()).To(Equal(int64(2)))
 		})
 
+		It("should SUnionCard", Label("NonRedisEnterprise"), func() {
+			sAdd := client.SAdd(ctx, "set1", "a", "b", "c")
+			Expect(sAdd.Err()).NotTo(HaveOccurred())
+			sAdd = client.SAdd(ctx, "set2", "c", "d")
+			Expect(sAdd.Err()).NotTo(HaveOccurred())
+
+			// exact union {a, b, c, d}
+			sUnionCard := client.SUnionCard(ctx, nil, "set1", "set2")
+			Expect(sUnionCard.Err()).NotTo(HaveOccurred())
+			Expect(sUnionCard.Val()).To(Equal(int64(4)))
+
+			// exact with LIMIT capped at 3
+			sUnionCard = client.SUnionCard(ctx, &redis.SUnionCardOptions{Limit: 3}, "set1", "set2")
+			Expect(sUnionCard.Err()).NotTo(HaveOccurred())
+			Expect(sUnionCard.Val()).To(Equal(int64(3)))
+
+			// missing key is treated as an empty set
+			sUnionCard = client.SUnionCard(ctx, nil, "set1", "missing")
+			Expect(sUnionCard.Err()).NotTo(HaveOccurred())
+			Expect(sUnionCard.Val()).To(Equal(int64(3)))
+
+			// APPROX: for small sets the approximate result matches the exact value
+			sUnionCard = client.SUnionCard(ctx, &redis.SUnionCardOptions{Approx: true}, "set1", "set2")
+			Expect(sUnionCard.Err()).NotTo(HaveOccurred())
+			Expect(sUnionCard.Val()).To(Equal(int64(4)))
+		})
+
+		It("should SDiffCard", Label("NonRedisEnterprise"), func() {
+			sAdd := client.SAdd(ctx, "set0", "a", "b", "c", "d", "e")
+			Expect(sAdd.Err()).NotTo(HaveOccurred())
+			sAdd = client.SAdd(ctx, "set1", "c", "d", "x")
+			Expect(sAdd.Err()).NotTo(HaveOccurred())
+			sAdd = client.SAdd(ctx, "set2", "e", "y")
+			Expect(sAdd.Err()).NotTo(HaveOccurred())
+
+			// s0 \ (s1 ∪ s2) = {a, b}
+			sDiffCard := client.SDiffCard(ctx, nil, "set0", "set1", "set2")
+			Expect(sDiffCard.Err()).NotTo(HaveOccurred())
+			Expect(sDiffCard.Val()).To(Equal(int64(2)))
+
+			// exact with LIMIT capped at 1
+			sDiffCard = client.SDiffCard(ctx, &redis.SDiffCardOptions{Limit: 1}, "set0", "set1", "set2")
+			Expect(sDiffCard.Err()).NotTo(HaveOccurred())
+			Expect(sDiffCard.Val()).To(Equal(int64(1)))
+
+			// missing subtrahend key does not affect the result
+			sDiffCard = client.SDiffCard(ctx, nil, "set0", "missing")
+			Expect(sDiffCard.Err()).NotTo(HaveOccurred())
+			Expect(sDiffCard.Val()).To(Equal(int64(5)))
+
+			// missing first key yields an empty base set
+			sDiffCard = client.SDiffCard(ctx, nil, "missing", "set0")
+			Expect(sDiffCard.Err()).NotTo(HaveOccurred())
+			Expect(sDiffCard.Val()).To(Equal(int64(0)))
+		})
+
 		It("should SInterStore", Label("NonRedisEnterprise"), func() {
 			sAdd := client.SAdd(ctx, "set1", "a")
 			Expect(sAdd.Err()).NotTo(HaveOccurred())

--- a/set_commands.go
+++ b/set_commands.go
@@ -127,6 +127,8 @@ func (c cmdable) SDiffCard(ctx context.Context, opts *SDiffCardOptions, keys ...
 	}
 	args = append(args, "limit", opts.Limit)
 	cmd := NewIntCmd(ctx, args...)
+	// Keys start after the numkeys arg: ["sdiffcard", numKeys, key1, ...].
+	cmd.SetFirstKeyPos(2)
 	_ = c(ctx, cmd)
 	return cmd
 }
@@ -384,6 +386,8 @@ func (c cmdable) SUnionCard(ctx context.Context, opts *SUnionCardOptions, keys .
 	}
 	args = append(args, "limit", opts.Limit)
 	cmd := NewIntCmd(ctx, args...)
+	// Keys start after the numkeys arg: ["sunioncard", numKeys, key1, ...].
+	cmd.SetFirstKeyPos(2)
 	_ = c(ctx, cmd)
 	return cmd
 }

--- a/set_commands.go
+++ b/set_commands.go
@@ -12,6 +12,7 @@ type SetCmdable interface {
 	SAdd(ctx context.Context, key string, members ...interface{}) *IntCmd
 	SCard(ctx context.Context, key string) *IntCmd
 	SDiff(ctx context.Context, keys ...string) *StringSliceCmd
+	SDiffCard(ctx context.Context, opts *SDiffCardOptions, keys ...string) *IntCmd
 	SDiffStore(ctx context.Context, destination string, keys ...string) *IntCmd
 	SInter(ctx context.Context, keys ...string) *StringSliceCmd
 	SInterCard(ctx context.Context, limit int64, keys ...string) *IntCmd
@@ -28,7 +29,19 @@ type SetCmdable interface {
 	SRem(ctx context.Context, key string, members ...interface{}) *IntCmd
 	SScan(ctx context.Context, key string, cursor uint64, match string, count int64) *ScanCmd
 	SUnion(ctx context.Context, keys ...string) *StringSliceCmd
+	SUnionCard(ctx context.Context, opts *SUnionCardOptions, keys ...string) *IntCmd
 	SUnionStore(ctx context.Context, destination string, keys ...string) *IntCmd
+}
+
+// SUnionCardOptions are the options for SUnionCard.
+type SUnionCardOptions struct {
+	Approx bool  // use an approximate (HyperLogLog) count.
+	Limit  int64 // cap the result; 0 means no limit.
+}
+
+// SDiffCardOptions are the options for SDiffCard.
+type SDiffCardOptions struct {
+	Limit int64 // cap the result; 0 means no limit.
 }
 
 // Returns the number of elements that were added to the set, not including all
@@ -91,6 +104,28 @@ func (c cmdable) SDiffStore(ctx context.Context, destination string, keys ...str
 	for i, key := range keys {
 		args[2+i] = key
 	}
+	cmd := NewIntCmd(ctx, args...)
+	_ = c(ctx, cmd)
+	return cmd
+}
+
+// Returns the cardinality of the difference of the first set and the rest.
+// Missing keys are treated as empty sets.
+//
+// For more information about the command please refer to [SDIFFCARD].
+//
+// [SDIFFCARD]: (https://redis.io/docs/latest/commands/sdiffcard/)
+func (c cmdable) SDiffCard(ctx context.Context, opts *SDiffCardOptions, keys ...string) *IntCmd {
+	if opts == nil {
+		opts = &SDiffCardOptions{}
+	}
+	numKeys := len(keys)
+	args := make([]interface{}, 0, 4+numKeys)
+	args = append(args, "sdiffcard", numKeys)
+	for _, key := range keys {
+		args = append(args, key)
+	}
+	args = append(args, "limit", opts.Limit)
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd
@@ -323,6 +358,31 @@ func (c cmdable) SUnionStore(ctx context.Context, destination string, keys ...st
 	for i, key := range keys {
 		args[2+i] = key
 	}
+	cmd := NewIntCmd(ctx, args...)
+	_ = c(ctx, cmd)
+	return cmd
+}
+
+// Returns the cardinality of the union of all the given sets.
+// Missing keys are treated as empty sets.
+//
+// For more information about the command please refer to [SUNIONCARD].
+//
+// [SUNIONCARD]: (https://redis.io/docs/latest/commands/sunioncard/)
+func (c cmdable) SUnionCard(ctx context.Context, opts *SUnionCardOptions, keys ...string) *IntCmd {
+	if opts == nil {
+		opts = &SUnionCardOptions{}
+	}
+	numKeys := len(keys)
+	args := make([]interface{}, 0, 4+numKeys+1)
+	args = append(args, "sunioncard", numKeys)
+	for _, key := range keys {
+		args = append(args, key)
+	}
+	if opts.Approx {
+		args = append(args, "approx")
+	}
+	args = append(args, "limit", opts.Limit)
 	cmd := NewIntCmd(ctx, args...)
 	_ = c(ctx, cmd)
 	return cmd


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive API and command wiring only; no changes to auth, persistence, or existing set command behavior.
> 
> **Overview**
> Adds client support for Redis **SUNIONCARD** and **SDIFFCARD** (8.10+), extending `SetCmdable` with `SUnionCard` and `SDiffCard` that return set-union and set-difference cardinalities without materializing member lists.
> 
> **`SUnionCard`** accepts optional `SUnionCardOptions` (`Limit`, `Approx` for HyperLogLog-style counting). **`SDiffCard`** accepts `SDiffCardOptions` (`Limit` only). Both build the Redis argument list (`numkeys`, keys, then `limit` / `approx` as applicable) and set first-key position for cluster routing, mirroring existing set-cardinality helpers like `SInterCard`.
> 
> Integration tests cover exact counts, capped `Limit`, missing keys, and approximate union on small sets, gated with `SkipBeforeRedisVersion("8.10")`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df4ea6225fbae9f77f9f3b2bc4b037f8ce8928dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->