### PR TITLE
fix(pool): fire OnRemove on putConn eviction paths

### DIFF
--- a/internal/pool/hooks_test.go
+++ b/internal/pool/hooks_test.go
@@ -265,3 +265,93 @@ func TestCloseConnInvokesOnRemove(t *testing.T) {
 		t.Errorf("Expected OnRemove to fire once for CloseConn, got %d", hook.OnRemoveCalled)
 	}
 }
+
+// closeOnPutHook is a PoolHook whose OnPut drives the connection to StateClosed while still
+// asking for it to be pooled, so that Put reaches the StateClosed-on-Put branch of putConn.
+type closeOnPutHook struct {
+	onRemoveCalled int
+}
+
+func (h *closeOnPutHook) OnGet(ctx context.Context, conn *Conn, isNewConn bool) (bool, error) {
+	return true, nil
+}
+
+func (h *closeOnPutHook) OnPut(ctx context.Context, conn *Conn) (bool, bool, error) {
+	conn.GetStateMachine().Transition(StateClosed)
+	return true, false, nil
+}
+
+func (h *closeOnPutHook) OnRemove(ctx context.Context, conn *Conn, reason error) {
+	h.onRemoveCalled++
+}
+
+func TestPutConnEvictsOnIdleFullInvokesOnRemove(t *testing.T) {
+	opt := &Options{
+		Dialer: func(ctx context.Context) (net.Conn, error) {
+			return &net.TCPConn{}, nil
+		},
+		PoolSize:           2,
+		MaxIdleConns:       1,
+		MaxConcurrentDials: 2,
+		DialTimeout:        time.Second,
+	}
+
+	p := NewConnPool(opt)
+	defer p.Close()
+
+	hook := &TestHook{ShouldPool: true, ShouldAccept: true}
+	p.AddPoolHook(hook)
+
+	ctx := context.Background()
+	cn1, err := p.newConn(ctx, true)
+	if err != nil {
+		t.Fatalf("newConn cn1 failed: %v", err)
+	}
+	cn1.GetStateMachine().Transition(StateInUse)
+	cn2, err := p.newConn(ctx, true)
+	if err != nil {
+		t.Fatalf("newConn cn2 failed: %v", err)
+	}
+	cn2.GetStateMachine().Transition(StateInUse)
+
+	p.putConnWithoutTurn(ctx, cn1) // pools: idle=1
+	p.putConnWithoutTurn(ctx, cn2) // idle pool full -> evicted on Put
+
+	if hook.OnRemoveCalled != 1 {
+		t.Errorf("Expected OnRemove to fire once for idle-full eviction, got %d", hook.OnRemoveCalled)
+	}
+	if got := p.Stats().StaleConns; got != 1 {
+		t.Errorf("Expected StaleConns=1, got %d", got)
+	}
+}
+
+func TestPutConnStateClosedByHookInvokesOnRemove(t *testing.T) {
+	opt := &Options{
+		Dialer: func(ctx context.Context) (net.Conn, error) {
+			return &net.TCPConn{}, nil
+		},
+		PoolSize:           1,
+		MaxIdleConns:       1,
+		MaxConcurrentDials: 1,
+		DialTimeout:        time.Second,
+	}
+
+	p := NewConnPool(opt)
+	defer p.Close()
+
+	hook := &closeOnPutHook{}
+	p.AddPoolHook(hook)
+
+	ctx := context.Background()
+	cn, err := p.newConn(ctx, true)
+	if err != nil {
+		t.Fatalf("newConn failed: %v", err)
+	}
+	cn.GetStateMachine().Transition(StateInUse)
+
+	p.putConnWithoutTurn(ctx, cn) // OnPut sets StateClosed -> StateClosed-on-Put branch
+
+	if hook.onRemoveCalled != 1 {
+		t.Errorf("Expected OnRemove to fire once for StateClosed-on-Put, got %d", hook.onRemoveCalled)
+	}
+}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -72,6 +72,11 @@ var (
 
 	// errConnNotPooled is returned when trying to return a non-pooled connection to the pool.
 	errConnNotPooled = errors.New("connection not pooled")
+
+	// errConnEvictedIdle is passed to OnRemove hooks when a pooled connection is evicted on
+	// Put because the idle pool is already at MaxIdleConns.
+	errConnEvictedIdle = errors.New("connection evicted: idle pool at capacity")
+
 	// metricCallbackMu protects all global metric callback functions for thread-safe access.
 	metricCallbackMu sync.RWMutex
 
@@ -1293,6 +1298,9 @@ func (p *ConnPool) putConn(ctx context.Context, cn *Conn, freeTurn bool) {
 				// expected state, don't log it
 			case StateClosed:
 				internal.Logger.Printf(ctx, "Unexpected conn[%d] state changed by hook to %v, closing it", cn.GetID(), currentState)
+				if hookManager != nil {
+					hookManager.ProcessOnRemove(ctx, cn, errHookRequestedRemoval)
+				}
 				shouldCloseConn = true
 				removedFromPool = p.removeConnWithLock(cn)
 			default:
@@ -1360,6 +1368,9 @@ func (p *ConnPool) putConn(ctx context.Context, cn *Conn, freeTurn bool) {
 		}
 	} else {
 		shouldCloseConn = true
+		if hookManager != nil {
+			hookManager.ProcessOnRemove(ctx, cn, errConnEvictedIdle)
+		}
 		removedFromPool = p.removeConnWithLock(cn)
 
 		// Only emit if we actually removed it from the map (not already taken by Close()).


### PR DESCRIPTION
closes #3931 

putConn's idle-pool-full branch and StateClosed-on-Put branch removed connections without firing ProcessOnRemove, so registered OnRemove hooks never ran. The streaming credentials ReAuthPoolHook.OnRemove is the sole cleaner for per-conn listeners (which hold *pool.Conn), skipping it leaked one listener per eviction, ~1:1 with StaleConns, until OOM.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path `putConn` hook and removal ordering; behavior change is intentional cleanup with targeted tests, but any hook relying on the old silent eviction could see new `OnRemove` calls.
> 
> **Overview**
> **`putConn`** now invokes **`ProcessOnRemove`** on two removal paths that previously dropped connections without notifying hooks: when **`OnPut`** leaves the conn in **`StateClosed`**, and when the idle pool is already at **`MaxIdleConns`** so the returned conn is evicted (reason **`errConnEvictedIdle`**).
> 
> That aligns hook cleanup with **`removeConnInternal`** / **`CloseConn`**, so per-connection teardown (e.g. streaming-credentials listeners in **`ReAuthPoolHook.OnRemove`**) runs on idle-capacity evictions instead of leaking until OOM.
> 
> Regression tests cover idle-full eviction (**`StaleConns`**) and hook-driven **`StateClosed`** on put.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d488782b438fbff05699f6642bf837e3c780d0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->