### PR TITLE
fix(command): reconcile declared entry-array length in reply parsers

### DIFF
--- a/command.go
+++ b/command.go
@@ -4823,9 +4823,22 @@ func (cmd *GeoSearchLocationCmd) readReply(rd *proto.Reader) error {
 	}
 
 	cmd.val = make([]GeoLocation, n)
+	// Each element is an array of [name, ...] whose length is fixed by the
+	// requested WITH flags. Validate it (like GeoLocationCmd) instead of
+	// discarding it, so a server declaring extra elements can't leave frames
+	// on the wire and desync the connection.
+	withLen := 1
+	if cmd.opt.WithDist {
+		withLen++
+	}
+	if cmd.opt.WithHash {
+		withLen++
+	}
+	if cmd.opt.WithCoord {
+		withLen++
+	}
 	for i := 0; i < n; i++ {
-		_, err = rd.ReadArrayLen()
-		if err != nil {
+		if err = rd.ReadFixedArrayLen(withLen); err != nil {
 			return err
 		}
 
@@ -5407,6 +5420,14 @@ func (cmd *SlowLogCmd) readReply(rd *proto.Reader) error {
 				return err
 			}
 		}
+
+		// Drain any elements past the 6 this parser knows about so a server
+		// that declares a longer entry array doesn't leave frames on the wire.
+		for j := 6; j < nn; j++ {
+			if err = rd.DiscardNext(); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
@@ -5488,8 +5509,8 @@ func (cmd *LatencyCmd) readReply(rd *proto.Reader) error {
 		if err != nil {
 			return err
 		}
-		if nn < 3 {
-			return fmt.Errorf("redis: got %d elements in latency get, expected at least 3", nn)
+		if nn < 4 {
+			return fmt.Errorf("redis: got %d elements in latency get, expected at least 4", nn)
 		}
 		if cmd.val[i].Name, err = rd.ReadString(); err != nil {
 			return err
@@ -5509,6 +5530,13 @@ func (cmd *LatencyCmd) readReply(rd *proto.Reader) error {
 			return err
 		}
 		cmd.val[i].Max = time.Duration(maximum) * time.Millisecond
+		// Drain any elements beyond the 4 this parser reads so a server that
+		// declares a longer entry array can't leave frames on the wire.
+		for j := 4; j < nn; j++ {
+			if err = rd.DiscardNext(); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
@@ -5699,6 +5727,14 @@ func (cmd *HotKeysCmd) readReply(rd *proto.Reader) error {
 
 	if v, ok := data["by-net-bytes"].([]interface{}); ok {
 		result.ByNetBytes = parseHotKeysKeyEntries(v)
+	}
+
+	// Only the first element of the outer array is parsed; drain the rest so a
+	// server that wraps more than one element doesn't leave frames on the wire.
+	for i := 1; i < arrayLen; i++ {
+		if err := rd.DiscardNext(); err != nil {
+			return err
+		}
 	}
 
 	cmd.val = result

--- a/command.go
+++ b/command.go
@@ -5405,9 +5405,6 @@ func (cmd *SlowLogCmd) readReply(rd *proto.Reader) error {
 		if nn < 4 {
 			return fmt.Errorf("redis: got %d elements in slowlog get, expected at least 4", nn)
 		}
-		if nn > 7 {
-			return fmt.Errorf("redis: got %d elements in slowlog get, expected at most 7", nn)
-		}
 
 		if cmd.val[i].ID, err = rd.ReadInt(); err != nil {
 			return err
@@ -5452,19 +5449,20 @@ func (cmd *SlowLogCmd) readReply(rd *proto.Reader) error {
 				return err
 			}
 		}
-    
+
 		// Redis 8.10+ appends a 7th field: the command's total argument count.
-	  if nn >= 7 {
+		if nn >= 7 {
 			if cmd.val[i].CommandArgc, err = rd.ReadInt(); err != nil {
 				return err
 			}
-    }
-    
+		}
+
 		// Drain any elements past the 7 this parser knows about so a server
 		// that declares a longer entry array doesn't leave frames on the wire.
 		for j := 7; j < nn; j++ {
 			if err = rd.DiscardNext(); err != nil {
-        return err
+				return err
+			}
 		}
 	}
 

--- a/command.go
+++ b/command.go
@@ -4823,10 +4823,10 @@ func (cmd *GeoSearchLocationCmd) readReply(rd *proto.Reader) error {
 	}
 
 	cmd.val = make([]GeoLocation, n)
-	// Each element is an array of [name, ...] whose length is fixed by the
-	// requested WITH flags. Validate it (like GeoLocationCmd) instead of
-	// discarding it, so a server declaring extra elements can't leave frames
-	// on the wire and desync the connection.
+	// Each element is an array of [name, ...] whose minimum length is set by
+	// the requested WITH flags. Entries shorter than that would make the
+	// parser read into the next reply; extra elements are drained below so a
+	// longer entry (e.g. from a newer server) can't leave frames on the wire.
 	withLen := 1
 	if cmd.opt.WithDist {
 		withLen++
@@ -4838,8 +4838,12 @@ func (cmd *GeoSearchLocationCmd) readReply(rd *proto.Reader) error {
 		withLen++
 	}
 	for i := 0; i < n; i++ {
-		if err = rd.ReadFixedArrayLen(withLen); err != nil {
+		nn, err := rd.ReadArrayLen()
+		if err != nil {
 			return err
+		}
+		if nn < withLen {
+			return fmt.Errorf("redis: got %d elements in GEOSEARCH reply, expected at least %d", nn, withLen)
 		}
 
 		var loc GeoLocation
@@ -4870,6 +4874,11 @@ func (cmd *GeoSearchLocationCmd) readReply(rd *proto.Reader) error {
 			}
 			loc.Latitude, err = rd.ReadFloat()
 			if err != nil {
+				return err
+			}
+		}
+		for j := withLen; j < nn; j++ {
+			if err := rd.DiscardNext(); err != nil {
 				return err
 			}
 		}

--- a/command_entry_array_desync_test.go
+++ b/command_entry_array_desync_test.go
@@ -1,0 +1,102 @@
+package redis
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/redis/go-redis/v9/internal/proto"
+)
+
+// These parsers read a fixed set of fields from each entry array but did not
+// reconcile that with the element count the server declares. A server that
+// declares a longer array leaves the trailing frames on the wire; readReply
+// returns nil and the desynced connection goes back to the pool, so the next
+// command reads the leftover frames as its own reply. Each case appends a
+// sentinel reply and checks it is still readable after readReply.
+
+func TestEntryArrayDrainsExtraElements(t *testing.T) {
+	t.Run("LatencyCmd", func(t *testing.T) {
+		// entry declares 5 elements: the 4 fields plus one extra
+		rd := proto.NewReader(strings.NewReader(
+			"*1\r\n*5\r\n$5\r\nevent\r\n:1000\r\n:5\r\n:9\r\n:7\r\n+PONG\r\n"))
+		cmd := NewLatencyCmd(context.Background())
+		if err := cmd.readReply(rd); err != nil {
+			t.Fatalf("readReply: %v", err)
+		}
+		assertSentinel(t, rd)
+	})
+
+	t.Run("SlowLogCmd", func(t *testing.T) {
+		// entry declares 7 elements: the 6 known fields plus one extra
+		rd := proto.NewReader(strings.NewReader(
+			"*1\r\n*7\r\n:1\r\n:1000\r\n:50\r\n*1\r\n$3\r\nGET\r\n$5\r\n1.2.3\r\n$4\r\nname\r\n:99\r\n+PONG\r\n"))
+		cmd := NewSlowLogCmd(context.Background())
+		if err := cmd.readReply(rd); err != nil {
+			t.Fatalf("readReply: %v", err)
+		}
+		assertSentinel(t, rd)
+	})
+
+	t.Run("HotKeysCmd", func(t *testing.T) {
+		// outer array wraps two elements; only the first is parsed
+		rd := proto.NewReader(strings.NewReader(
+			"*2\r\n%1\r\n$15\r\ntracking-active\r\n:1\r\n%0\r\n+PONG\r\n"))
+		cmd := NewHotKeysCmd(context.Background())
+		if err := cmd.readReply(rd); err != nil {
+			t.Fatalf("readReply: %v", err)
+		}
+		assertSentinel(t, rd)
+	})
+}
+
+// LATENCY GET entries hold 4 fields; a 3-element entry must be rejected rather
+// than over-read into the next reply.
+func TestLatencyCmdShortEntryRejected(t *testing.T) {
+	// The trailing :9 belongs to the next reply; the unpatched parser reads it
+	// as the 4th field and returns nil, desyncing the connection.
+	rd := proto.NewReader(strings.NewReader(
+		"*1\r\n*3\r\n$5\r\nevent\r\n:1000\r\n:5\r\n:9\r\n"))
+	cmd := NewLatencyCmd(context.Background())
+	if err := cmd.readReply(rd); err == nil {
+		t.Fatalf("short latency entry accepted; readReply returned nil (val=%+v)", cmd.val)
+	}
+}
+
+// GeoSearchLocationCmd must validate each entry array against the requested
+// WITH flags, like GeoLocationCmd, instead of discarding the length.
+func TestGeoSearchLocationEntryLengthValidated(t *testing.T) {
+	opt := &GeoSearchLocationQuery{WithDist: true} // withLen == 2
+
+	t.Run("oversized rejected", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader(
+			"*1\r\n*3\r\n$1\r\na\r\n$3\r\n1.5\r\n:9\r\n"))
+		cmd := NewGeoSearchLocationCmd(context.Background(), opt)
+		if err := cmd.readReply(rd); err == nil {
+			t.Fatalf("oversized geo entry accepted; readReply returned nil (val=%+v)", cmd.val)
+		}
+	})
+
+	t.Run("valid parses", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader(
+			"*1\r\n*2\r\n$1\r\na\r\n$3\r\n1.5\r\n"))
+		cmd := NewGeoSearchLocationCmd(context.Background(), opt)
+		if err := cmd.readReply(rd); err != nil {
+			t.Fatalf("valid geo entry: %v", err)
+		}
+		if len(cmd.val) != 1 || cmd.val[0].Name != "a" || cmd.val[0].Dist != 1.5 {
+			t.Fatalf("unexpected val: %+v", cmd.val)
+		}
+	})
+}
+
+func assertSentinel(t *testing.T, rd *proto.Reader) {
+	t.Helper()
+	s, err := rd.ReadString()
+	if err != nil {
+		t.Fatalf("stream desynced, sentinel unreadable: %v", err)
+	}
+	if s != "PONG" {
+		t.Fatalf("stream desynced, got %q want PONG", s)
+	}
+}

--- a/command_entry_array_desync_test.go
+++ b/command_entry_array_desync_test.go
@@ -63,17 +63,32 @@ func TestLatencyCmdShortEntryRejected(t *testing.T) {
 	}
 }
 
-// GeoSearchLocationCmd must validate each entry array against the requested
-// WITH flags, like GeoLocationCmd, instead of discarding the length.
-func TestGeoSearchLocationEntryLengthValidated(t *testing.T) {
+// GeoSearchLocationCmd must reconcile each entry array against the requested
+// WITH flags: extra elements are drained (forwards compatible with servers
+// that append fields), while entries shorter than the flags require are
+// rejected rather than over-read into the next reply.
+func TestGeoSearchLocationEntryLengthReconciled(t *testing.T) {
 	opt := &GeoSearchLocationQuery{WithDist: true} // withLen == 2
 
-	t.Run("oversized rejected", func(t *testing.T) {
+	t.Run("oversized drained", func(t *testing.T) {
 		rd := proto.NewReader(strings.NewReader(
-			"*1\r\n*3\r\n$1\r\na\r\n$3\r\n1.5\r\n:9\r\n"))
+			"*1\r\n*3\r\n$1\r\na\r\n$3\r\n1.5\r\n:9\r\n+PONG\r\n"))
+		cmd := NewGeoSearchLocationCmd(context.Background(), opt)
+		if err := cmd.readReply(rd); err != nil {
+			t.Fatalf("readReply: %v", err)
+		}
+		if len(cmd.val) != 1 || cmd.val[0].Name != "a" || cmd.val[0].Dist != 1.5 {
+			t.Fatalf("unexpected val: %+v", cmd.val)
+		}
+		assertSentinel(t, rd)
+	})
+
+	t.Run("short rejected", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader(
+			"*1\r\n*1\r\n$1\r\na\r\n"))
 		cmd := NewGeoSearchLocationCmd(context.Background(), opt)
 		if err := cmd.readReply(rd); err == nil {
-			t.Fatalf("oversized geo entry accepted; readReply returned nil (val=%+v)", cmd.val)
+			t.Fatalf("short geo entry accepted; readReply returned nil (val=%+v)", cmd.val)
 		}
 	})
 

--- a/command_entry_array_desync_test.go
+++ b/command_entry_array_desync_test.go
@@ -28,12 +28,16 @@ func TestEntryArrayDrainsExtraElements(t *testing.T) {
 	})
 
 	t.Run("SlowLogCmd", func(t *testing.T) {
-		// entry declares 7 elements: the 6 known fields plus one extra
+		// entry declares 8 elements: the 7 known fields (through CommandArgc)
+		// plus one extra that only the drain loop can consume
 		rd := proto.NewReader(strings.NewReader(
-			"*1\r\n*7\r\n:1\r\n:1000\r\n:50\r\n*1\r\n$3\r\nGET\r\n$5\r\n1.2.3\r\n$4\r\nname\r\n:99\r\n+PONG\r\n"))
+			"*1\r\n*8\r\n:1\r\n:1000\r\n:50\r\n*1\r\n$3\r\nGET\r\n$5\r\n1.2.3\r\n$4\r\nname\r\n:99\r\n$5\r\nextra\r\n+PONG\r\n"))
 		cmd := NewSlowLogCmd(context.Background())
 		if err := cmd.readReply(rd); err != nil {
 			t.Fatalf("readReply: %v", err)
+		}
+		if len(cmd.val) != 1 || cmd.val[0].CommandArgc != 99 {
+			t.Fatalf("CommandArgc not parsed before drain: %+v", cmd.val)
 		}
 		assertSentinel(t, rd)
 	})


### PR DESCRIPTION
Malicious-server reply driven through proto.NewReader, unpatched tree:

    command_entry_array_desync_test.go:27: stream desynced, got "7" want PONG

LatencyCmd/SlowLogCmd/HotKeysCmd/GeoSearchLocationCmd each read a fixed set of fields from an entry array but never reconcile that with the element count the server declares. When a reply declares more elements than the parser reads (LATENCY LATEST guarded `nn < 3` while reading 4 fields; SLOWLOG never drains past field 6; HOTKEYS parses only the first element of the outer aggregation array; GEOSEARCH discarded the per-entry length), the trailing frames stay buffered, readReply returns nil, and the desynced connection goes back to the pool so the next command reads the leftovers as its own reply.

Same trust boundary as the sibling parsers XAutoClaim/ClusterSlots/GeoLocationCmd, which already reconcile the count. Fix drains the extra declared frames (LATENCY/SLOWLOG/HOTKEYS) or validates the entry length via ReadFixedArrayLen like GeoLocationCmd (GEOSEARCH); LATENCY's off-by-one guard becomes `nn < 4`. Regression test drives each case through proto.NewReader and checks the sentinel reply after readReply is still aligned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core wire-protocol parsing for admin/geo commands; behavior changes include rejecting malformed short entries and accepting longer server replies, but the fix reduces connection-pool corruption risk from hostile or newer Redis responses.
> 
> **Overview**
> Fixes **RESP reply parsers** that could leave unread frames on the connection when the server declares more (or fewer) array elements than the client consumes. Unread bytes make `readReply` succeed while the stream is misaligned; pooled connections then corrupt the next command’s reply.
> 
> **`GeoSearchLocationCmd`** now derives a minimum entry length from `WITH` flags, **errors on short entries**, and **`DiscardNext`s** any extra fields per location. **`LatencyCmd`** tightens validation to require at least four fields per entry (was three while reading four) and drains surplus elements. **`SlowLogCmd`** drops the hard cap at seven fields and drains anything beyond the seven known slots so newer Redis (e.g. 8.10+ `CommandArgc`) and future fields stay forward-compatible. **`HotKeysCmd`** drains additional top-level aggregation array elements after the first map.
> 
> Regression coverage in **`command_entry_array_desync_test.go`** feeds crafted RESP through `proto.NewReader` and asserts a trailing **PONG** sentinel still parses, plus negative cases for undersized latency/geo entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22430eeaff2894c6cc3b7b2c9afbcee719e3a67e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->