### PR TITLE
re-route whole tx pipeline on redirect/abort, not per-command

### DIFF
--- a/osscluster.go
+++ b/osscluster.go
@@ -1837,18 +1837,108 @@ func (c *ClusterClient) TxPipelined(ctx context.Context, fn func(Pipeliner) erro
 	return c.TxPipeline().Pipelined(ctx, fn)
 }
 
-func (c *ClusterClient) processTxPipeline(ctx context.Context, cmds []Cmder) error {
-	// Only call time.Now() if pipeline operation duration callback is set to avoid overhead
+// A cluster tx pipeline sends MULTI, c1..cN, EXEC — N+2 commands, or N+3 with a
+// leading ASKING — and always receives exactly that many replies, so every
+// redirect/abort path leaves the connection clean.
+//
+// Possible reply sequences:
+//	1. Slot owned here, no migration:
+//	     +OK,  +QUEUED x N,  *N (array of N results)   -> success
+//	2. Slot already migrated away:
+//	     +OK,  -MOVED x N,  -EXECABORT                 -> re-route whole tx
+//	3. Slot in migrating state (still owned here, keys draining out). Per
+//	   cmd, the queue reply is +QUEUED / -ASK / -TRYAGAIN (keys present /
+//	   all gone / some gone); any -ASK or -TRYAGAIN dirties the tx, so
+//	   EXEC is -EXECABORT. Still N+2 replies, like the cases above:
+//	     +OK,  (+QUEUED|-ASK|-TRYAGAIN) x N,  -EXECABORT  -> follow first redirect
+//	4. Narrow race (all +QUEUED, slot moves before EXEC):
+//	     +OK,  +QUEUED x N,  -MOVED <slot> <addr>         -> re-route whole tx
+//	5. Non-cluster command error (arity / ACL / unknown):
+//	     +OK,  +QUEUED..., -ERR...,  -EXECABORT           -> surface, not retryable
+//	6. Narrow race (all +QUEUED, slot still migrating, keys drain before EXEC):
+//	     +OK,  +QUEUED x N,  -ASK / -TRYAGAIN             -> re-route on -ASK, back off on -TRYAGAIN
+//
+// EXEC reply — the reply that decides the outcome:
+//
+//	*N                    success; read N per-command results
+//	-EXECABORT            a queue-stage command failed; follow the first queue
+//	                      redirect (MOVED/ASK/TRYAGAIN), else surface the trigger
+//	-MOVED <slot> <addr>  case 4; re-route whole tx to addr, reload topology
+//	-ASK <slot> <addr>    race: slot entered migrating state; re-route to addr
+//	                      with a top-level ASKING before MULTI
+//	-TRYAGAIN             race: migrating with split keys, or slot being trimmed
+//	                      (CLUSTER_REDIR_TRIMMING on a write); back off and retry
+//	                      the whole tx (same node still owns it)
+//	-CLUSTERDOWN          cluster degraded; back off and retry whole tx
+//
+// ASK retry: the ASKING flag is NOT cleared between commands inside a MULTI
+// so one top-level ASKING before MULTI covers the whole tx and lets the importing
+// slot serve at EXEC. ASKING placed inside the MULTI would be queued and leave
+// the flag unset during queueing, so the keyed commands would still get MOVED.
+//
+// Out of scope: WATCH's null-array EXEC and -CROSSSLOT;
+// cluster TxPipeline is not used with WATCH and cross-slot is rejected client-side.
+
+type txOutcomeKind int
+
+const (
+	txSuccess       txOutcomeKind = iota // transaction executed; per-command results are set
+	txRetryMoved                         // MOVED: reload topology and re-route the whole tx
+	txRetryAsk                           // ASK: re-route to the target with a top-level ASKING
+	txRetryTryAgain                      // TRYAGAIN: back off and re-route the whole tx
+	txRetryConn                          // connection/write/read failure: re-route the whole tx
+	txFatal                              // non-retryable error; surface to the caller
+)
+
+// txOutcome is the result of a single tx attempt. err is the error to report
+// when the redirect/retry loop is exhausted (or the fatal error to surface);
+// addr is the ASK target; execErr is the EXEC reply error used to mark
+// aborted commands; unreadReplies forces the connection to be discarded
+// when the read loop exited before consuming all N+2 replies, leaving bytes
+// on the wire.
+type txOutcome struct {
+	kind          txOutcomeKind
+	err           error
+	addr          string
+	execErr       error
+	unreadReplies bool
+}
+
+// txRedirect records the first queue-stage redirect (MOVED/ASK/TRYAGAIN) seen
+// while reading +QUEUED replies. Redis dirties and aborts the transaction on
+// any such reply, so the EXEC reply will be EXECABORT and the client must
+// follow the recorded redirect with the whole transaction.
+type txRedirect struct {
+	moved    bool
+	ask      bool
+	tryAgain bool
+	addr     string
+	err      error
+}
+
+// errTxDirtyConn forces releaseConn to discard a connection that may still have
+// unread transaction replies on it (an early exit before consuming all N+2).
+var errTxDirtyConn = errors.New("redis: connection has unread transaction replies")
+
+func (c *ClusterClient) processTxPipeline(ctx context.Context, cmds []Cmder) (retErr error) {
 	var operationStart time.Time
 	pipelineOpDurationCallback := otel.GetPipelineOperationDurationCallback()
 	if pipelineOpDurationCallback != nil {
 		operationStart = time.Now()
 	}
 	totalAttempts := 0
+	var lastErr error
+
+	defer func() {
+		if pipelineOpDurationCallback == nil {
+			return
+		}
+		finalErr := cmp.Or(retErr, cmdsFirstErr(cmds), lastErr)
+		pipelineOpDurationCallback(ctx, time.Since(operationStart), "MULTI", len(cmds), totalAttempts, finalErr, nil, 0)
+	}()
 
 	// Trim multi .. exec.
 	cmds = cmds[1 : len(cmds)-1]
-
 	if len(cmds) == 0 {
 		return nil
 	}
@@ -1856,10 +1946,6 @@ func (c *ClusterClient) processTxPipeline(ctx context.Context, cmds []Cmder) err
 	state, err := c.state.Get(ctx)
 	if err != nil {
 		setCmdsErr(cmds, err)
-		if pipelineOpDurationCallback != nil {
-			operationDuration := time.Since(operationStart)
-			pipelineOpDurationCallback(ctx, operationDuration, "MULTI", len(cmds), 1, err, nil, 0)
-		}
 		return err
 	}
 
@@ -1871,77 +1957,85 @@ func (c *ClusterClient) processTxPipeline(ctx context.Context, cmds []Cmder) err
 	case 1:
 		for sl := range keyedCmdsBySlot {
 			slot = sl
-			break
 		}
 	default:
 		// TxPipeline does not support cross slot transaction.
 		setCmdsErr(cmds, ErrCrossSlot)
-		if pipelineOpDurationCallback != nil {
-			operationDuration := time.Since(operationStart)
-			pipelineOpDurationCallback(ctx, operationDuration, "MULTI", len(cmds), 1, ErrCrossSlot, nil, 0)
-		}
 		return ErrCrossSlot
 	}
 
 	node, err := state.slotMasterNode(slot)
 	if err != nil {
 		setCmdsErr(cmds, err)
-		if pipelineOpDurationCallback != nil {
-			operationDuration := time.Since(operationStart)
-			pipelineOpDurationCallback(ctx, operationDuration, "MULTI", len(cmds), 1, err, nil, 0)
-		}
 		return err
 	}
 
-	var lastErr error
-	cmdsMap := map[*clusterNode][]Cmder{node: cmds}
+	asking := false
+	// MOVED/ASK are routing changes, not transient failures: follow them immediately.
+	redirected := false
 	for attempt := 0; attempt <= c.opt.MaxRedirects; attempt++ {
 		totalAttempts++
-		if attempt > 0 {
+		if attempt > 0 && !redirected {
 			if err := internal.Sleep(ctx, c.retryBackoff(attempt)); err != nil {
 				setCmdsErr(cmds, err)
-				if pipelineOpDurationCallback != nil {
-					operationDuration := time.Since(operationStart)
-					pipelineOpDurationCallback(ctx, operationDuration, "MULTI", len(cmds), totalAttempts, err, nil, 0)
-				}
 				return err
 			}
 		}
 
-		failedCmds := newCmdsMap()
-		var wg sync.WaitGroup
-
-		for node, cmds := range cmdsMap {
-			wg.Add(1)
-			go func(node *clusterNode, cmds []Cmder) {
-				defer wg.Done()
-				c.processTxPipelineNode(ctx, node, cmds, failedCmds)
-			}(node, cmds)
+		outcome := c.processTxPipelineNode(ctx, node, cmds, asking)
+		lastErr = outcome.err
+		redirected = false
+		switch outcome.kind {
+		case txSuccess:
+			return cmdsFirstErr(cmds)
+		case txRetryMoved:
+			// Route directly to the authoritative addr from the MOVED; the
+			// cached slot state may be stale until LazyReload lands.
+			redirected = true
+			asking = false
+			c.state.LazyReload()
+			if node, err = c.nodes.GetOrCreate(outcome.addr); err != nil {
+				setCmdsErr(cmds, err)
+				return err
+			}
+		case txRetryAsk:
+			redirected = true
+			asking = true
+			if node, err = c.nodes.GetOrCreate(outcome.addr); err != nil {
+				setCmdsErr(cmds, err)
+				return err
+			}
+		case txRetryTryAgain, txRetryConn:
+			// Same node, fresh connection: TRYAGAIN comes from the migrating
+			// source (still the owner), and a conn failure only needs a new
+			// connection. Preserve a prior ASKING flag: if we followed an ASK
+			// to the importing target, the retry must still send ASKING (the
+			// slot is still importing). ASKING is harmless if the migration
+			// has since completed, since the flag is only consulted for
+			// importing slots.
+		case txFatal:
+			// Mark every queued-but-never-executed command with the abort
+			// error; the command that triggered EXECABORT already has its
+			// own error and keeps it, so callers can tell what went wrong.
+			abortErr := cmp.Or(outcome.execErr, outcome.err)
+			for _, cmd := range cmds {
+				if cmd.Err() == nil {
+					cmd.SetErr(abortErr)
+				}
+			}
+			return lastErr
 		}
-
-		wg.Wait()
-		if len(failedCmds.m) == 0 {
-			break
-		}
-		cmdsMap = failedCmds.m
-		lastErr = cmdsFirstErr(cmds)
 	}
 
-	if pipelineOpDurationCallback != nil {
-		operationDuration := time.Since(operationStart)
-		finalErr := cmdsFirstErr(cmds)
-		if finalErr == nil {
-			finalErr = lastErr
-		}
-		pipelineOpDurationCallback(ctx, operationDuration, "MULTI", len(cmds), totalAttempts, finalErr, nil, 0)
+	if lastErr != nil {
+		setCmdsErr(cmds, lastErr)
 	}
-
 	return cmdsFirstErr(cmds)
 }
 
 // slottedKeyedCommands returns a map of slot to commands taking into account
 // only commands that have keys.
-func (c *ClusterClient) slottedKeyedCommands(ctx context.Context, cmds []Cmder) map[int][]Cmder {
+func (c *ClusterClient) slottedKeyedCommands(_ context.Context, cmds []Cmder) map[int][]Cmder {
 	cmdsSlots := map[int][]Cmder{}
 
 	// Peek once outside the loop, one RLock for the whole batch instead of
@@ -1972,151 +2066,217 @@ func (c *ClusterClient) slottedKeyedCommands(ctx context.Context, cmds []Cmder) 
 }
 
 func (c *ClusterClient) processTxPipelineNode(
-	ctx context.Context, node *clusterNode, cmds []Cmder, failedCmds *cmdsMap,
-) {
-	cmds = wrapMultiExec(ctx, cmds)
-	_ = node.Client.withProcessPipelineHook(ctx, cmds, func(ctx context.Context, cmds []Cmder) error {
+	ctx context.Context, node *clusterNode, cmds []Cmder, asking bool,
+) *txOutcome {
+	wire := wrapMultiExec(ctx, cmds)
+	if asking {
+		// ASKING must precede MULTI so the flag stays set for the whole tx.
+		wire = append([]Cmder{NewCmd(ctx, "asking")}, wire...)
+	}
+
+	var outcome *txOutcome
+	_ = node.Client.withProcessPipelineHook(ctx, wire, func(ctx context.Context, wire []Cmder) error {
 		cn, err := node.Client.getConn(ctx)
 		if err != nil {
-			_ = c.mapCmdsByNode(ctx, failedCmds, cmds)
-			setCmdsErr(cmds, err)
+			if shouldRetry(err, true) && !cmdsContainNoRetry(cmds) {
+				outcome = &txOutcome{kind: txRetryConn, err: err}
+			} else {
+				outcome = &txOutcome{kind: txFatal, err: err}
+			}
 			return err
 		}
 
-		var processErr error
-		defer func() {
-			node.Client.releaseConn(ctx, cn, processErr)
-		}()
-		processErr = c.processTxPipelineNodeConn(ctx, node, cn, cmds, failedCmds)
-
-		return processErr
+		outcome = c.processTxPipelineNodeConn(ctx, node, cn, wire, cmds, asking)
+		connErr := outcome.err
+		if isRedisError(outcome.err) {
+			connErr = nil
+		}
+		if outcome.unreadReplies {
+			connErr = errTxDirtyConn
+		}
+		node.Client.releaseConn(ctx, cn, connErr)
+		return connErr
 	})
+
+	if outcome == nil {
+		outcome = &txOutcome{kind: txFatal, err: fmt.Errorf("redis: tx pipeline produced no outcome")}
+	}
+	return outcome
 }
 
 func (c *ClusterClient) processTxPipelineNodeConn(
-	ctx context.Context, node *clusterNode, cn *pool.Conn, cmds []Cmder, failedCmds *cmdsMap,
-) error {
+	ctx context.Context, node *clusterNode, cn *pool.Conn, wire []Cmder, cmds []Cmder, asking bool,
+) *txOutcome {
 	if err := cn.WithWriter(c.context(ctx), c.opt.WriteTimeout, func(wr *proto.Writer) error {
-		return writeCmds(wr, cmds)
+		return writeCmds(wr, wire)
 	}); err != nil {
+		// Write failure: re-route the whole tx on a fresh connection.
 		if shouldRetry(err, true) && !cmdsContainNoRetry(cmds) {
-			_ = c.mapCmdsByNode(ctx, failedCmds, cmds)
+			return &txOutcome{kind: txRetryConn, err: err}
 		}
-		setCmdsErr(cmds, err)
-		return err
+		return &txOutcome{kind: txFatal, err: err}
 	}
 
-	return cn.WithReader(c.context(ctx), c.opt.ReadTimeout, func(rd *proto.Reader) error {
-		statusCmd := cmds[0].(*StatusCmd)
-		// Trim multi and exec.
-		trimmedCmds := cmds[1 : len(cmds)-1]
-
-		if err := c.txPipelineReadQueued(
-			ctx, node, cn, rd, statusCmd, trimmedCmds, failedCmds,
-		); err != nil {
-			setCmdsErr(cmds, err)
-
-			moved, ask, addr := isMovedError(err)
-			if moved || ask {
-				return c.cmdsMoved(ctx, trimmedCmds, moved, ask, addr, failedCmds)
-			}
-
-			return err
-		}
-
-		return node.Client.pipelineReadCmds(ctx, cn, rd, trimmedCmds)
+	var outcome *txOutcome
+	readErr := cn.WithReader(c.context(ctx), c.opt.ReadTimeout, func(rd *proto.Reader) error {
+		outcome = c.readTxPipelineReplies(ctx, node, cn, rd, cmds, asking)
+		return nil
 	})
+
+	if readErr != nil {
+		// Reader-level failure (deadline setup, nil conn) around the read loop.
+		// The batch was already written, so the server may have committed;
+		// surface the error as fatal and discard the suspect connection rather
+		// than re-executing the transaction.
+		return c.txReadFatal(readErr)
+	}
+	return outcome
 }
 
-func (c *ClusterClient) txPipelineReadQueued(
-	ctx context.Context,
-	node *clusterNode,
-	cn *pool.Conn,
-	rd *proto.Reader,
-	statusCmd *StatusCmd,
-	cmds []Cmder,
-	failedCmds *cmdsMap,
-) error {
-	// Parse queued replies.
-	// To be sure there are no buffered push notifications, we process them before reading the reply
-	if err := node.Client.processPendingPushNotificationWithReader(ctx, cn, rd); err != nil {
-		// Log the error but don't fail the command execution
-		// Push notification processing errors shouldn't break normal Redis operations
-		internal.Logger.Printf(ctx, "push: error processing pending notifications before reading reply: %v", err)
-	}
-	if err := statusCmd.readReply(rd); err != nil {
-		return err
+// readTxPipelineReplies reads the replies of one MULTI..EXEC unit and
+// classifies the outcome. The reply count always matches the number of sent
+// commands, so success/redirect paths leave the connection clean; only an early
+// MULTI read failure can leave unread replies.
+func (c *ClusterClient) readTxPipelineReplies(
+	ctx context.Context, node *clusterNode, cn *pool.Conn, rd *proto.Reader, cmds []Cmder, asking bool,
+) *txOutcome {
+	scratch := NewStatusCmd(ctx)
+
+	readStatus := func() error {
+		c.txProcessPush(ctx, node, cn, rd)
+		return scratch.readReply(rd)
 	}
 
+	// Optional top-level ASKING reply (+OK).
+	if asking {
+		if err := readStatus(); err != nil {
+			return c.txReadFatal(err)
+		}
+	}
+
+	// MULTI reply (+OK, or an error such as -LOADING during failover).
+	if err := readStatus(); err != nil {
+		return c.txMultiErrorOutcome(err, cmds)
+	}
+
+	// Queue replies: +QUEUED, or a redirect / command error that dirties the tx.
+	var firstRedirect *txRedirect
+	var firstFatal error
 	for _, cmd := range cmds {
-		// To be sure there are no buffered push notifications, we process them before reading the reply
-		if err := node.Client.processPendingPushNotificationWithReader(ctx, cn, rd); err != nil {
-			// Log the error but don't fail the command execution
-			// Push notification processing errors shouldn't break normal Redis operations
-			internal.Logger.Printf(ctx, "push: error processing pending notifications before reading reply: %v", err)
+		err := readStatus()
+		if err == nil {
+			continue // +QUEUED
 		}
-		err := statusCmd.readReply(rd)
-		if err != nil {
-			if c.checkMovedErr(ctx, cmd, err, failedCmds) {
-				// will be processed later
-				continue
+		if !isRedisError(err) {
+			return c.txReadFatal(err) // IO error
+		}
+		if moved, ask, addr := isMovedError(err); moved || ask {
+			if firstRedirect == nil {
+				firstRedirect = &txRedirect{moved: moved, ask: ask, addr: addr, err: err}
 			}
-			cmd.SetErr(err)
-			if !isRedisError(err) {
-				return err
+			continue
+		}
+		if proto.IsTryAgainError(err) {
+			if firstRedirect == nil {
+				firstRedirect = &txRedirect{tryAgain: true, err: err}
 			}
+			continue
+		}
+		// Non-redirect command error (e.g. wrong arity) dirties the tx.
+		cmd.SetErr(err)
+		if firstFatal == nil {
+			firstFatal = err
 		}
 	}
 
-	// To be sure there are no buffered push notifications, we process them before reading the reply
-	if err := node.Client.processPendingPushNotificationWithReader(ctx, cn, rd); err != nil {
-		// Log the error but don't fail the command execution
-		// Push notification processing errors shouldn't break normal Redis operations
-		internal.Logger.Printf(ctx, "push: error processing pending notifications before reading reply: %v", err)
-	}
-	// Parse number of replies.
+	// EXEC reply. ReadLine parses error lines into typed errors, so a non-nil
+	// err means EXEC returned an error rather than the result array.
+	c.txProcessPush(ctx, node, cn, rd)
 	line, err := rd.ReadLine()
 	if err != nil {
-		if err == Nil {
-			err = TxFailedErr
+		if !isRedisError(err) {
+			return c.txReadFatal(err) // IO error
 		}
-		return err
+		return c.classifyExecError(err, firstRedirect, firstFatal)
 	}
 
 	if line[0] != proto.RespArray {
-		return fmt.Errorf("redis: expected '*', but got line %q", line)
+		err := fmt.Errorf("redis: unexpected EXEC reply %q", line)
+		setCmdsErr(cmds, err)
+		// A non-array aggregate reply may carry an unread payload.
+		return &txOutcome{kind: txFatal, err: err, unreadReplies: true}
 	}
 
-	return nil
+	// Success: read the N command results.
+	if err := node.Client.pipelineReadCmds(ctx, cn, rd, cmds); err != nil && !isRedisError(err) {
+		return c.txReadFatal(err) // IO error mid-results
+	}
+	return &txOutcome{kind: txSuccess}
 }
 
-func (c *ClusterClient) cmdsMoved(
-	ctx context.Context, cmds []Cmder,
-	moved, ask bool,
-	addr string,
-	failedCmds *cmdsMap,
-) error {
-	node, err := c.nodes.GetOrCreate(addr)
-	if err != nil {
-		return err
+func (c *ClusterClient) txProcessPush(ctx context.Context, node *clusterNode, cn *pool.Conn, rd *proto.Reader) {
+	if err := node.Client.processPendingPushNotificationWithReader(ctx, cn, rd); err != nil {
+		internal.Logger.Printf(ctx, "push: error processing pending notifications before reading reply: %v", err)
 	}
+}
 
-	if moved {
-		c.state.LazyReload()
-		for _, cmd := range cmds {
-			failedCmds.Add(node, cmd)
+// txReadFatal classifies a read-phase IO error. The MULTI..EXEC batch was
+// already written, so the server may have committed the transaction; retrying
+// would re-execute it, double-applying non-idempotent commands (INCR/APPEND,
+// which are not NoRetry). Surface the error as fatal and discard the
+// connection, since replies may still be unread on the wire.
+func (c *ClusterClient) txReadFatal(err error) *txOutcome {
+	return &txOutcome{kind: txFatal, err: err, unreadReplies: true}
+}
+
+// txMultiErrorOutcome classifies a MULTI reply error (e.g. -LOADING). A failed
+// MULTI still leaves the N+1 subsequent replies on the wire -- the server
+// replies to each following command and to EXEC regardless -- so the
+// connection must always be discarded.
+func (c *ClusterClient) txMultiErrorOutcome(err error, cmds []Cmder) *txOutcome {
+	if !isRedisError(err) {
+		return c.txReadFatal(err)
+	}
+	if shouldRetry(err, true) && !cmdsContainNoRetry(cmds) {
+		return &txOutcome{kind: txRetryConn, err: err, unreadReplies: true}
+	}
+	return &txOutcome{kind: txFatal, err: err, unreadReplies: true}
+}
+
+// classifyExecError turns an EXEC reply error into a retry/fatal outcome. If a
+// queue-stage redirect dirtied the tx (EXECABORT), follow that redirect with
+// the whole transaction; otherwise surface the triggering command error.
+func (c *ClusterClient) classifyExecError(execErr error, firstRedirect *txRedirect, firstFatal error) *txOutcome {
+	if moved, ask, addr := isMovedError(execErr); moved || ask {
+		// Narrow race: the slot moved after every command was queued.
+		if ask {
+			return &txOutcome{kind: txRetryAsk, err: execErr, addr: addr}
 		}
-		return nil
+		return &txOutcome{kind: txRetryMoved, err: execErr, addr: addr}
 	}
-
-	if ask {
-		for _, cmd := range cmds {
-			failedCmds.Add(node, NewCmd(ctx, "asking"), cmd)
+	if proto.IsTryAgainError(execErr) {
+		return &txOutcome{kind: txRetryTryAgain, err: execErr}
+	}
+	if proto.IsClusterDownError(execErr) {
+		// Cluster degraded: back off and retry. Replies were fully consumed.
+		return &txOutcome{kind: txRetryConn, err: execErr}
+	}
+	if proto.IsExecAbortError(execErr) {
+		if firstRedirect != nil {
+			switch {
+			case firstRedirect.moved:
+				return &txOutcome{kind: txRetryMoved, err: firstRedirect.err, addr: firstRedirect.addr}
+			case firstRedirect.ask:
+				return &txOutcome{kind: txRetryAsk, err: firstRedirect.err, addr: firstRedirect.addr}
+			case firstRedirect.tryAgain:
+				return &txOutcome{kind: txRetryTryAgain, err: firstRedirect.err}
+			}
 		}
-		return nil
+		// Non-redirect abort: surface the triggering command error.
+		ferr := cmp.Or(firstFatal, execErr)
+		return &txOutcome{kind: txFatal, err: ferr, execErr: execErr}
 	}
-
-	return nil
+	return &txOutcome{kind: txFatal, err: execErr}
 }
 
 func (c *ClusterClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {

--- a/osscluster.go
+++ b/osscluster.go
@@ -2245,9 +2245,7 @@ func (c *ClusterClient) txPreQueueErrorOutcome(err error, cmds []Cmder) *txOutco
 	return &txOutcome{kind: txFatal, err: err, unreadReplies: true}
 }
 
-// classifyExecError turns an EXEC reply error into a retry/fatal outcome. If a
-// queue-stage redirect dirtied the tx (EXECABORT), follow that redirect with
-// the whole transaction; otherwise surface the triggering command error.
+// classifyExecError turns an EXEC reply error into a retry/fatal outcome.
 func (c *ClusterClient) classifyExecError(execErr error, firstRedirect *txRedirect, firstFatal error) *txOutcome {
 	if moved, ask, addr := isMovedError(execErr); moved || ask {
 		// Narrow race: the slot moved after every command was queued.
@@ -2264,6 +2262,9 @@ func (c *ClusterClient) classifyExecError(execErr error, firstRedirect *txRedire
 		return &txOutcome{kind: txRetryConn, err: execErr}
 	}
 	if proto.IsExecAbortError(execErr) {
+		if firstFatal != nil {
+			return &txOutcome{kind: txFatal, err: firstFatal, execErr: execErr}
+		}
 		if firstRedirect != nil {
 			switch {
 			case firstRedirect.moved:
@@ -2274,9 +2275,7 @@ func (c *ClusterClient) classifyExecError(execErr error, firstRedirect *txRedire
 				return &txOutcome{kind: txRetryTryAgain, err: firstRedirect.err}
 			}
 		}
-		// Non-redirect abort: surface the triggering command error.
-		ferr := cmp.Or(firstFatal, execErr)
-		return &txOutcome{kind: txFatal, err: ferr, execErr: execErr}
+		return &txOutcome{kind: txFatal, err: execErr, execErr: execErr}
 	}
 	return &txOutcome{kind: txFatal, err: execErr}
 }

--- a/osscluster.go
+++ b/osscluster.go
@@ -2147,16 +2147,16 @@ func (c *ClusterClient) readTxPipelineReplies(
 		return scratch.readReply(rd)
 	}
 
-	// Optional top-level ASKING reply (+OK).
+	// Optional top-level ASKING reply (+OK, or a retryable error such as -LOADING).
 	if asking {
 		if err := readStatus(); err != nil {
-			return c.txReadFatal(err)
+			return c.txPreQueueErrorOutcome(err, cmds)
 		}
 	}
 
 	// MULTI reply (+OK, or an error such as -LOADING during failover).
 	if err := readStatus(); err != nil {
-		return c.txMultiErrorOutcome(err, cmds)
+		return c.txPreQueueErrorOutcome(err, cmds)
 	}
 
 	// Queue replies: +QUEUED, or a redirect / command error that dirties the tx.
@@ -2229,11 +2229,13 @@ func (c *ClusterClient) txReadFatal(err error) *txOutcome {
 	return &txOutcome{kind: txFatal, err: err, unreadReplies: true}
 }
 
-// txMultiErrorOutcome classifies a MULTI reply error (e.g. -LOADING). A failed
-// MULTI still leaves the N+1 subsequent replies on the wire -- the server
-// replies to each following command and to EXEC regardless -- so the
-// connection must always be discarded.
-func (c *ClusterClient) txMultiErrorOutcome(err error, cmds []Cmder) *txOutcome {
+// txPreQueueErrorOutcome classifies a setup-phase reply error: the top-level
+// ASKING reply or the MULTI reply. The transaction body never executes (EXEC
+// returns -EXECABORT), so retryable errors such as -LOADING are safe to retry
+// on a fresh connection. A failed setup reply still leaves the remaining
+// replies on the wire -- the server replies to each following command and to
+// EXEC regardless -- so the connection is always discarded.
+func (c *ClusterClient) txPreQueueErrorOutcome(err error, cmds []Cmder) *txOutcome {
 	if !isRedisError(err) {
 		return c.txReadFatal(err)
 	}

--- a/osscluster_test.go
+++ b/osscluster_test.go
@@ -1,6 +1,7 @@
 package redis_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -11,10 +12,12 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"
+
 	"github.com/redis/go-redis/v9"
 	"github.com/redis/go-redis/v9/internal/hashtag"
 	"github.com/redis/go-redis/v9/internal/routing"
@@ -255,6 +258,170 @@ func slotEqual(s1, s2 redis.ClusterSlot) bool {
 		}
 	}
 	return true
+}
+
+// txWriteRecorder captures, per node addr, each Write payload that carries a
+// MULTI/EXEC transaction. txWriteCount uses it to prove whether the client
+// retried a transaction (e.g. after a transient write/read failure or an ASK).
+type txWriteRecorder struct {
+	mu     sync.Mutex
+	writes map[string][][]byte // addr -> tx write payloads
+}
+
+func newTxWriteRecorder() *txWriteRecorder {
+	return &txWriteRecorder{writes: map[string][][]byte{}}
+}
+
+func (r *txWriteRecorder) record(addr string, b []byte) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.writes[addr] = append(r.writes[addr], bytes.Clone(b))
+}
+
+// txWriteCount returns the number of tx writes (MULTI-containing batches) sent
+// to addr. Used to prove whether the client retried a transaction.
+func (r *txWriteRecorder) txWriteCount(addr string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, b := range r.writes[addr] {
+		if countRespCmd(b, "MULTI") > 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// countRespCmd counts occurrences of a RESP command name (e.g. "MULTI") within a
+// raw Write payload by matching the bulk-string framing "$<len>\r\n<NAME>\r\n".
+// Matching is case-insensitive: go-redis writes tx commands in lower case
+// ("multi"/"exec") but other commands may differ.
+func countRespCmd(b []byte, cmd string) int {
+	needle := []byte("$" + strconv.Itoa(len(cmd)) + "\r\n" + strings.ToUpper(cmd) + "\r\n")
+	return bytes.Count(bytes.ToUpper(b), needle)
+}
+
+// txFaultConn wraps a real redis connection. Non-tx traffic is forwarded
+// unchanged so the cluster client can still load topology; tx writes (those
+// containing MULTI) are always recorded. When failOnce is non-nil
+// (transient-retry test), the first MULTI write across all sharing conns
+// fails with io.EOF and subsequent ones are forwarded, so the client must retry the
+// whole tx and then succeed.
+type txFaultConn struct {
+	net.Conn
+	addr     string
+	rec      *txWriteRecorder
+	failOnce *atomic.Int32
+	// failAddr, when set, restricts failOnce to writes whose addr matches; an
+	// empty failAddr (the default) fires on the first MULTI write to any addr.
+	failAddr string
+	// failRead makes reads return io.EOF once a MULTI write has been seen on
+	// this conn, so the tx batch is committed server-side but the client cannot
+	// read the reply. Used to prove a post-commit read failure is not retried.
+	failRead bool
+	sawMulti atomic.Bool
+}
+
+func (c *txFaultConn) Write(b []byte) (int, error) {
+	if countRespCmd(b, "MULTI") > 0 {
+		c.sawMulti.Store(true)
+		c.rec.record(c.addr, b)
+		if c.failOnce != nil && (c.failAddr == "" || c.addr == c.failAddr) &&
+			c.failOnce.CompareAndSwap(0, 1) {
+			return 0, io.EOF
+		}
+	}
+	return c.Conn.Write(b)
+}
+
+func (c *txFaultConn) Read(b []byte) (int, error) {
+	if c.failRead && c.sawMulti.Load() {
+		return 0, io.EOF
+	}
+	return c.Conn.Read(b)
+}
+
+// slotMasterPort returns the port of the master owning `slot` in the test
+// cluster's fixed distribution (0-5460 -> 16600, 5461-10922 -> 16601,
+// 10923-16383 -> 16602), matching clusterScenario.slots().
+func slotMasterPort(slot int) string {
+	switch {
+	case slot < 5461:
+		return cluster.ports[0]
+	case slot < 10923:
+		return cluster.ports[1]
+	default:
+		return cluster.ports[2]
+	}
+}
+
+// slotOtherMasterPort returns the port of a master that does NOT own `slot`,
+// matching the migration target that setupAskMigration picks (the first master
+// port != the slot's owner).
+func slotOtherMasterPort(slot int) string {
+	src := slotMasterPort(slot)
+	for _, p := range cluster.ports[:3] {
+		if p != src {
+			return p
+		}
+	}
+	return ""
+}
+
+// resetSlot restores `slot` to a clean, fully-owned state on its master and
+// deletes `keys` from all masters. It is idempotent and best-effort, used to
+// recover from a prior run that left the slot migrating/importing.
+func resetSlot(ctx context.Context, slot int, keys ...string) {
+	srcPort := slotMasterPort(slot)
+	srcCli := redis.NewClient(&redis.Options{Addr: "127.0.0.1:" + srcPort})
+	srcID, _ := srcCli.ClusterMyID(ctx).Result()
+	_ = srcCli.Close()
+	for _, p := range cluster.ports[:3] {
+		c := redis.NewClient(&redis.Options{Addr: "127.0.0.1:" + p})
+		_ = c.Do(ctx, "cluster", "setslot", slot, "node", srcID).Err()
+		for _, k := range keys {
+			_ = c.Del(ctx, k).Err()
+		}
+		_ = c.Close()
+	}
+}
+
+// setupAskMigration puts `slot` into MIGRATING on its owner (source) and IMPORTING
+// on a different master (target), leaving the slot's keys absent from both. The
+// source then returns -ASK for any absent key in the slot. The returned cleanup
+// restores slot ownership on all masters.
+func setupAskMigration(ctx context.Context, slot int) func() {
+	resetSlot(ctx, slot)
+	srcPort := slotMasterPort(slot)
+	tgtPort := ""
+	for _, p := range cluster.ports[:3] {
+		if p != srcPort {
+			tgtPort = p
+			break
+		}
+	}
+	srcCli := redis.NewClient(&redis.Options{Addr: "127.0.0.1:" + srcPort})
+	tgtCli := redis.NewClient(&redis.Options{Addr: "127.0.0.1:" + tgtPort})
+
+	srcID, err := srcCli.ClusterMyID(ctx).Result()
+	Expect(err).NotTo(HaveOccurred())
+	dstID, err := tgtCli.ClusterMyID(ctx).Result()
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(srcCli.Do(ctx, "cluster", "setslot", slot, "migrating", dstID).Err()).
+		NotTo(HaveOccurred())
+	Expect(tgtCli.Do(ctx, "cluster", "setslot", slot, "importing", srcID).Err()).
+		NotTo(HaveOccurred())
+
+	return func() {
+		for _, p := range cluster.ports[:3] {
+			c := redis.NewClient(&redis.Options{Addr: "127.0.0.1:" + p})
+			_ = c.Do(ctx, "cluster", "setslot", slot, "node", srcID).Err()
+			_ = c.Close()
+		}
+		_ = srcCli.Close()
+		_ = tgtCli.Close()
+	}
 }
 
 // ------------------------------------------------------------------------------
@@ -859,8 +1026,198 @@ var _ = Describe("ClusterClient", func() {
 			Expect(client.Close()).NotTo(HaveOccurred())
 		})
 
+		// A TxPipeline whose slot is initially routed at a replica gets -MOVED on
+		// the write; the client must follow the redirect and run the whole tx on
+		// the real master, with the written values visible afterwards.
+		It("should follow MOVED redirect for TxPipeline", func() {
+			// {s} hashtag forces a single-slot, single-node transaction.
+			_, err := client.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, "A{s}", "1", 0)
+				pipe.Set(ctx, "B{s}", "2", 0)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Route the slot at a replica so the write tx is MOVED back to the real master.
+			Eventually(func() error {
+				return client.SwapNodes(ctx, "A{s}")
+			}, 30*time.Second).ShouldNot(HaveOccurred())
+
+			_, err = client.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, "A{s}", "11", 0)
+				pipe.Set(ctx, "B{s}", "22", 0)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// The MOVED triggers a topology reload that un-swaps the state, so
+			// reads eventually land on the real master with the new values.
+			Eventually(func() string {
+				return client.Get(ctx, "A{s}").Val()
+			}, 30*time.Second).Should(Equal("11"))
+			Eventually(func() string {
+				return client.Get(ctx, "B{s}").Val()
+			}, 30*time.Second).Should(Equal("22"))
+		})
+
+		// When a queued command fails with a non-redirect error (here GET with
+		// wrong arity), Redis aborts the tx with -EXECABORT. The surfaced error
+		// should name the triggering command's error ("wrong number of
+		// arguments"), not a generic parse error.
+		It("should surface the triggering error on TxPipeline EXECABORT instead of 'expected'", func() {
+			_, err := client.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, "A{s}", "1", 0)
+				pipe.Do(ctx, "GET", "A{s}", "extra")
+				pipe.Set(ctx, "B{s}", "2", 0)
+				return nil
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).NotTo(ContainSubstring("expected '*'"))
+			Expect(err.Error()).To(ContainSubstring("wrong number of arguments"))
+		})
+
+		// With redirects disabled (MaxRedirects = -1), a TxPipeline that hits
+		// -MOVED must surface a MOVED error so the caller can tell it was a
+		// redirect, not a generic parse error.
+		It("should return MOVED (not 'expected') for TxPipeline when redirects are exhausted", func() {
+			opt := redisClusterOptions()
+			opt.MaxRedirects = -1
+			redirectClient := cluster.newClusterClient(ctx, opt)
+			defer func() { Expect(redirectClient.Close()).NotTo(HaveOccurred()) }()
+
+			Eventually(func() error {
+				return redirectClient.SwapNodes(ctx, "A{s}")
+			}, 30*time.Second).ShouldNot(HaveOccurred())
+
+			_, err := redirectClient.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, "A{s}", "1", 0)
+				pipe.Set(ctx, "B{s}", "2", 0)
+				return nil
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("MOVED"))
+			Expect(err.Error()).NotTo(ContainSubstring("expected '*'"))
+		})
+
+		// A transient write failure during a tx must be retried as a whole
+		// transaction and ultimately succeed, with both values actually written.
+		// The first tx write is failed with io.EOF and the retry is let through.
+		It("retries the whole tx after a transient write failure and succeeds", func() {
+			rec := newTxWriteRecorder()
+			var failOnce atomic.Int32 // first MULTI write fails, subsequent ones forward
+			opt := redisClusterOptions()
+			opt.Dialer = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				var d net.Dialer
+				cn, err := d.DialContext(ctx, network, addr)
+				if err != nil {
+					return nil, err
+				}
+				return &txFaultConn{Conn: cn, addr: addr, rec: rec, failOnce: &failOnce}, nil
+			}
+			retryClient := cluster.newClusterClient(ctx, opt)
+			defer func() { Expect(retryClient.Close()).NotTo(HaveOccurred()) }()
+
+			_, err := retryClient.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, "retry1{s}", "1", 0)
+				pipe.Set(ctx, "retry2{s}", "2", 0)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred(),
+				"a transient write failure should be retried as a whole tx and succeed")
+
+			// The retried tx must have executed: both values are present on the
+			// slot master.
+			Expect(retryClient.Get(ctx, "retry1{s}").Val()).To(Equal("1"))
+			Expect(retryClient.Get(ctx, "retry2{s}").Val()).To(Equal("2"))
+
+			// The slot master received more than one tx write, so the first
+			// attempt really failed and the tx was retried.
+			srcAddr := "127.0.0.1:" + slotMasterPort(hashtag.Slot("retry1{s}"))
+			Expect(rec.txWriteCount(srcAddr)).To(BeNumerically(">=", 2),
+				"the first tx write failed and the client should have retried the whole tx")
+		})
+
+		// During an ASK redirect, a transient connection failure to the
+		// importing target must be retried with the ASKING flag preserved, so the
+		// tx still executes on the target.
+		It("preserves ASKING when retrying a conn failure on the ASK target", func() {
+			key := "askretry{s}"
+			slot := hashtag.Slot(key)
+			defer resetSlot(ctx, slot, key)
+			cleanup := setupAskMigration(ctx, slot)
+			defer cleanup()
+
+			tgtAddr := "127.0.0.1:" + slotOtherMasterPort(slot)
+			rec := newTxWriteRecorder()
+			var failOnce atomic.Int32 // first MULTI write to the target fails, then forwards
+			opt := redisClusterOptions()
+			opt.MaxRedirects = 2 // source-ASK (0) + target-connfail (1) + target-success (2)
+			opt.Dialer = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				var d net.Dialer
+				cn, err := d.DialContext(ctx, network, addr)
+				if err != nil {
+					return nil, err
+				}
+				return &txFaultConn{Conn: cn, addr: addr, rec: rec, failOnce: &failOnce, failAddr: tgtAddr}, nil
+			}
+			askClient := cluster.newClusterClient(ctx, opt)
+			defer func() { Expect(askClient.Close()).NotTo(HaveOccurred()) }()
+
+			_, err := askClient.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, key, "v", 0)
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred(),
+				"a transient write failure on the ASK target should be retried with ASKING preserved and succeed")
+
+			// The tx executed on the target (with ASKING); a Get follows the
+			// ASK back to the target and reads the value.
+			Expect(askClient.Get(ctx, key).Val()).To(Equal("v"))
+
+			// The target received >=2 tx writes: the failed first attempt and
+			// the successful retry, both with a leading ASKING.
+			Expect(rec.txWriteCount(tgtAddr)).To(BeNumerically(">=", 2))
+		})
+
+		// A read failure after the tx batch was written must not be retried: the
+		// server may have committed the transaction, and re-sending the batch
+		// would double-execute non-idempotent commands. The batch should be sent
+		// exactly once.
+		It("does not retry a read failure after the tx batch is written", func() {
+			rec := newTxWriteRecorder()
+			opt := redisClusterOptions()
+			opt.MaxRedirects = 3
+			opt.Dialer = func(ctx context.Context, network, addr string) (net.Conn, error) {
+				var d net.Dialer
+				cn, err := d.DialContext(ctx, network, addr)
+				if err != nil {
+					return nil, err
+				}
+				// failRead returns EOF from every read once a MULTI write has
+				// been seen on the conn: the batch is committed server-side but
+				// the client cannot read the reply.
+				return &txFaultConn{Conn: cn, addr: addr, rec: rec, failRead: true}, nil
+			}
+			readClient := cluster.newClusterClient(ctx, opt)
+			defer func() { Expect(readClient.Close()).NotTo(HaveOccurred()) }()
+
+			_, err := readClient.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				pipe.Set(ctx, "rdretry1{s}", "1", 0)
+				pipe.Set(ctx, "rdretry2{s}", "2", 0)
+				return nil
+			})
+			Expect(err).To(HaveOccurred(),
+				"a read failure after the batch was written should surface an error")
+
+			// The batch was written exactly once: the read failure is fatal, so
+			// the tx is not re-sent (no double-execution).
+			srcAddr := "127.0.0.1:" + slotMasterPort(hashtag.Slot("rdretry1{s}"))
+			Expect(rec.txWriteCount(srcAddr)).To(Equal(1),
+				"a post-commit read failure must not re-send the tx batch")
+		})
+
 		It("should call fn for every master node", func() {
-			for i := 0; i < 10; i++ {
+			for i := range 10 {
 				Expect(client.Set(ctx, strconv.Itoa(i), "", 0).Err()).NotTo(HaveOccurred())
 			}
 


### PR DESCRIPTION
The cluster tx pipeline treated a MULTI..EXEC as if each command could be retried independently and EXEC always returned a *N result array. That conflicts with Redis's transaction semantics: any queue-stage redirect (MOVED/ASK/TRYAGAIN) or command error calls flagTransaction, dirties the tx, and EXEC returns -EXECABORT (or an EXEC-level MOVED/ASK/TRYAGAIN/ CLUSTERDOWN) -- the whole tx is aborted with no partial execution and no result array. The old code consequently broke six ways:

  - Scattering: on getConn/writer failure it ran the already-wrapped [MULTI..EXEC] through mapCmdsByNode, routing the keyless MULTI/EXEC to a different (round-robined) master and sending a malformed tx.
  - Double-wrap latent: mapCmdsByNode ran after wrap, and retry wrapped again; masked only by the scattering above.
  - Per-command MOVED/ASK retry via checkMovedErr/cmdsMoved, impossible once the tx is already aborted.
  - EXECABORT and EXEC-level MOVED masked as a generic "expected '*'" error, dropping the redirect addr.
  - TRYAGAIN at queue stage only SetErr'd the command, never retried.
  - A for+goroutine+WaitGroup retry loop that was pure overhead since the cmds map was always single-node.

Redesign processTxPipeline around a per-attempt txOutcome classified as success / retryMoved / retryAsk / retryTryAgain / retryConn / fatal, and re-route the whole trimmed transaction accordingly. Read replies without assuming EXEC is an array: collect the first queue-stage redirect and the first fatal command error, then classify the EXEC reply (array = success; MOVED/ASK/TRYAGAIN/CLUSTERDOWN/EXECABORT each map to a retry or fatal outcome).

ASK retries now send a single top-level ASKING before MULTI -- the flag persists across a MULTI per server semantics (it is only cleared outside MULTI), so one ASKING covers the whole tx and lets the importing slot serve at EXEC. Placing ASKING inside the MULTI queued it and left the flag unset during queueing, so keyed commands still got MOVED. The ASKING flag is preserved across a subsequent TRYAGAIN/conn retry while still following an ASK, since the slot may still be importing.

Connections that early-exit before consuming all N+2 replies (a MULTI read failure, or a non-array aggregate EXEC reply) are marked unreadReplies so releaseConn discards them rather than returning a connection with bytes left on the wire.

The pipeline-operation-duration callback now runs in a defer and reports cmp.Or(retErr, cmdsFirstErr(cmds), lastErr), so a final success after retries is no longer reported as a failure via a stale lastErr.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core cluster transaction routing, retry, and connection lifecycle; incorrect retry after a committed tx could double-apply writes, though new tests explicitly guard the post-write read path.
> 
> **Overview**
> **Cluster `TxPipeline` (`processTxPipeline`) is redesigned** so each attempt returns a `txOutcome` (success, MOVED/ASK/TRYAGAIN/conn retry, or fatal) and the **entire** transaction is re-sent on redirects—not split or re-wrapped through `mapCmdsByNode`.
> 
> Reply handling no longer assumes `EXEC` is always a `*N` array: it records the first queue-stage redirect or command error, classifies `EXEC` (`EXECABORT`, `MOVED`, `ASK`, `TRYAGAIN`, `CLUSTERDOWN`), surfaces the triggering error on abort, and **skips retry** when the batch was already written but the read failed (avoids double-execution).
> 
> **ASK retries** send one **top-level `ASKING` before `MULTI`** (not inside the tx); that flag is kept across conn/`TRYAGAIN` retries on the importing node. Dirty connections with unread replies are discarded via `errTxDirtyConn` / `unreadReplies`. Pipeline duration metrics use a `defer` with `cmp.Or(retErr, cmdsFirstErr, lastErr)`.
> 
> Integration tests cover MOVED/EXECABORT errors, transient write retry, ASK+ASKING preservation, and no retry after post-commit read failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0bba1c7cc0301130f71fdc723eaaeeffc3ab38a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->