### PR TITLE
fix: return error on ModuleLoadex with nil config

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -798,6 +798,11 @@ func (c *ModuleLoadexConfig) toArgs() []interface{} {
 
 // ModuleLoadex Redis `MODULE LOADEX path [CONFIG name value [CONFIG name value ...]] [ARGS args [args ...]]` command.
 func (c cmdable) ModuleLoadex(ctx context.Context, conf *ModuleLoadexConfig) *StringCmd {
+	if conf == nil {
+		cmd := NewStringCmd(ctx)
+		cmd.SetErr(errors.New("redis: ModuleLoadex nil config"))
+		return cmd
+	}
 	cmd := NewStringCmd(ctx, conf.toArgs()...)
 	_ = c(ctx, cmd)
 	return cmd

--- a/moduleloadex_nil_test.go
+++ b/moduleloadex_nil_test.go
@@ -1,0 +1,17 @@
+package redis
+
+import (
+	"context"
+	"testing"
+)
+
+func TestModuleLoadexNilConfig(t *testing.T) {
+	rdb := NewClient(&Options{Addr: "localhost:6379"})
+	cmd := rdb.ModuleLoadex(context.Background(), nil)
+	if cmd.Err() == nil {
+		t.Fatal("expected error for nil config")
+	}
+	if cmd.Err().Error() != "redis: ModuleLoadex nil config" {
+		t.Fatalf("got %v", cmd.Err())
+	}
+}


### PR DESCRIPTION
ModuleLoadex(nil) panics; return cmd error instead.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small input-validation change on a single admin command; no network or auth behavior change for valid callers.
> 
> **Overview**
> **`ModuleLoadex`** no longer panics when called with a **nil** `*ModuleLoadexConfig`. It now returns a `*StringCmd` with error `redis: ModuleLoadex nil config` and skips sending the command to Redis, matching how other commands surface invalid arguments.
> 
> A unit test asserts the error message when `nil` is passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73cf55c75b3787e5f104d3e0a7bd7c7e43785346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->