### PR TITLE
Compare Redis versions by major.minor so 8.10+ gates correctly

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -47,6 +47,7 @@ runs:
         elif [[ -n "$REDIS_VERSION" ]]; then
           # Mapping of redis version to redis testing containers
           declare -A redis_version_mapping=(
+            ["8.10.x"]="custom-29557896054-debian"
             ["8.8.x"]="8.8.0"
             ["8.6.x"]="8.6.1"
             ["8.4.x"]="8.4.0"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         redis-version:
+          - "8.10.x" # Redis CE 8.10
           - "8.8.x" # Redis CE 8.8
           - "8.6.x" # Redis CE 8.6
           - "8.4.x" # Redis CE 8.4
@@ -47,6 +48,7 @@ jobs:
           
           # Mapping of redis version to redis testing containers
           declare -A redis_version_mapping=(
+            ["8.10.x"]="custom-29557896054-debian"
             ["8.8.x"]="8.8.0"
             ["8.6.x"]="8.6.1"
             ["8.4.x"]="8.4.0"
@@ -79,6 +81,7 @@ jobs:
         fail-fast: false
         matrix:
           redis-version:
+            - "8.10.x" # Redis CE 8.10
             - "8.8.x" # Redis CE 8.8
             - "8.6.x" # Redis CE 8.6
             - "8.4.x" # Redis CE 8.4

--- a/acl_commands_test.go
+++ b/acl_commands_test.go
@@ -265,7 +265,7 @@ var _ = Describe("ACL permissions", Label("NonRedisEnterprise"), func() {
 	})
 
 	It("set permissions for module commands", func() {
-		SkipBeforeRedisVersion(8, "permissions for modules are supported for Redis Version >=8")
+		SkipBeforeRedisVersion("8", "permissions for modules are supported for Redis Version >=8")
 		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -345,7 +345,7 @@ var _ = Describe("ACL permissions", Label("NonRedisEnterprise"), func() {
 	})
 
 	It("set permissions for module categories", func() {
-		SkipBeforeRedisVersion(8, "permissions for modules are supported for Redis Version >=8")
+		SkipBeforeRedisVersion("8", "permissions for modules are supported for Redis Version >=8")
 		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 		val, err := client.FTCreate(ctx, "txt", &redis.FTCreateOptions{}, &redis.FieldSchema{FieldName: "txt", FieldType: redis.SearchFieldTypeText}).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -442,7 +442,7 @@ var _ = Describe("ACL Categories", func() {
 	})
 
 	It("lists acl categories and subcategories with Modules", func() {
-		SkipBeforeRedisVersion(8, "modules are included in acl for redis version >= 8")
+		SkipBeforeRedisVersion("8", "modules are included in acl for redis version >= 8")
 		aclTestCase := map[string]string{
 			"search":     "FT.CREATE",
 			"bloom":      "bf.add",

--- a/array_commands_test.go
+++ b/array_commands_test.go
@@ -17,7 +17,7 @@ var _ = Describe("Array Commands", Label("array"), func() {
 	var client *redis.Client
 
 	BeforeEach(func() {
-		SkipBeforeRedisVersion(8.8, "Redis 8.8.0 introduces support for Array")
+		SkipBeforeRedisVersion("8.8", "Redis 8.8.0 introduces support for Array")
 		client = redis.NewClient(redisOptions())
 		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 	})

--- a/command.go
+++ b/command.go
@@ -5312,6 +5312,10 @@ type SlowLog struct {
 	// https://redis.io/commands/slowlog#output-format
 	ClientAddr string
 	ClientName string
+	// CommandArgc is the command's total argument count (including the command
+	// name), emitted only by Redis 8.10 or greater. It may exceed len(Args) when
+	// the slow log truncates the stored arguments (slowlog-max-argc, default 32).
+	CommandArgc int64
 }
 
 type SlowLogCmd struct {
@@ -5363,6 +5367,9 @@ func (cmd *SlowLogCmd) readReply(rd *proto.Reader) error {
 		if nn < 4 {
 			return fmt.Errorf("redis: got %d elements in slowlog get, expected at least 4", nn)
 		}
+		if nn > 7 {
+			return fmt.Errorf("redis: got %d elements in slowlog get, expected at most 7", nn)
+		}
 
 		if cmd.val[i].ID, err = rd.ReadInt(); err != nil {
 			return err
@@ -5407,6 +5414,13 @@ func (cmd *SlowLogCmd) readReply(rd *proto.Reader) error {
 				return err
 			}
 		}
+
+		// Redis 8.10+ appends a 7th field: the command's total argument count.
+		if nn >= 7 {
+			if cmd.val[i].CommandArgc, err = rd.ReadInt(); err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
@@ -5418,11 +5432,12 @@ func (cmd *SlowLogCmd) Clone() Cmder {
 		val = make([]SlowLog, len(cmd.val))
 		for i, log := range cmd.val {
 			val[i] = SlowLog{
-				ID:         log.ID,
-				Time:       log.Time,
-				Duration:   log.Duration,
-				ClientAddr: log.ClientAddr,
-				ClientName: log.ClientName,
+				ID:          log.ID,
+				Time:        log.Time,
+				Duration:    log.Duration,
+				ClientAddr:  log.ClientAddr,
+				ClientName:  log.ClientName,
+				CommandArgc: log.CommandArgc,
 			}
 			if log.Args != nil {
 				val[i].Args = make([]string, len(log.Args))

--- a/commands_test.go
+++ b/commands_test.go
@@ -9649,6 +9649,57 @@ var _ = Describe("Commands", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).Should(Equal(int64(1)))
 		})
+
+		It("returns the command argument count", Label("NonRedisEnterprise"), func() {
+			SkipBeforeRedisVersion("8.10", "SLOWLOG GET reports the command argument count since Redis 8.10")
+
+			const key = "slowlog-log-slower-than"
+			old := client.ConfigGet(ctx, key).Val()
+			client.ConfigSet(ctx, key, "0")
+			defer client.ConfigSet(ctx, key, old[key])
+
+			// A short command: CommandArgc matches the number of stored Args.
+			Expect(client.Do(ctx, "slowlog", "reset").Err()).NotTo(HaveOccurred())
+			client.Set(ctx, "test", "true", 0)
+
+			result, err := client.SlowLogGet(ctx, -1).Result()
+			Expect(err).NotTo(HaveOccurred())
+			var setEntry *redis.SlowLog
+			for i := range result {
+				if len(result[i].Args) > 0 && result[i].Args[0] == "set" {
+					setEntry = &result[i]
+				}
+			}
+			Expect(setEntry).NotTo(BeNil())
+			Expect(setEntry.CommandArgc).To(Equal(int64(3))) // SET test true
+
+			// A long command: Redis truncates the stored Args at slowlog-max-argc,
+			// but CommandArgc still reports the full original argument count.
+			maxArgc := client.ConfigGet(ctx, "slowlog-max-argc").Val()["slowlog-max-argc"]
+			client.ConfigSet(ctx, "slowlog-max-argc", "32")
+			defer client.ConfigSet(ctx, "slowlog-max-argc", maxArgc)
+			Expect(client.Do(ctx, "slowlog", "reset").Err()).NotTo(HaveOccurred())
+
+			args := []interface{}{"rpush", "slowlog-big-list"}
+			for i := 0; i < 50; i++ {
+				args = append(args, fmt.Sprintf("v%d", i))
+			}
+			Expect(client.Do(ctx, args...).Err()).NotTo(HaveOccurred())
+
+			result, err = client.SlowLogGet(ctx, -1).Result()
+			Expect(err).NotTo(HaveOccurred())
+			var pushEntry *redis.SlowLog
+			for i := range result {
+				if len(result[i].Args) > 0 && result[i].Args[0] == "rpush" {
+					pushEntry = &result[i]
+				}
+			}
+			Expect(pushEntry).NotTo(BeNil())
+			// "rpush" + key + 50 values = 52 arguments.
+			Expect(pushEntry.CommandArgc).To(Equal(int64(52)))
+			// Stored Args are truncated, so the full count is only available via CommandArgc.
+			Expect(int64(len(pushEntry.Args))).To(BeNumerically("<", pushEntry.CommandArgc))
+		})
 	})
 
 	Describe("Latency", Label("NonRedisEnterprise"), func() {

--- a/commands_test.go
+++ b/commands_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ClientKillByFilter with MAXAGE", Label("NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			var s []string
 			started := make(chan bool)
 			done := make(chan bool)
@@ -380,7 +380,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ConfigGet Modules", func() {
-			SkipBeforeRedisVersion(8, "Config doesn't include modules before Redis 8")
+			SkipBeforeRedisVersion("8", "Config doesn't include modules before Redis 8")
 			expected := map[string]string{
 				"search-*": "search-timeout",
 				"ts-*":     "ts-retention-policy",
@@ -415,7 +415,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ConfigGet with Modules", Label("NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(8, "config get won't return modules configs before redis 8")
+			SkipBeforeRedisVersion("8", "config get won't return modules configs before redis 8")
 			configGet := client.ConfigGet(ctx, "*")
 			Expect(configGet.Err()).NotTo(HaveOccurred())
 			Expect(configGet.Val()).To(HaveKey("maxmemory"))
@@ -426,7 +426,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ConfigSet FT DIALECT", func() {
-			SkipBeforeRedisVersion(8, "config doesn't include modules before Redis 8")
+			SkipBeforeRedisVersion("8", "config doesn't include modules before Redis 8")
 			defaultState, err := client.ConfigGet(ctx, "search-default-dialect").Result()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -472,13 +472,13 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should ConfigSet fail for ReadOnly", func() {
-			SkipBeforeRedisVersion(8, "Config doesn't include modules before Redis 8")
+			SkipBeforeRedisVersion("8", "Config doesn't include modules before Redis 8")
 			_, err := client.ConfigSet(ctx, "search-max-doctablesize", "100000").Result()
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should ConfigSet Modules", func() {
-			SkipBeforeRedisVersion(8, "Config doesn't include modules before Redis 8")
+			SkipBeforeRedisVersion("8", "Config doesn't include modules before Redis 8")
 			defaults := map[string]string{}
 			expected := map[string]string{
 				"search-timeout":      "100",
@@ -519,7 +519,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should Fail ConfigSet Modules", func() {
-			SkipBeforeRedisVersion(8, "Config doesn't include modules before Redis 8")
+			SkipBeforeRedisVersion("8", "Config doesn't include modules before Redis 8")
 			expected := map[string]string{
 				"search-timeout":      "-100",
 				"ts-retention-policy": "-10",
@@ -568,7 +568,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should Info Modules", Label("redis.info"), func() {
-			SkipBeforeRedisVersion(8, "modules are included in info for Redis Version >= 8")
+			SkipBeforeRedisVersion("8", "modules are included in info for Redis Version >= 8")
 			info := client.Info(ctx)
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(BeNil())
@@ -593,7 +593,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should InfoMap Modules", Label("redis.info"), func() {
-			SkipBeforeRedisVersion(8, "modules are included in info for Redis Version >= 8")
+			SkipBeforeRedisVersion("8", "modules are included in info for Redis Version >= 8")
 			info := client.InfoMap(ctx)
 			Expect(info.Err()).NotTo(HaveOccurred())
 			Expect(info.Val()).NotTo(BeNil())
@@ -696,7 +696,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should Command Tips", Label("NonRedisEnterprise"), func() {
-			SkipAfterRedisVersion(7.9, "Redis 8 changed the COMMAND reply format")
+			SkipAfterRedisVersion("7.9", "Redis 8 changed the COMMAND reply format")
 			cmds, err := client.Command(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1396,7 +1396,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HScan without values", Label("NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			for i := 0; i < 1000; i++ {
 				sadd := client.HSet(ctx, "myhash", fmt.Sprintf("key%d", i), "hello")
 				Expect(sadd.Err()).NotTo(HaveOccurred())
@@ -1527,7 +1527,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should BitOpDiff", Label("NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(8.2, "BITOP DIFF is available since Redis 8.2")
+			SkipBeforeRedisVersion("8.2", "BITOP DIFF is available since Redis 8.2")
 			set := client.Set(ctx, "key1", "\xff", 0)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Val()).To(Equal("OK"))
@@ -1546,7 +1546,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should BitOpDiff1", Label("NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(8.2, "BITOP DIFF is available since Redis 8.2")
+			SkipBeforeRedisVersion("8.2", "BITOP DIFF is available since Redis 8.2")
 			set := client.Set(ctx, "key1", "\xff", 0)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Val()).To(Equal("OK"))
@@ -1565,7 +1565,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should BitOpAndOr", Label("NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(8.2, "BITOP ANDOR is available since Redis 8.2")
+			SkipBeforeRedisVersion("8.2", "BITOP ANDOR is available since Redis 8.2")
 			set := client.Set(ctx, "key1", "\xff", 0)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Val()).To(Equal("OK"))
@@ -1584,7 +1584,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should BitOpOne", Label("NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(8.2, "BITOP ONE is available since Redis 8.2")
+			SkipBeforeRedisVersion("8.2", "BITOP ONE is available since Redis 8.2")
 			set := client.Set(ctx, "key1", "\xff", 0)
 			Expect(set.Err()).NotTo(HaveOccurred())
 			Expect(set.Val()).To(Equal("OK"))
@@ -1928,7 +1928,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should DelExArgs when value matches", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "lock", "token-123", 0).Err()
@@ -1948,7 +1948,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should DelExArgs fail when value does not match", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "lock", "token-123", 0).Err()
@@ -1969,7 +1969,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should DelExArgs on non-existent key", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Try to delete non-existent key
 			deleted := client.DelExArgs(ctx, "nonexistent", redis.DelExArgs{
@@ -1981,7 +1981,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should DelExArgs with IFEQ", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "temp-key", "temp-value", 0).Err()
@@ -2002,7 +2002,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should DelExArgs with IFNE", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "temporary", 0).Err()
@@ -2023,7 +2023,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should DelExArgs with IFNE fail when value matches", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "permanent", 0).Err()
@@ -2045,7 +2045,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should Digest", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set a value
 			err := client.Set(ctx, "my-key", "my-value", 0).Err()
@@ -2063,7 +2063,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should Digest on non-existent key", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Get digest of non-existent key
 			digest := client.Digest(ctx, "nonexistent")
@@ -2071,7 +2071,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should use Digest with SetArgs IFDEQ", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "value1", 0).Err()
@@ -2097,7 +2097,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should use Digest with DelExArgs IFDEQ", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "value", 0).Err()
@@ -2170,7 +2170,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should IncrEXInt default", func() {
-			SkipBeforeRedisVersion(8.8, "IncrEX is available since Redis 8.8")
+			SkipBeforeRedisVersion("8.8", "IncrEX is available since Redis 8.8")
 
 			Expect(client.Set(ctx, "key", "10", 0).Err()).NotTo(HaveOccurred())
 
@@ -2183,7 +2183,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should IncrEXInt BYINT", func() {
-			SkipBeforeRedisVersion(8.8, "IncrEX is available since Redis 8.8")
+			SkipBeforeRedisVersion("8.8", "IncrEX is available since Redis 8.8")
 
 			Expect(client.Set(ctx, "key", "20", 0).Err()).NotTo(HaveOccurred())
 
@@ -2194,7 +2194,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should IncrEXFloat with bounds", func() {
-			SkipBeforeRedisVersion(8.8, "IncrEX is available since Redis 8.8")
+			SkipBeforeRedisVersion("8.8", "IncrEX is available since Redis 8.8")
 
 			Expect(client.Set(ctx, "key", "1.5", 0).Err()).NotTo(HaveOccurred())
 
@@ -2211,7 +2211,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should IncrEXFloat saturating overflow", func() {
-			SkipBeforeRedisVersion(8.8, "IncrEX is available since Redis 8.8")
+			SkipBeforeRedisVersion("8.8", "IncrEX is available since Redis 8.8")
 
 			Expect(client.Set(ctx, "key", "1.8", 0).Err()).NotTo(HaveOccurred())
 
@@ -2227,7 +2227,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should IncrEXInt out-of-bounds default rejects", func() {
-			SkipBeforeRedisVersion(8.8, "IncrEX is available since Redis 8.8")
+			SkipBeforeRedisVersion("8.8", "IncrEX is available since Redis 8.8")
 
 			Expect(client.Set(ctx, "key", "10", 0).Err()).NotTo(HaveOccurred())
 
@@ -2243,7 +2243,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should IncrEXInt out-of-bounds with LBOUND default rejects", func() {
-			SkipBeforeRedisVersion(8.8, "IncrEX is available since Redis 8.8")
+			SkipBeforeRedisVersion("8.8", "IncrEX is available since Redis 8.8")
 
 			Expect(client.Set(ctx, "key", "5", 0).Err()).NotTo(HaveOccurred())
 
@@ -2259,7 +2259,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should IncrEXInt with EX expiration and ENX", func() {
-			SkipBeforeRedisVersion(8.8, "IncrEX is available since Redis 8.8")
+			SkipBeforeRedisVersion("8.8", "IncrEX is available since Redis 8.8")
 
 			Expect(client.Set(ctx, "key", "40", 0).Err()).NotTo(HaveOccurred())
 			Expect(client.TTL(ctx, "key").Val()).To(Equal(time.Duration(-1)))
@@ -2292,7 +2292,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should IncrEXInt SATURATE clamps to LBOUND with negative increment", func() {
-			SkipBeforeRedisVersion(8.8, "IncrEX is available since Redis 8.8")
+			SkipBeforeRedisVersion("8.8", "IncrEX is available since Redis 8.8")
 
 			Expect(client.Set(ctx, "credits", "50", 0).Err()).NotTo(HaveOccurred())
 
@@ -2307,7 +2307,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should IncrEXInt PERSIST removes TTL", func() {
-			SkipBeforeRedisVersion(8.8, "IncrEX is available since Redis 8.8")
+			SkipBeforeRedisVersion("8.8", "IncrEX is available since Redis 8.8")
 
 			Expect(client.Set(ctx, "key", "1", 60*time.Second).Err()).NotTo(HaveOccurred())
 			Expect(client.TTL(ctx, "key").Val()).To(BeNumerically(">", 0))
@@ -2321,7 +2321,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should IncrEXInt SATURATE without bounds clamps to LLONG_MAX", func() {
-			SkipBeforeRedisVersion(8.8, "IncrEX is available since Redis 8.8")
+			SkipBeforeRedisVersion("8.8", "IncrEX is available since Redis 8.8")
 
 			// Start near LLONG_MAX; with no UBOUND the server should clamp to LLONG_MAX.
 			Expect(client.Set(ctx, "key", "9223372036854775800", 0).Err()).NotTo(HaveOccurred())
@@ -2336,7 +2336,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should IncrEXInt default reject leaves TTL untouched", func() {
-			SkipBeforeRedisVersion(8.8, "IncrEX is available since Redis 8.8")
+			SkipBeforeRedisVersion("8.8", "IncrEX is available since Redis 8.8")
 
 			Expect(client.Set(ctx, "key", "10", 60*time.Second).Err()).NotTo(HaveOccurred())
 			ttlBefore := client.TTL(ctx, "key").Val()
@@ -2361,7 +2361,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should IncrEXInt on non-numeric key returns error", func() {
-			SkipBeforeRedisVersion(8.8, "IncrEX is available since Redis 8.8")
+			SkipBeforeRedisVersion("8.8", "IncrEX is available since Redis 8.8")
 
 			Expect(client.Set(ctx, "key", "not-a-number", 0).Err()).NotTo(HaveOccurred())
 
@@ -2464,7 +2464,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should MSetEX", func() {
-			SkipBeforeRedisVersion(8.3, "MSetEX is available since redis 8.4")
+			SkipBeforeRedisVersion("8.3", "MSetEX is available since redis 8.4")
 			args := redis.MSetEXArgs{
 				Expiration: &redis.ExpirationOption{
 					Mode:  redis.EX,
@@ -2497,7 +2497,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should MSetEX with NX mode", func() {
-			SkipBeforeRedisVersion(8.3, "MSetEX is available since redis 8.4")
+			SkipBeforeRedisVersion("8.3", "MSetEX is available since redis 8.4")
 
 			client.Set(ctx, "key1", "existing", 0)
 
@@ -2537,7 +2537,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should MSetEX with XX mode", func() {
-			SkipBeforeRedisVersion(8.3, "MSetEX is available since redis 8.4")
+			SkipBeforeRedisVersion("8.3", "MSetEX is available since redis 8.4")
 
 			args := redis.MSetEXArgs{
 				Condition: redis.XX,
@@ -2571,7 +2571,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should MSetEX with map", func() {
-			SkipBeforeRedisVersion(8.3, "MSetEX is available since redis 8.4")
+			SkipBeforeRedisVersion("8.3", "MSetEX is available since redis 8.4")
 			args := redis.MSetEXArgs{
 				Expiration: &redis.ExpirationOption{
 					Mode:  redis.EX,
@@ -3003,7 +3003,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetIFEQ when value matches", func() {
-			if RedisVersion < 8.4 {
+			if !redisVersionAtLeast("8.4") {
 				Skip("CAS/CAD commands require Redis >= 8.4")
 			}
 
@@ -3023,7 +3023,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetIFEQ fail when value does not match", func() {
-			if RedisVersion < 8.4 {
+			if !redisVersionAtLeast("8.4") {
 				Skip("CAS/CAD commands require Redis >= 8.4")
 			}
 
@@ -3042,7 +3042,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetIFEQ with expiration", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "token-123", 0).Err()
@@ -3065,7 +3065,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetIFNE when value does not match", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "pending", 0).Err()
@@ -3083,7 +3083,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetIFNE fail when value matches", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "completed", 0).Err()
@@ -3100,7 +3100,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetArgs with IFEQ", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "counter", "100", 0).Err()
@@ -3123,7 +3123,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetArgs with IFEQ and GET", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "old", 0).Err()
@@ -3146,7 +3146,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetArgs with IFNE", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "status", "pending", 0).Err()
@@ -3169,7 +3169,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetIFEQGet return previous value", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "old-value", 0).Err()
@@ -3187,7 +3187,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetIFNEGet return previous value", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "pending", 0).Err()
@@ -3205,7 +3205,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetIFDEQ when digest matches", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "value1", 0).Err()
@@ -3227,7 +3227,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetIFDEQ fail when digest does not match", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "value1", 0).Err()
@@ -3250,7 +3250,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetIFDEQGet return previous value", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "value1", 0).Err()
@@ -3272,7 +3272,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetIFDNE when digest does not match", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "value1", 0).Err()
@@ -3296,7 +3296,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should SetIFDNE fail when digest matches", func() {
-			SkipBeforeRedisVersion(8.4, "CAS/CAD commands require Redis >= 8.4")
+			SkipBeforeRedisVersion("8.4", "CAS/CAD commands require Redis >= 8.4")
 
 			// Set initial value
 			err := client.Set(ctx, "key", "value1", 0).Err()
@@ -3859,7 +3859,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HExpire", Label("hash-expiration", "NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			res, err := client.HExpire(ctx, "no_such_key", 10*time.Second, "field1", "field2", "field3").Result()
 			Expect(err).To(BeNil())
 			Expect(res).To(BeEquivalentTo([]int64{-2, -2, -2}))
@@ -3875,7 +3875,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HPExpire", Label("hash-expiration", "NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			res, err := client.HPExpire(ctx, "no_such_key", 10*time.Second, "field1", "field2", "field3").Result()
 			Expect(err).To(BeNil())
 			Expect(res).To(BeEquivalentTo([]int64{-2, -2, -2}))
@@ -3891,7 +3891,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HExpireAt", Label("hash-expiration", "NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			resEmpty, err := client.HExpireAt(ctx, "no_such_key", time.Now().Add(10*time.Second), "field1", "field2", "field3").Result()
 			Expect(err).To(BeNil())
 			Expect(resEmpty).To(BeEquivalentTo([]int64{-2, -2, -2}))
@@ -3907,7 +3907,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HPExpireAt", Label("hash-expiration", "NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			resEmpty, err := client.HPExpireAt(ctx, "no_such_key", time.Now().Add(10*time.Second), "field1", "field2", "field3").Result()
 			Expect(err).To(BeNil())
 			Expect(resEmpty).To(BeEquivalentTo([]int64{-2, -2, -2}))
@@ -3923,7 +3923,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HPersist", Label("hash-expiration", "NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			resEmpty, err := client.HPersist(ctx, "no_such_key", "field1", "field2", "field3").Result()
 			Expect(err).To(BeNil())
 			Expect(resEmpty).To(BeEquivalentTo([]int64{-2, -2, -2}))
@@ -3947,7 +3947,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HExpireTime", Label("hash-expiration", "NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			resEmpty, err := client.HExpireTime(ctx, "no_such_key", "field1", "field2", "field3").Result()
 			Expect(err).To(BeNil())
 			Expect(resEmpty).To(BeEquivalentTo([]int64{-2, -2, -2}))
@@ -3967,7 +3967,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HPExpireTime", Label("hash-expiration", "NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			resEmpty, err := client.HPExpireTime(ctx, "no_such_key", "field1", "field2", "field3").Result()
 			Expect(err).To(BeNil())
 			Expect(resEmpty).To(BeEquivalentTo([]int64{-2, -2, -2}))
@@ -3988,7 +3988,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HTTL", Label("hash-expiration", "NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			resEmpty, err := client.HTTL(ctx, "no_such_key", "field1", "field2", "field3").Result()
 			Expect(err).To(BeNil())
 			Expect(resEmpty).To(BeEquivalentTo([]int64{-2, -2, -2}))
@@ -4008,7 +4008,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HPTTL", Label("hash-expiration", "NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			resEmpty, err := client.HPTTL(ctx, "no_such_key", "field1", "field2", "field3").Result()
 			Expect(err).To(BeNil())
 			Expect(resEmpty).To(BeEquivalentTo([]int64{-2, -2, -2}))
@@ -4029,7 +4029,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HGETDEL", Label("hash", "HGETDEL"), func() {
-			SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+			SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 
 			err := client.HSet(ctx, "myhash", "f1", "val1", "f2", "val2", "f3", "val3").Err()
 			Expect(err).NotTo(HaveOccurred())
@@ -4049,7 +4049,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should return nil responses for HGETDEL on non-existent key", Label("hash", "HGETDEL"), func() {
-			SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+			SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 			// HGETDEL on a key that does not exist.
 			res, err := client.HGetDel(ctx, "nonexistent", "f1", "f2").Result()
 			Expect(err).To(BeNil())
@@ -4060,7 +4060,7 @@ var _ = Describe("Commands", func() {
 		// HGETEX with various TTL options
 		// -----------------------------
 		It("should HGETEX with EX option", Label("hash", "HGETEX"), func() {
-			SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+			SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 
 			err := client.HSet(ctx, "myhash", "f1", "val1", "f2", "val2").Err()
 			Expect(err).NotTo(HaveOccurred())
@@ -4076,7 +4076,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HGETEX with PERSIST option", Label("hash", "HGETEX"), func() {
-			SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+			SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 
 			err := client.HSet(ctx, "myhash", "f1", "val1", "f2", "val2").Err()
 			Expect(err).NotTo(HaveOccurred())
@@ -4089,7 +4089,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HGETEX with EXAT option", Label("hash", "HGETEX"), func() {
-			SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+			SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 
 			err := client.HSet(ctx, "myhash", "f1", "val1", "f2", "val2").Err()
 			Expect(err).NotTo(HaveOccurred())
@@ -4109,7 +4109,7 @@ var _ = Describe("Commands", func() {
 		// HSETEX with FNX/FXX options
 		// -----------------------------
 		It("should HSETEX with FNX condition", Label("hash", "HSETEX"), func() {
-			SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+			SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 
 			opt := redis.HSetEXOptions{
 				Condition:      redis.HSetEXFNX,
@@ -4131,7 +4131,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HSETEX with FXX condition", Label("hash", "HSETEX"), func() {
-			SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+			SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 
 			err := client.HSet(ctx, "myhash", "f2", "val1").Err()
 			Expect(err).NotTo(HaveOccurred())
@@ -4155,7 +4155,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should HSETEX with multiple field operations", Label("hash", "HSETEX"), func() {
-			SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+			SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 
 			opt := redis.HSetEXOptions{
 				ExpirationType: redis.HSetEXExpirationEX,
@@ -7076,7 +7076,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should support COUNT aggregate for ZUnion and ZInter", Label("NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(8.8, "COUNT aggregate requires Redis 8.8+")
+			SkipBeforeRedisVersion("8.8", "COUNT aggregate requires Redis 8.8+")
 
 			err := client.ZAddArgs(ctx, "zset1", redis.ZAddArgs{
 				Members: []redis.Z{
@@ -7396,28 +7396,28 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should XTrimMaxLenMode", func() {
-			SkipBeforeRedisVersion(8.2, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("8.2", "doesn't work with older redis stack images")
 			n, err := client.XTrimMaxLenMode(ctx, "stream", 0, "KEEPREF").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(n).To(BeNumerically(">=", 0))
 		})
 
 		It("should XTrimMaxLenApproxMode", func() {
-			SkipBeforeRedisVersion(8.2, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("8.2", "doesn't work with older redis stack images")
 			n, err := client.XTrimMaxLenApproxMode(ctx, "stream", 0, 0, "KEEPREF").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(n).To(BeNumerically(">=", 0))
 		})
 
 		It("should XTrimMinIDMode", func() {
-			SkipBeforeRedisVersion(8.2, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("8.2", "doesn't work with older redis stack images")
 			n, err := client.XTrimMinIDMode(ctx, "stream", "4-0", "KEEPREF").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(n).To(BeNumerically(">=", 0))
 		})
 
 		It("should XTrimMinIDApproxMode", func() {
-			SkipBeforeRedisVersion(8.2, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("8.2", "doesn't work with older redis stack images")
 			n, err := client.XTrimMinIDApproxMode(ctx, "stream", "4-0", 0, "KEEPREF").Result()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(n).To(BeNumerically(">=", 0))
@@ -7471,7 +7471,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should XAdd with IDMP (idempotent production)", func() {
-			SkipBeforeRedisVersion(8.6, "IDMP requires Redis 8.6+")
+			SkipBeforeRedisVersion("8.6", "IDMP requires Redis 8.6+")
 			streamName := "idmp-stream"
 			defer client.Del(ctx, streamName)
 
@@ -7526,7 +7526,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should XAdd with IDMPAUTO (auto-generated idempotent ID)", func() {
-			SkipBeforeRedisVersion(8.6, "IDMPAUTO requires Redis 8.6+")
+			SkipBeforeRedisVersion("8.6", "IDMPAUTO requires Redis 8.6+")
 			streamName := "idmpauto-stream"
 			defer client.Del(ctx, streamName)
 
@@ -7578,7 +7578,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should XCfgSet configure idempotent production settings", func() {
-			SkipBeforeRedisVersion(8.6, "XCFGSET requires Redis 8.6+")
+			SkipBeforeRedisVersion("8.6", "XCFGSET requires Redis 8.6+")
 			streamName := "xcfgset-stream"
 			defer client.Del(ctx, streamName)
 
@@ -7633,7 +7633,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should XAckDel", func() {
-			SkipBeforeRedisVersion(8.2, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("8.2", "doesn't work with older redis stack images")
 			// First, create a consumer group
 			err := client.XGroupCreate(ctx, "stream", "testgroup", "0").Err()
 			Expect(err).NotTo(HaveOccurred())
@@ -7656,7 +7656,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should XDelEx", func() {
-			SkipBeforeRedisVersion(8.2, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("8.2", "doesn't work with older redis stack images")
 			// Test XDelEx with KEEPREF mode
 			n, err := client.XDelEx(ctx, "stream", "KEEPREF", "1-0", "2-0").Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -7790,7 +7790,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should XRead LastEntry", Label("NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			res, err := client.XRead(ctx, &redis.XReadArgs{
 				Streams: []string{"stream"},
 				Count:   2, // we expect 1 message
@@ -7808,7 +7808,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should XRead LastEntry from two streams", Label("NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			res, err := client.XRead(ctx, &redis.XReadArgs{
 				Streams: []string{"stream", "stream"},
 				ID:      "+",
@@ -7831,7 +7831,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should XRead LastEntry blocks", Label("NonRedisEnterprise"), func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			start := time.Now()
 			// Wait for the goroutine to finish before the spec returns so it
 			// can't outlive AfterEach's client.Close() and trip "use of closed
@@ -8076,7 +8076,7 @@ var _ = Describe("Commands", func() {
 			})
 
 			It("should not XNack with no mode", func() {
-				SkipBeforeRedisVersion(8.8, "XNACK requires Redis 8.8+")
+				SkipBeforeRedisVersion("8.8", "XNACK requires Redis 8.8+")
 
 				// Mode is required by Redis; omitting it should return a server-side error.
 				_, err := client.XNack(ctx, &redis.XNackArgs{
@@ -8088,7 +8088,7 @@ var _ = Describe("Commands", func() {
 			})
 
 			It("should XNack with SILENT mode", func() {
-				SkipBeforeRedisVersion(8.8, "XNACK requires Redis 8.8+")
+				SkipBeforeRedisVersion("8.8", "XNACK requires Redis 8.8+")
 
 				// All 3 messages are pending (delivered by BeforeEach), each with delivery_count=1.
 				// SILENT: consumer shutting down; delivery counter decremented by 1 (1 → 0).
@@ -8125,7 +8125,7 @@ var _ = Describe("Commands", func() {
 			})
 
 			It("should XNack with FAIL mode", func() {
-				SkipBeforeRedisVersion(8.8, "XNACK requires Redis 8.8+")
+				SkipBeforeRedisVersion("8.8", "XNACK requires Redis 8.8+")
 
 				// FAIL: delivery counter stays the same (1 → 1).
 				n, err := client.XNack(ctx, &redis.XNackArgs{
@@ -8161,7 +8161,7 @@ var _ = Describe("Commands", func() {
 			})
 
 			It("should XNack with FATAL mode", func() {
-				SkipBeforeRedisVersion(8.8, "XNACK requires Redis 8.8+")
+				SkipBeforeRedisVersion("8.8", "XNACK requires Redis 8.8+")
 
 				// FATAL: delivery counter set to MAXINT (for invalid/malicious messages).
 				n, err := client.XNack(ctx, &redis.XNackArgs{
@@ -8196,7 +8196,7 @@ var _ = Describe("Commands", func() {
 			})
 
 			It("should XNack nacked-count reflected in XINFO STREAM FULL", func() {
-				SkipBeforeRedisVersion(8.8, "XNACK requires Redis 8.8+")
+				SkipBeforeRedisVersion("8.8", "XNACK requires Redis 8.8+")
 
 				// NACK two messages.
 				n, err := client.XNack(ctx, &redis.XNackArgs{
@@ -8216,7 +8216,7 @@ var _ = Describe("Commands", func() {
 			})
 
 			It("should XNack with RetryCount", func() {
-				SkipBeforeRedisVersion(8.8, "XNACK requires Redis 8.8+")
+				SkipBeforeRedisVersion("8.8", "XNACK requires Redis 8.8+")
 
 				retryCount := uint64(5)
 				n, err := client.XNack(ctx, &redis.XNackArgs{
@@ -8252,7 +8252,7 @@ var _ = Describe("Commands", func() {
 			})
 
 			It("should XNack with Force", func() {
-				SkipBeforeRedisVersion(8.8, "XNACK requires Redis 8.8+")
+				SkipBeforeRedisVersion("8.8", "XNACK requires Redis 8.8+")
 
 				// Force creates a new NACKed PEL entry for an ID that was never
 				// delivered to a consumer via XREADGROUP. Without Force this would
@@ -8275,7 +8275,7 @@ var _ = Describe("Commands", func() {
 			})
 
 			It("should XReadGroup with CLAIM argument", func() {
-				SkipBeforeRedisVersion(8.3, "XREADGROUP CLAIM requires Redis 8.3+")
+				SkipBeforeRedisVersion("8.3", "XREADGROUP CLAIM requires Redis 8.3+")
 
 				time.Sleep(100 * time.Millisecond)
 
@@ -8301,7 +8301,7 @@ var _ = Describe("Commands", func() {
 			})
 
 			It("should XReadGroup with CLAIM and COUNT", func() {
-				SkipBeforeRedisVersion(8.3, "XREADGROUP CLAIM requires Redis 8.3+")
+				SkipBeforeRedisVersion("8.3", "XREADGROUP CLAIM requires Redis 8.3+")
 
 				time.Sleep(100 * time.Millisecond)
 
@@ -8320,7 +8320,7 @@ var _ = Describe("Commands", func() {
 			})
 
 			It("should XReadGroup with CLAIM and NOACK", func() {
-				SkipBeforeRedisVersion(8.3, "XREADGROUP CLAIM requires Redis 8.3+")
+				SkipBeforeRedisVersion("8.3", "XREADGROUP CLAIM requires Redis 8.3+")
 
 				time.Sleep(100 * time.Millisecond)
 
@@ -8339,7 +8339,7 @@ var _ = Describe("Commands", func() {
 			})
 
 			It("should XReadGroup CLAIM empties PEL after acknowledgment", func() {
-				SkipBeforeRedisVersion(8.3, "XREADGROUP CLAIM requires Redis 8.3+")
+				SkipBeforeRedisVersion("8.3", "XREADGROUP CLAIM requires Redis 8.3+")
 
 				time.Sleep(100 * time.Millisecond)
 
@@ -8384,7 +8384,7 @@ var _ = Describe("Commands", func() {
 			})
 
 			It("should XReadGroup CLAIM with multiple streams", func() {
-				SkipBeforeRedisVersion(8.3, "XREADGROUP CLAIM requires Redis 8.3+")
+				SkipBeforeRedisVersion("8.3", "XREADGROUP CLAIM requires Redis 8.3+")
 
 				id, err := client.XAdd(ctx, &redis.XAddArgs{
 					Stream: "stream2",
@@ -8435,7 +8435,7 @@ var _ = Describe("Commands", func() {
 			})
 
 			It("should XReadGroup CLAIM work consistently on RESP2 and RESP3", func() {
-				SkipBeforeRedisVersion(8.3, "XREADGROUP CLAIM requires Redis 8.3+")
+				SkipBeforeRedisVersion("8.3", "XREADGROUP CLAIM requires Redis 8.3+")
 
 				streamName := "stream-resp-test"
 				err := client.XAdd(ctx, &redis.XAddArgs{
@@ -8606,7 +8606,7 @@ var _ = Describe("Commands", func() {
 					IIDsAdded:            0,
 					IIDsDuplicates:       0,
 				}
-				if RedisVersion < 8.6 {
+				if !redisVersionAtLeast("8.6") {
 					expectedRes.IDMPDuration = 0
 					expectedRes.IDMPMaxSize = 0
 					expectedRes.PIDsTracked = 0
@@ -8643,7 +8643,7 @@ var _ = Describe("Commands", func() {
 					IIDsAdded:            0,
 					IIDsDuplicates:       0,
 				}
-				if RedisVersion < 8.6 {
+				if !redisVersionAtLeast("8.6") {
 					expectedRes.IDMPDuration = 0
 					expectedRes.IDMPMaxSize = 0
 					expectedRes.PIDsTracked = 0
@@ -9537,7 +9537,7 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("Shows function stats", func() {
-			SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+			SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 			defer client.FunctionKill(ctx)
 
 			// We can not run blocking commands in Redis functions, so we're using an infinite loop,

--- a/digest_test.go
+++ b/digest_test.go
@@ -3,7 +3,6 @@ package redis_test
 import (
 	"context"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -12,19 +11,17 @@ import (
 )
 
 func init() {
-	// Initialize RedisVersion from environment variable for regular Go tests
-	// (Ginkgo tests initialize this in BeforeSuite)
-	if version := os.Getenv("REDIS_VERSION"); version != "" {
-		if v, err := strconv.ParseFloat(strings.Trim(version, "\""), 64); err == nil && v > 0 {
-			RedisVersion = v
-		}
+	// Initialize version vars from environment for regular Go tests
+	// (Ginkgo tests initialize these in BeforeSuite)
+	if version := strings.Trim(os.Getenv("REDIS_VERSION"), "\""); version != "" {
+		redisMajorVersion, redisMinorVersion = parseRedisVersionStr(version)
 	}
 }
 
 // skipIfRedisBelow84 checks if Redis version is below 8.4 and skips the test if so
 func skipIfRedisBelow84(t *testing.T) {
-	if RedisVersion < 8.4 {
-		t.Skipf("Skipping test: Redis version %.1f < 8.4 (DIGEST command requires Redis 8.4+)", RedisVersion)
+	if !redisVersionAtLeast("8.4") {
+		t.Skipf("Skipping test: redis version < 8.4 (DIGEST command requires Redis 8.4+)")
 	}
 }
 

--- a/hotkeys_commands_test.go
+++ b/hotkeys_commands_test.go
@@ -25,7 +25,7 @@ var _ = Describe("HotKeys Commands", func() {
 
 	Describe("HOTKEYS", func() {
 		It("should start, get, stop, and reset hotkeys tracking", func() {
-			SkipBeforeRedisVersion(8.6, "HOTKEYS commands require Redis >= 8.6")
+			SkipBeforeRedisVersion("8.6", "HOTKEYS commands require Redis >= 8.6")
 
 			startArgs := &redis.HotKeysStartArgs{
 				Metrics:  []redis.HotKeysMetric{redis.HotKeysMetricCPU, redis.HotKeysMetricNET},
@@ -89,7 +89,7 @@ var _ = Describe("HotKeys Commands", func() {
 		})
 
 		It("should start hotkeys tracking with CPU metric only", func() {
-			SkipBeforeRedisVersion(8.6, "HOTKEYS commands require Redis >= 8.6")
+			SkipBeforeRedisVersion("8.6", "HOTKEYS commands require Redis >= 8.6")
 
 			startArgs := &redis.HotKeysStartArgs{
 				Metrics: []redis.HotKeysMetric{redis.HotKeysMetricCPU},
@@ -104,7 +104,7 @@ var _ = Describe("HotKeys Commands", func() {
 		})
 
 		It("should start hotkeys tracking with NET metric only", func() {
-			SkipBeforeRedisVersion(8.6, "HOTKEYS commands require Redis >= 8.6")
+			SkipBeforeRedisVersion("8.6", "HOTKEYS commands require Redis >= 8.6")
 
 			startArgs := &redis.HotKeysStartArgs{
 				Metrics: []redis.HotKeysMetric{redis.HotKeysMetricNET},
@@ -119,7 +119,7 @@ var _ = Describe("HotKeys Commands", func() {
 		})
 
 		It("should start hotkeys tracking with duration", func() {
-			SkipBeforeRedisVersion(8.6, "HOTKEYS commands require Redis >= 8.6")
+			SkipBeforeRedisVersion("8.6", "HOTKEYS commands require Redis >= 8.6")
 
 			startArgs := &redis.HotKeysStartArgs{
 				Metrics:  []redis.HotKeysMetric{redis.HotKeysMetricCPU, redis.HotKeysMetricNET},
@@ -140,7 +140,7 @@ var _ = Describe("HotKeys Commands", func() {
 		})
 
 		It("should start hotkeys tracking with sampling", func() {
-			SkipBeforeRedisVersion(8.6, "HOTKEYS commands require Redis >= 8.6")
+			SkipBeforeRedisVersion("8.6", "HOTKEYS commands require Redis >= 8.6")
 
 			startArgs := &redis.HotKeysStartArgs{
 				Metrics: []redis.HotKeysMetric{redis.HotKeysMetricCPU, redis.HotKeysMetricNET},
@@ -156,7 +156,7 @@ var _ = Describe("HotKeys Commands", func() {
 		})
 
 		It("should error when using slots in non-cluster mode", func() {
-			SkipBeforeRedisVersion(8.6, "HOTKEYS commands require Redis >= 8.6")
+			SkipBeforeRedisVersion("8.6", "HOTKEYS commands require Redis >= 8.6")
 
 			startArgs := &redis.HotKeysStartArgs{
 				Metrics: []redis.HotKeysMetric{redis.HotKeysMetricCPU, redis.HotKeysMetricNET},
@@ -178,7 +178,7 @@ var _ = Describe("HotKeys Commands", func() {
 		})
 
 		It("should error when starting tracking while already active", func() {
-			SkipBeforeRedisVersion(8.6, "HOTKEYS commands require Redis >= 8.6")
+			SkipBeforeRedisVersion("8.6", "HOTKEYS commands require Redis >= 8.6")
 
 			startArgs := &redis.HotKeysStartArgs{
 				Metrics: []redis.HotKeysMetric{redis.HotKeysMetricCPU},
@@ -195,7 +195,7 @@ var _ = Describe("HotKeys Commands", func() {
 		})
 
 		It("should error when resetting while tracking is active", func() {
-			SkipBeforeRedisVersion(8.6, "HOTKEYS commands require Redis >= 8.6")
+			SkipBeforeRedisVersion("8.6", "HOTKEYS commands require Redis >= 8.6")
 
 			startArgs := &redis.HotKeysStartArgs{
 				Metrics: []redis.HotKeysMetric{redis.HotKeysMetricCPU},

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -85,7 +85,7 @@ var _ = Describe("ScanIterator", func() {
 	})
 
 	It("should hscan across multiple pages", func() {
-		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+		SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 		Expect(hashSeed(71)).NotTo(HaveOccurred())
 
 		var vals []string
@@ -101,7 +101,7 @@ var _ = Describe("ScanIterator", func() {
 	})
 
 	It("should hscan without values across multiple pages", Label("NonRedisEnterprise"), func() {
-		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+		SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 		Expect(hashSeed(71)).NotTo(HaveOccurred())
 
 		var vals []string

--- a/json_test.go
+++ b/json_test.go
@@ -264,7 +264,7 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 			})
 
 			It("should JSONSetWithArgs with FPHA", Label("json.set", "json"), func() {
-				SkipBeforeRedisVersion(8.8, "FPHA argument requires Redis 8.8+")
+				SkipBeforeRedisVersion("8.8", "FPHA argument requires Redis 8.8+")
 
 				fpArray := `[1.1, 2.2, 3.3, 4.4]`
 				for _, fpha := range []redis.FPHAType{
@@ -285,7 +285,7 @@ var _ = Describe("JSON Commands", Label("json"), func() {
 			})
 
 			It("should JSONSetWithArgs with FPHA and NX/XX", Label("json.set", "json"), func() {
-				SkipBeforeRedisVersion(8.8, "FPHA argument requires Redis 8.8+")
+				SkipBeforeRedisVersion("8.8", "FPHA argument requires Redis 8.8+")
 
 				key := "fpha_nx"
 				fpArray := `[1.5, 2.5, 3.5]`

--- a/main_test.go
+++ b/main_test.go
@@ -80,16 +80,37 @@ var RCEDocker = false
 // This can be used before we change the bsm fork of ginkgo for one,
 // which have support for label sets, so we can filter tests per redis version.
 var RedisVersion float64 = 8.4
+var redisMajorVersion = 8
+var redisMinorVersion = 4
 
-func SkipBeforeRedisVersion(version float64, msg string) {
-	if RedisVersion < version {
-		Skip(fmt.Sprintf("(redis version < %f) %s", version, msg))
+// parseRedisVersionStr splits "major.minor" into two ints. Minor defaults to 0.
+func parseRedisVersionStr(v string) (int, int) {
+	parts := strings.SplitN(v, ".", 2)
+	major, _ := strconv.Atoi(parts[0])
+	if len(parts) < 2 {
+		return major, 0
+	}
+	minor, _ := strconv.Atoi(parts[1])
+	return major, minor
+}
+
+// redisVersionAtLeast returns true when the running Redis is >= major.minor.
+func redisVersionAtLeast(version string) bool {
+	major, minor := parseRedisVersionStr(version)
+	return redisMajorVersion > major || (redisMajorVersion == major && redisMinorVersion >= minor)
+}
+
+func SkipBeforeRedisVersion(version string, msg string) {
+	major, minor := parseRedisVersionStr(version)
+	if redisMajorVersion < major || (redisMajorVersion == major && redisMinorVersion < minor) {
+		Skip(fmt.Sprintf("(redis version < %s) %s", version, msg))
 	}
 }
 
-func SkipAfterRedisVersion(version float64, msg string) {
-	if RedisVersion > version {
-		Skip(fmt.Sprintf("(redis version > %f) %s", version, msg))
+func SkipAfterRedisVersion(version string, msg string) {
+	major, minor := parseRedisVersionStr(version)
+	if redisMajorVersion > major || (redisMajorVersion == major && redisMinorVersion > minor) {
+		Skip(fmt.Sprintf("(redis version > %s) %s", version, msg))
 	}
 }
 
@@ -103,19 +124,25 @@ var _ = BeforeSuite(func() {
 	RECluster, _ = strconv.ParseBool(os.Getenv("RE_CLUSTER"))
 	RCEDocker, _ = strconv.ParseBool(os.Getenv("RCE_DOCKER"))
 
-	RedisVersion, _ = strconv.ParseFloat(strings.Trim(os.Getenv("REDIS_VERSION"), "\""), 64)
+	vStr := strings.Trim(os.Getenv("REDIS_VERSION"), "\"")
+	if vStr != "" {
+		redisMajorVersion, redisMinorVersion = parseRedisVersionStr(vStr)
+		RedisVersion, _ = strconv.ParseFloat(vStr, 64)
+	}
 
-	if RedisVersion == 0 {
+	if redisMajorVersion == 0 {
+		redisMajorVersion = 8
+		redisMinorVersion = 4
 		RedisVersion = 8.4
 	}
 
 	fmt.Printf("RECluster: %v\n", RECluster)
 	fmt.Printf("RCEDocker: %v\n", RCEDocker)
-	fmt.Printf("REDIS_VERSION: %.1f\n", RedisVersion)
+	fmt.Printf("REDIS_VERSION: %d.%d\n", redisMajorVersion, redisMinorVersion)
 	fmt.Printf("CLIENT_LIBS_TEST_IMAGE: %v\n", os.Getenv("CLIENT_LIBS_TEST_IMAGE"))
 	logging.Disable()
 
-	if RedisVersion < 7.0 || RedisVersion > 9 {
+	if redisMajorVersion < 7 || redisMajorVersion > 9 {
 		panic("incorrect or not supported redis version")
 	}
 

--- a/osscluster_test.go
+++ b/osscluster_test.go
@@ -1766,7 +1766,7 @@ var _ = Describe("Command Tips tests", func() {
 	})
 
 	It("should verify COMMAND tips match router policy types", func() {
-		SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+		SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 		expectedPolicies := map[string]struct {
 			RequestPolicy  string
 			ResponsePolicy string
@@ -1801,7 +1801,7 @@ var _ = Describe("Command Tips tests", func() {
 
 	Describe("Explicit Routing Policy Tests", func() {
 		It("should test explicit routing policy for TOUCH", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 			// Verify TOUCH command has multi_shard policy
 			cmds, err := client.Command(ctx).Result()
@@ -1825,7 +1825,7 @@ var _ = Describe("Command Tips tests", func() {
 		})
 
 		It("should test explicit routing policy for FLUSHALL", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 			// Verify FLUSHALL command has all_shards policy
 			cmds, err := client.Command(ctx).Result()
@@ -1853,7 +1853,7 @@ var _ = Describe("Command Tips tests", func() {
 		})
 
 		It("should test explicit routing policy for PING", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 			// Verify PING command has all_shards policy
 			cmds, err := client.Command(ctx).Result()
@@ -1870,7 +1870,7 @@ var _ = Describe("Command Tips tests", func() {
 		})
 
 		It("should test explicit routing policy for DBSIZE", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 			// Verify DBSIZE command has all_shards policy with agg_sum response
 			cmds, err := client.Command(ctx).Result()
@@ -1902,7 +1902,7 @@ var _ = Describe("Command Tips tests", func() {
 		})
 
 		It("should test DDL commands routing policy for FT.CREATE", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 			// Verify FT.CREATE command routing policy
 			cmds, err := client.Command(ctx).Result()
@@ -1941,7 +1941,7 @@ var _ = Describe("Command Tips tests", func() {
 		})
 
 		It("should test DDL commands routing policy for FT.ALTER", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 			// Verify FT.ALTER command routing policy
 			cmds, err := client.Command(ctx).Result()
@@ -1979,7 +1979,7 @@ var _ = Describe("Command Tips tests", func() {
 		})
 
 		It("should route keyed commands to correct shard based on hash slot", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 			type masterNode struct {
 				client *redis.Client
@@ -2055,7 +2055,7 @@ var _ = Describe("Command Tips tests", func() {
 		})
 
 		It("should aggregate responses according to explicit aggregation policies", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 			type masterNode struct {
 				client *redis.Client
@@ -2216,7 +2216,7 @@ var _ = Describe("Command Tips tests", func() {
 		})
 
 		It("should verify command aggregation policies", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 			cmds, err := client.Command(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -2246,7 +2246,7 @@ var _ = Describe("Command Tips tests", func() {
 		})
 
 		It("should properly aggregate responses from keyless commands executed on multiple shards", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 			type masterNode struct {
 				client *redis.Client
@@ -2322,7 +2322,7 @@ var _ = Describe("Command Tips tests", func() {
 		})
 
 		It("should properly aggregate responses from keyed commands executed on multiple shards", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 			type masterNode struct {
 				client *redis.Client
 				addr   string
@@ -2418,7 +2418,7 @@ var _ = Describe("Command Tips tests", func() {
 		})
 
 		It("should propagate coordinator errors to client without modification", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 			type masterNode struct {
 				client *redis.Client
@@ -2545,7 +2545,7 @@ var _ = Describe("Command Tips tests", func() {
 
 		Describe("Routing Policies Comprehensive Test Suite", func() {
 			It("should test MGET command with multi-slot routing and key order preservation", func() {
-				SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+				SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 				// Set up test data across multiple shards
 				testData := map[string]string{
@@ -2590,7 +2590,7 @@ var _ = Describe("Command Tips tests", func() {
 			})
 
 			It("should test MGET with non-existent keys across multiple shards", func() {
-				SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+				SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 				// Set up some keys
 				Expect(client.Set(ctx, "mget_exists_1111", "value1", 0).Err()).NotTo(HaveOccurred())
@@ -2618,7 +2618,7 @@ var _ = Describe("Command Tips tests", func() {
 			})
 
 			It("should test TOUCH command with multi-slot routing", func() {
-				SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+				SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 				// Set up keys across multiple shards
 				keys := []string{
@@ -2648,7 +2648,7 @@ var _ = Describe("Command Tips tests", func() {
 			})
 
 			It("should test DEL command with multi-slot routing", func() {
-				SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+				SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 				// Set up keys across multiple shards
 				keys := []string{
@@ -2683,7 +2683,7 @@ var _ = Describe("Command Tips tests", func() {
 			})
 
 			It("should test DBSIZE command with agg_sum aggregation across all shards", func() {
-				SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+				SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 				// Set keys across multiple shards
 				keys := []string{
@@ -2709,7 +2709,7 @@ var _ = Describe("Command Tips tests", func() {
 			})
 
 			It("should test PING command with all_shards routing", func() {
-				SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+				SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 				// PING should be sent to all shards and return one successful response
 				result := client.Ping(ctx)
@@ -2718,7 +2718,7 @@ var _ = Describe("Command Tips tests", func() {
 			})
 
 			It("should test MGET with single shard optimization", func() {
-				SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+				SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 				// Use hash tags to ensure all keys are on the same shard
 				keys := []string{
@@ -2750,7 +2750,7 @@ var _ = Describe("Command Tips tests", func() {
 			})
 
 			It("should test empty MGET command returns error", func() {
-				SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+				SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 				// MGET with no keys should return an error
 				result := client.MGet(ctx)
@@ -2759,7 +2759,7 @@ var _ = Describe("Command Tips tests", func() {
 			})
 
 			It("should test MGET integration with MSET across multiple shards", func() {
-				SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+				SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 				// Create test data
 				testData := map[string]string{
@@ -2801,7 +2801,7 @@ var _ = Describe("Command Tips tests", func() {
 			})
 
 			It("should test multi-shard commands cannot be used in pipeline", func() {
-				SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+				SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 				// Create keys across multiple shards
 				keys := []string{
@@ -2827,7 +2827,7 @@ var _ = Describe("Command Tips tests", func() {
 			})
 
 			It("should test DisableRoutingPolicies option disables routing policies", func() {
-				SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+				SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 				// Test 1: With routing policies enabled (default), MGET should work across slots
 				testData := map[string]string{
@@ -2872,7 +2872,7 @@ var _ = Describe("Command Tips tests", func() {
 			})
 
 			It("should test large MGET with many keys across all shards", func() {
-				SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+				SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 				// Create many keys to ensure coverage across all shards
 				numKeys := 100
@@ -2909,7 +2909,7 @@ var _ = Describe("Command Tips tests", func() {
 		})
 
 		It("should route keyless commands to arbitrary shards using round robin", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 			var numMasters int
 			var numMastersMu sync.Mutex
@@ -3170,7 +3170,7 @@ var _ = Describe("Command Tips tests", func() {
 		})
 
 		It("should distribute keyless commands randomly across shards using random shard picker", func() {
-			SkipBeforeRedisVersion(7.9, "The tips are included from Redis 8")
+			SkipBeforeRedisVersion("7.9", "The tips are included from Redis 8")
 
 			// Create a cluster client with random shard picker
 			opt := redisClusterOptions()

--- a/pubsub_test.go
+++ b/pubsub_test.go
@@ -82,7 +82,7 @@ var _ = Describe("PubSub", func() {
 	})
 
 	It("should receive hash field subkey notifications", Label("hash-expiration", "NonRedisEnterprise"), func() {
-		SkipBeforeRedisVersion(8.8, "subkeyspace notifications require Redis 8.8")
+		SkipBeforeRedisVersion("8.8", "subkeyspace notifications require Redis 8.8")
 
 		config, err := client.ConfigGet(ctx, "notify-keyspace-events").Result()
 		Expect(err).NotTo(HaveOccurred())

--- a/search_test.go
+++ b/search_test.go
@@ -409,7 +409,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	// up until redis 8 the default scorer was TFIDF, in redis 8 it is BM25
 	// this test expect redis major version >= 8
 	It("should FTSearch WithScores", Label("search", "ftsearch"), func() {
-		SkipBeforeRedisVersion(7.9, "default scorer is not BM25STD")
+		SkipBeforeRedisVersion("7.9", "default scorer is not BM25STD")
 
 		text1 := &redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText}
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1).Result()
@@ -452,7 +452,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	// up until redis 8 the default scorer was TFIDF, in redis 8 it is BM25
 	// this test expect redis version < 8.0
 	It("should FTSearch WithScores", Label("search", "ftsearch"), func() {
-		SkipAfterRedisVersion(7.9, "default scorer is not TFIDF")
+		SkipAfterRedisVersion("7.9", "default scorer is not TFIDF")
 		text1 := &redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText}
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, text1).Result()
 		Expect(err).NotTo(HaveOccurred())
@@ -695,7 +695,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should FTAggregate with scorer and addscores", Label("search", "ftaggregate", "NonRedisEnterprise"), func() {
-		SkipBeforeRedisVersion(7.4, "no addscores support")
+		SkipBeforeRedisVersion("7.4", "no addscores support")
 		title := &redis.FieldSchema{FieldName: "title", FieldType: redis.SearchFieldTypeText, Sortable: false}
 		description := &redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText, Sortable: false}
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{OnHash: true, Prefix: []interface{}{"product:"}}, title, description).Result()
@@ -1508,7 +1508,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test dialect 4", Label("search", "ftcreate", "ftsearch", "NonRedisEnterprise"), func() {
-		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+		SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{
 			Prefix: []interface{}{"resource:"},
 		}, &redis.FieldSchema{
@@ -1641,7 +1641,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should create search index with FLOAT16 and BFLOAT16 vectors", Label("search", "ftcreate", "NonRedisEnterprise"), func() {
-		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+		SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 		val, err := client.FTCreate(ctx, "index", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "float16", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{FlatOptions: &redis.FTFlatOptions{Type: "FLOAT16", Dim: 768, DistanceMetric: "COSINE"}}},
 			&redis.FieldSchema{FieldName: "bfloat16", FieldType: redis.SearchFieldTypeVector, VectorArgs: &redis.FTVectorArgs{FlatOptions: &redis.FTFlatOptions{Type: "BFLOAT16", Dim: 768, DistanceMetric: "COSINE"}}},
@@ -1652,7 +1652,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test geoshapes query intersects and disjoint", Label("NonRedisEnterprise"), func() {
-		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+		SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 		_, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{}, &redis.FieldSchema{
 			FieldName:         "g",
 			FieldType:         redis.SearchFieldTypeGeoShape,
@@ -1721,7 +1721,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should search missing fields", Label("search", "ftcreate", "ftsearch", "NonRedisEnterprise"), func() {
-		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+		SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{Prefix: []interface{}{"property:"}},
 			&redis.FieldSchema{FieldName: "title", FieldType: redis.SearchFieldTypeText, Sortable: true},
 			&redis.FieldSchema{FieldName: "features", FieldType: redis.SearchFieldTypeTag, IndexMissing: true},
@@ -1766,7 +1766,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should search empty fields", Label("search", "ftcreate", "ftsearch", "NonRedisEnterprise"), func() {
-		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+		SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{Prefix: []interface{}{"property:"}},
 			&redis.FieldSchema{FieldName: "title", FieldType: redis.SearchFieldTypeText, Sortable: true},
 			&redis.FieldSchema{FieldName: "features", FieldType: redis.SearchFieldTypeTag, IndexEmpty: true},
@@ -1813,7 +1813,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should FTCreate VECTOR with int8 and uint8 types", Label("search", "ftcreate"), func() {
-		SkipBeforeRedisVersion(7.9, "doesn't work with older redis")
+		SkipBeforeRedisVersion("7.9", "doesn't work with older redis")
 		// Define INT8 vector field
 		hnswOptionsInt8 := &redis.FTHNSWOptions{
 			Type:           "INT8",
@@ -1869,7 +1869,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should return special float scores in FT.SEARCH vecsim", Label("search", "ftsearch", "vecsim"), func() {
-		SkipBeforeRedisVersion(7.4, "doesn't work with older redis stack images")
+		SkipBeforeRedisVersion("7.4", "doesn't work with older redis stack images")
 
 		vecField := &redis.FTFlatOptions{
 			Type:           "FLOAT32",
@@ -1919,7 +1919,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should FTCreate VECTOR with VAMANA algorithm - basic", Label("search", "ftcreate"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:           "FLOAT32",
 			Dim:            2,
@@ -1949,7 +1949,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should FTCreate VECTOR with VAMANA algorithm - with compression", Label("search", "ftcreate"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:              "FLOAT16",
 			Dim:               256,
@@ -1966,7 +1966,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should FTCreate VECTOR with VAMANA algorithm - advanced parameters", Label("search", "ftcreate"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:                   "FLOAT32",
 			Dim:                    512,
@@ -2041,7 +2041,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA L2 distance metric", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:           "FLOAT32",
 			Dim:            3,
@@ -2080,7 +2080,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA COSINE distance metric", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:           "FLOAT32",
 			Dim:            3,
@@ -2118,7 +2118,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA IP distance metric", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:           "FLOAT32",
 			Dim:            3,
@@ -2156,7 +2156,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA basic functionality", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:           "FLOAT32",
 			Dim:            4,
@@ -2194,7 +2194,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA FLOAT16 type", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:           "FLOAT16",
 			Dim:            4,
@@ -2229,7 +2229,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA FLOAT32 type", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:           "FLOAT32",
 			Dim:            4,
@@ -2264,7 +2264,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA with default dialect", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:           "FLOAT32",
 			Dim:            2,
@@ -2292,7 +2292,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA with LVQ8 compression", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:              "FLOAT32",
 			Dim:               8,
@@ -2329,7 +2329,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA compression with both vector types", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 
 		// Test FLOAT16 with LVQ8
 		vamanaOptions16 := &redis.FTVamanaOptions{
@@ -2395,7 +2395,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA construction window size", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:                   "FLOAT32",
 			Dim:                    6,
@@ -2431,7 +2431,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA graph max degree", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:           "FLOAT32",
 			Dim:            6,
@@ -2467,7 +2467,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA search window size", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:             "FLOAT32",
 			Dim:              6,
@@ -2503,7 +2503,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA all advanced parameters", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:                   "FLOAT32",
 			Dim:                    8,
@@ -2544,7 +2544,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should fail when using a non-zero offset with a zero limit", Label("search", "ftsearch"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "testIdx", &redis.FTCreateOptions{}, &redis.FieldSchema{
 			FieldName: "txt",
 			FieldType: redis.SearchFieldTypeText,
@@ -2564,7 +2564,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should evaluate exponentiation precedence in APPLY expressions correctly", Label("search", "ftaggregate"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "txns", &redis.FTCreateOptions{}, &redis.FieldSchema{
 			FieldName: "dummy",
 			FieldType: redis.SearchFieldTypeText,
@@ -2588,7 +2588,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should return a syntax error when empty strings are used for numeric parameters", Label("search", "ftsearch"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "idx", &redis.FTCreateOptions{}, &redis.FieldSchema{
 			FieldName: "n",
 			FieldType: redis.SearchFieldTypeNumeric,
@@ -2611,7 +2611,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should return NaN as default for AVG reducer when no numeric values are present", Label("search", "ftaggregate"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "aggTestAvg", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "grp", FieldType: redis.SearchFieldTypeText},
 			&redis.FieldSchema{FieldName: "n", FieldType: redis.SearchFieldTypeNumeric},
@@ -2637,7 +2637,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should return 1 as default for COUNT reducer when no numeric values are present", Label("search", "ftaggregate"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "aggTestCount", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "grp", FieldType: redis.SearchFieldTypeText},
 			&redis.FieldSchema{FieldName: "n", FieldType: redis.SearchFieldTypeNumeric},
@@ -2663,7 +2663,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should return NaN as default for SUM reducer when no numeric values are present", Label("search", "ftaggregate"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "aggTestSum", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "grp", FieldType: redis.SearchFieldTypeText},
 			&redis.FieldSchema{FieldName: "n", FieldType: redis.SearchFieldTypeNumeric},
@@ -2689,7 +2689,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should return the full requested number of results by re-running the query when some results expire", Label("search", "ftsearch"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "aggExpired", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "order", FieldType: redis.SearchFieldTypeNumeric, Sortable: true},
 		).Result()
@@ -2722,7 +2722,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should stop processing and return an error when a timeout occurs", Label("search", "ftaggregate"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "aggTimeoutHeavy", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "n", FieldType: redis.SearchFieldTypeNumeric, Sortable: true},
 		).Result()
@@ -2752,7 +2752,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should return 0 as default for COUNT_DISTINCT reducer when no values are present", Label("search", "ftaggregate"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "aggTestCountDistinct", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "grp", FieldType: redis.SearchFieldTypeText},
 			&redis.FieldSchema{FieldName: "x", FieldType: redis.SearchFieldTypeText},
@@ -2778,7 +2778,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should return 0 as default for COUNT_DISTINCTISH reducer when no values are present", Label("search", "ftaggregate"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "aggTestCountDistinctIsh", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "grp", FieldType: redis.SearchFieldTypeText},
 			&redis.FieldSchema{FieldName: "y", FieldType: redis.SearchFieldTypeText},
@@ -2804,7 +2804,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should use BM25 as the default scorer", Label("search", "ftsearch"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "scoringTest", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "description", FieldType: redis.SearchFieldTypeText},
 		).Result()
@@ -2830,7 +2830,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should return 0 as default for STDDEV reducer when no numeric values are present", Label("search", "ftaggregate"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "aggTestStddev", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "grp", FieldType: redis.SearchFieldTypeText},
 			&redis.FieldSchema{FieldName: "n", FieldType: redis.SearchFieldTypeNumeric},
@@ -2857,7 +2857,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should return NaN as default for QUANTILE reducer when no numeric values are present", Label("search", "ftaggregate"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "aggTestQuantile", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "grp", FieldType: redis.SearchFieldTypeText},
 			&redis.FieldSchema{FieldName: "n", FieldType: redis.SearchFieldTypeNumeric},
@@ -2883,7 +2883,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should return nil as default for FIRST_VALUE reducer when no values are present", Label("search", "ftaggregate"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "aggTestFirstValue", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "grp", FieldType: redis.SearchFieldTypeText},
 			&redis.FieldSchema{FieldName: "t", FieldType: redis.SearchFieldTypeText},
@@ -2909,7 +2909,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should fail to add an alias that is an existing index name", Label("search", "ftalias"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "idx1", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "name", FieldType: redis.SearchFieldTypeText},
 		).Result()
@@ -2968,7 +2968,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should reject deprecated configuration keys", Label("search", "ftconfig"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		// List of deprecated configuration keys.
 		deprecatedKeys := []string{
 			"_FREE_RESOURCE_ON_THREAD",
@@ -3032,7 +3032,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should return INF for MIN reducer and -INF for MAX reducer when no numeric values are present", Label("search", "ftaggregate"), func() {
-		SkipBeforeRedisVersion(7.9, "requires Redis 8.x")
+		SkipBeforeRedisVersion("7.9", "requires Redis 8.x")
 		val, err := client.FTCreate(ctx, "aggTestMinMax", &redis.FTCreateOptions{},
 			&redis.FieldSchema{FieldName: "grp", FieldType: redis.SearchFieldTypeText},
 			&redis.FieldSchema{FieldName: "n", FieldType: redis.SearchFieldTypeNumeric},
@@ -3061,7 +3061,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA with LVQ4 compression", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:              "FLOAT32",
 			Dim:               8,
@@ -3099,7 +3099,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA with LeanVec4x8 compression and reduce parameter", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:              "FLOAT32",
 			Dim:               8,
@@ -3138,7 +3138,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA compression algorithms with FLOAT16 type", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 
 		compressionAlgorithms := []string{"LVQ4", "LVQ4x4", "LVQ4x8", "LeanVec4x8", "LeanVec8x8"}
 
@@ -3185,7 +3185,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA compression algorithms with FLOAT32 type", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 
 		compressionAlgorithms := []string{"LVQ4", "LVQ4x4", "LVQ4x8", "LeanVec4x8", "LeanVec8x8"}
 
@@ -3232,7 +3232,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA compression with different distance metrics", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 
 		compressionAlgorithms := []string{"LVQ4", "LVQ4x4", "LVQ4x8", "LeanVec4x8", "LeanVec8x8"}
 		distanceMetrics := []string{"L2", "COSINE", "IP"}
@@ -3282,7 +3282,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA compression with all advanced parameters", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 
 		compressionAlgorithms := []string{"LVQ4", "LVQ4x4", "LVQ4x8", "LeanVec4x8", "LeanVec8x8"}
 
@@ -3333,7 +3333,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should fail when using reduce parameter with non-LeanVec compression", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:              "FLOAT32",
 			Dim:               8,
@@ -3349,7 +3349,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA with LVQ4 compression in RESP3", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:              "FLOAT32",
 			Dim:               8,
@@ -3387,7 +3387,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA with LeanVec4x8 compression and reduce parameter in RESP3", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 		vamanaOptions := &redis.FTVamanaOptions{
 			Type:              "FLOAT32",
 			Dim:               8,
@@ -3426,7 +3426,7 @@ var _ = Describe("RediSearch commands Resp 2", Label("search"), func() {
 	})
 
 	It("should test VAMANA compression algorithms with FLOAT16 type in RESP3", Label("search", "ftcreate", "vamana"), func() {
-		SkipBeforeRedisVersion(8.2, "VAMANA requires Redis 8.2+")
+		SkipBeforeRedisVersion("8.2", "VAMANA requires Redis 8.2+")
 
 		compressionAlgorithms := []string{"LVQ4", "LVQ4x4", "LVQ4x8", "LeanVec4x8", "LeanVec8x8"}
 
@@ -3678,7 +3678,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform basic hybrid search", Label("search", "fthybrid"), func() {
-		SkipBeforeRedisVersion(8.4, "no support")
+		SkipBeforeRedisVersion("8.4", "no support")
 		// Basic hybrid search combining text and vector search
 		searchQuery := "@color:{red}"
 		vectorData := encodeFloat32Vector([]float32{-100, -200, -200, -300})
@@ -3698,7 +3698,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with scorer", Label("search", "fthybrid", "scorer"), func() {
-		SkipBeforeRedisVersion(8.4, "no support")
+		SkipBeforeRedisVersion("8.4", "no support")
 		// Test with TFIDF scorer
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
@@ -3734,7 +3734,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with vector filter", Label("search", "fthybrid", "filter"), func() {
-		SkipBeforeRedisVersion(8.4, "no support")
+		SkipBeforeRedisVersion("8.4", "no support")
 		// This query won't have results from search, so we can validate vector filter
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
@@ -3777,7 +3777,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with KNN method", Label("search", "fthybrid", "knn"), func() {
-		SkipBeforeRedisVersion(8.4, "no support")
+		SkipBeforeRedisVersion("8.4", "no support")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -3802,7 +3802,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with RANGE method", Label("search", "fthybrid", "range"), func() {
-		SkipBeforeRedisVersion(8.4, "no support")
+		SkipBeforeRedisVersion("8.4", "no support")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -3829,7 +3829,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with LINEAR combine method", Label("search", "fthybrid", "combine"), func() {
-		SkipBeforeRedisVersion(8.4, "no support")
+		SkipBeforeRedisVersion("8.4", "no support")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -3859,7 +3859,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with RRF combine method", Label("search", "fthybrid", "rrf"), func() {
-		SkipBeforeRedisVersion(8.4, "no support")
+		SkipBeforeRedisVersion("8.4", "no support")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -3887,7 +3887,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with LOAD and APPLY", Label("search", "fthybrid", "load", "apply"), func() {
-		SkipBeforeRedisVersion(8.4, "no support")
+		SkipBeforeRedisVersion("8.4", "no support")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -3929,7 +3929,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with LIMIT", Label("search", "fthybrid", "limit"), func() {
-		SkipBeforeRedisVersion(8.4, "no support")
+		SkipBeforeRedisVersion("8.4", "no support")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -3953,7 +3953,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with SORTBY", Label("search", "fthybrid", "sortby"), func() {
-		SkipBeforeRedisVersion(8.4, "no support")
+		SkipBeforeRedisVersion("8.4", "no support")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -4002,7 +4002,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 
 	// Redis 8.6+ tests using PARAMS-based vector approach
 	It("should perform basic hybrid search (8.6+ PARAMS)", Label("search", "fthybrid", "params"), func() {
-		SkipBeforeRedisVersion(8.6, "PARAMS-based vector support requires Redis 8.6+")
+		SkipBeforeRedisVersion("8.6", "PARAMS-based vector support requires Redis 8.6+")
 		// Basic hybrid search combining text and vector search
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
@@ -4031,7 +4031,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with scorer (8.6+ PARAMS)", Label("search", "fthybrid", "scorer", "params"), func() {
-		SkipBeforeRedisVersion(8.6, "PARAMS-based vector support requires Redis 8.6+")
+		SkipBeforeRedisVersion("8.6", "PARAMS-based vector support requires Redis 8.6+")
 		// Test with TFIDF scorer
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
@@ -4066,7 +4066,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with vector filter (8.6+ PARAMS)", Label("search", "fthybrid", "filter", "params"), func() {
-		SkipBeforeRedisVersion(8.6, "PARAMS-based vector support requires Redis 8.6+")
+		SkipBeforeRedisVersion("8.6", "PARAMS-based vector support requires Redis 8.6+")
 		// This query won't have results from search, so we can validate vector filter
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
@@ -4108,7 +4108,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with KNN method (8.6+ PARAMS)", Label("search", "fthybrid", "knn", "params"), func() {
-		SkipBeforeRedisVersion(8.6, "PARAMS-based vector support requires Redis 8.6+")
+		SkipBeforeRedisVersion("8.6", "PARAMS-based vector support requires Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -4132,7 +4132,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with RANGE method (8.6+ PARAMS)", Label("search", "fthybrid", "range", "params"), func() {
-		SkipBeforeRedisVersion(8.6, "PARAMS-based vector support requires Redis 8.6+")
+		SkipBeforeRedisVersion("8.6", "PARAMS-based vector support requires Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -4158,7 +4158,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with LINEAR combine method (8.6+ PARAMS)", Label("search", "fthybrid", "combine", "params"), func() {
-		SkipBeforeRedisVersion(8.6, "PARAMS-based vector support requires Redis 8.6+")
+		SkipBeforeRedisVersion("8.6", "PARAMS-based vector support requires Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -4187,7 +4187,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with RRF combine method (8.6+ PARAMS)", Label("search", "fthybrid", "rrf", "params"), func() {
-		SkipBeforeRedisVersion(8.6, "PARAMS-based vector support requires Redis 8.6+")
+		SkipBeforeRedisVersion("8.6", "PARAMS-based vector support requires Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -4216,7 +4216,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with LOAD and APPLY (8.6+ PARAMS)", Label("search", "fthybrid", "load", "apply", "params"), func() {
-		SkipBeforeRedisVersion(8.6, "PARAMS-based vector support requires Redis 8.6+")
+		SkipBeforeRedisVersion("8.6", "PARAMS-based vector support requires Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -4257,7 +4257,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with LIMIT (8.6+ PARAMS)", Label("search", "fthybrid", "limit", "params"), func() {
-		SkipBeforeRedisVersion(8.6, "PARAMS-based vector support requires Redis 8.6+")
+		SkipBeforeRedisVersion("8.6", "PARAMS-based vector support requires Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{
@@ -4280,7 +4280,7 @@ var _ = Describe("FT.HYBRID Commands", func() {
 	})
 
 	It("should perform hybrid search with SORTBY (8.6+ PARAMS)", Label("search", "fthybrid", "sortby", "params"), func() {
-		SkipBeforeRedisVersion(8.6, "PARAMS-based vector support requires Redis 8.6+")
+		SkipBeforeRedisVersion("8.6", "PARAMS-based vector support requires Redis 8.6+")
 		options := &redis.FTHybridOptions{
 			CountExpressions: 2,
 			SearchExpressions: []redis.FTHybridSearchExpression{

--- a/timeseries_commands_test.go
+++ b/timeseries_commands_test.go
@@ -45,7 +45,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should TSCreate and TSCreateWithArgs", Label("timeseries", "tscreate", "tscreateWithArgs", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(7.4, "older redis stack has different results for timeseries module")
+				SkipBeforeRedisVersion("7.4", "older redis stack has different results for timeseries module")
 				result, err := client.TSCreate(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeEquivalentTo("OK"))
@@ -142,7 +142,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 					{Timestamp: 1013, Value: 10.0}}))
 			})
 			It("should TSAdd and TSAddWithArgs", Label("timeseries", "tsadd", "tsaddWithArgs", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(7.4, "older redis stack has different results for timeseries module")
+				SkipBeforeRedisVersion("7.4", "older redis stack has different results for timeseries module")
 				result, err := client.TSAdd(ctx, "1", 1, 1).Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeEquivalentTo(1))
@@ -236,7 +236,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should TSAlter", Label("timeseries", "tsalter", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(7.4, "older redis stack has different results for timeseries module")
+				SkipBeforeRedisVersion("7.4", "older redis stack has different results for timeseries module")
 				result, err := client.TSCreate(ctx, "1").Result()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeEquivalentTo("OK"))
@@ -271,7 +271,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				if client.Options().Protocol == 2 {
 					Expect(resultInfo["labels"].([]interface{})[0]).To(BeEquivalentTo([]interface{}{"Time", "Series"}))
 					Expect(resultInfo["retentionTime"]).To(BeEquivalentTo(10))
-					if RedisVersion >= 8 {
+					if redisVersionAtLeast("8") {
 						Expect(resultInfo["duplicatePolicy"]).To(BeEquivalentTo("block"))
 					} else {
 						// Older versions of Redis had a bug where the duplicate policy was not set correctly
@@ -280,7 +280,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				} else {
 					Expect(resultInfo["labels"].(map[interface{}]interface{})["Time"]).To(BeEquivalentTo("Series"))
 					Expect(resultInfo["retentionTime"]).To(BeEquivalentTo(10))
-					if RedisVersion >= 8 {
+					if redisVersionAtLeast("8") {
 						Expect(resultInfo["duplicatePolicy"]).To(BeEquivalentTo("block"))
 					} else {
 						// Older versions of Redis had a bug where the duplicate policy was not set correctly
@@ -364,7 +364,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should TSIncrBy, TSIncrByWithArgs, TSDecrBy and TSDecrByWithArgs", Label("timeseries", "tsincrby", "tsdecrby", "tsincrbyWithArgs", "tsdecrbyWithArgs", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(7.4, "older redis stack has different results for timeseries module")
+				SkipBeforeRedisVersion("7.4", "older redis stack has different results for timeseries module")
 				for i := 0; i < 100; i++ {
 					_, err := client.TSIncrBy(ctx, "1", 1).Result()
 					Expect(err).NotTo(HaveOccurred())
@@ -757,7 +757,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should TSRangeWithArgs support multiple aggregators", Label("timeseries", "tsrange", "tsrangeWithArgs", "aggregators", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(8.8, "multiple aggregators require Redis 8.8+")
+				SkipBeforeRedisVersion("8.8", "multiple aggregators require Redis 8.8+")
 
 				_, err := client.TSCreate(ctx, "multi-range").Result()
 				Expect(err).NotTo(HaveOccurred())
@@ -938,7 +938,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should TSRevRangeWithArgs support multiple aggregators", Label("timeseries", "tsrevrange", "tsrevrangeWithArgs", "aggregators", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(8.8, "multiple aggregators require Redis 8.8+")
+				SkipBeforeRedisVersion("8.8", "multiple aggregators require Redis 8.8+")
 
 				_, err := client.TSCreate(ctx, "multi-revrange").Result()
 				Expect(err).NotTo(HaveOccurred())
@@ -1153,7 +1153,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				}
 			})
 			It("should TSMRangeWithArgs support multiple aggregators", Label("timeseries", "tsmrange", "tsmrangeWithArgs", "aggregators", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(8.8, "multiple aggregators require Redis 8.8+")
+				SkipBeforeRedisVersion("8.8", "multiple aggregators require Redis 8.8+")
 
 				_, err := client.TSCreateWithArgs(ctx, "multi-mrange-a", &redis.TSOptions{
 					Labels: map[string]string{"type": "sensor", "name": "a"},
@@ -1340,7 +1340,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should TSMRevRangeWithArgs support multiple aggregators", Label("timeseries", "tsmrevrange", "tsmrevrangeWithArgs", "aggregators", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(8.8, "multiple aggregators require Redis 8.8+")
+				SkipBeforeRedisVersion("8.8", "multiple aggregators require Redis 8.8+")
 
 				_, err := client.TSCreateWithArgs(ctx, "multi-mrevrange-a", &redis.TSOptions{
 					Labels: map[string]string{"type": "sensor", "name": "a"},
@@ -1454,7 +1454,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 
 			// NaN Value Support Tests
 			It("should support NaN values in TSAdd and TSAddWithArgs", Label("timeseries", "tsadd", "nan", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(8.6, "NaN support requires Redis 8.6+")
+				SkipBeforeRedisVersion("8.6", "NaN support requires Redis 8.6+")
 
 				// Test basic NaN insertion with TSAdd
 				result, err := client.TSAdd(ctx, "nan-test-1", 1000, math.NaN()).Result()
@@ -1475,7 +1475,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should support NaN values in TSMAdd", Label("timeseries", "tsmadd", "nan", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(8.6, "NaN support requires Redis 8.6+")
+				SkipBeforeRedisVersion("8.6", "NaN support requires Redis 8.6+")
 
 				// Create time series
 				_, err := client.TSCreate(ctx, "nan-madd-1").Result()
@@ -1503,7 +1503,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should retrieve NaN values with TSGet and TSMGet", Label("timeseries", "tsget", "tsmget", "nan", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(8.6, "NaN support requires Redis 8.6+")
+				SkipBeforeRedisVersion("8.6", "NaN support requires Redis 8.6+")
 
 				// Add NaN values to multiple time series
 				opt := &redis.TSOptions{Labels: map[string]string{"type": "sensor"}}
@@ -1550,7 +1550,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should support NaN values in TSRange and TSRevRange", Label("timeseries", "tsrange", "tsrevrange", "nan", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(8.6, "NaN support requires Redis 8.6+")
+				SkipBeforeRedisVersion("8.6", "NaN support requires Redis 8.6+")
 
 				// Create time series with mixed NaN and regular values
 				_, err := client.TSCreate(ctx, "mixed-values").Result()
@@ -1590,7 +1590,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should support CountNaN and CountAll aggregators", Label("timeseries", "aggregator", "nan", "countnan", "countall", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(8.6, "NaN aggregators require Redis 8.6+")
+				SkipBeforeRedisVersion("8.6", "NaN aggregators require Redis 8.6+")
 
 				// Create time series with mixed NaN and regular values
 				_, err := client.TSCreate(ctx, "agg-test").Result()
@@ -1630,7 +1630,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should ignore NaN values in existing aggregators", Label("timeseries", "aggregator", "nan", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(8.6, "NaN support requires Redis 8.6+")
+				SkipBeforeRedisVersion("8.6", "NaN support requires Redis 8.6+")
 
 				// Create time series with mixed NaN and regular values
 				_, err := client.TSCreate(ctx, "agg-ignore-nan").Result()
@@ -1700,7 +1700,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should support NaN values in TSMRange and TSMRevRange", Label("timeseries", "tsmrange", "tsmrevrange", "nan", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(8.6, "NaN support requires Redis 8.6+")
+				SkipBeforeRedisVersion("8.6", "NaN support requires Redis 8.6+")
 
 				// Create multiple time series with NaN values
 				opt := &redis.TSOptions{Labels: map[string]string{"location": "sensor-room"}}
@@ -1731,7 +1731,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should support NaN with CountNaN and CountAll in TSMRange", Label("timeseries", "tsmrange", "aggregator", "nan", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(8.6, "NaN aggregators require Redis 8.6+")
+				SkipBeforeRedisVersion("8.6", "NaN aggregators require Redis 8.6+")
 
 				// Create multiple time series with NaN values
 				opt := &redis.TSOptions{Labels: map[string]string{"device": "temp-sensor"}}
@@ -1775,7 +1775,7 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 			})
 
 			It("should handle duplicate policy with NaN values", Label("timeseries", "nan", "duplicatepolicy", "NonRedisEnterprise"), func() {
-				SkipBeforeRedisVersion(8.6, "NaN support requires Redis 8.6+")
+				SkipBeforeRedisVersion("8.6", "NaN support requires Redis 8.6+")
 
 				// Test BLOCK duplicate policy with NaN (should work - just blocks duplicates)
 				opt := &redis.TSOptions{DuplicatePolicy: "BLOCK"}

--- a/tls_cert_auth_test.go
+++ b/tls_cert_auth_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -13,20 +12,18 @@ import (
 )
 
 func init() {
-	// Initialize RedisVersion from environment variable for regular Go tests
-	// (Ginkgo tests initialize this in BeforeSuite)
-	if version := os.Getenv("REDIS_VERSION"); version != "" {
-		if v, err := strconv.ParseFloat(strings.Trim(version, "\""), 64); err == nil && v > 0 {
-			RedisVersion = v
-		}
+	// Initialize version vars from environment for regular Go tests
+	// (Ginkgo tests initialize these in BeforeSuite)
+	if version := strings.Trim(os.Getenv("REDIS_VERSION"), "\""); version != "" {
+		redisMajorVersion, redisMinorVersion = parseRedisVersionStr(version)
 	}
 }
 
 // skipBeforeRedisVersion checks if Redis version is below the specified version and skips the test if so
-func skipBeforeRedisVersion(t *testing.T, version float64, msg string) {
+func skipBeforeRedisVersion(t *testing.T, version string, msg string) {
 	t.Helper()
-	if RedisVersion < version {
-		t.Skipf("Skipping test: Redis version %.1f < %.1f: %s", RedisVersion, version, msg)
+	if !redisVersionAtLeast(version) {
+		t.Skipf("Skipping test: redis version < %s: %s", version, msg)
 	}
 }
 
@@ -44,7 +41,7 @@ func skipBeforeRedisVersion(t *testing.T, version float64, msg string) {
 // 3. Connect using TLS with that certificate
 // 4. Verify that Redis automatically authenticates as that user (no AUTH command needed)
 func TestTLSCertificateAuthentication(t *testing.T) {
-	skipBeforeRedisVersion(t, 8.6, "tls-auth-clients-user CN requires Redis 8.6+")
+	skipBeforeRedisVersion(t, "8.6", "tls-auth-clients-user CN requires Redis 8.6+")
 
 	ctx := context.Background()
 	testUsername := "testcertuser"
@@ -174,7 +171,7 @@ func TestTLSCertificateAuthentication(t *testing.T) {
 // 2. Connects with a certificate that has CN=testcertuser
 // 3. Verifies that Redis authenticates as "default" (fallback behavior)
 func TestTLSCertificateAuthenticationNoUser(t *testing.T) {
-	skipBeforeRedisVersion(t, 8.6, "tls-auth-clients-user CN requires Redis 8.6+")
+	skipBeforeRedisVersion(t, "8.6", "tls-auth-clients-user CN requires Redis 8.6+")
 
 	ctx := context.Background()
 	testUsername := "testcertuser"

--- a/vectorset_commands_integration_test.go
+++ b/vectorset_commands_integration_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Redis VectorSet commands", Label("vectorset"), func() {
 			})
 
 			It("basic", func() {
-				SkipBeforeRedisVersion(8.0, "Redis 8.0 introduces support for VectorSet")
+				SkipBeforeRedisVersion("8.0", "Redis 8.0 introduces support for VectorSet")
 				vecName := "basic"
 				val := &redis.VectorValues{
 					Val: []float64{1.5, 2.4, 3.3, 4.2},
@@ -98,7 +98,7 @@ var _ = Describe("Redis VectorSet commands", Label("vectorset"), func() {
 			})
 
 			It("basic similarity", func() {
-				SkipBeforeRedisVersion(8.0, "Redis 8.0 introduces support for VectorSet")
+				SkipBeforeRedisVersion("8.0", "Redis 8.0 introduces support for VectorSet")
 				vecName := "basic_similarity"
 
 				ok, err := client.VAdd(ctx, vecName, "k1", &redis.VectorValues{
@@ -132,7 +132,7 @@ var _ = Describe("Redis VectorSet commands", Label("vectorset"), func() {
 			})
 
 			It("dimension operation", func() {
-				SkipBeforeRedisVersion(8.0, "Redis 8.0 introduces support for VectorSet")
+				SkipBeforeRedisVersion("8.0", "Redis 8.0 introduces support for VectorSet")
 				vecName := "dimension_op"
 				originalDim := 100
 				reducedDim := 50
@@ -167,7 +167,7 @@ var _ = Describe("Redis VectorSet commands", Label("vectorset"), func() {
 			})
 
 			It("remove", func() {
-				SkipBeforeRedisVersion(8.0, "Redis 8.0 introduces support for VectorSet")
+				SkipBeforeRedisVersion("8.0", "Redis 8.0 introduces support for VectorSet")
 				vecName := "remove"
 				v1 := generateRandomVector(5)
 				ok, err := client.VAdd(ctx, vecName, "k1", &v1).Result()
@@ -188,7 +188,7 @@ var _ = Describe("Redis VectorSet commands", Label("vectorset"), func() {
 			})
 
 			It("all operations", func() {
-				SkipBeforeRedisVersion(8.0, "Redis 8.0 introduces support for VectorSet")
+				SkipBeforeRedisVersion("8.0", "Redis 8.0 introduces support for VectorSet")
 				vecName := "commands"
 				vals := []struct {
 					name string
@@ -258,7 +258,7 @@ var _ = Describe("Redis VectorSet commands", Label("vectorset"), func() {
 				expectNil(err)
 				expectEqual(len(res), len(vals))
 
-				if RedisVersion >= 8.4 {
+				if redisVersionAtLeast("8.4") {
 					res, err = client.VRange(ctx, vecName, "[k1", "[k2", -1).Result()
 					expectNil(err)
 					expectEqual(len(res), 2)
@@ -355,7 +355,7 @@ var _ = Describe("Redis VectorSet commands", Label("vectorset"), func() {
 				expectEqual(simScores[0].Name, vals[0].name)
 				expectEqual(simScores[0].Score, float64(1))
 
-				if RedisVersion >= 8.2 {
+				if redisVersionAtLeast("8.2") {
 					// test withattribs
 					simAttribs, err := client.VSimWithArgsWithAttribs(ctx, vecName, &vals[0].v, &redis.VSimArgs{
 						Filter: `.age < 30 or .age > 35`,
@@ -414,7 +414,7 @@ var _ = Describe("Redis VectorSet commands", Label("vectorset"), func() {
 			})
 
 			It("vlinks with single element", func() {
-				SkipBeforeRedisVersion(8.0, "Redis 8.0 introduces support for VectorSet")
+				SkipBeforeRedisVersion("8.0", "Redis 8.0 introduces support for VectorSet")
 				vecName := "vlinks_single"
 
 				// Add only one vector


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly test/CI and backward-compatible optional slowlog field parsing; client behavior on older Redis unchanged when the 7th field is absent.
> 
> **Overview**
> Adds **Redis CE 8.10** to CI (`benchmark` and `test-redis-ce` matrices) and maps `8.10.x` to the `client-libs-test` image in GitHub Actions.
> 
> **Version gating** no longer uses a single `float64` (`RedisVersion`), which misclassified **8.10** as **8.1**. Tests now parse `REDIS_VERSION` as **major.minor** (`redisMajorVersion` / `redisMinorVersion`) with `redisVersionAtLeast`, and `SkipBeforeRedisVersion` / `SkipAfterRedisVersion` take **string** thresholds (e.g. `"8.10"`). Call sites across the suite were updated accordingly.
> 
> **SLOWLOG GET** parsing gains optional **`SlowLog.CommandArgc`** (7th array element on Redis **8.10+**), including clone support and a cap of at most 7 slowlog fields; integration tests cover short commands and truncated `Args` when `slowlog-max-argc` is low.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24b97aedccc9424b274dd296c1be27bbdf15ab40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->