### PR TITLE
chore(options): align default config values with cross-SDK proposal

### DIFF
--- a/options.go
+++ b/options.go
@@ -442,21 +442,24 @@ func (opt *Options) NewDialer() func(context.Context, string, string) (net.Conn,
 	return NewDialer(opt)
 }
 
+// defaultKeepAliveConfig is the TCP keep-alive policy of the default dialers
+// here and in sentinel.go: start probing after 30s idle (below typical LB/NAT
+// idle timeouts), then declare the peer dead after 3 unanswered probes 5s
+// apart.
+var defaultKeepAliveConfig = net.KeepAliveConfig{
+	Enable:   true,
+	Idle:     30 * time.Second,
+	Interval: 5 * time.Second,
+	Count:    3,
+}
+
 // NewDialer returns a function that will be used as the default dialer
 // when none is specified in Options.Dialer.
 func NewDialer(opt *Options) func(context.Context, string, string) (net.Conn, error) {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		netDialer := &net.Dialer{
-			Timeout: opt.DialTimeout,
-			// Start probing after 30s idle (below typical LB/NAT idle
-			// timeouts), then declare the peer dead after 3 unanswered
-			// probes 5s apart.
-			KeepAliveConfig: net.KeepAliveConfig{
-				Enable:   true,
-				Idle:     30 * time.Second,
-				Interval: 5 * time.Second,
-				Count:    3,
-			},
+			Timeout:         opt.DialTimeout,
+			KeepAliveConfig: defaultKeepAliveConfig,
 		}
 		if opt.TLSConfig == nil {
 			return netDialer.DialContext(ctx, network, addr)

--- a/options.go
+++ b/options.go
@@ -121,12 +121,12 @@ type Options struct {
 	// MinRetryBackoff is the minimum backoff between each retry.
 	// -1 disables backoff.
 	//
-	// default: 8 milliseconds
+	// default: 10 milliseconds
 	MinRetryBackoff time.Duration
 
 	// MaxRetryBackoff is the maximum backoff between each retry.
 	// -1 disables backoff.
-	// default: 512 milliseconds;
+	// default: 1 second;
 	MaxRetryBackoff time.Duration
 
 	// DialTimeout for establishing new connections.
@@ -157,7 +157,7 @@ type Options struct {
 	//	- `-1` - no timeout (block indefinitely).
 	//	- `-2` - disables SetReadDeadline calls completely.
 	//
-	// default: 3 seconds
+	// default: 5 seconds
 	ReadTimeout time.Duration
 
 	// WriteTimeout for socket writes. If reached, commands will fail
@@ -166,7 +166,7 @@ type Options struct {
 	//	- `-1` - no timeout (block indefinitely).
 	//	- `-2` - disables SetWriteDeadline calls completely.
 	//
-	// default: 3 seconds
+	// default: 5 seconds (same as ReadTimeout, which it follows when unset)
 	WriteTimeout time.Duration
 
 	// ContextTimeoutEnabled controls whether the client respects context timeouts and deadlines.
@@ -367,7 +367,7 @@ func (opt *Options) init() {
 	case -1:
 		opt.ReadTimeout = 0
 	case 0:
-		opt.ReadTimeout = 3 * time.Second
+		opt.ReadTimeout = 5 * time.Second
 	}
 	switch opt.WriteTimeout {
 	case -2:
@@ -400,13 +400,13 @@ func (opt *Options) init() {
 	case -1:
 		opt.MinRetryBackoff = 0
 	case 0:
-		opt.MinRetryBackoff = 8 * time.Millisecond
+		opt.MinRetryBackoff = 10 * time.Millisecond
 	}
 	switch opt.MaxRetryBackoff {
 	case -1:
 		opt.MaxRetryBackoff = 0
 	case 0:
-		opt.MaxRetryBackoff = 512 * time.Millisecond
+		opt.MaxRetryBackoff = time.Second
 	}
 
 	if opt.FailingTimeoutSeconds == 0 {
@@ -447,8 +447,16 @@ func (opt *Options) NewDialer() func(context.Context, string, string) (net.Conn,
 func NewDialer(opt *Options) func(context.Context, string, string) (net.Conn, error) {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
 		netDialer := &net.Dialer{
-			Timeout:   opt.DialTimeout,
-			KeepAlive: 5 * time.Minute,
+			Timeout: opt.DialTimeout,
+			// Start probing after 30s idle (below typical LB/NAT idle
+			// timeouts), then declare the peer dead after 3 unanswered
+			// probes 5s apart.
+			KeepAliveConfig: net.KeepAliveConfig{
+				Enable:   true,
+				Idle:     30 * time.Second,
+				Interval: 5 * time.Second,
+				Count:    3,
+			},
 		}
 		if opt.TLSConfig == nil {
 			return netDialer.DialContext(ctx, network, addr)

--- a/options_test.go
+++ b/options_test.go
@@ -1,10 +1,9 @@
-//go:build go1.7
-
 package redis
 
 import (
 	"crypto/tls"
 	"errors"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -285,6 +284,70 @@ func TestReadTimeoutOptions(t *testing.T) {
 		if o.WriteTimeout != o.ReadTimeout {
 			t.Errorf("got %d instead of %d as WriteTimeout option", o.WriteTimeout, o.ReadTimeout)
 		}
+	}
+}
+
+// Pin the retry backoff defaults shared by Options, ClusterOptions and
+// RingOptions, including the -1 escape hatch.
+func TestRetryBackoffOptions(t *testing.T) {
+	check := func(t *testing.T, kind string, min, max time.Duration) {
+		t.Helper()
+		if min != 10*time.Millisecond {
+			t.Errorf("%s: got %s as default MinRetryBackoff, want 10ms", kind, min)
+		}
+		if max != time.Second {
+			t.Errorf("%s: got %s as default MaxRetryBackoff, want 1s", kind, max)
+		}
+	}
+
+	o := &Options{}
+	o.init()
+	check(t, "Options", o.MinRetryBackoff, o.MaxRetryBackoff)
+
+	co := &ClusterOptions{}
+	co.init()
+	check(t, "ClusterOptions", co.MinRetryBackoff, co.MaxRetryBackoff)
+
+	ro := &RingOptions{}
+	ro.init()
+	check(t, "RingOptions", ro.MinRetryBackoff, ro.MaxRetryBackoff)
+
+	disabled := &Options{MinRetryBackoff: -1, MaxRetryBackoff: -1}
+	disabled.init()
+	if disabled.MinRetryBackoff != 0 || disabled.MaxRetryBackoff != 0 {
+		t.Errorf("-1 must disable backoff, got min=%s max=%s",
+			disabled.MinRetryBackoff, disabled.MaxRetryBackoff)
+	}
+}
+
+func TestClusterStateReloadIntervalOption(t *testing.T) {
+	o := &ClusterOptions{}
+	o.init()
+	if o.ClusterStateReloadInterval != 60*time.Second {
+		t.Errorf("got %s as default ClusterStateReloadInterval, want 60s",
+			o.ClusterStateReloadInterval)
+	}
+
+	o = &ClusterOptions{ClusterStateReloadInterval: 5 * time.Minute}
+	o.init()
+	if o.ClusterStateReloadInterval != 5*time.Minute {
+		t.Errorf("explicit ClusterStateReloadInterval overridden: got %s",
+			o.ClusterStateReloadInterval)
+	}
+}
+
+// The keep-alive policy is shared by the default dialer (options.go) and the
+// sentinel master/replica dialer (sentinel.go); pin it so a change shows up
+// in review instead of drifting silently.
+func TestDefaultKeepAliveConfig(t *testing.T) {
+	want := net.KeepAliveConfig{
+		Enable:   true,
+		Idle:     30 * time.Second,
+		Interval: 5 * time.Second,
+		Count:    3,
+	}
+	if defaultKeepAliveConfig != want {
+		t.Errorf("defaultKeepAliveConfig = %+v, want %+v", defaultKeepAliveConfig, want)
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -270,7 +270,7 @@ func comprareOptions(t *testing.T, actual, expected *Options) {
 func TestReadTimeoutOptions(t *testing.T) {
 	testDataInputOutputMap := map[time.Duration]time.Duration{
 		-1: 0 * time.Second,
-		0:  3 * time.Second,
+		0:  5 * time.Second,
 		1:  1 * time.Nanosecond,
 		3:  3 * time.Nanosecond,
 	}

--- a/osscluster.go
+++ b/osscluster.go
@@ -190,7 +190,9 @@ type ClusterOptions struct {
 	ShardPicker routing.ShardPicker
 
 	// ClusterStateReloadInterval is the interval for reloading the cluster state.
-	// Default is 10 seconds.
+	// MOVED/ASK redirects still trigger an immediate reactive reload, so this
+	// only bounds how stale a topology can get without traffic errors.
+	// Default is 60 seconds.
 	ClusterStateReloadInterval time.Duration
 }
 
@@ -235,7 +237,7 @@ func (opt *ClusterOptions) init() {
 	case -1:
 		opt.ReadTimeout = 0
 	case 0:
-		opt.ReadTimeout = 3 * time.Second
+		opt.ReadTimeout = 5 * time.Second
 	}
 	switch opt.WriteTimeout {
 	case -1:
@@ -251,13 +253,13 @@ func (opt *ClusterOptions) init() {
 	case -1:
 		opt.MinRetryBackoff = 0
 	case 0:
-		opt.MinRetryBackoff = 8 * time.Millisecond
+		opt.MinRetryBackoff = 10 * time.Millisecond
 	}
 	switch opt.MaxRetryBackoff {
 	case -1:
 		opt.MaxRetryBackoff = 0
 	case 0:
-		opt.MaxRetryBackoff = 512 * time.Millisecond
+		opt.MaxRetryBackoff = time.Second
 	}
 
 	if opt.NewClient == nil {
@@ -273,7 +275,7 @@ func (opt *ClusterOptions) init() {
 	}
 
 	if opt.ClusterStateReloadInterval == 0 {
-		opt.ClusterStateReloadInterval = 10 * time.Second
+		opt.ClusterStateReloadInterval = 60 * time.Second
 	}
 }
 

--- a/ring.go
+++ b/ring.go
@@ -194,13 +194,13 @@ func (opt *RingOptions) init() {
 	case -1:
 		opt.MinRetryBackoff = 0
 	case 0:
-		opt.MinRetryBackoff = 8 * time.Millisecond
+		opt.MinRetryBackoff = 10 * time.Millisecond
 	}
 	switch opt.MaxRetryBackoff {
 	case -1:
 		opt.MaxRetryBackoff = 0
 	case 0:
-		opt.MaxRetryBackoff = 512 * time.Millisecond
+		opt.MaxRetryBackoff = time.Second
 	}
 
 	if opt.ReadBufferSize == 0 {

--- a/sentinel.go
+++ b/sentinel.go
@@ -599,14 +599,8 @@ func masterReplicaDialer(
 		}
 
 		netDialer := &net.Dialer{
-			Timeout: failover.opt.DialTimeout,
-			// Same keep-alive policy as the default dialer in options.go.
-			KeepAliveConfig: net.KeepAliveConfig{
-				Enable:   true,
-				Idle:     30 * time.Second,
-				Interval: 5 * time.Second,
-				Count:    3,
-			},
+			Timeout:         failover.opt.DialTimeout,
+			KeepAliveConfig: defaultKeepAliveConfig,
 		}
 		if failover.opt.TLSConfig == nil {
 			return netDialer.DialContext(ctx, network, addr)

--- a/sentinel.go
+++ b/sentinel.go
@@ -599,8 +599,14 @@ func masterReplicaDialer(
 		}
 
 		netDialer := &net.Dialer{
-			Timeout:   failover.opt.DialTimeout,
-			KeepAlive: 5 * time.Minute,
+			Timeout: failover.opt.DialTimeout,
+			// Same keep-alive policy as the default dialer in options.go.
+			KeepAliveConfig: net.KeepAliveConfig{
+				Enable:   true,
+				Idle:     30 * time.Second,
+				Interval: 5 * time.Second,
+				Count:    3,
+			},
 		}
 		if failover.opt.TLSConfig == nil {
 			return netDialer.DialContext(ctx, network, addr)


### PR DESCRIPTION
  Read/Write timeout 3s -> 5s, retry backoff 8ms/512ms -> 10ms/1s,
  cluster state reload 10s -> 60s, TCP keep-alive 5min blanket ->
  30s idle / 5s interval / 3 probes via net.KeepAliveConfig.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes behavior for every deployment that relies on zero-value options (longer socket timeouts, slower/faster retry spread, less frequent cluster topology refresh, more aggressive TCP keepalive), without an API break.
> 
> **Overview**
> Aligns **implicit client defaults** with a cross-SDK proposal so go-redis matches peer Redis clients when options are left unset.
> 
> **Timeouts and retries:** default `ReadTimeout` / `WriteTimeout` move from **3s → 5s** (`Options` and `ClusterOptions`). Retry backoff defaults become **10ms / 1s** (was 8ms / 512ms) on `Options`, `ClusterOptions`, and `RingOptions`.
> 
> **Cluster:** periodic `ClusterStateReloadInterval` default is **60s** (was 10s); docs note **MOVED/ASK** still force an immediate reload.
> 
> **TCP:** default dialers stop using a **5-minute** `KeepAlive` and share **`defaultKeepAliveConfig`** (`net.KeepAliveConfig`: 30s idle, 5s probe interval, 3 probes) in `NewDialer` and the Sentinel failover dialer.
> 
> **Tests** pin the new defaults (retry backoff across client types, cluster reload interval, keep-alive struct) and update read-timeout expectations; the `go1.7` build tag is dropped from `options_test.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44fbe02b099cc2d9a60bc9f92fbdc1aa9b21ca1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->