### PR TITLE
fix(pubsub): data race on shared opt.Addr during reconnect

### DIFF
--- a/pubsub_opt_race_test.go
+++ b/pubsub_opt_race_test.go
@@ -1,0 +1,53 @@
+package redis
+
+import (
+	"sync"
+	"testing"
+)
+
+// Client.pubSub / SentinelClient.pubSub used to alias the client's *Options
+// (opt: c.opt) instead of taking a private copy. PubSub.reconnect rewrites
+// c.opt.Addr (pubsub.go) under the PubSub mutex when a connection is handed
+// off, while the client's connection pool dialer reads opt.Addr (options.go,
+// the Dialer closure) lock-free on every dial. Both point at the same Options,
+// so the rewrite and the dial read race.
+//
+// Run with -race. Before the fix the shared Addr is read and written
+// concurrently; after it the PubSub owns a private copy and the pointer
+// identity check below also fails without -race.
+func TestPubSubDoesNotAliasClientOptions(t *testing.T) {
+	client := NewClient(&Options{Addr: "127.0.0.1:1"})
+	defer client.Close()
+
+	ps := client.pubSub()
+	defer ps.Close()
+
+	const iters = 100000
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: mirror PubSub.reconnect rewriting opt.Addr under the PubSub mutex.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			ps.mu.Lock()
+			ps.opt.Addr = "127.0.0.1:2"
+			ps.mu.Unlock()
+		}
+	}()
+
+	// Reader: the pool dialer reads client.opt.Addr lock-free (options.go).
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			_ = client.opt.Addr
+		}
+	}()
+
+	wg.Wait()
+
+	if ps.opt == client.opt {
+		t.Fatal("PubSub aliases the client's *Options; reconnect races the pool dialer")
+	}
+}

--- a/redis.go
+++ b/redis.go
@@ -1568,7 +1568,7 @@ func (c *Client) TxPipeline() Pipeliner {
 
 func (c *Client) pubSub() *PubSub {
 	pubsub := &PubSub{
-		opt: c.opt,
+		opt: c.opt.clone(),
 		newConn: func(ctx context.Context, addr string, channels []string) (*pool.Conn, error) {
 			cn, err := c.pubSubPool.NewConn(ctx, c.opt.Network, addr, channels)
 			if err != nil {

--- a/redis.go
+++ b/redis.go
@@ -1568,7 +1568,7 @@ func (c *Client) TxPipeline() Pipeliner {
 
 func (c *Client) pubSub() *PubSub {
 	pubsub := &PubSub{
-		opt: c.opt.clone(),
+		opt: c.cloneOpt(),
 		newConn: func(ctx context.Context, addr string, channels []string) (*pool.Conn, error) {
 			cn, err := c.pubSubPool.NewConn(ctx, c.opt.Network, addr, channels)
 			if err != nil {

--- a/sentinel.go
+++ b/sentinel.go
@@ -678,7 +678,7 @@ func (c *SentinelClient) Process(ctx context.Context, cmd Cmder) error {
 
 func (c *SentinelClient) pubSub() *PubSub {
 	pubsub := &PubSub{
-		opt: c.opt.clone(),
+		opt: c.cloneOpt(),
 		newConn: func(ctx context.Context, addr string, channels []string) (*pool.Conn, error) {
 			cn, err := c.pubSubPool.NewConn(ctx, c.opt.Network, addr, channels)
 			if err != nil {

--- a/sentinel.go
+++ b/sentinel.go
@@ -678,7 +678,7 @@ func (c *SentinelClient) Process(ctx context.Context, cmd Cmder) error {
 
 func (c *SentinelClient) pubSub() *PubSub {
 	pubsub := &PubSub{
-		opt: c.opt,
+		opt: c.opt.clone(),
 		newConn: func(ctx context.Context, addr string, channels []string) (*pool.Conn, error) {
 			cn, err := c.pubSubPool.NewConn(ctx, c.opt.Network, addr, channels)
 			if err != nil {


### PR DESCRIPTION
1. Client.pubSub and SentinelClient.pubSub build the PubSub with opt: c.opt, so it shares the client's *Options with the connection pool.
2. reconnect rewrites c.opt.Addr on a handoff under the PubSub mutex, while the pool dialer reads opt.Addr lock-free on every dial (the Dialer closure in newConnPool), so the two race on the shared field.

Clone the options at both constructors, matching ClusterClient.pubSub which already passes a fresh Options; the PubSub's Addr rewrites then stay on its own copy. Confirmed with go test -race.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection/pubsub setup for standalone and Sentinel clients; behavior change is isolating Options copies, but reconnect and dialing paths are concurrency-sensitive.
> 
> **Overview**
> Fixes a **data race** where `PubSub` shared the client’s `*Options` with the connection pool. During reconnect, pub/sub could rewrite **`opt.Addr`** under the PubSub mutex while the pool dialer read the same field lock-free on every dial.
> 
> **`Client.pubSub`** and **`SentinelClient.pubSub`** now pass **`c.cloneOpt()`** instead of **`c.opt`**, so reconnect address updates stay on a private copy (same idea as **`ClusterClient.pubSub`**). Adds **`TestPubSubDoesNotAliasClientOptions`** (`go test -race`) to assert PubSub no longer aliases client options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76bf82970038deaffeda27b0e5a22d54d61b2d94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->