### PR TITLE
test: run the Redis Enterprise suite against an external cluster

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -43,7 +43,10 @@ var _ = Describe("Commands", func() {
 	})
 
 	Describe("server", func() {
-		It("should Auth", func() {
+		// NonRedisEnterprise: Redis Enterprise returns "WRONGPASS invalid
+		// username-password pair" on a failed AUTH, whereas OSS Redis returns an
+		// "ERR AUTH ..." message; this assertion is OSS-specific.
+		It("should Auth", Label("NonRedisEnterprise"), func() {
 			cmds, err := client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 				pipe.Auth(ctx, "password")
 				pipe.Auth(ctx, "")
@@ -283,7 +286,9 @@ var _ = Describe("Commands", func() {
 			Expect(r).To(Equal(int64(0)))
 		})
 
-		It("should ClientInfo", func() {
+		// NonRedisEnterprise: Redis Enterprise CLIENT INFO advertises an extra
+		// connection flag ("m") that the OSS client-info parser does not recognize.
+		It("should ClientInfo", Label("NonRedisEnterprise"), func() {
 			info, err := client.ClientInfo(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(info).NotTo(BeNil())
@@ -313,7 +318,9 @@ var _ = Describe("Commands", func() {
 			Expect(get.Val()).To(Equal("theclientname"))
 		})
 
-		It("should ClientSetInfo", func() {
+		// NonRedisEnterprise: CLIENT SETINFO against Redis Enterprise triggers a nil-pointer
+		// panic in the client (RE response not handled); skipped pending investigation.
+		It("should ClientSetInfo", Label("NonRedisEnterprise"), func() {
 			pipe := client.Pipeline()
 
 			// Test setting the libName
@@ -379,7 +386,9 @@ var _ = Describe("Commands", func() {
 			Expect(val).NotTo(BeEmpty())
 		})
 
-		It("should ConfigGet Modules", func() {
+		// NonRedisEnterprise: module configuration is not exposed via CONFIG GET on
+		// Redis Enterprise the way it is on OSS Redis.
+		It("should ConfigGet Modules", Label("NonRedisEnterprise"), func() {
 			SkipBeforeRedisVersion(8, "Config doesn't include modules before Redis 8")
 			expected := map[string]string{
 				"search-*": "search-timeout",
@@ -425,7 +434,9 @@ var _ = Describe("Commands", func() {
 			Expect(configGet.Val()).To(HaveKey("cf-initial-size"))
 		})
 
-		It("should ConfigSet FT DIALECT", func() {
+		// NonRedisEnterprise: FT.CONFIG is not available on Redis Enterprise
+		// (superseded by CONFIG GET/SET in Redis 8), so this OSS-only path errors.
+		It("should ConfigSet FT DIALECT", Label("NonRedisEnterprise"), func() {
 			SkipBeforeRedisVersion(8, "config doesn't include modules before Redis 8")
 			defaultState, err := client.ConfigGet(ctx, "search-default-dialect").Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -477,7 +488,9 @@ var _ = Describe("Commands", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should ConfigSet Modules", func() {
+		// NonRedisEnterprise: the "search-timeout" module CONFIG parameter is not
+		// supported on Redis Enterprise.
+		It("should ConfigSet Modules", Label("NonRedisEnterprise"), func() {
 			SkipBeforeRedisVersion(8, "Config doesn't include modules before Redis 8")
 			defaults := map[string]string{}
 			expected := map[string]string{
@@ -567,7 +580,9 @@ var _ = Describe("Commands", func() {
 			Expect(info.Val()).To(HaveLen(1))
 		})
 
-		It("should Info Modules", Label("redis.info"), func() {
+		// NonRedisEnterprise: Redis Enterprise reports loaded modules in a different
+		// INFO shape, so the OSS module-name assertions do not hold.
+		It("should Info Modules", Label("redis.info", "NonRedisEnterprise"), func() {
 			SkipBeforeRedisVersion(8, "modules are included in info for Redis Version >= 8")
 			info := client.Info(ctx)
 			Expect(info.Err()).NotTo(HaveOccurred())
@@ -592,7 +607,9 @@ var _ = Describe("Commands", func() {
 			Expect(info.Val()).To(ContainSubstring("bf"))
 		})
 
-		It("should InfoMap Modules", Label("redis.info"), func() {
+		// NonRedisEnterprise: see "should Info Modules" - RE reports modules in a
+		// different INFO layout from OSS, so the parsed module map is empty here.
+		It("should InfoMap Modules", Label("redis.info", "NonRedisEnterprise"), func() {
 			SkipBeforeRedisVersion(8, "modules are included in info for Redis Version >= 8")
 			info := client.InfoMap(ctx)
 			Expect(info.Err()).NotTo(HaveOccurred())
@@ -1015,7 +1032,9 @@ var _ = Describe("Commands", func() {
 			Expect(ttl.Val() < 0).To(Equal(true))
 		})
 
-		It("should PExpire", func() {
+		// NonRedisEnterprise: asserts the remaining TTL within 100ms, which is unreliable
+		// against a remote Redis Enterprise endpoint due to network round-trip latency.
+		It("should PExpire", Label("NonRedisEnterprise"), func() {
 			set := client.Set(ctx, "key", "Hello", 0)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Val()).To(Equal("OK"))
@@ -1034,7 +1053,9 @@ var _ = Describe("Commands", func() {
 			Expect(pttl.Val()).To(BeNumerically("~", expiration, 100*time.Millisecond))
 		})
 
-		It("should PExpireAt", func() {
+		// NonRedisEnterprise: asserts the remaining TTL within 100ms, which is unreliable
+		// against a remote Redis Enterprise endpoint due to network round-trip latency.
+		It("should PExpireAt", Label("NonRedisEnterprise"), func() {
 			set := client.Set(ctx, "key", "Hello", 0)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Val()).To(Equal("OK"))
@@ -8464,10 +8485,7 @@ var _ = Describe("Commands", func() {
 				time.Sleep(100 * time.Millisecond)
 
 				// Test with RESP2 (protocol 2)
-				resp2Client := redis.NewClient(&redis.Options{
-					Addr:     redisAddr,
-					Protocol: 2,
-				})
+				resp2Client := reNewClient(2, false)
 				defer resp2Client.Close()
 
 				resp2Result, err := resp2Client.XReadGroup(ctx, &redis.XReadGroupArgs{
@@ -8480,10 +8498,7 @@ var _ = Describe("Commands", func() {
 				Expect(resp2Result).To(HaveLen(1))
 
 				// Test with RESP3 (protocol 3)
-				resp3Client := redis.NewClient(&redis.Options{
-					Addr:     redisAddr,
-					Protocol: 3,
-				})
+				resp3Client := reNewClient(3, false)
 				defer resp3Client.Close()
 
 				resp3Result, err := resp3Client.XReadGroup(ctx, &redis.XReadGroupArgs{
@@ -8577,7 +8592,9 @@ var _ = Describe("Commands", func() {
 				Expect(n).To(Equal(int64(1)))
 			})
 
-			It("should XINFO STREAM", func() {
+			// NonRedisEnterprise: Redis Enterprise returns different stream radix-tree fields in
+			// XINFO STREAM than the OSS values this spec asserts.
+			It("should XINFO STREAM", Label("NonRedisEnterprise"), func() {
 				res, err := client.XInfoStream(ctx, "stream").Result()
 				Expect(err).NotTo(HaveOccurred())
 				res.RadixTreeKeys = 0

--- a/commands_test.go
+++ b/commands_test.go
@@ -43,22 +43,36 @@ var _ = Describe("Commands", func() {
 	})
 
 	Describe("server", func() {
-		// NonRedisEnterprise: Redis Enterprise returns "WRONGPASS invalid
-		// username-password pair" on a failed AUTH, whereas OSS Redis returns an
-		// "ERR AUTH ..." message; this assertion is OSS-specific.
-		It("should Auth", Label("NonRedisEnterprise"), func() {
+		It("should Auth", func() {
+			// A failed AUTH is reported as "ERR AUTH ..." by a passwordless OSS
+			// Redis and as "WRONGPASS invalid username-password pair" by a
+			// password-protected server (e.g. Redis Enterprise); accept both.
+			//
+			// The two failing AUTH commands are deliberately issued in separate
+			// pipelines: on a password-protected server a second failed AUTH in
+			// the same pipeline is throttled by the server's brute-force
+			// protection and never answered, stalling the read until the client
+			// times out.
+			authErr := SatisfyAny(ContainSubstring("ERR AUTH"), ContainSubstring("WRONGPASS"))
+
 			cmds, err := client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 				pipe.Auth(ctx, "password")
+				return nil
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(authErr)
+			Expect(cmds[0].Err().Error()).To(authErr)
+
+			cmds, err = client.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 				pipe.Auth(ctx, "")
 				return nil
 			})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("ERR AUTH"))
-			Expect(cmds[0].Err().Error()).To(ContainSubstring("ERR AUTH"))
-			Expect(cmds[1].Err().Error()).To(ContainSubstring("ERR AUTH"))
+			Expect(err.Error()).To(authErr)
+			Expect(cmds[0].Err().Error()).To(authErr)
 
 			stats := client.PoolStats()
-			Expect(stats.Hits).To(Equal(uint32(1)))
+			Expect(stats.Hits).To(Equal(uint32(2)))
 			Expect(stats.Misses).To(Equal(uint32(1)))
 			Expect(stats.Timeouts).To(Equal(uint32(0)))
 			Expect(stats.TotalConns).To(Equal(uint32(1)))

--- a/internal_test.go
+++ b/internal_test.go
@@ -686,7 +686,10 @@ func (e timeoutErr) Error() string {
 	return "i/o timeout"
 }
 
-var _ = Describe("withConn", func() {
+// NonRedisEnterprise: exercises connection-pool replacement internals against a
+// local Redis and requires a localhost server; not meaningful against a remote
+// Enterprise cluster.
+var _ = Describe("withConn", Label("NonRedisEnterprise"), func() {
 	var client *Client
 
 	BeforeEach(func() {

--- a/json_test.go
+++ b/json_test.go
@@ -21,12 +21,14 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 	var client *redis.Client
 
 	setupRedisClient := func(protocolVersion int) *redis.Client {
-		return redis.NewClient(&redis.Options{
+		opt := &redis.Options{
 			Addr:          "localhost:6379",
 			DB:            0,
 			Protocol:      protocolVersion,
 			UnstableResp3: true,
-		})
+		}
+		applyREConnection(opt)
+		return redis.NewClient(opt)
 	}
 
 	AfterEach(func() {
@@ -787,12 +789,14 @@ var _ = Describe("Go-Redis Advanced JSON and RediSearch Tests", func() {
 	var ctx = context.Background()
 
 	setupRedisClient := func(protocolVersion int) *redis.Client {
-		return redis.NewClient(&redis.Options{
+		opt := &redis.Options{
 			Addr:          "localhost:6379",
 			DB:            0,
 			Protocol:      protocolVersion, // Setting RESP2 or RESP3 protocol
 			UnstableResp3: true,            // Enable RESP3 features
-		})
+		}
+		applyREConnection(opt)
+		return redis.NewClient(opt)
 	}
 
 	AfterEach(func() {

--- a/main_test.go
+++ b/main_test.go
@@ -121,6 +121,12 @@ var _ = BeforeSuite(func() {
 
 	redisPort = redisStackPort
 	redisAddr = redisStackAddr
+	if RECluster && os.Getenv("REDIS_ENDPOINTS_CONFIG_PATH") != "" {
+		reConn, err = loadREConnection()
+		Expect(err).NotTo(HaveOccurred())
+		redisAddr = reConn.Addr
+		fmt.Printf("RE endpoint: %s (tls=%v)\n", reConn.Addr, reConn.TLS)
+	}
 	if !RECluster {
 		ringShard1, err = connectTo(ringShard1Port)
 		Expect(err).NotTo(HaveOccurred())
@@ -179,7 +185,7 @@ func TestGinkgoSuite(t *testing.T) {
 
 func redisOptions() *redis.Options {
 	if RECluster {
-		return &redis.Options{
+		opt := &redis.Options{
 			Addr: redisAddr,
 			DB:   0,
 
@@ -194,6 +200,8 @@ func redisOptions() *redis.Options {
 			PoolTimeout:     30 * time.Second,
 			ConnMaxIdleTime: time.Minute,
 		}
+		applyREConnection(opt)
+		return opt
 	}
 	return &redis.Options{
 		Addr: redisAddr,

--- a/probabilistic_test.go
+++ b/probabilistic_test.go
@@ -15,11 +15,13 @@ var _ = Describe("Probabilistic commands", Label("probabilistic"), func() {
 	ctx := context.TODO()
 
 	setupRedisClient := func(protocolVersion int) *redis.Client {
-		return redis.NewClient(&redis.Options{
+		opt := &redis.Options{
 			Addr:     "localhost:6379",
 			DB:       0,
 			Protocol: protocolVersion,
-		})
+		}
+		applyREConnection(opt)
+		return redis.NewClient(opt)
 	}
 
 	protocols := []int{2, 3}

--- a/race_test.go
+++ b/race_test.go
@@ -180,7 +180,10 @@ var _ = Describe("races", func() {
 		})
 	})
 
-	It("should Watch/Unwatch", func() {
+	// NonRedisEnterprise: 10 goroutines running 1000 contended WATCH/MULTI/EXEC iterations
+	// on a single key is impractically slow against a remote Redis Enterprise endpoint
+	// (optimistic-lock retries x network latency); it needs a low-latency local server.
+	It("should Watch/Unwatch", Label("NonRedisEnterprise"), func() {
 		err := client.Set(ctx, "key", "0", 0).Err()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/re_endpoints_test.go
+++ b/re_endpoints_test.go
@@ -102,8 +102,11 @@ func loadREConnection() (*reConnection, error) {
 func resolveREEndpoint(db reDatabaseConfig) (string, int, bool, error) {
 	tlsEnabled := db.TLS
 	if len(db.RawEndpoints) > 0 {
-		ep := db.RawEndpoints[0]
-		return ep.DNSName, ep.Port, tlsEnabled, nil
+		// Fall through to the endpoint URLs when the raw endpoint carries no
+		// DNS name, so a sparse config fails loudly instead of dialing ":port".
+		if ep := db.RawEndpoints[0]; ep.DNSName != "" {
+			return ep.DNSName, ep.Port, tlsEnabled, nil
+		}
 	}
 	if len(db.Endpoints) > 0 {
 		u, err := url.Parse(db.Endpoints[0])
@@ -131,6 +134,16 @@ func resolveREEndpoint(db reDatabaseConfig) (string, int, bool, error) {
 	return "", 0, false, fmt.Errorf("no endpoints found in database configuration")
 }
 
+// A remote Redis Enterprise endpoint has higher latency than a local server, so
+// the overlays below use the same relaxed timeouts as redisOptions() instead of
+// the ~3s defaults; otherwise module/search/timeseries helpers can flake on
+// slower commands.
+const (
+	reDialTimeout  = 10 * time.Second
+	reReadTimeout  = 30 * time.Second
+	reWriteTimeout = 30 * time.Second
+)
+
 // applyREConnection overlays the resolved Redis Enterprise credentials and TLS
 // settings onto opt. It is a no-op when reConn has not been populated.
 func applyREConnection(opt *redis.Options) {
@@ -143,12 +156,9 @@ func applyREConnection(opt *redis.Options) {
 	if reConn.TLS {
 		opt.TLSConfig = &tls.Config{InsecureSkipVerify: true}
 	}
-	// A remote Redis Enterprise endpoint has higher latency than a local server, so
-	// use the same relaxed timeouts as redisOptions() instead of the ~3s defaults;
-	// otherwise module/search/timeseries helpers can flake on slower commands.
-	opt.DialTimeout = 10 * time.Second
-	opt.ReadTimeout = 30 * time.Second
-	opt.WriteTimeout = 30 * time.Second
+	opt.DialTimeout = reDialTimeout
+	opt.ReadTimeout = reReadTimeout
+	opt.WriteTimeout = reWriteTimeout
 	opt.ContextTimeoutEnabled = true
 }
 
@@ -165,9 +175,9 @@ func applyREConnectionUniversal(opt *redis.UniversalOptions) {
 	if reConn.TLS {
 		opt.TLSConfig = &tls.Config{InsecureSkipVerify: true}
 	}
-	opt.DialTimeout = 10 * time.Second
-	opt.ReadTimeout = 30 * time.Second
-	opt.WriteTimeout = 30 * time.Second
+	opt.DialTimeout = reDialTimeout
+	opt.ReadTimeout = reReadTimeout
+	opt.WriteTimeout = reWriteTimeout
 	opt.ContextTimeoutEnabled = true
 }
 

--- a/re_endpoints_test.go
+++ b/re_endpoints_test.go
@@ -4,10 +4,13 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
+	"testing"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -90,7 +93,9 @@ func loadREConnection() (*reConnection, error) {
 	}
 
 	return &reConnection{
-		Addr:     fmt.Sprintf("%s:%d", host, port),
+		// JoinHostPort brackets IPv6 literals ("[::1]:6379"); Sprintf would
+		// produce an undialable "::1:6379".
+		Addr:     net.JoinHostPort(host, strconv.Itoa(port)),
 		Username: db.Username,
 		Password: db.Password,
 		TLS:      tlsEnabled,
@@ -132,6 +137,30 @@ func resolveREEndpoint(db reDatabaseConfig) (string, int, bool, error) {
 		return u.Hostname(), port, tlsEnabled, nil
 	}
 	return "", 0, false, fmt.Errorf("no endpoints found in database configuration")
+}
+
+// TestLoadREConnectionIPv6 pins the bracketed address form: url.Hostname()
+// strips the brackets from an IPv6 literal, and joining with a plain "%s:%d"
+// produced an undialable "::1:12000".
+func TestLoadREConnectionIPv6(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "endpoints.json")
+	cfg := `{"db": {"tls": true, "endpoints": ["rediss://[::1]:12000"]}}`
+	if err := os.WriteFile(path, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("REDIS_ENDPOINTS_CONFIG_PATH", path)
+	t.Setenv("RE_DB_NAME", "db")
+
+	conn, err := loadREConnection()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "[::1]:12000"; conn.Addr != want {
+		t.Fatalf("Addr = %q, want %q", conn.Addr, want)
+	}
+	if !conn.TLS {
+		t.Fatal("rediss endpoint must enable TLS")
+	}
 }
 
 // A remote Redis Enterprise endpoint has higher latency than a local server, so

--- a/re_endpoints_test.go
+++ b/re_endpoints_test.go
@@ -1,0 +1,185 @@
+package redis_test
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// reDatabaseEndpoint mirrors a raw_endpoints entry from the env0 endpoints config.
+type reDatabaseEndpoint struct {
+	DNSName string `json:"dns_name"`
+	Port    int    `json:"port"`
+}
+
+// reDatabaseConfig is a single database entry in the env0 endpoints config file
+// referenced by REDIS_ENDPOINTS_CONFIG_PATH.
+type reDatabaseConfig struct {
+	Username     string               `json:"username"`
+	Password     string               `json:"password"`
+	TLS          bool                 `json:"tls"`
+	RawEndpoints []reDatabaseEndpoint `json:"raw_endpoints"`
+	Endpoints    []string             `json:"endpoints"`
+}
+
+// reConnection holds the resolved connection parameters for the Redis Enterprise
+// database the suite runs against.
+type reConnection struct {
+	Addr     string
+	Username string
+	Password string
+	TLS      bool
+}
+
+// reConn is populated in BeforeSuite when running against a Redis Enterprise
+// cluster provisioned outside the test process (RE_CLUSTER=true and
+// REDIS_ENDPOINTS_CONFIG_PATH pointing at the env0 endpoints file).
+var reConn *reConnection
+
+// loadREConnection reads REDIS_ENDPOINTS_CONFIG_PATH and resolves the database to
+// run the Redis Enterprise suite against. RE_DB_NAME selects a named database;
+// when empty the first database in the config is used.
+func loadREConnection() (*reConnection, error) {
+	path := os.Getenv("REDIS_ENDPOINTS_CONFIG_PATH")
+	if path == "" {
+		return nil, fmt.Errorf("REDIS_ENDPOINTS_CONFIG_PATH is not set")
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+
+	var databases map[string]reDatabaseConfig
+	if err := json.Unmarshal(content, &databases); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
+	}
+	if len(databases) == 0 {
+		return nil, fmt.Errorf("no databases found in %s", path)
+	}
+
+	name := os.Getenv("RE_DB_NAME")
+	var db reDatabaseConfig
+	if name != "" {
+		found, ok := databases[name]
+		if !ok {
+			return nil, fmt.Errorf("database %q not found in %s", name, path)
+		}
+		db = found
+	} else {
+		// Map iteration order is undefined, so pick the first database by sorted
+		// name to make the default selection deterministic across runs.
+		names := make([]string, 0, len(databases))
+		for n := range databases {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		db = databases[names[0]]
+	}
+
+	host, port, tlsEnabled, err := resolveREEndpoint(db)
+	if err != nil {
+		return nil, err
+	}
+
+	return &reConnection{
+		Addr:     fmt.Sprintf("%s:%d", host, port),
+		Username: db.Username,
+		Password: db.Password,
+		TLS:      tlsEnabled,
+	}, nil
+}
+
+// resolveREEndpoint extracts host, port and TLS from a database config, preferring
+// raw_endpoints (which carry the resolvable DNS name and port) over the endpoint URLs.
+func resolveREEndpoint(db reDatabaseConfig) (string, int, bool, error) {
+	tlsEnabled := db.TLS
+	if len(db.RawEndpoints) > 0 {
+		ep := db.RawEndpoints[0]
+		return ep.DNSName, ep.Port, tlsEnabled, nil
+	}
+	if len(db.Endpoints) > 0 {
+		u, err := url.Parse(db.Endpoints[0])
+		if err != nil {
+			return "", 0, false, fmt.Errorf("failed to parse endpoint %q: %w", db.Endpoints[0], err)
+		}
+		if u.Scheme == "rediss" {
+			tlsEnabled = true
+		}
+		// The env0 endpoints format may omit the port; fall back to the scheme
+		// default (6379 for redis, 6380 for rediss), matching maintnotifications/e2e.
+		port := 6379
+		if u.Scheme == "rediss" {
+			port = 6380
+		}
+		if p := u.Port(); p != "" {
+			parsed, err := strconv.Atoi(p)
+			if err != nil {
+				return "", 0, false, fmt.Errorf("invalid port in endpoint %q: %w", db.Endpoints[0], err)
+			}
+			port = parsed
+		}
+		return u.Hostname(), port, tlsEnabled, nil
+	}
+	return "", 0, false, fmt.Errorf("no endpoints found in database configuration")
+}
+
+// applyREConnection overlays the resolved Redis Enterprise credentials and TLS
+// settings onto opt. It is a no-op when reConn has not been populated.
+func applyREConnection(opt *redis.Options) {
+	if reConn == nil {
+		return
+	}
+	opt.Addr = reConn.Addr
+	opt.Username = reConn.Username
+	opt.Password = reConn.Password
+	if reConn.TLS {
+		opt.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	// A remote Redis Enterprise endpoint has higher latency than a local server, so
+	// use the same relaxed timeouts as redisOptions() instead of the ~3s defaults;
+	// otherwise module/search/timeseries helpers can flake on slower commands.
+	opt.DialTimeout = 10 * time.Second
+	opt.ReadTimeout = 30 * time.Second
+	opt.WriteTimeout = 30 * time.Second
+	opt.ContextTimeoutEnabled = true
+}
+
+// applyREConnectionUniversal overlays the resolved Redis Enterprise endpoint,
+// credentials and TLS settings onto a UniversalOptions. It is a no-op when
+// reConn has not been populated.
+func applyREConnectionUniversal(opt *redis.UniversalOptions) {
+	if reConn == nil {
+		return
+	}
+	opt.Addrs = []string{reConn.Addr}
+	opt.Username = reConn.Username
+	opt.Password = reConn.Password
+	if reConn.TLS {
+		opt.TLSConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	opt.DialTimeout = 10 * time.Second
+	opt.ReadTimeout = 30 * time.Second
+	opt.WriteTimeout = 30 * time.Second
+	opt.ContextTimeoutEnabled = true
+}
+
+// reNewClient builds a *redis.Client for the configured endpoint, applying the
+// Redis Enterprise connection details (host, credentials, TLS) when running
+// against an external cluster via REDIS_ENDPOINTS_CONFIG_PATH.
+func reNewClient(protocol int, unstableResp3 bool) *redis.Client {
+	opt := &redis.Options{
+		Addr:          redisAddr,
+		Protocol:      protocol,
+		UnstableResp3: unstableResp3,
+	}
+	applyREConnection(opt)
+	return redis.NewClient(opt)
+}

--- a/redis_test.go
+++ b/redis_test.go
@@ -65,7 +65,9 @@ var _ = Describe("Client", func() {
 		client.Close()
 	})
 
-	It("should Stringer", func() {
+	// NonRedisEnterprise: asserts the exact local address in the client's String()
+	// representation, which does not match a remote Redis Enterprise endpoint.
+	It("should Stringer", Label("NonRedisEnterprise"), func() {
 		Expect(client.String()).To(Equal(fmt.Sprintf("Redis<:%s db:0>", redisPort)))
 	})
 
@@ -126,7 +128,10 @@ var _ = Describe("Client", func() {
 		Expect(client.PoolStats()).To(BeAssignableToTypeOf(&redis.PoolStats{}))
 	})
 
-	It("should support custom dialers", func() {
+	// NonRedisEnterprise: this spec installs a plain custom net.Dialer, which replaces
+	// go-redis' TLS-aware dial path, so it cannot connect to a TLS-enabled Redis
+	// Enterprise endpoint; it exercises client dialer wiring against a local server.
+	It("should support custom dialers", Label("NonRedisEnterprise"), func() {
 		custom := redis.NewClient(&redis.Options{
 			Network: "tcp",
 			Addr:    redisAddr,
@@ -337,10 +342,12 @@ var _ = Describe("Client", func() {
 	It("should retry command on network error", func() {
 		Expect(client.Close()).NotTo(HaveOccurred())
 
-		client = redis.NewClient(&redis.Options{
+		retryOpt := &redis.Options{
 			Addr:       redisAddr,
 			MaxRetries: 1,
-		})
+		}
+		applyREConnection(retryOpt)
+		client = redis.NewClient(retryOpt)
 
 		// Put bad connection in the pool.
 		cn, err := client.Pool().Get(ctx)
@@ -813,7 +820,10 @@ var _ = Describe("Dialer connection timeouts", func() {
 	})
 })
 
-var _ = Describe("Credentials Provider Priority", func() {
+// NonRedisEnterprise: these specs exercise client-side credential-provider
+// precedence against a local Redis (recording the AUTH command sent) and require
+// a localhost server; they are not meaningful against a remote Enterprise cluster.
+var _ = Describe("Credentials Provider Priority", Label("NonRedisEnterprise"), func() {
 	var client *redis.Client
 	var opt *redis.Options
 	var recorder *commandRecorder

--- a/search_builders_test.go
+++ b/search_builders_test.go
@@ -14,7 +14,7 @@ var _ = Describe("RediSearch Builders", Label("search", "builders"), func() {
 	var client *redis.Client
 
 	BeforeEach(func() {
-		client = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 2})
+		client = reNewClient(2, false)
 		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
 

--- a/search_test.go
+++ b/search_test.go
@@ -59,7 +59,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	var client *redis.Client
 
 	BeforeEach(func() {
-		client = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 2})
+		client = reNewClient(2, false)
 		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
 
@@ -2721,7 +2721,10 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 		}
 	})
 
-	It("should stop processing and return an error when a timeout occurs", Label("search", "ftaggregate"), func() {
+	// NonRedisEnterprise: relies on the "search-timeout" module CONFIG parameter,
+	// which Redis Enterprise does not support; without it the heavy FT.AGGREGATE
+	// query never times out and the spec hangs until the suite timeout.
+	It("should stop processing and return an error when a timeout occurs", Label("search", "ftaggregate", "NonRedisEnterprise"), func() {
 		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "aggTimeoutHeavy", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "n", FieldType: redis.SearchFieldTypeNumeric, Sortable: true},
@@ -3609,7 +3612,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	var client *redis.Client
 
 	BeforeEach(func() {
-		client = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 2})
+		client = reNewClient(2, false)
 		// Create index with text, numeric, tag fields and vector fields
 		err := client.FTCreate(ctx, "hybrid_idx", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText},
@@ -4341,8 +4344,8 @@ var _ = Describe("RediSearch FT.Config with Resp2 and Resp3", Label("search", "N
 	var clientResp2 *redis.Client
 	var clientResp3 *redis.Client
 	BeforeEach(func() {
-		clientResp2 = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 2})
-		clientResp3 = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 3, UnstableResp3: true})
+		clientResp2 = reNewClient(2, false)
+		clientResp3 = reNewClient(3, true)
 		Expect(clientResp3.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
 
@@ -4382,8 +4385,8 @@ var _ = Describe("RediSearch commands Resp 3", Label("search"), func() {
 	var client2 *redis.Client
 
 	BeforeEach(func() {
-		client = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 3, UnstableResp3: true})
-		client2 = redis.NewClient(&redis.Options{Addr: ":6379", Protocol: 3})
+		client = reNewClient(3, true)
+		client2 = reNewClient(3, false)
 		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})
 

--- a/timeseries_commands_test.go
+++ b/timeseries_commands_test.go
@@ -17,12 +17,14 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 	ctx := context.TODO()
 
 	setupRedisClient := func(protocolVersion int) *redis.Client {
-		return redis.NewClient(&redis.Options{
+		opt := &redis.Options{
 			Addr:          "localhost:6379",
 			DB:            0,
 			Protocol:      protocolVersion,
 			UnstableResp3: true,
-		})
+		}
+		applyREConnection(opt)
+		return redis.NewClient(opt)
 	}
 
 	protocols := []int{2, 3}
@@ -324,7 +326,9 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 					{Timestamp: 1013, Value: 10.0}}))
 			})
 
-			It("should TSCreateRule and TSDeleteRule", Label("timeseries", "tscreaterule", "tsdeleterule"), func() {
+			// NonRedisEnterprise: TS.CREATERULE targets two keys that hash to different slots,
+			// which a sharded Redis Enterprise database rejects with CROSSSLOT.
+			It("should TSCreateRule and TSDeleteRule", Label("timeseries", "tscreaterule", "tsdeleterule", "NonRedisEnterprise"), func() {
 				result, err := client.TSCreate(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeEquivalentTo("OK"))

--- a/tls_standalone_test.go
+++ b/tls_standalone_test.go
@@ -2,13 +2,28 @@ package redis_test
 
 import (
 	"crypto/tls"
+	"os"
+	"strconv"
 	"testing"
 
 	"github.com/redis/go-redis/v9"
 )
 
+// skipIfRECluster skips tests that depend on the TLS-enabled local Redis from
+// docker-compose (localhost:6666), which does not exist when the suite runs
+// against an external Redis Enterprise cluster (RE_CLUSTER=true). These are
+// plain Go tests, so the NonRedisEnterprise Ginkgo label filter cannot exclude
+// them.
+func skipIfRECluster(t *testing.T) {
+	if ok, _ := strconv.ParseBool(os.Getenv("RE_CLUSTER")); ok {
+		t.Skip("Skipping test: requires the local TLS-enabled Redis, not available on a Redis Enterprise run")
+	}
+}
+
 // TestTLSStandalone tests TLS connection to standalone Redis
 func TestTLSStandalone(t *testing.T) {
+	skipIfRECluster(t)
+
 	// Use InsecureSkipVerify for testing with self-signed certificates
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
@@ -51,6 +66,8 @@ func TestTLSStandalone(t *testing.T) {
 
 // TestTLSRedissURL tests rediss:// URL scheme
 func TestTLSRedissURL(t *testing.T) {
+	skipIfRECluster(t)
+
 	opt, err := redis.ParseURL("rediss://localhost:6666")
 	if err != nil {
 		t.Fatalf("ParseURL failed: %v", err)

--- a/universal_test.go
+++ b/universal_test.go
@@ -37,9 +37,11 @@ var _ = Describe("UniversalClient", Serial, func() {
 	})
 
 	It("should connect to simple servers", func() {
-		client = redis.NewUniversalClient(&redis.UniversalOptions{
+		opt := &redis.UniversalOptions{
 			Addrs: []string{redisAddr},
-		})
+		}
+		applyREConnectionUniversal(opt)
+		client = redis.NewUniversalClient(opt)
 		Expect(client.Ping(ctx).Err()).NotTo(HaveOccurred())
 	})
 

--- a/vectorset_commands_integration_test.go
+++ b/vectorset_commands_integration_test.go
@@ -35,12 +35,14 @@ var _ = Describe("Redis VectorSet commands", Label("vectorset"), func() {
 	ctx := context.TODO()
 
 	setupRedisClient := func(protocolVersion int) *redis.Client {
-		return redis.NewClient(&redis.Options{
+		opt := &redis.Options{
 			Addr:          "localhost:6379",
 			DB:            0,
 			Protocol:      protocolVersion,
 			UnstableResp3: true,
-		})
+		}
+		applyREConnection(opt)
+		return redis.NewClient(opt)
 	}
 
 	protocols := []int{2, 3}


### PR DESCRIPTION
Supersedes #3899 — includes @kiryazovi-redis's commit unchanged, plus three maintainer commits addressing review findings.

## From #3899

When `REDIS_ENDPOINTS_CONFIG_PATH` is set, the Redis Enterprise suite (`RE_CLUSTER=true`, `!NonRedisEnterprise`) resolves the target database's host, port, credentials and TLS from the env0 endpoints config (same format as `maintnotifications/e2e`) instead of assuming a passwordless `localhost:6379`. `RE_DB_NAME` selects a named database. Behaviour is unchanged when the variable is unset. Specs that cannot run against a remote managed cluster are labelled `NonRedisEnterprise`, each with a comment explaining why.

## Maintainer additions

- **Skip the local-TLS tests on RE runs.** `TestTLSStandalone`/`TestTLSRedissURL` are plain Go tests, so the Ginkgo label filter cannot exclude them, and they `t.Fatalf` when the docker-compose TLS server (`localhost:6666`) is absent — this alone kept the nightly red. They now skip when `RE_CLUSTER=true`.
- **Harden endpoint resolution.** An empty `dns_name` in `raw_endpoints` now falls through to the endpoint URLs instead of producing a `":port"` address that silently dials localhost; the `Options`/`UniversalOptions` overlays share timeout constants.
- **Re-enable the `should Auth` spec everywhere.** It now accepts both failure shapes — `ERR AUTH ...` (passwordless OSS) and `WRONGPASS ...` (password-protected servers such as Redis Enterprise) — and issues the two failing `AUTH` commands in separate pipelines. On a password-protected Redis 8.x, a second failed `AUTH` in the same pipeline is throttled by the server's brute-force protection and never answered, stalling the read until the client times out; the spec only passed in CI because a passwordless server's `ERR AUTH` reply doesn't count as an auth failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test harness, labels, and connection setup; production client code is untouched.
> 
> **Overview**
> Enables the Ginkgo suite to target a **remote Redis Enterprise** database when `RE_CLUSTER=true` and `REDIS_ENDPOINTS_CONFIG_PATH` is set: a new `re_endpoints_test.go` loads host/credentials/TLS from the env0 config (`RE_DB_NAME` optional), and `applyREConnection` / `reNewClient` overlay those settings (with longer timeouts) across `redisOptions()` and module/search/json helpers.
> 
> Specs that assume local OSS behavior are gated with **`NonRedisEnterprise`** (module CONFIG/INFO, tight PTTL checks, CROSSSLOT timeseries rules, local TLS docker, credential-provider recording, etc.). Plain **`TestTLS*`** tests skip on RE runs because Ginkgo labels cannot filter them.
> 
> **`should Auth`** now accepts both `ERR AUTH` and `WRONGPASS`, runs the two failing AUTHs in **separate pipelines** to avoid RE brute-force throttling, and expects two pool hits. Endpoint resolution uses **`net.JoinHostPort`** for IPv6 and falls through when `raw_endpoints` has an empty DNS name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90ae165f4720d2fbd151799a9d54fde36dacf1e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->