### PR TITLE
fix: pass caller context to SlowLogGet command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -707,7 +707,7 @@ func (c cmdable) ReplicaOf(ctx context.Context, host, port string) *StatusCmd {
 }
 
 func (c cmdable) SlowLogGet(ctx context.Context, num int64) *SlowLogCmd {
-	cmd := NewSlowLogCmd(context.Background(), "slowlog", "get", num)
+	cmd := NewSlowLogCmd(ctx, "slowlog", "get", num)
 	_ = c(ctx, cmd)
 	return cmd
 }


### PR DESCRIPTION
SlowLogGet constructed the command with context.Background() instead of the caller ctx.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line context wiring fix with no behavior change beyond proper cancellation/deadline propagation for SlowLogGet.
> 
> **Overview**
> **`SlowLogGet`** now builds its `SlowLogCmd` with the method’s **`ctx`** instead of **`context.Background()`**, matching other commands in `commands.go`.
> 
> Callers get correct **cancellation**, **deadlines**, and **context values** on the slowlog command object and anything that reads the command’s stored context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbb35ef8c49c0889edf86e3b57a2f2a3fb4f5700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->