### PR TITLE
fix(command): reject odd-length flat replies in Z/KeyValue parsers

### DIFF
--- a/command.go
+++ b/command.go
@@ -2030,6 +2030,9 @@ func (cmd *KeyValueSliceCmd) readReply(rd *proto.Reader) error { // nolint:dupl
 	if array {
 		cmd.val = make([]KeyValue, n)
 	} else {
+		if n%2 != 0 {
+			return fmt.Errorf("redis: got %d elements in the key-value array, wanted a multiple of 2", n)
+		}
 		cmd.val = make([]KeyValue, n/2)
 	}
 
@@ -4132,6 +4135,9 @@ func (cmd *ZSliceCmd) readReply(rd *proto.Reader) error { // nolint:dupl
 	if array {
 		cmd.val = make([]Z, n)
 	} else {
+		if n%2 != 0 {
+			return fmt.Errorf("redis: got %d elements in the sorted set array, wanted a multiple of 2", n)
+		}
 		cmd.val = make([]Z, n/2)
 	}
 
@@ -6230,6 +6236,9 @@ func (cmd *ZSliceWithKeyCmd) readReply(rd *proto.Reader) (err error) {
 	if array {
 		cmd.val = make([]Z, n)
 	} else {
+		if n%2 != 0 {
+			return fmt.Errorf("redis: got %d elements in the sorted set array, wanted a multiple of 2", n)
+		}
 		cmd.val = make([]Z, n/2)
 	}
 

--- a/command_flat_reply_test.go
+++ b/command_flat_reply_test.go
@@ -1,0 +1,62 @@
+package redis
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/redis/go-redis/v9/internal/proto"
+)
+
+// A RESP2 flat reply (a single array of alternating member/score or key/value
+// elements) must have an even length. An odd length means the parser would read
+// n/2 pairs and leave the trailing element on the wire, desyncing the pooled
+// connection. These parsers must reject it, matching the guard the sibling flat
+// parsers (VLINKS, VSIM) already have.
+func TestFlatReplyOddLengthRejected(t *testing.T) {
+	t.Run("ZSliceCmd", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader("*3\r\n$1\r\na\r\n$3\r\n1.5\r\n$1\r\nb\r\n"))
+		cmd := NewZSliceCmd(context.Background())
+		if err := cmd.readReply(rd); err == nil {
+			t.Fatalf("odd-length flat reply accepted; readReply returned nil (val=%+v)", cmd.val)
+		}
+	})
+	t.Run("KeyValueSliceCmd", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader("*3\r\n$1\r\nk\r\n$1\r\nv\r\n$1\r\nx\r\n"))
+		cmd := NewKeyValueSliceCmd(context.Background())
+		if err := cmd.readReply(rd); err == nil {
+			t.Fatalf("odd-length flat reply accepted; readReply returned nil (val=%+v)", cmd.val)
+		}
+	})
+	t.Run("ZSliceWithKeyCmd", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader("*2\r\n$3\r\nzst\r\n*3\r\n$1\r\na\r\n$3\r\n1.5\r\n$1\r\nb\r\n"))
+		cmd := NewZSliceWithKeyCmd(context.Background())
+		if err := cmd.readReply(rd); err == nil {
+			t.Fatalf("odd-length flat reply accepted; readReply returned nil (val=%+v)", cmd.val)
+		}
+	})
+}
+
+// Even-length flat replies and the nested-array form must still parse cleanly.
+func TestFlatReplyValidStillParses(t *testing.T) {
+	t.Run("flat", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader("*4\r\n$1\r\na\r\n$3\r\n1.5\r\n$1\r\nb\r\n$3\r\n2.5\r\n"))
+		cmd := NewZSliceCmd(context.Background())
+		if err := cmd.readReply(rd); err != nil {
+			t.Fatalf("valid flat reply: %v", err)
+		}
+		if len(cmd.val) != 2 || cmd.val[0].Member != "a" || cmd.val[1].Member != "b" {
+			t.Fatalf("unexpected val: %+v", cmd.val)
+		}
+	})
+	t.Run("nested", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader("*2\r\n*2\r\n$1\r\na\r\n$3\r\n1.5\r\n*2\r\n$1\r\nb\r\n$3\r\n2.5\r\n"))
+		cmd := NewZSliceCmd(context.Background())
+		if err := cmd.readReply(rd); err != nil {
+			t.Fatalf("valid nested reply: %v", err)
+		}
+		if len(cmd.val) != 2 {
+			t.Fatalf("unexpected val: %+v", cmd.val)
+		}
+	})
+}


### PR DESCRIPTION
Odd-length RESP2 flat reply (member/score or key/value) on a pooled connection:

    ZSliceCmd.readReply err=<nil>          // reports success
    proto.Reader.ReadString => "b"         // next command reads the leftover element

The flat (non-array) branch of ZSliceCmd, KeyValueSliceCmd and ZSliceWithKeyCmd
allocates make([]T, n/2) and reads n/2 pairs without checking n is even, so an
odd count leaves the trailing element buffered and desyncs the connection for the
next command. Adds the even-length guard the sibling flat parsers (VLINKS, VSIM,
VectorAttrib) already have.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RESP reply parsing on pooled connections; behavior change is stricter validation (errors where malformed replies previously slipped through), which is safer but could surface latent server/proxy bugs.
> 
> **Overview**
> Fixes a **RESP2 flat-reply parsing bug** where odd-length member/score or key/value arrays could be treated as success while leaving one element unread on the connection, corrupting the next command on pooled clients.
> 
> The **flat (non-nested-array) branches** of `KeyValueSliceCmd`, `ZSliceCmd`, and `ZSliceWithKeyCmd` now **require an even element count** and return a clear error instead of partially consuming the reply—aligned with guards already used by flat parsers such as VLINKS/VSIM.
> 
> Adds **`command_flat_reply_test.go`** to assert odd-length flat replies are rejected and that valid flat and nested replies still parse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a21bf675d5e46010108b0e41100fddcd8c0e3a28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->