### PR TITLE
Add optional EXCLUDEEMPTY to TS.MRANGE, TS.MREVRANGE

### DIFF
--- a/timeseries_commands.go
+++ b/timeseries_commands.go
@@ -163,6 +163,7 @@ func (a Aggregator) String() string {
 var (
 	errTSMultiAggregationGroupBy = errors.New("redis: GROUPBY is not allowed when multiple aggregators are specified")
 	errTSAggregationConflict     = errors.New("redis: setting both Aggregator and Aggregators is not allowed; use Aggregators instead because Aggregator is deprecated")
+	errTSExcludeEmptyGroupBy     = errors.New("redis: EXCLUDEEMPTY is not allowed with GROUPBY")
 )
 
 func formatAggregationArgs(aggregator Aggregator, aggregators []Aggregator) (string, int, error) {
@@ -245,8 +246,10 @@ type TSMRangeOptions struct {
 	BucketDuration  int
 	BucketTimestamp interface{}
 	Empty           bool
-	GroupByLabel    interface{}
-	Reducer         interface{}
+	// ExcludeEmpty omits matching series that have no samples. Not allowed with GroupByLabel/Reducer. Redis 8.10+.
+	ExcludeEmpty bool
+	GroupByLabel interface{}
+	Reducer      interface{}
 }
 
 type TSMRevRangeOptions struct {
@@ -263,8 +266,10 @@ type TSMRevRangeOptions struct {
 	BucketDuration  int
 	BucketTimestamp interface{}
 	Empty           bool
-	GroupByLabel    interface{}
-	Reducer         interface{}
+	// ExcludeEmpty omits matching series that have no samples. Not allowed with GroupByLabel/Reducer. Redis 8.10+.
+	ExcludeEmpty bool
+	GroupByLabel interface{}
+	Reducer      interface{}
 }
 
 type TSMGetOptions struct {
@@ -955,11 +960,8 @@ func (c cmdable) TSMRange(ctx context.Context, fromTimestamp int, toTimestamp in
 	return cmd
 }
 
-// TSMRangeWithArgs - Returns a range of samples from multiple time-series keys with additional options.
-// This function allows for specifying additional options such as:
-// Latest, FilterByTS, FilterByValue, WithLabels, SelectedLabels,
-// Count, Align, Aggregator, BucketDuration, BucketTimestamp,
-// Empty, GroupByLabel and Reducer.
+// TSMRangeWithArgs - Returns a range of samples from multiple time-series keys.
+// Options are set via TSMRangeOptions.
 // For more information - https://redis.io/commands/ts.mrange/
 func (c cmdable) TSMRangeWithArgs(ctx context.Context, fromTimestamp int, toTimestamp int, filterExpr []string, options *TSMRangeOptions) *MapStringSliceInterfaceCmd {
 	args := []interface{}{"TS.MRANGE", fromTimestamp, toTimestamp}
@@ -1012,12 +1014,20 @@ func (c cmdable) TSMRangeWithArgs(ctx context.Context, fromTimestamp int, toTime
 		if options.Empty {
 			args = append(args, "EMPTY")
 		}
+		if options.ExcludeEmpty {
+			args = append(args, "EXCLUDEEMPTY")
+		}
 	}
 	args = append(args, "FILTER")
 	for _, f := range filterExpr {
 		args = append(args, f)
 	}
 	if options != nil {
+		if options.ExcludeEmpty && (options.GroupByLabel != nil || options.Reducer != nil) {
+			cmd := NewMapStringSliceInterfaceCmd(ctx, args...)
+			cmd.SetErr(errTSExcludeEmptyGroupBy)
+			return cmd
+		}
 		if multiAggregationCount > 1 && (options.GroupByLabel != nil || options.Reducer != nil) {
 			cmd := NewMapStringSliceInterfaceCmd(ctx, args...)
 			cmd.SetErr(errTSMultiAggregationGroupBy)
@@ -1047,11 +1057,8 @@ func (c cmdable) TSMRevRange(ctx context.Context, fromTimestamp int, toTimestamp
 	return cmd
 }
 
-// TSMRevRangeWithArgs - Returns a range of samples from multiple time-series keys in reverse order with additional options.
-// This function allows for specifying additional options such as:
-// Latest, FilterByTS, FilterByValue, WithLabels, SelectedLabels,
-// Count, Align, Aggregator, BucketDuration, BucketTimestamp,
-// Empty, GroupByLabel and Reducer.
+// TSMRevRangeWithArgs - Returns a range of samples from multiple time-series keys in reverse order.
+// Options are set via TSMRevRangeOptions.
 // For more information - https://redis.io/commands/ts.mrevrange/
 func (c cmdable) TSMRevRangeWithArgs(ctx context.Context, fromTimestamp int, toTimestamp int, filterExpr []string, options *TSMRevRangeOptions) *MapStringSliceInterfaceCmd {
 	args := []interface{}{"TS.MREVRANGE", fromTimestamp, toTimestamp}
@@ -1104,12 +1111,20 @@ func (c cmdable) TSMRevRangeWithArgs(ctx context.Context, fromTimestamp int, toT
 		if options.Empty {
 			args = append(args, "EMPTY")
 		}
+		if options.ExcludeEmpty {
+			args = append(args, "EXCLUDEEMPTY")
+		}
 	}
 	args = append(args, "FILTER")
 	for _, f := range filterExpr {
 		args = append(args, f)
 	}
 	if options != nil {
+		if options.ExcludeEmpty && (options.GroupByLabel != nil || options.Reducer != nil) {
+			cmd := NewMapStringSliceInterfaceCmd(ctx, args...)
+			cmd.SetErr(errTSExcludeEmptyGroupBy)
+			return cmd
+		}
 		if multiAggregationCount > 1 && (options.GroupByLabel != nil || options.Reducer != nil) {
 			cmd := NewMapStringSliceInterfaceCmd(ctx, args...)
 			cmd.SetErr(errTSMultiAggregationGroupBy)

--- a/timeseries_commands_test.go
+++ b/timeseries_commands_test.go
@@ -1400,6 +1400,79 @@ var _ = Describe("RedisTimeseries commands", Label("timeseries"), func() {
 				Expect(cmd.Err()).To(MatchError("redis: GROUPBY is not allowed when multiple aggregators are specified"))
 			})
 
+			It("should TSMRange and TSMRevRange with ExcludeEmpty", Label("timeseries", "tsmrange", "tsmrevrange", "excludeempty", "NonRedisEnterprise"), func() {
+				SkipBeforeRedisVersion("8.10", "EXCLUDEEMPTY requires Redis 8.10+")
+
+				for _, key := range []string{"s", "t", "u"} {
+					opt := &redis.TSOptions{Labels: map[string]string{"sensor": "1", "type": "demo"}}
+					_, err := client.TSCreateWithArgs(ctx, key, opt).Result()
+					Expect(err).NotTo(HaveOccurred())
+				}
+				_, err := client.TSMAdd(ctx, [][]interface{}{
+					{"s", 100, 100}, {"t", 100, 100},
+					{"s", 200, 200}, {"t", 300, 300},
+					{"s", 400, 400}, {"t", 400, 400},
+					{"u", 2000, 2000},
+				}).Result()
+				Expect(err).NotTo(HaveOccurred())
+
+				// Without ExcludeEmpty, "u" is returned with an empty samples array.
+				result, err := client.TSMRange(ctx, 0, 500, []string{"sensor=1"}).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(HaveLen(3))
+				Expect(result).To(HaveKey("u"))
+
+				// With ExcludeEmpty, "u" is omitted because it has no samples in range.
+				result, err = client.TSMRangeWithArgs(ctx, 0, 500, []string{"sensor=1"}, &redis.TSMRangeOptions{
+					WithLabels:   true,
+					ExcludeEmpty: true,
+				}).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(HaveLen(2))
+				Expect(result).To(HaveKey("s"))
+				Expect(result).To(HaveKey("t"))
+				Expect(result).NotTo(HaveKey("u"))
+
+				// ExcludeEmpty composes with AGGREGATION.
+				result, err = client.TSMRangeWithArgs(ctx, 0, 500, []string{"sensor=1"}, &redis.TSMRangeOptions{
+					Aggregator:     redis.Min,
+					BucketDuration: 100,
+					ExcludeEmpty:   true,
+				}).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(HaveLen(2))
+				Expect(result).NotTo(HaveKey("u"))
+
+				// TSMRevRange with ExcludeEmpty behaves the same.
+				result, err = client.TSMRevRangeWithArgs(ctx, 0, 500, []string{"sensor=1"}, &redis.TSMRevRangeOptions{
+					ExcludeEmpty: true,
+				}).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(HaveLen(2))
+				Expect(result).NotTo(HaveKey("u"))
+
+				// When every matching series is empty, the reply is empty.
+				result, err = client.TSMRangeWithArgs(ctx, 1, 50, []string{"sensor=1"}, &redis.TSMRangeOptions{
+					ExcludeEmpty: true,
+				}).Result()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(BeEmpty())
+			})
+			It("should reject ExcludeEmpty combined with GroupBy", Label("timeseries", "tsmrange", "tsmrevrange", "excludeempty"), func() {
+				mrangeCmd := client.TSMRangeWithArgs(ctx, 0, 500, []string{"sensor=1"}, &redis.TSMRangeOptions{
+					ExcludeEmpty: true,
+					GroupByLabel: "sensor",
+					Reducer:      "max",
+				})
+				Expect(mrangeCmd.Err()).To(MatchError("redis: EXCLUDEEMPTY is not allowed with GROUPBY"))
+
+				mrevrangeCmd := client.TSMRevRangeWithArgs(ctx, 0, 500, []string{"sensor=1"}, &redis.TSMRevRangeOptions{
+					ExcludeEmpty: true,
+					GroupByLabel: "sensor",
+					Reducer:      "max",
+				})
+				Expect(mrevrangeCmd.Err()).To(MatchError("redis: EXCLUDEEMPTY is not allowed with GROUPBY"))
+			})
 			It("should TSMRevRangeWithArgs Latest", Label("timeseries", "tsmrevrangeWithArgs", "tsmrevrangelatest", "NonRedisEnterprise"), func() {
 				resultCreate, err := client.TSCreate(ctx, "a").Result()
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive optional flag on existing commands with client-side validation only; no changes to auth, data paths, or default behavior when unset.
> 
> **Overview**
> Adds **Redis 8.10+** `EXCLUDEEMPTY` support for `TSMRangeWithArgs` and `TSMRevRangeWithArgs` via a new `ExcludeEmpty` field on `TSMRangeOptions` and `TSMRevRangeOptions`. When set, the client emits the `EXCLUDEEMPTY` argument so matching series with no samples in the requested range are omitted from the reply (including with aggregation).
> 
> **ExcludeEmpty** cannot be used with `GROUPBY` / `REDUCE`; the client returns `redis: EXCLUDEEMPTY is not allowed with GROUPBY` before sending the command, matching the existing pattern for multi-aggregator + GROUPBY validation.
> 
> Integration tests cover filtering empty series, composition with aggregation, `TS.MREVRANGE`, and the GROUPBY rejection path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60e0cf3d513dd1bbd1b083fbf330a1fcb218edd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->