### PR TITLE
docs: clarify ExpireTime/PExpireTime return Unix timestamps

### DIFF
--- a/generic_commands.go
+++ b/generic_commands.go
@@ -129,6 +129,9 @@ func (c cmdable) ExpireAt(ctx context.Context, key string, tm time.Time) *BoolCm
 	return cmd
 }
 
+// ExpireTime returns the absolute expiration time of key as a Unix timestamp
+// encoded in *DurationCmd (seconds since the epoch), not a remaining TTL.
+// Convert with: time.Unix(int64(d/time.Second), 0). Use TTL/PTTL for remaining TTL.
 func (c cmdable) ExpireTime(ctx context.Context, key string) *DurationCmd {
 	cmd := NewDurationCmd(ctx, time.Second, "expiretime", key)
 	_ = c(ctx, cmd)
@@ -209,6 +212,9 @@ func (c cmdable) PExpireAt(ctx context.Context, key string, tm time.Time) *BoolC
 	return cmd
 }
 
+// PExpireTime returns the absolute expiration time of key as a Unix timestamp
+// encoded in *DurationCmd (milliseconds since the epoch), not a remaining TTL.
+// Convert with: time.UnixMilli(int64(d/time.Millisecond)). Use TTL/PTTL for remaining TTL.
 func (c cmdable) PExpireTime(ctx context.Context, key string) *DurationCmd {
 	cmd := NewDurationCmd(ctx, time.Millisecond, "pexpiretime", key)
 	_ = c(ctx, cmd)


### PR DESCRIPTION
Document that EXPIRETIME/PEXPIRETIME are absolute Unix times encoded in DurationCmd, not remaining TTLs (refs #2657).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no runtime or API behavior impact.
> 
> **Overview**
> Adds godoc on **`ExpireTime`** and **`PExpireTime`** so callers know Redis `EXPIRETIME` / `PEXPIRETIME` values are **absolute Unix times** carried in `*DurationCmd`, not remaining TTL like **`TTL`** / **`PTTL`**.
> 
> Each comment notes the unit (seconds vs milliseconds), shows conversion with `time.Unix` / `time.UnixMilli`, and directs readers to **`TTL`** / **`PTTL`** when they need time left.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2612e82f8e83787f4554be4bfc4bc033be070f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->