### PR TITLE
fix(command): handle nil element in int/uint/bool slice parsers

### DIFF
--- a/command.go
+++ b/command.go
@@ -1322,8 +1322,13 @@ func (cmd *IntSliceCmd) readReply(rd *proto.Reader) error {
 	}
 	cmd.val = make([]int64, n)
 	for i := 0; i < len(cmd.val); i++ {
-		if cmd.val[i], err = rd.ReadInt(); err != nil {
+		switch num, err := rd.ReadInt(); {
+		case err == Nil:
+			cmd.val[i] = 0
+		case err != nil:
 			return err
+		default:
+			cmd.val[i] = num
 		}
 	}
 	return nil
@@ -1382,8 +1387,13 @@ func (cmd *UintSliceCmd) readReply(rd *proto.Reader) error {
 	}
 	cmd.val = make([]uint64, n)
 	for i := range cmd.val {
-		if cmd.val[i], err = rd.ReadUint(); err != nil {
+		switch num, err := rd.ReadUint(); {
+		case err == Nil:
+			cmd.val[i] = 0
+		case err != nil:
 			return err
+		default:
+			cmd.val[i] = num
 		}
 	}
 	return nil
@@ -2107,8 +2117,13 @@ func (cmd *BoolSliceCmd) readReply(rd *proto.Reader) error {
 	}
 	cmd.val = make([]bool, n)
 	for i := 0; i < len(cmd.val); i++ {
-		if cmd.val[i], err = rd.ReadBool(); err != nil {
+		switch b, err := rd.ReadBool(); {
+		case err == Nil:
+			cmd.val[i] = false
+		case err != nil:
 			return err
+		default:
+			cmd.val[i] = b
 		}
 	}
 	return nil

--- a/command_nil_element_desync_test.go
+++ b/command_nil_element_desync_test.go
@@ -1,0 +1,67 @@
+package redis
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/redis/go-redis/v9/internal/proto"
+)
+
+// A flat scalar array can carry a nil in a non-final position. BITFIELD with
+// OVERFLOW FAIL returns nil for an operation that would overflow, e.g.
+// `BITFIELD k OVERFLOW FAIL INCRBY u8 0 255 INCRBY u8 0 255 GET u8 0` replies
+// [255, nil, 255]. IntSliceCmd, UintSliceCmd and BoolSliceCmd used to return on
+// the nil element, leaving the trailing elements on the wire and desyncing the
+// pooled connection so the next command read them as its reply. They must
+// consume the whole array like FloatSliceCmd and StringSliceCmd already do.
+func TestSliceCmdNilElementNoDesync(t *testing.T) {
+	// Each reply is [ v, nil, v ] followed by the next command's reply :999.
+	// A correct parser consumes all three elements and leaves :999 for the next read.
+	t.Run("IntSliceCmd", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader("*3\r\n:255\r\n_\r\n:100\r\n:999\r\n"))
+		cmd := NewIntSliceCmd(context.Background())
+		if err := cmd.readReply(rd); err != nil {
+			t.Fatalf("readReply: %v", err)
+		}
+		if got := cmd.val; len(got) != 3 || got[0] != 255 || got[1] != 0 || got[2] != 100 {
+			t.Fatalf("unexpected val: %+v", got)
+		}
+		assertNextReplyInt(t, rd, 999)
+	})
+
+	t.Run("UintSliceCmd", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader("*3\r\n:255\r\n_\r\n:100\r\n:999\r\n"))
+		cmd := NewUintSliceCmd(context.Background())
+		if err := cmd.readReply(rd); err != nil {
+			t.Fatalf("readReply: %v", err)
+		}
+		if got := cmd.val; len(got) != 3 || got[0] != 255 || got[1] != 0 || got[2] != 100 {
+			t.Fatalf("unexpected val: %+v", got)
+		}
+		assertNextReplyInt(t, rd, 999)
+	})
+
+	t.Run("BoolSliceCmd", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader("*3\r\n:1\r\n_\r\n:1\r\n:999\r\n"))
+		cmd := NewBoolSliceCmd(context.Background())
+		if err := cmd.readReply(rd); err != nil {
+			t.Fatalf("readReply: %v", err)
+		}
+		if got := cmd.val; len(got) != 3 || !got[0] || got[1] || !got[2] {
+			t.Fatalf("unexpected val: %+v", got)
+		}
+		assertNextReplyInt(t, rd, 999)
+	})
+}
+
+func assertNextReplyInt(t *testing.T, rd *proto.Reader, want int64) {
+	t.Helper()
+	got, err := rd.ReadInt()
+	if err != nil {
+		t.Fatalf("next reply read failed (connection desynced): %v", err)
+	}
+	if got != want {
+		t.Fatalf("connection desynced: next reply = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
`BITFIELD ... OVERFLOW FAIL` returns nil for an operation that overflows, so a reply can carry a nil in a non-final slot, e.g. `[255, nil, 100]`:

    *3\r\n:255\r\n_\r\n:100\r\n:999\r\n
    IntSliceCmd.readReply -> redis.Nil (only :255 read), next read = 100 not 999

`ReadInt`/`ReadUint`/`ReadBool` return `redis.Nil` on the nil element and the loop returns there, leaving the rest of the array on the wire. `redis.Nil` is not a bad conn, so the connection goes back to the pool desynced and the next command reads the leftovers. `FloatSliceCmd` and `StringSliceCmd` already store the zero value and keep going; the int/uint/bool parsers now do the same.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RESP parsing for pooled connections; behavior change maps nil slots to zero values rather than failing the command.
> 
> **Overview**
> Fixes **connection desync** when Redis returns a **nil in the middle of a scalar array** (e.g. `BITFIELD ... OVERFLOW FAIL` → `[255, nil, 100]`).
> 
> `IntSliceCmd`, `UintSliceCmd`, and `BoolSliceCmd` used to **abort** on `redis.Nil` from `ReadInt`/`ReadUint`/`ReadBool`, so trailing array elements stayed on the wire and the next command on a pooled connection read garbage. They now **consume the full array**, mapping nil slots to **0** / **false** (same pattern as `FloatSliceCmd` and `StringSliceCmd`).
> 
> Adds **`TestSliceCmdNilElementNoDesync`** to assert the reader is aligned for the following reply after a `*3` reply with a middle `_` nil.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f659a31e941bc753c0792a3963c60a13058c4a7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->