### PR TITLE
Add  RERANK parameter on HNSW vector field definitions in FT.CREATE

### DIFF
--- a/search_commands.go
+++ b/search_commands.go
@@ -107,6 +107,13 @@ type FTHNSWOptions struct {
 	MaxAllowedEdgesPerNode int
 	EFRunTime              int
 	Epsilon                float64
+	// Rerank toggles the exact re-scoring pass over approximate candidates on
+	// disk-backed HNSW indexes (Redis 8.10+), where the server requires it to
+	// be set explicitly. Rerank=true emits RERANK TRUE on its own; to emit
+	// RERANK FALSE, set HasRerank=true with Rerank=false, so that an explicit
+	// false can be distinguished from unset (omitted).
+	Rerank    bool
+	HasRerank bool
 }
 
 type FTVamanaOptions struct {
@@ -1494,6 +1501,13 @@ func (c cmdable) FTCreate(ctx context.Context, index string, options *FTCreateOp
 				}
 				if schema.VectorArgs.HNSWOptions.Epsilon > 0 {
 					hnswArgs = append(hnswArgs, "EPSILON", schema.VectorArgs.HNSWOptions.Epsilon)
+				}
+				if schema.VectorArgs.HNSWOptions.Rerank || schema.VectorArgs.HNSWOptions.HasRerank {
+					rerank := "FALSE"
+					if schema.VectorArgs.HNSWOptions.Rerank {
+						rerank = "TRUE"
+					}
+					hnswArgs = append(hnswArgs, "RERANK", rerank)
 				}
 				args = append(args, len(hnswArgs))
 				args = append(args, hnswArgs...)

--- a/search_commands_unit_test.go
+++ b/search_commands_unit_test.go
@@ -462,6 +462,68 @@ func TestFTHybridWithArgs_ShardKRatio(t *testing.T) {
 	})
 }
 
+// TestFTCreateHNSWRerank_Args verifies the RERANK attribute (Redis 8.10+,
+// disk-backed HNSW) is emitted as an explicit RERANK TRUE/FALSE key-value pair
+// counted in the attribute-count token, and omitted when HasRerank is unset.
+func TestFTCreateHNSWRerank_Args(t *testing.T) {
+	tests := []struct {
+		name string
+		opts *FTHNSWOptions
+		want []interface{}
+	}{
+		{
+			name: "rerank_unset",
+			opts: &FTHNSWOptions{Type: "FLOAT32", Dim: 2, DistanceMetric: "L2"},
+			want: []interface{}{
+				"FT.CREATE", "idx", "SCHEMA", "v", "VECTOR", "HNSW", 6,
+				"TYPE", "FLOAT32", "DIM", 2, "DISTANCE_METRIC", "L2",
+			},
+		},
+		{
+			name: "rerank_true",
+			opts: &FTHNSWOptions{Type: "FLOAT32", Dim: 2, DistanceMetric: "L2", Rerank: true, HasRerank: true},
+			want: []interface{}{
+				"FT.CREATE", "idx", "SCHEMA", "v", "VECTOR", "HNSW", 8,
+				"TYPE", "FLOAT32", "DIM", 2, "DISTANCE_METRIC", "L2", "RERANK", "TRUE",
+			},
+		},
+		{
+			name: "rerank_true_without_has_flag",
+			opts: &FTHNSWOptions{Type: "FLOAT32", Dim: 2, DistanceMetric: "L2", Rerank: true},
+			want: []interface{}{
+				"FT.CREATE", "idx", "SCHEMA", "v", "VECTOR", "HNSW", 8,
+				"TYPE", "FLOAT32", "DIM", 2, "DISTANCE_METRIC", "L2", "RERANK", "TRUE",
+			},
+		},
+		{
+			name: "rerank_false_explicit",
+			opts: &FTHNSWOptions{Type: "FLOAT32", Dim: 2, DistanceMetric: "L2", Rerank: false, HasRerank: true},
+			want: []interface{}{
+				"FT.CREATE", "idx", "SCHEMA", "v", "VECTOR", "HNSW", 8,
+				"TYPE", "FLOAT32", "DIM", 2, "DISTANCE_METRIC", "L2", "RERANK", "FALSE",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &mockCmdable{}
+			c := m.asCmdable()
+			cmd := c.FTCreate(context.Background(), "idx", nil, &FieldSchema{
+				FieldName:  "v",
+				FieldType:  SearchFieldTypeVector,
+				VectorArgs: &FTVectorArgs{HNSWOptions: tt.opts},
+			})
+			if cmd.Err() != nil {
+				t.Fatalf("unexpected error: %v", cmd.Err())
+			}
+			if !reflect.DeepEqual(cmd.Args(), tt.want) {
+				t.Errorf("args mismatch\n got: %#v\nwant: %#v", cmd.Args(), tt.want)
+			}
+		})
+	}
+}
+
 // TestParseFTHybridWarnings checks that FT.HYBRID warnings populate from either
 // the "warning" or "warnings" key.
 func TestParseFTHybridWarnings(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive FT.CREATE command encoding and struct fields only; no runtime or auth changes.
> 
> **Overview**
> Adds support for the **RERANK** attribute on **VECTOR HNSW** fields when building `FT.CREATE` (Redis 8.10+, disk-backed HNSW), so callers can control the exact re-scoring pass over approximate candidates.
> 
> `FTHNSWOptions` gains `Rerank` and `HasRerank`: `Rerank: true` emits `RERANK TRUE`; `HasRerank: true` with `Rerank: false` emits `RERANK FALSE`; when neither is set, **RERANK** is omitted. The HNSW attribute count in the command is updated when **RERANK** is included.
> 
> Unit tests assert the full `FT.CREATE` argument list for unset, true, true without `HasRerank`, and explicit false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8a9ee917a55d64929cda346856838c31aebb7c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->