### PR TITLE
chore(cmd): remove dead assertUnstableCommand RESP3 path

### DIFF
--- a/command.go
+++ b/command.go
@@ -225,7 +225,6 @@ type Cmder interface {
 
 	readTimeout() *time.Duration
 	readReply(rd *proto.Reader) error
-	readRawReply(rd *proto.Reader) error
 	SetErr(error)
 	Err() error
 
@@ -428,11 +427,6 @@ func (cmd *baseCmd) readTimeout() *time.Duration {
 
 func (cmd *baseCmd) setReadTimeout(d time.Duration) {
 	cmd._readTimeout = &d
-}
-
-func (cmd *baseCmd) readRawReply(rd *proto.Reader) (err error) {
-	cmd.rawVal, err = rd.ReadReply()
-	return err
 }
 
 // NoRetry returns true if the command should not be retried on failure.

--- a/command.go
+++ b/command.go
@@ -225,6 +225,7 @@ type Cmder interface {
 
 	readTimeout() *time.Duration
 	readReply(rd *proto.Reader) error
+	readRawReply(rd *proto.Reader) error
 	SetErr(error)
 	Err() error
 
@@ -427,6 +428,11 @@ func (cmd *baseCmd) readTimeout() *time.Duration {
 
 func (cmd *baseCmd) setReadTimeout(d time.Duration) {
 	cmd._readTimeout = &d
+}
+
+func (cmd *baseCmd) readRawReply(rd *proto.Reader) (err error) {
+	cmd.rawVal, err = rd.ReadReply()
+	return err
 }
 
 // NoRetry returns true if the command should not be retried on failure.

--- a/redis.go
+++ b/redis.go
@@ -978,12 +978,6 @@ func classifyCommandError(err error) (errorType, statusCode string, isInternal b
 	return "UNKNOWN", "UNKNOWN", true
 }
 
-func (c *baseClient) assertUnstableCommand(cmd Cmder) (bool, error) {
-	// All search commands (FTSearchCmd, AggregateCmd, FTInfoCmd, FTSpellCheckCmd, FTSynDumpCmd)
-	// now have stable RESP3 parsing. No commands require the UnstableResp3 flag anymore.
-	return false, nil
-}
-
 func (c *baseClient) _process(ctx context.Context, cmd Cmder, attempt int) (bool, *pool.Conn, error) {
 	if attempt > 0 {
 		if err := internal.Sleep(ctx, c.retryBackoff(attempt)); err != nil {
@@ -1006,23 +1000,12 @@ func (c *baseClient) _process(ctx context.Context, cmd Cmder, attempt int) (bool
 			retryTimeout.Store(1)
 			return err
 		}
-		readReplyFunc := cmd.readReply
-		// Apply unstable RESP3 search module.
-		if c.opt.Protocol != 2 {
-			useRawReply, err := c.assertUnstableCommand(cmd)
-			if err != nil {
-				return err
-			}
-			if useRawReply {
-				readReplyFunc = cmd.readRawReply
-			}
-		}
 		if err := cn.WithReader(c.context(ctx), c.cmdTimeout(cmd), func(rd *proto.Reader) error {
 			// To be sure there are no buffered push notifications, we process them before reading the reply
 			if err := c.processPendingPushNotificationWithReader(ctx, cn, rd); err != nil {
 				internal.Logger.Printf(ctx, "push: error processing pending notifications before reading reply: %v", err)
 			}
-			return readReplyFunc(rd)
+			return cmd.readReply(rd)
 		}); err != nil {
 			if cmd.readTimeout() == nil {
 				retryTimeout.Store(1)


### PR DESCRIPTION
Drop the now-unused Cmder.readRawReply interface method and its baseCmd implementation too. readRawReply is unexported and Cmder is a sealed interface, so this is not a public API break. baseCmd.rawVal is retained (search commands still use it directly). The deprecated UnstableResp3 option is retained as well (removing it is a API break).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal cleanup of a no-op code path in the core command loop; behavior should be unchanged because the removed branch never selected raw reply parsing.
> 
> **Overview**
> Removes the legacy **unstable RESP3** branch from single-command execution in `baseClient._process`. Responses are always parsed via `cmd.readReply` instead of optionally routing through `readRawReply` when protocol is not RESP2.
> 
> Deletes `assertUnstableCommand`, which had become a stub that always returned “use normal reply parsing.” That matches RediSearch commands now having stable RESP3 parsing without the old `UnstableResp3` workaround at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e23a589c79979cec97e60de4923003ec663cacd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->