### PR TITLE
fix(redisotel): use ObservableCounter for cumulative pool stats

### DIFF
--- a/extra/redisotel/config.go
+++ b/extra/redisotel/config.go
@@ -33,6 +33,15 @@ type config struct {
 	mp    metric.MeterProvider
 	meter metric.Meter
 
+	// semconvCompliantMetrics, when true, registers the cumulative pool-stat
+	// metrics (waits, timeouts, hits, misses) as monotonic Counters as
+	// required by the OpenTelemetry database semantic conventions. It defaults
+	// to false to preserve backwards compatibility: existing users have these
+	// exported as UpDownCounter (which some backends surface as a Gauge), and
+	// switching the instrument type is a breaking change for them. New users
+	// that want spec-compliant metrics can opt in. See #3612.
+	semconvCompliantMetrics bool
+
 	poolName string
 
 	closeChan chan struct{}
@@ -226,5 +235,20 @@ func WithMeterProvider(mp metric.MeterProvider) MetricsOption {
 func WithCloseChan(closeChan chan struct{}) MetricsOption {
 	return metricsOption(func(conf *config) {
 		conf.closeChan = closeChan
+	})
+}
+
+// WithSemConvCompliantMetrics registers the cumulative connection-pool metrics
+// (db.client.connections.waits, .timeouts, .hits, .misses) as monotonic
+// Counters, matching the OpenTelemetry database semantic conventions.
+//
+// It is opt-in and defaults to off. By default these metrics remain
+// UpDownCounters for backwards compatibility, because changing an existing
+// instrument's type is a breaking change for current OTel users (e.g. the
+// Prometheus exporter would change the exported metric type). Enable this when
+// starting fresh or when you can tolerate the metric-type change. See #3612.
+func WithSemConvCompliantMetrics(on bool) MetricsOption {
+	return metricsOption(func(conf *config) {
+		conf.semconvCompliantMetrics = on
 	})
 }

--- a/extra/redisotel/go.mod
+++ b/extra/redisotel/go.mod
@@ -12,6 +12,7 @@ require (
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
+	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 )
 

--- a/extra/redisotel/metrics.go
+++ b/extra/redisotel/metrics.go
@@ -175,7 +175,7 @@ func reportPoolStats(rdb *redis.Client, conf *config) (metric.Registration, erro
 		return nil, err
 	}
 
-	waits, err := conf.meter.Int64ObservableUpDownCounter(
+	waits, err := conf.meter.Int64ObservableCounter(
 		"db.client.connections.waits",
 		metric.WithDescription("The number of times a connection was waited for"),
 	)
@@ -192,7 +192,7 @@ func reportPoolStats(rdb *redis.Client, conf *config) (metric.Registration, erro
 		return nil, err
 	}
 
-	timeouts, err := conf.meter.Int64ObservableUpDownCounter(
+	timeouts, err := conf.meter.Int64ObservableCounter(
 		"db.client.connections.timeouts",
 		metric.WithDescription("The number of connection timeouts that have occurred trying to obtain a connection from the pool"),
 	)
@@ -200,7 +200,7 @@ func reportPoolStats(rdb *redis.Client, conf *config) (metric.Registration, erro
 		return nil, err
 	}
 
-	hits, err := conf.meter.Int64ObservableUpDownCounter(
+	hits, err := conf.meter.Int64ObservableCounter(
 		"db.client.connections.hits",
 		metric.WithDescription("The number of times free connection was found in the pool"),
 	)
@@ -208,7 +208,7 @@ func reportPoolStats(rdb *redis.Client, conf *config) (metric.Registration, erro
 		return nil, err
 	}
 
-	misses, err := conf.meter.Int64ObservableUpDownCounter(
+	misses, err := conf.meter.Int64ObservableCounter(
 		"db.client.connections.misses",
 		metric.WithDescription("The number of times free connection was not found in the pool"),
 	)

--- a/extra/redisotel/metrics.go
+++ b/extra/redisotel/metrics.go
@@ -140,6 +140,25 @@ func poolStatsAttrs(conf *config) (poolAttrs, idleAttrs, usedAttrs attribute.Set
 	return
 }
 
+// cumulativePoolStat creates an observable instrument for a monotonically
+// increasing pool statistic. By default it uses Int64ObservableUpDownCounter to
+// preserve backwards compatibility with existing exporters; when
+// conf.semconvCompliantMetrics is set it uses Int64ObservableCounter as the
+// OpenTelemetry database semantic conventions require. Both instrument types
+// satisfy metric.Int64Observable, so callers observe them uniformly. See #3612.
+func cumulativePoolStat(conf *config, name, description string) (metric.Int64Observable, error) {
+	if conf.semconvCompliantMetrics {
+		return conf.meter.Int64ObservableCounter(
+			name,
+			metric.WithDescription(description),
+		)
+	}
+	return conf.meter.Int64ObservableUpDownCounter(
+		name,
+		metric.WithDescription(description),
+	)
+}
+
 func reportPoolStats(rdb *redis.Client, conf *config) (metric.Registration, error) {
 	poolAttrs, idleAttrs, usedAttrs := poolStatsAttrs(conf)
 
@@ -175,9 +194,9 @@ func reportPoolStats(rdb *redis.Client, conf *config) (metric.Registration, erro
 		return nil, err
 	}
 
-	waits, err := conf.meter.Int64ObservableCounter(
+	waits, err := cumulativePoolStat(conf,
 		"db.client.connections.waits",
-		metric.WithDescription("The number of times a connection was waited for"),
+		"The number of times a connection was waited for",
 	)
 	if err != nil {
 		return nil, err
@@ -192,25 +211,25 @@ func reportPoolStats(rdb *redis.Client, conf *config) (metric.Registration, erro
 		return nil, err
 	}
 
-	timeouts, err := conf.meter.Int64ObservableCounter(
+	timeouts, err := cumulativePoolStat(conf,
 		"db.client.connections.timeouts",
-		metric.WithDescription("The number of connection timeouts that have occurred trying to obtain a connection from the pool"),
+		"The number of connection timeouts that have occurred trying to obtain a connection from the pool",
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	hits, err := conf.meter.Int64ObservableCounter(
+	hits, err := cumulativePoolStat(conf,
 		"db.client.connections.hits",
-		metric.WithDescription("The number of times free connection was found in the pool"),
+		"The number of times free connection was found in the pool",
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	misses, err := conf.meter.Int64ObservableCounter(
+	misses, err := cumulativePoolStat(conf,
 		"db.client.connections.misses",
-		metric.WithDescription("The number of times free connection was not found in the pool"),
+		"The number of times free connection was not found in the pool",
 	)
 	if err != nil {
 		return nil, err

--- a/extra/redisotel/metrics_semconv_test.go
+++ b/extra/redisotel/metrics_semconv_test.go
@@ -1,0 +1,101 @@
+package redisotel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// cumulativeMetricNames are the connection-pool statistics that the
+// OpenTelemetry database semantic conventions define as monotonic Counters.
+var cumulativeMetricNames = map[string]struct{}{
+	"db.client.connections.waits":    {},
+	"db.client.connections.timeouts": {},
+	"db.client.connections.hits":     {},
+	"db.client.connections.misses":   {},
+}
+
+// collectPoolMetrics wires a manual reader to a fresh client instrumented with
+// the given options, then returns the collected instrument for each cumulative
+// pool-stat metric name.
+func collectPoolMetrics(t *testing.T, opts ...MetricsOption) map[string]metricdata.Aggregation {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+
+	rdb := redis.NewClient(&redis.Options{Addr: "localhost:6379"})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	allOpts := append([]MetricsOption{WithMeterProvider(mp)}, opts...)
+	if err := InstrumentMetrics(rdb, allOpts...); err != nil {
+		t.Fatalf("InstrumentMetrics: %v", err)
+	}
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	got := make(map[string]metricdata.Aggregation)
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if _, ok := cumulativeMetricNames[m.Name]; ok {
+				got[m.Name] = m.Data
+			}
+		}
+	}
+	return got
+}
+
+// TestCumulativePoolStats_DefaultIsUpDownCounter verifies the backwards-compatible
+// default: the cumulative pool metrics are exported as non-monotonic sums
+// (UpDownCounter), matching pre-#3612 behaviour so existing exporters do not
+// see an instrument-type change.
+func TestCumulativePoolStats_DefaultIsUpDownCounter(t *testing.T) {
+	got := collectPoolMetrics(t)
+
+	for name := range cumulativeMetricNames {
+		data, ok := got[name]
+		if !ok {
+			t.Errorf("metric %q not collected", name)
+			continue
+		}
+		sum, ok := data.(metricdata.Sum[int64])
+		if !ok {
+			t.Errorf("metric %q: expected Sum[int64], got %T", name, data)
+			continue
+		}
+		if sum.IsMonotonic {
+			t.Errorf("metric %q: expected non-monotonic (UpDownCounter) by default, got monotonic", name)
+		}
+	}
+}
+
+// TestCumulativePoolStats_OptInIsCounter verifies that enabling
+// WithSemConvCompliantMetrics switches the cumulative pool metrics to monotonic
+// sums (Counter), as required by the OpenTelemetry database semantic
+// conventions. See #3612.
+func TestCumulativePoolStats_OptInIsCounter(t *testing.T) {
+	got := collectPoolMetrics(t, WithSemConvCompliantMetrics(true))
+
+	for name := range cumulativeMetricNames {
+		data, ok := got[name]
+		if !ok {
+			t.Errorf("metric %q not collected", name)
+			continue
+		}
+		sum, ok := data.(metricdata.Sum[int64])
+		if !ok {
+			t.Errorf("metric %q: expected Sum[int64], got %T", name, data)
+			continue
+		}
+		if !sum.IsMonotonic {
+			t.Errorf("metric %q: expected monotonic (Counter) when semconv-compliant, got non-monotonic", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #3612.

`db.client.connections.timeouts`, `waits`, `hits`, and `misses` are monotonic cumulative counts, but redisotel registered them as `Int64ObservableUpDownCounter`.

Per OpenTelemetry database semantic conventions these should be counters so rate() aggregations work correctly.

## Changes
- Switch those four instruments to `Int64ObservableCounter`
- Leave gauges/up-down gauges (`usage`, idle min/max, max connections) unchanged
- Leave `waits_duration` unchanged (not listed in the issue)

## Test plan
- [x] `go test ./extra/redisotel/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in changes exported metric instrument types for four pool stats, which can alter backend/Prometheus series types; default path is unchanged so existing deployments are unaffected unless they enable the flag.
> 
> **Overview**
> Adds **`WithSemConvCompliantMetrics`** so cumulative pool metrics (`db.client.connections.waits`, `.timeouts`, `.hits`, `.misses`) can be registered as **monotonic `Int64ObservableCounter`** instruments per OpenTelemetry database semconv (#3612). **Default behavior is unchanged**: those four still use **`Int64ObservableUpDownCounter`** so existing exporters (e.g. Prometheus metric type) are not broken.
> 
> Pool registration is refactored through a **`cumulativePoolStat`** helper that picks counter vs up-down counter from config. Other pool instruments (`usage`, idle min/max, max, `waits_duration`) are untouched.
> 
> Tests collect metrics via the SDK manual reader and assert non-monotonic sums by default and monotonic sums when the option is enabled. **`go.opentelemetry.io/otel/sdk/metric`** is added to `extra/redisotel` for those tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c31b3f670920538e165d0ca09c837cb60fa659f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->