### PR TITLE
feat(options): add TLS params to ParseURL

### DIFF
--- a/options.go
+++ b/options.go
@@ -3,11 +3,13 @@ package redis
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"maps"
 	"net"
 	"net/url"
+	"os"
 	"runtime"
 	"slices"
 	"strconv"
@@ -491,7 +493,13 @@ func NewDialer(opt *Options) func(context.Context, string, string) (net.Conn, er
 //     URL attributes (scheme, host, userinfo, resp.), query parameters using these
 //     names will be treated as unknown parameters
 //   - unknown parameter names will result in an error
-//   - use "skip_verify=true" to ignore TLS certificate validation
+//   - TLS options (applied when the scheme is rediss://, or when any TLS file path /
+//     skip-verify option is present — in which case a tls.Config is created):
+//   - tls_cert_file, tls_key_file: paths to a client certificate and private key
+//     (PEM); both must be set together
+//   - tls_ca_file: path to a CA certificate file (PEM) used to verify the server
+//   - tls_insecure_skip_verify=true or skip_verify=true: skip server certificate
+//     verification (for testing only)
 //
 // Examples:
 //
@@ -505,6 +513,8 @@ func NewDialer(opt *Options) func(context.Context, string, string) (net.Conn, er
 //		ReadTimeout: 6 * time.Second,
 //		MaxRetries:  2,
 //	}
+//
+//	rediss://localhost:6379?tls_cert_file=/path/cert.pem&tls_key_file=/path/key.pem&tls_ca_file=/path/ca.pem
 func ParseURL(redisURL string) (*Options, error) {
 	u, err := url.Parse(redisURL)
 	if err != nil {
@@ -719,9 +729,12 @@ func setupConnParams(u *url.URL, o *Options) (*Options, error) {
 	if q.err != nil {
 		return nil, q.err
 	}
-	if o.TLSConfig != nil && q.has("skip_verify") {
-		o.TLSConfig.InsecureSkipVerify = q.bool("skip_verify")
+
+	tlsCfg, err := applyTLSQueryOptions(&q, o.TLSConfig, tlsServerName(o.Addr))
+	if err != nil {
+		return nil, err
 	}
+	o.TLSConfig = tlsCfg
 
 	// any parameters left?
 	if r := q.remaining(); len(r) > 0 {
@@ -729,6 +742,86 @@ func setupConnParams(u *url.URL, o *Options) (*Options, error) {
 	}
 
 	return o, nil
+}
+
+// applyTLSQueryOptions applies TLS-related URL query parameters to cfg.
+//
+// Supported parameters:
+//   - tls_cert_file / tls_key_file: client certificate and private key (PEM). Both
+//     must be provided together.
+//   - tls_ca_file: CA certificate file (PEM) used as RootCAs for server verification.
+//   - tls_insecure_skip_verify / skip_verify: when true, set InsecureSkipVerify.
+//
+// If cfg is nil and any TLS option is present, a new tls.Config is created with
+// ServerName set to serverName and MinVersion TLS 1.2. When the scheme is rediss://
+// the caller already provides a non-nil cfg; file paths then load into that config.
+// Parameters are always consumed from q so they do not appear as unknown options.
+func applyTLSQueryOptions(q *queryOptions, cfg *tls.Config, serverName string) (*tls.Config, error) {
+	certFile := q.string("tls_cert_file")
+	keyFile := q.string("tls_key_file")
+	caFile := q.string("tls_ca_file")
+
+	var skipVerify bool
+	hasSkipVerify := false
+	if q.has("skip_verify") {
+		hasSkipVerify = true
+		skipVerify = skipVerify || q.bool("skip_verify")
+	}
+	if q.has("tls_insecure_skip_verify") {
+		hasSkipVerify = true
+		skipVerify = skipVerify || q.bool("tls_insecure_skip_verify")
+	}
+
+	if certFile == "" && keyFile == "" && caFile == "" && !hasSkipVerify {
+		return cfg, nil
+	}
+
+	if (certFile == "") != (keyFile == "") {
+		return nil, fmt.Errorf("redis: tls_cert_file and tls_key_file must both be set or both omitted")
+	}
+
+	if cfg == nil {
+		cfg = &tls.Config{
+			ServerName: serverName,
+			MinVersion: tls.VersionTLS12,
+		}
+	}
+
+	if certFile != "" {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("redis: error loading TLS certificate: %w", err)
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+
+	if caFile != "" {
+		pemData, err := os.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("redis: error loading TLS CA certificate: %w", err)
+		}
+		certPool := x509.NewCertPool()
+		if !certPool.AppendCertsFromPEM(pemData) {
+			return nil, fmt.Errorf("redis: failed to parse TLS CA certificate from %q", caFile)
+		}
+		cfg.RootCAs = certPool
+	}
+
+	if hasSkipVerify {
+		cfg.InsecureSkipVerify = skipVerify
+	}
+
+	return cfg, nil
+}
+
+// tlsServerName extracts the host portion of addr for use as tls.Config.ServerName.
+// addr is expected to be host:port as produced by net.JoinHostPort.
+func tlsServerName(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return addr
+	}
+	return host
 }
 
 func getUserPassword(u *url.URL) (string, string) {

--- a/options.go
+++ b/options.go
@@ -734,6 +734,10 @@ func setupConnParams(u *url.URL, o *Options) (*Options, error) {
 	if err != nil {
 		return nil, err
 	}
+	// applyTLSQueryOptions may set q.err via q.bool (e.g. invalid boolean values).
+	if q.err != nil {
+		return nil, q.err
+	}
 	o.TLSConfig = tlsCfg
 
 	// any parameters left?
@@ -761,15 +765,21 @@ func applyTLSQueryOptions(q *queryOptions, cfg *tls.Config, serverName string) (
 	keyFile := q.string("tls_key_file")
 	caFile := q.string("tls_ca_file")
 
+	// Always evaluate both bool params (no short-circuit) so each is consumed
+	// from the query and parse errors on either name are recorded in q.err.
 	var skipVerify bool
 	hasSkipVerify := false
 	if q.has("skip_verify") {
 		hasSkipVerify = true
-		skipVerify = skipVerify || q.bool("skip_verify")
+		if q.bool("skip_verify") {
+			skipVerify = true
+		}
 	}
 	if q.has("tls_insecure_skip_verify") {
 		hasSkipVerify = true
-		skipVerify = skipVerify || q.bool("tls_insecure_skip_verify")
+		if q.bool("tls_insecure_skip_verify") {
+			skipVerify = true
+		}
 	}
 
 	if certFile == "" && keyFile == "" && caFile == "" && !hasSkipVerify {

--- a/options.go
+++ b/options.go
@@ -734,10 +734,6 @@ func setupConnParams(u *url.URL, o *Options) (*Options, error) {
 	if err != nil {
 		return nil, err
 	}
-	// applyTLSQueryOptions may set q.err via q.bool (e.g. invalid boolean values).
-	if q.err != nil {
-		return nil, q.err
-	}
 	o.TLSConfig = tlsCfg
 
 	// any parameters left?
@@ -821,6 +817,10 @@ func applyTLSQueryOptions(q *queryOptions, cfg *tls.Config, serverName string) (
 		cfg.InsecureSkipVerify = skipVerify
 	}
 
+	// q.bool records parse failures in q.err without returning them.
+	if q.err != nil {
+		return nil, q.err
+	}
 	return cfg, nil
 }
 

--- a/options.go
+++ b/options.go
@@ -493,8 +493,9 @@ func NewDialer(opt *Options) func(context.Context, string, string) (net.Conn, er
 //     URL attributes (scheme, host, userinfo, resp.), query parameters using these
 //     names will be treated as unknown parameters
 //   - unknown parameter names will result in an error
-//   - TLS options (applied when the scheme is rediss://, or when any TLS file path /
-//     skip-verify option is present — in which case a tls.Config is created):
+//   - TLS options (applied when the scheme is rediss://, or when any TLS file path is
+//     present, or when skip_verify/tls_insecure_skip_verify is true — in which case a
+//     tls.Config is created). A false skip-verify value alone does not enable TLS:
 //   - tls_cert_file, tls_key_file: paths to a client certificate and private key
 //     (PEM); both must be set together
 //   - tls_ca_file: path to a CA certificate file (PEM) used to verify the server
@@ -752,9 +753,12 @@ func setupConnParams(u *url.URL, o *Options) (*Options, error) {
 //   - tls_ca_file: CA certificate file (PEM) used as RootCAs for server verification.
 //   - tls_insecure_skip_verify / skip_verify: when true, set InsecureSkipVerify.
 //
-// If cfg is nil and any TLS option is present, a new tls.Config is created with
-// ServerName set to serverName and MinVersion TLS 1.2. When the scheme is rediss://
-// the caller already provides a non-nil cfg; file paths then load into that config.
+// If cfg is nil, a new tls.Config is created only when TLS material is present
+// (cert/key/ca files) or when skip-verify is true. A false skip-verify value alone
+// does not enable TLS on redis://. When a new config is created, ServerName is set
+// to serverName (may be empty for multi-endpoint clients so each dial uses the
+// connection host) and MinVersion TLS 1.2. When the scheme is rediss:// the caller
+// already provides a non-nil cfg; file paths then load into that config.
 // Parameters are always consumed from q so they do not appear as unknown options.
 func applyTLSQueryOptions(q *queryOptions, cfg *tls.Config, serverName string) (*tls.Config, error) {
 	certFile := q.string("tls_cert_file")
@@ -778,7 +782,19 @@ func applyTLSQueryOptions(q *queryOptions, cfg *tls.Config, serverName string) (
 		}
 	}
 
-	if certFile == "" && keyFile == "" && caFile == "" && !hasSkipVerify {
+	// q.bool records parse failures in q.err without returning them.
+	if q.err != nil {
+		return nil, q.err
+	}
+
+	// Material that requires a TLS config: cert paths, CA, or skip_verify=true.
+	// Presence of skip_verify=false alone must not enable TLS on redis://.
+	needsTLS := certFile != "" || keyFile != "" || caFile != "" || skipVerify
+	if !needsTLS {
+		// Explicit skip_verify=false on rediss:// still applies to the existing cfg.
+		if hasSkipVerify && cfg != nil {
+			cfg.InsecureSkipVerify = false
+		}
 		return cfg, nil
 	}
 
@@ -817,10 +833,6 @@ func applyTLSQueryOptions(q *queryOptions, cfg *tls.Config, serverName string) (
 		cfg.InsecureSkipVerify = skipVerify
 	}
 
-	// q.bool records parse failures in q.err without returning them.
-	if q.err != nil {
-		return nil, q.err
-	}
 	return cfg, nil
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -1,9 +1,20 @@
 package redis
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
+	"math/big"
 	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -193,6 +204,294 @@ func TestParseURLIPv6TLSServerName(t *testing.T) {
 	if got, want := o.TLSConfig.ServerName, "2001:db8::1"; got != want {
 		t.Errorf("TLSConfig.ServerName: got %q, want %q", got, want)
 	}
+}
+
+// writeTempTLSMaterial generates a self-signed ECDSA cert/key pair and CA PEM
+// under t.TempDir(). No network is involved; material is only used by ParseURL.
+func writeTempTLSMaterial(t *testing.T) (certFile, keyFile, caFile string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"go-redis test"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:              []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+
+	dir := t.TempDir()
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	caFile = filepath.Join(dir, "ca.pem")
+
+	certOut, err := os.Create(certFile)
+	if err != nil {
+		t.Fatalf("create cert file: %v", err)
+	}
+	if err := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		t.Fatalf("encode cert: %v", err)
+	}
+	if err := certOut.Close(); err != nil {
+		t.Fatalf("close cert: %v", err)
+	}
+
+	// CA file is the same self-signed cert (acts as trust root).
+	if err := os.WriteFile(caFile, mustRead(t, certFile), 0o600); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+
+	keyBytes, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyOut, err := os.Create(keyFile)
+	if err != nil {
+		t.Fatalf("create key file: %v", err)
+	}
+	if err := pem.Encode(keyOut, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes}); err != nil {
+		t.Fatalf("encode key: %v", err)
+	}
+	if err := keyOut.Close(); err != nil {
+		t.Fatalf("close key: %v", err)
+	}
+
+	return certFile, keyFile, caFile
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return b
+}
+
+func TestParseURLTLSOptions(t *testing.T) {
+	certFile, keyFile, caFile := writeTempTLSMaterial(t)
+
+	t.Run("rediss skip_verify", func(t *testing.T) {
+		o, err := ParseURL("rediss://localhost:123/?skip_verify=true")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil {
+			t.Fatal("expected TLSConfig")
+		}
+		if !o.TLSConfig.InsecureSkipVerify {
+			t.Error("expected InsecureSkipVerify=true")
+		}
+		if o.TLSConfig.ServerName != "localhost" {
+			t.Errorf("ServerName: got %q, want localhost", o.TLSConfig.ServerName)
+		}
+	})
+
+	t.Run("rediss tls_insecure_skip_verify", func(t *testing.T) {
+		o, err := ParseURL("rediss://localhost:123/?tls_insecure_skip_verify=true")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil || !o.TLSConfig.InsecureSkipVerify {
+			t.Fatal("expected TLSConfig with InsecureSkipVerify=true")
+		}
+	})
+
+	t.Run("client cert and key on rediss", func(t *testing.T) {
+		u := "rediss://localhost:123/?tls_cert_file=" + url.QueryEscape(certFile) +
+			"&tls_key_file=" + url.QueryEscape(keyFile)
+		o, err := ParseURL(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil {
+			t.Fatal("expected TLSConfig")
+		}
+		if len(o.TLSConfig.Certificates) != 1 {
+			t.Fatalf("Certificates: got %d, want 1", len(o.TLSConfig.Certificates))
+		}
+		if o.TLSConfig.ServerName != "localhost" {
+			t.Errorf("ServerName: got %q, want localhost", o.TLSConfig.ServerName)
+		}
+	})
+
+	t.Run("ca file on rediss", func(t *testing.T) {
+		u := "rediss://localhost:123/?tls_ca_file=" + url.QueryEscape(caFile)
+		o, err := ParseURL(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil || o.TLSConfig.RootCAs == nil {
+			t.Fatal("expected TLSConfig with RootCAs set")
+		}
+	})
+
+	t.Run("all tls files on rediss", func(t *testing.T) {
+		u := "rediss://localhost:123/?tls_cert_file=" + url.QueryEscape(certFile) +
+			"&tls_key_file=" + url.QueryEscape(keyFile) +
+			"&tls_ca_file=" + url.QueryEscape(caFile) +
+			"&tls_insecure_skip_verify=false"
+		o, err := ParseURL(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil {
+			t.Fatal("expected TLSConfig")
+		}
+		if len(o.TLSConfig.Certificates) != 1 {
+			t.Fatalf("Certificates: got %d, want 1", len(o.TLSConfig.Certificates))
+		}
+		if o.TLSConfig.RootCAs == nil {
+			t.Fatal("expected RootCAs")
+		}
+		if o.TLSConfig.InsecureSkipVerify {
+			t.Error("expected InsecureSkipVerify=false")
+		}
+	})
+
+	t.Run("tls files enable TLS on redis scheme", func(t *testing.T) {
+		// Providing cert paths on redis:// (not rediss://) should still build a TLSConfig.
+		u := "redis://localhost:123/?tls_cert_file=" + url.QueryEscape(certFile) +
+			"&tls_key_file=" + url.QueryEscape(keyFile)
+		o, err := ParseURL(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil {
+			t.Fatal("expected TLSConfig when cert files are provided")
+		}
+		if o.TLSConfig.MinVersion != tls.VersionTLS12 {
+			t.Errorf("MinVersion: got %d, want TLS 1.2", o.TLSConfig.MinVersion)
+		}
+		if o.TLSConfig.ServerName != "localhost" {
+			t.Errorf("ServerName: got %q, want localhost", o.TLSConfig.ServerName)
+		}
+		if len(o.TLSConfig.Certificates) != 1 {
+			t.Fatalf("Certificates: got %d, want 1", len(o.TLSConfig.Certificates))
+		}
+	})
+
+	t.Run("tls_insecure_skip_verify enables TLS on redis scheme", func(t *testing.T) {
+		o, err := ParseURL("redis://localhost:123/?tls_insecure_skip_verify=true")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil || !o.TLSConfig.InsecureSkipVerify {
+			t.Fatal("expected TLSConfig with InsecureSkipVerify=true")
+		}
+	})
+
+	t.Run("cert without key", func(t *testing.T) {
+		u := "rediss://localhost:123/?tls_cert_file=" + url.QueryEscape(certFile)
+		_, err := ParseURL(u)
+		if err == nil {
+			t.Fatal("expected error when only tls_cert_file is set")
+		}
+		if !strings.Contains(err.Error(), "tls_cert_file and tls_key_file") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("key without cert", func(t *testing.T) {
+		u := "rediss://localhost:123/?tls_key_file=" + url.QueryEscape(keyFile)
+		_, err := ParseURL(u)
+		if err == nil {
+			t.Fatal("expected error when only tls_key_file is set")
+		}
+		if !strings.Contains(err.Error(), "tls_cert_file and tls_key_file") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("missing cert file", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "missing-cert.pem")
+		u := "rediss://localhost:123/?tls_cert_file=" + url.QueryEscape(missing) +
+			"&tls_key_file=" + url.QueryEscape(keyFile)
+		_, err := ParseURL(u)
+		if err == nil {
+			t.Fatal("expected error for missing cert file")
+		}
+		if !strings.Contains(err.Error(), "error loading TLS certificate") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("missing ca file", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "missing-ca.pem")
+		u := "rediss://localhost:123/?tls_ca_file=" + url.QueryEscape(missing)
+		_, err := ParseURL(u)
+		if err == nil {
+			t.Fatal("expected error for missing ca file")
+		}
+		if !strings.Contains(err.Error(), "error loading TLS CA certificate") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid ca pem", func(t *testing.T) {
+		bad := filepath.Join(t.TempDir(), "bad-ca.pem")
+		if err := os.WriteFile(bad, []byte("not a pem"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		u := "rediss://localhost:123/?tls_ca_file=" + url.QueryEscape(bad)
+		_, err := ParseURL(u)
+		if err == nil {
+			t.Fatal("expected error for invalid CA PEM")
+		}
+		if !strings.Contains(err.Error(), "failed to parse TLS CA certificate") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("cluster url with tls options", func(t *testing.T) {
+		u := "rediss://localhost:123?tls_cert_file=" + url.QueryEscape(certFile) +
+			"&tls_key_file=" + url.QueryEscape(keyFile) +
+			"&skip_verify=true"
+		o, err := ParseClusterURL(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil {
+			t.Fatal("expected TLSConfig")
+		}
+		if len(o.TLSConfig.Certificates) != 1 {
+			t.Fatalf("Certificates: got %d, want 1", len(o.TLSConfig.Certificates))
+		}
+		if !o.TLSConfig.InsecureSkipVerify {
+			t.Error("expected InsecureSkipVerify=true")
+		}
+	})
+
+	t.Run("failover url with tls options", func(t *testing.T) {
+		u := "rediss://localhost:6379/5?master_name=test&tls_ca_file=" + url.QueryEscape(caFile) +
+			"&tls_insecure_skip_verify=true"
+		o, err := ParseFailoverURL(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil {
+			t.Fatal("expected TLSConfig")
+		}
+		if o.TLSConfig.RootCAs == nil {
+			t.Fatal("expected RootCAs")
+		}
+		if !o.TLSConfig.InsecureSkipVerify {
+			t.Error("expected InsecureSkipVerify=true")
+		}
+	})
 }
 
 func comprareOptions(t *testing.T, actual, expected *Options) {

--- a/options_test.go
+++ b/options_test.go
@@ -310,6 +310,38 @@ func TestParseURLTLSOptions(t *testing.T) {
 		}
 	})
 
+	t.Run("both skip_verify aliases true", func(t *testing.T) {
+		// Both query keys must be consumed and OR'd; short-circuit would skip the second.
+		o, err := ParseURL("rediss://localhost:123/?skip_verify=true&tls_insecure_skip_verify=false")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil || !o.TLSConfig.InsecureSkipVerify {
+			t.Fatal("expected InsecureSkipVerify=true when either alias is true")
+		}
+	})
+
+	t.Run("invalid tls_insecure_skip_verify boolean", func(t *testing.T) {
+		_, err := ParseURL("rediss://localhost:123/?tls_insecure_skip_verify=ture")
+		if err == nil {
+			t.Fatal("expected error for invalid boolean")
+		}
+		if !strings.Contains(err.Error(), "invalid tls_insecure_skip_verify boolean") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid skip_verify still checked when both set", func(t *testing.T) {
+		// skip_verify=true would short-circuit || and hide a bad tls_insecure_skip_verify.
+		_, err := ParseURL("rediss://localhost:123/?skip_verify=true&tls_insecure_skip_verify=yes")
+		if err == nil {
+			t.Fatal("expected error for invalid tls_insecure_skip_verify boolean")
+		}
+		if !strings.Contains(err.Error(), "invalid tls_insecure_skip_verify boolean") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
 	t.Run("client cert and key on rediss", func(t *testing.T) {
 		u := "rediss://localhost:123/?tls_cert_file=" + url.QueryEscape(certFile) +
 			"&tls_key_file=" + url.QueryEscape(keyFile)

--- a/options_test.go
+++ b/options_test.go
@@ -426,6 +426,61 @@ func TestParseURLTLSOptions(t *testing.T) {
 		}
 	})
 
+	t.Run("skip_verify false alone does not enable TLS on redis scheme", func(t *testing.T) {
+		o, err := ParseURL("redis://localhost:123/?skip_verify=false")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig != nil {
+			t.Fatalf("expected nil TLSConfig when skip_verify=false alone, got %+v", o.TLSConfig)
+		}
+	})
+
+	t.Run("tls_insecure_skip_verify false alone does not enable TLS on redis scheme", func(t *testing.T) {
+		o, err := ParseURL("redis://localhost:123/?tls_insecure_skip_verify=false")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig != nil {
+			t.Fatalf("expected nil TLSConfig, got %+v", o.TLSConfig)
+		}
+	})
+
+	t.Run("skip_verify false on rediss keeps TLS without insecure", func(t *testing.T) {
+		o, err := ParseURL("rediss://localhost:123/?skip_verify=false")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil {
+			t.Fatal("expected TLSConfig for rediss scheme")
+		}
+		if o.TLSConfig.InsecureSkipVerify {
+			t.Error("expected InsecureSkipVerify=false")
+		}
+		if o.TLSConfig.ServerName != "localhost" {
+			t.Errorf("ServerName: got %q, want localhost", o.TLSConfig.ServerName)
+		}
+	})
+
+	t.Run("skip_verify false with cert files still enables TLS", func(t *testing.T) {
+		u := "redis://localhost:123/?tls_cert_file=" + url.QueryEscape(certFile) +
+			"&tls_key_file=" + url.QueryEscape(keyFile) +
+			"&skip_verify=false"
+		o, err := ParseURL(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil {
+			t.Fatal("expected TLSConfig when cert files are provided")
+		}
+		if o.TLSConfig.InsecureSkipVerify {
+			t.Error("expected InsecureSkipVerify=false")
+		}
+		if len(o.TLSConfig.Certificates) != 1 {
+			t.Fatalf("Certificates: got %d, want 1", len(o.TLSConfig.Certificates))
+		}
+	})
+
 	t.Run("cert without key", func(t *testing.T) {
 		u := "rediss://localhost:123/?tls_cert_file=" + url.QueryEscape(certFile)
 		_, err := ParseURL(u)
@@ -522,6 +577,40 @@ func TestParseURLTLSOptions(t *testing.T) {
 		}
 		if !o.TLSConfig.InsecureSkipVerify {
 			t.Error("expected InsecureSkipVerify=true")
+		}
+	})
+
+	t.Run("cluster redis scheme TLS leaves ServerName empty for multi-node", func(t *testing.T) {
+		// When TLS is enabled via query params on redis://, do not pin ServerName
+		// to the first seed; tls.Dial fills it from each connection address.
+		o, err := ParseClusterURL("redis://node-a:6379?addr=node-b:6379&tls_insecure_skip_verify=true")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil || !o.TLSConfig.InsecureSkipVerify {
+			t.Fatal("expected TLSConfig with InsecureSkipVerify=true")
+		}
+		if o.TLSConfig.ServerName != "" {
+			t.Errorf("ServerName: got %q, want empty for multi-node", o.TLSConfig.ServerName)
+		}
+	})
+
+	t.Run("cluster rediss keeps scheme ServerName when applying certs", func(t *testing.T) {
+		u := "rediss://localhost:123?tls_cert_file=" + url.QueryEscape(certFile) +
+			"&tls_key_file=" + url.QueryEscape(keyFile)
+		o, err := ParseClusterURL(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if o.TLSConfig == nil {
+			t.Fatal("expected TLSConfig")
+		}
+		// rediss:// still sets ServerName from the URL host in setupClusterConn.
+		if o.TLSConfig.ServerName != "localhost" {
+			t.Errorf("ServerName: got %q, want localhost", o.TLSConfig.ServerName)
+		}
+		if len(o.TLSConfig.Certificates) != 1 {
+			t.Fatalf("Certificates: got %d, want 1", len(o.TLSConfig.Certificates))
 		}
 	})
 

--- a/options_test.go
+++ b/options_test.go
@@ -524,6 +524,26 @@ func TestParseURLTLSOptions(t *testing.T) {
 			t.Error("expected InsecureSkipVerify=true")
 		}
 	})
+
+	t.Run("cluster url rejects invalid skip_verify", func(t *testing.T) {
+		_, err := ParseClusterURL("rediss://localhost:123?skip_verify=ture")
+		if err == nil {
+			t.Fatal("expected error for invalid boolean")
+		}
+		if !strings.Contains(err.Error(), "invalid skip_verify boolean") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("failover url rejects invalid tls_insecure_skip_verify", func(t *testing.T) {
+		_, err := ParseFailoverURL("rediss://localhost:6379?master_name=m&tls_insecure_skip_verify=yes")
+		if err == nil {
+			t.Fatal("expected error for invalid boolean")
+		}
+		if !strings.Contains(err.Error(), "invalid tls_insecure_skip_verify boolean") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func comprareOptions(t *testing.T, actual, expected *Options) {

--- a/osscluster.go
+++ b/osscluster.go
@@ -304,6 +304,13 @@ func (opt *ClusterOptions) init() {
 //     URL attributes (scheme, host, userinfo, resp.), query parameters using these
 //     names will be treated as unknown parameters
 //   - unknown parameter names will result in an error
+//   - TLS options (applied when the scheme is rediss://, or when any TLS file path /
+//     skip-verify option is present — in which case a tls.Config is created):
+//   - tls_cert_file, tls_key_file: paths to a client certificate and private key
+//     (PEM); both must be set together
+//   - tls_ca_file: path to a CA certificate file (PEM) used to verify the server
+//   - tls_insecure_skip_verify=true or skip_verify=true: skip server certificate
+//     verification (for testing only)
 //
 // Example:
 //
@@ -403,6 +410,16 @@ func setupClusterQueryParams(u *url.URL, o *ClusterOptions) (*ClusterOptions, er
 
 		o.Addrs = append(o.Addrs, net.JoinHostPort(h, p))
 	}
+
+	serverName := ""
+	if len(o.Addrs) > 0 {
+		serverName = tlsServerName(o.Addrs[0])
+	}
+	tlsCfg, err := applyTLSQueryOptions(&q, o.TLSConfig, serverName)
+	if err != nil {
+		return nil, err
+	}
+	o.TLSConfig = tlsCfg
 
 	// any parameters left?
 	if r := q.remaining(); len(r) > 0 {

--- a/osscluster.go
+++ b/osscluster.go
@@ -304,8 +304,9 @@ func (opt *ClusterOptions) init() {
 //     URL attributes (scheme, host, userinfo, resp.), query parameters using these
 //     names will be treated as unknown parameters
 //   - unknown parameter names will result in an error
-//   - TLS options (applied when the scheme is rediss://, or when any TLS file path /
-//     skip-verify option is present — in which case a tls.Config is created):
+//   - TLS options (applied when the scheme is rediss://, or when any TLS file path is
+//     present, or when skip_verify/tls_insecure_skip_verify is true — in which case a
+//     tls.Config is created). A false skip-verify value alone does not enable TLS:
 //   - tls_cert_file, tls_key_file: paths to a client certificate and private key
 //     (PEM); both must be set together
 //   - tls_ca_file: path to a CA certificate file (PEM) used to verify the server
@@ -411,11 +412,9 @@ func setupClusterQueryParams(u *url.URL, o *ClusterOptions) (*ClusterOptions, er
 		o.Addrs = append(o.Addrs, net.JoinHostPort(h, p))
 	}
 
-	serverName := ""
-	if len(o.Addrs) > 0 {
-		serverName = tlsServerName(o.Addrs[0])
-	}
-	tlsCfg, err := applyTLSQueryOptions(&q, o.TLSConfig, serverName)
+	// Leave ServerName empty for multi-node TLS so tls.Dial uses each dial addr
+	// as the server name instead of pinning every node to the first seed.
+	tlsCfg, err := applyTLSQueryOptions(&q, o.TLSConfig, "")
 	if err != nil {
 		return nil, err
 	}

--- a/sentinel.go
+++ b/sentinel.go
@@ -176,7 +176,7 @@ type FailoverOptions struct {
 	// seamlessly. Requires Protocol: 3 (RESP3) for push notifications.
 	// If nil, maintnotifications upgrades are disabled.
 	// (however if Mode is nil, it defaults to "auto" - enable if server supports it)
-	//MaintNotificationsConfig *maintnotifications.Config
+	// MaintNotificationsConfig *maintnotifications.Config
 }
 
 func (opt *FailoverOptions) clientOptions() *Options {
@@ -376,7 +376,13 @@ func (opt *FailoverOptions) clusterOptions() *ClusterOptions {
 //     URL attributes (scheme, host, userinfo, resp.), query parameters using these
 //     names will be treated as unknown parameters
 //   - unknown parameter names will result in an error
-//   - use "skip_verify=true" to ignore TLS certificate validation
+//   - TLS options (applied when the scheme is rediss://, or when any TLS file path /
+//     skip-verify option is present — in which case a tls.Config is created):
+//   - tls_cert_file, tls_key_file: paths to a client certificate and private key
+//     (PEM); both must be set together
+//   - tls_ca_file: path to a CA certificate file (PEM) used to verify the server
+//   - tls_insecure_skip_verify=true or skip_verify=true: skip server certificate
+//     verification (for testing only)
 //
 // Example:
 //
@@ -490,9 +496,15 @@ func setupFailoverConnParams(u *url.URL, o *FailoverOptions) (*FailoverOptions, 
 		o.SentinelAddrs = append(o.SentinelAddrs, net.JoinHostPort(h, p))
 	}
 
-	if o.TLSConfig != nil && q.has("skip_verify") {
-		o.TLSConfig.InsecureSkipVerify = q.bool("skip_verify")
+	serverName := ""
+	if len(o.SentinelAddrs) > 0 {
+		serverName = tlsServerName(o.SentinelAddrs[0])
 	}
+	tlsCfg, err := applyTLSQueryOptions(&q, o.TLSConfig, serverName)
+	if err != nil {
+		return nil, err
+	}
+	o.TLSConfig = tlsCfg
 
 	// any parameters left?
 	if r := q.remaining(); len(r) > 0 {

--- a/sentinel.go
+++ b/sentinel.go
@@ -376,8 +376,9 @@ func (opt *FailoverOptions) clusterOptions() *ClusterOptions {
 //     URL attributes (scheme, host, userinfo, resp.), query parameters using these
 //     names will be treated as unknown parameters
 //   - unknown parameter names will result in an error
-//   - TLS options (applied when the scheme is rediss://, or when any TLS file path /
-//     skip-verify option is present — in which case a tls.Config is created):
+//   - TLS options (applied when the scheme is rediss://, or when any TLS file path is
+//     present, or when skip_verify/tls_insecure_skip_verify is true — in which case a
+//     tls.Config is created). A false skip-verify value alone does not enable TLS:
 //   - tls_cert_file, tls_key_file: paths to a client certificate and private key
 //     (PEM); both must be set together
 //   - tls_ca_file: path to a CA certificate file (PEM) used to verify the server
@@ -496,11 +497,9 @@ func setupFailoverConnParams(u *url.URL, o *FailoverOptions) (*FailoverOptions, 
 		o.SentinelAddrs = append(o.SentinelAddrs, net.JoinHostPort(h, p))
 	}
 
-	serverName := ""
-	if len(o.SentinelAddrs) > 0 {
-		serverName = tlsServerName(o.SentinelAddrs[0])
-	}
-	tlsCfg, err := applyTLSQueryOptions(&q, o.TLSConfig, serverName)
+	// Leave ServerName empty: Failover TLS is shared across master/replicas and
+	// must not pin verification to the first sentinel host from the URL.
+	tlsCfg, err := applyTLSQueryOptions(&q, o.TLSConfig, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Adds TLS file-path and skip-verify query parameters to `ParseURL` (and the cluster/failover URL parsers) so callers can configure client certs, CA trust, and `InsecureSkipVerify` from a connection string.

Closes #2024

Supported query parameters:
- `tls_cert_file` / `tls_key_file` — client certificate and private key (PEM); both required if either is set
- `tls_ca_file` — CA certificate (PEM) loaded into `RootCAs`
- `tls_insecure_skip_verify` — skip server cert verification (testing only)
- `skip_verify` — existing alias, still supported

Behavior:
- Applied for `rediss://`, or when any TLS option is present on `redis://` (creates a `tls.Config` with `MinVersion` TLS 1.2 and `ServerName` from the host)
- Shared `applyTLSQueryOptions` helper used by `ParseURL`, `ParseClusterURL`, and `ParseFailoverURL`
- Load errors (missing files, invalid PEM, cert without key) return clear `redis: ...` errors

## Test plan

- [x] Unit tests generate self-signed PEMs in `t.TempDir()` (no network, no committed private keys)
- [x] Cover cert/key/CA load, redis:// enabling TLS when files present, skip-verify aliases, error paths, cluster and failover URLs
- [x] `go test -run 'TestParseURL' .`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TLS setup for all URL-based clients, including skip-verify and file loading; mistakes could weaken verification or break mTLS, but behavior is heavily tested and scoped to parsing.
> 
> **Overview**
> Extends **Redis connection URL parsing** so TLS can be configured from query parameters, not only via `rediss://` and inline `skip_verify`.
> 
> A shared **`applyTLSQueryOptions`** helper now loads **`tls_cert_file` / `tls_key_file`** (client PEM, both required), **`tls_ca_file`** (custom **`RootCAs`**), and **`tls_insecure_skip_verify`** or **`skip_verify`** (OR’d; both names are always parsed so invalid values are not hidden). **`redis://`** gets a **`tls.Config`** only when cert/CA paths are present or skip-verify is **true**; **`skip_verify=false` alone** does not turn on TLS. New configs use **TLS 1.2** minimum and **`ServerName`** from the URL host for standalone **`ParseURL`** via **`tlsServerName`**.
> 
> **`ParseClusterURL`** and **`ParseFailoverURL`** use the same helper with an **empty `ServerName`** so multi-node / failover dials are not pinned to the first seed host. Docs for all three parsers are updated; **`sentinel.go`** has a trivial comment whitespace fix.
> 
> **`TestParseURLTLSOptions`** adds broad coverage (temp PEMs, error paths, cluster/failover URLs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2c9cb6a1b88eb6ce466c4cd6bf09594e05c92f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->