### PR TITLE
fix: add InfoMap to Cmdable interface

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -209,6 +209,7 @@ type Cmdable interface {
 	FlushDB(ctx context.Context) *StatusCmd
 	FlushDBAsync(ctx context.Context) *StatusCmd
 	Info(ctx context.Context, section ...string) *StringCmd
+	InfoMap(ctx context.Context, section ...string) *InfoCmd
 	LastSave(ctx context.Context) *IntCmd
 	Save(ctx context.Context) *StatusCmd
 	Shutdown(ctx context.Context) *StatusCmd


### PR DESCRIPTION
## Summary
- `InfoMap` is fully implemented on `cmdable` in `commands.go` (parallel to `Info`), but was never added to the `Cmdable` interface declaration.
- Since `UniversalClient` embeds `Cmdable`, any code using the `UniversalClient` or `Cmdable` interface type (rather than a concrete `*Client`/`*ClusterClient`/`*Ring`) had no way to call `.InfoMap(...)`, even though every concrete client already supports it.
- This adds the missing one-line method declaration to the `Cmdable` interface so it's reachable through `UniversalClient` as well.

Fixes #3902

## Test plan
- [x] `go build ./...` passes, confirming `Client`, `ClusterClient`, and `Ring` still satisfy `Cmdable`/`UniversalClient` with the new method in the interface.
- [x] `go vet ./...` passes.
- [x] Existing `InfoMap` Ginkgo specs in `commands_test.go` (`"should InfoMap"`, `"should InfoMap Modules"`) already cover the method's runtime behavior against a live Redis server; this change only exposes the existing method through the interface, so no new test was needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line interface addition with no logic changes; existing compile-time checks and InfoMap tests already cover behavior.
> 
> **Overview**
> Adds **`InfoMap`** to the **`Cmdable`** interface so callers using **`UniversalClient`** or any **`Cmdable`**-typed handle can invoke it, matching the existing **`Info`** declaration and the **`cmdable`** implementation that was already in place.
> 
> No runtime or command behavior changes—only interface surface area for typed API consumers (fixes #3902).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2f3835d4400b0e01747d2acf87cf677a31d030a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->