### PR TITLE
fix: nil Options.clone returns nil

### DIFF
--- a/options.go
+++ b/options.go
@@ -425,6 +425,9 @@ func (opt *Options) init() {
 }
 
 func (opt *Options) clone() *Options {
+	if opt == nil {
+		return nil
+	}
 	clone := *opt
 
 	// Deep clone MaintNotificationsConfig to avoid sharing between clients

--- a/options_clone_nil_test.go
+++ b/options_clone_nil_test.go
@@ -1,0 +1,15 @@
+package redis
+
+import "testing"
+
+func TestOptionsCloneNil(t *testing.T) {
+	var o *Options
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	if o.clone() != nil {
+		t.Fatal("want nil")
+	}
+}


### PR DESCRIPTION
```go
var o *redis.Options
o.clone() // panic
```

Return nil.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny defensive change to option cloning with a unit test; no auth, networking, or behavior change for non-nil options.
> 
> **Overview**
> **`Options.clone()`** no longer panics when called on a nil receiver; it returns `nil` instead of dereferencing the pointer.
> 
> A regression test (`TestOptionsCloneNil`) asserts nil-in, nil-out without panic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ec417b85735ccf94ac50bc41906ec5538d448ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->