### PR TITLE
fix(json): return read error from JSONSliceCmd.readReply

### DIFF
--- a/json.go
+++ b/json.go
@@ -238,7 +238,7 @@ func (cmd *JSONSliceCmd) readReply(rd *proto.Reader) error {
 	} else if readType == proto.RespArray {
 		response, err := rd.ReadReply()
 		if err != nil {
-			return nil
+			return err
 		} else {
 			cmd.val = response.([]interface{})
 		}

--- a/json_desync_test.go
+++ b/json_desync_test.go
@@ -1,0 +1,24 @@
+package redis
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/redis/go-redis/v9/internal/proto"
+)
+
+// A malformed array reply must surface the read error so the pooled connection
+// is dropped by isBadConn. Before the fix JSONSliceCmd.readReply returned nil
+// when rd.ReadReply() failed, so the failed read was reported as success and
+// the connection went back to the pool in an indeterminate state, letting the
+// next command read leftover bytes as its own reply.
+func TestJSONSliceCmdReturnsReadError(t *testing.T) {
+	// RESP2 array whose element is a malformed integer; ReadReply errors.
+	reply := "*1\r\n:notanint\r\n"
+	cmd := NewJSONSliceCmd(context.Background())
+	rd := proto.NewReader(strings.NewReader(reply + "+NEXT\r\n"))
+	if err := cmd.readReply(rd); err == nil {
+		t.Fatalf("readReply() = nil, want error")
+	}
+}


### PR DESCRIPTION
proto.NewReader over a malformed JSON array reply:

    *1\r\n:notanint\r\n+NEXT\r\n

    JSONSliceCmd.readReply() -> nil   // ReadReply() errored, error dropped
    next command reads +NEXT as its own reply

The RESP array branch calls rd.ReadReply() and on error does return nil, so a failed array read is reported as success. The connection skips isBadConn and goes back to the pool desynced, so leftover bytes from the failed reply surface as the next command's response. Reachable from a malicious or MITM server returning a bad array for a JSON command.

Change it to return err, matching the else branch below it and the sibling readReply parsers. Test drives the malformed reply through proto.NewReader and asserts readReply now returns the error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level RESP parsing for JSON commands; behavior change surfaces errors that were previously hidden, which is correct but affects any caller that assumed silent success on parse failure.
> 
> **Overview**
> Fixes a **connection pool desync** when `JSONSliceCmd` parses a RESP array reply (e.g. `JSON.MGET` / `JSON.TYPE`).
> 
> In the `RespArray` branch, **`readReply` now returns `err` from `rd.ReadReply()`** instead of `nil`. A malformed or truncated array no longer looks like success, so the client can treat the connection as bad (`isBadConn`) and avoid returning the pooled socket with unread bytes that the next command would misinterpret as its reply.
> 
> Adds **`TestJSONSliceCmdReturnsReadError`** with a malformed array element (`:notanint`) to assert the read error is surfaced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a17fa552a272e4f7dc880900b43c68f2ddf98cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->