### PR TITLE
chore(ci): bump test image to 8.10-rc2 and default to 8.10

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -47,7 +47,7 @@ runs:
         elif [[ -n "$REDIS_VERSION" ]]; then
           # Mapping of redis version to redis testing containers
           declare -A redis_version_mapping=(
-            ["8.10.x"]="custom-29557896054-debian"
+            ["8.10.x"]="8.10-rc2"
             ["8.8.x"]="8.8.0"
             ["8.6.x"]="8.6.1"
             ["8.4.x"]="8.4.0"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           
           # Mapping of redis version to redis testing containers
           declare -A redis_version_mapping=(
-            ["8.10.x"]="custom-29557896054-debian"
+            ["8.10.x"]="8.10-rc2"
             ["8.8.x"]="8.8.0"
             ["8.6.x"]="8.6.1"
             ["8.4.x"]="8.4.0"

--- a/.github/workflows/doctests.yaml
+++ b/.github/workflows/doctests.yaml
@@ -16,7 +16,7 @@ jobs:
 
     services:
       redis-stack:
-        image: redislabs/client-libs-test:8.8.0
+        image: redislabs/client-libs-test:8.10-rc2
         env:
           TLS_ENABLED: no
           REDIS_CLUSTER: no

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Here's how to get started with your code contribution:
 > Note: this clones and builds the docker containers specified in `docker-compose.yml`, to understand more about
 > the infrastructure that will be started you can check the `docker-compose.yml`. You also have the possiblity
 > to specify the redis image that will be pulled with the env variable `CLIENT_LIBS_TEST_IMAGE`.
-> By default the docker image that will be pulled and started is `redislabs/client-libs-test:8.2.1-pre`.
+> By default the docker image that will be pulled and started is `redislabs/client-libs-test:8.10-rc2`.
 > If you want to test with newer Redis version, using a newer version of `redislabs/client-libs-test` should work out of the box.
 
 4.  While developing, make sure the tests pass by running `make test` (if you have the docker containers running, `make test.ci` may be sufficient).

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 GO_MOD_DIRS := $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort)
-REDIS_VERSION ?= 8.8
+REDIS_VERSION ?= 8.10
 RE_CLUSTER ?= false
 RCE_DOCKER ?= true
-CLIENT_LIBS_TEST_IMAGE ?= redislabs/client-libs-test:8.8.0
+CLIENT_LIBS_TEST_IMAGE ?= redislabs/client-libs-test:8.10-rc2
 
 docker.start:
 	export RE_CLUSTER=$(RE_CLUSTER) && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 ---
 
-x-default-image: &default-image ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.8.0}
+x-default-image: &default-image ${CLIENT_LIBS_TEST_IMAGE:-redislabs/client-libs-test:8.10-rc2}
 
 services:
   redis:


### PR DESCRIPTION
Bumps the `redislabs/client-libs-test` image for Redis 8.10 from the transient custom build to the `8.10-rc2` release candidate, and promotes 8.10 to the local-dev default.

## Changes
- **CI mappings** (both `redis_version_mapping` arrays, kept in lockstep): `["8.10.x"]` → `8.10-rc2`
  - `.github/workflows/build.yml`
  - `.github/actions/run-tests/action.yml`
- **Local-dev default** promoted to 8.10-rc2 / `REDIS_VERSION=8.10`:
  - `Makefile`
  - `docker-compose.yml`
  - `.github/workflows/doctests.yaml`
  - `CONTRIBUTING.md` (doc)

## Notes
- `REDIS_VERSION` numeric gating (`SkipBeforeRedisVersion`/`SkipAfterRedisVersion`) now defaults to 8.10; major.minor comparison already handles 8.10+ (see 108f7cd0 / ac7b2d5a).
- No stale `custom-29557896054-debian` / `8.8.0` image references remain in CI or local config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and local Docker defaults only; no changes to library runtime code or security-sensitive paths.
> 
> **Overview**
> Switches Redis **8.10.x** CI and local testing from the transient `custom-29557896054-debian` image to **`redislabs/client-libs-test:8.10-rc2`**, and makes **8.10** the default dev/test Redis line (was 8.8).
> 
> The `redis_version_mapping` for `8.10.x` is updated in **`build.yml`** and **`run-tests/action.yml`**. Defaults move to `8.10-rc2` in the **Makefile**, **docker-compose.yml**, **doctests** service image, and **CONTRIBUTING.md**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b17f524f9aae59577ad1cc4b0ef045efa2c9e8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->