### PR TITLE
fix(rediscmd): redact credential args in AppendCmd

### DIFF
--- a/extra/rediscmd/rediscmd.go
+++ b/extra/rediscmd/rediscmd.go
@@ -46,9 +46,16 @@ func CmdsString(cmds []redis.Cmder) (string, string) {
 }
 
 func AppendCmd(b []byte, cmd redis.Cmder) []byte {
-	for i, arg := range cmd.Args() {
+	args := cmd.Args()
+	secret := secretArgs(args)
+
+	for i, arg := range args {
 		if i > 0 {
 			b = append(b, ' ')
+		}
+		if secret != nil && secret[i] {
+			b = append(b, redactedArg...)
+			continue
 		}
 		b = appendArg(b, arg)
 	}
@@ -59,6 +66,108 @@ func AppendCmd(b []byte, cmd redis.Cmder) []byte {
 	}
 
 	return b
+}
+
+const redactedArg = "<redacted>"
+
+// secretConfigParams are the CONFIG SET parameters whose value is a credential.
+var secretConfigParams = []string{
+	"requirepass",
+	"masterauth",
+	"tls-key-file-pass",
+	"tls-client-key-file-pass",
+}
+
+// secretArgs marks the positions in args that hold a credential. It returns nil
+// when the command carries none, which is the common case.
+//
+// The client sends HELLO ... AUTH on every handshake and AUTH on every
+// streaming-credentials rotation, both through the regular hook chain, so a
+// tracing hook sees them whether or not the caller ever issued one.
+func secretArgs(args []interface{}) []bool {
+	if len(args) < 2 {
+		return nil
+	}
+
+	var marks []bool
+	mark := func(i int) {
+		if i < 1 || i >= len(args) {
+			return
+		}
+		if marks == nil {
+			marks = make([]bool, len(args))
+		}
+		marks[i] = true
+	}
+
+	switch {
+	case equalFoldArg(args, 0, "auth"):
+		// AUTH password | AUTH username password
+		mark(len(args) - 1)
+
+	case equalFoldArg(args, 0, "hello"):
+		// HELLO ver [AUTH username password] [SETNAME name]
+		if equalFoldArg(args, 2, "auth") {
+			mark(4)
+		}
+
+	case equalFoldArg(args, 0, "config") && equalFoldArg(args, 1, "set"):
+		// CONFIG SET param value [param value ...]
+		for i := 2; i+1 < len(args); i += 2 {
+			for _, param := range secretConfigParams {
+				if equalFoldArg(args, i, param) {
+					mark(i + 1)
+					break
+				}
+			}
+		}
+
+	case equalFoldArg(args, 0, "acl") && equalFoldArg(args, 1, "setuser"):
+		// ACL SETUSER username rule...; the >pass, <pass, #hash and !hash rules
+		// embed the credential in the rule itself.
+		for i := 3; i < len(args); i++ {
+			rule := argString(args, i)
+			if len(rule) < 2 {
+				continue
+			}
+			switch rule[0] {
+			case '>', '<', '#', '!':
+				mark(i)
+			}
+		}
+
+	case equalFoldArg(args, 0, "migrate"):
+		// MIGRATE host port key db timeout [AUTH password] [AUTH2 user password]
+		for i := 6; i < len(args); i++ {
+			if equalFoldArg(args, i, "keys") {
+				break
+			}
+			if equalFoldArg(args, i, "auth") {
+				mark(i + 1)
+			} else if equalFoldArg(args, i, "auth2") {
+				mark(i + 2)
+			}
+		}
+	}
+
+	return marks
+}
+
+func equalFoldArg(args []interface{}, i int, want string) bool {
+	return strings.EqualFold(argString(args, i), want)
+}
+
+func argString(args []interface{}, i int) string {
+	if i < 0 || i >= len(args) {
+		return ""
+	}
+	switch v := args[i].(type) {
+	case string:
+		return v
+	case []byte:
+		return String(v)
+	}
+	return ""
 }
 
 func appendArg(b []byte, v interface{}) []byte {

--- a/extra/rediscmd/rediscmd_test.go
+++ b/extra/rediscmd/rediscmd_test.go
@@ -1,10 +1,13 @@
 package rediscmd
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"
+
+	"github.com/redis/go-redis/v9"
 )
 
 func TestGinkgo(t *testing.T) {
@@ -28,5 +31,33 @@ var _ = Describe("AppendArg", func() {
 		Entry("", "foo-123_BAR", "foo-123_BAR"),
 		Entry("", "foo\nbar", "666f6f0a626172"),
 		Entry("", "\000", "00"),
+	)
+})
+
+var _ = Describe("CmdString", func() {
+	DescribeTable("keeps credentials out of the rendered command",
+		func(args []interface{}, wanted string) {
+			Expect(CmdString(redis.NewCmd(context.Background(), args...))).To(Equal(wanted))
+		},
+
+		Entry("", []interface{}{"auth", "s3cret"}, "auth <redacted>"),
+		Entry("", []interface{}{"auth", "alice", "s3cret"}, "auth alice <redacted>"),
+		Entry("", []interface{}{"AUTH", "s3cret"}, "AUTH <redacted>"),
+		Entry("", []interface{}{"hello", 3, "auth", "alice", "s3cret", "setname", "app"},
+			"hello 3 auth alice <redacted> setname app"),
+		Entry("", []interface{}{"hello", 3, "setname", "app"}, "hello 3 setname app"),
+		Entry("", []interface{}{"config", "set", "requirepass", "s3cret"},
+			"config set requirepass <redacted>"),
+		Entry("", []interface{}{"config", "set", "maxmemory", "100mb", "masterauth", "s3cret"},
+			"config set maxmemory 100mb masterauth <redacted>"),
+		Entry("", []interface{}{"config", "get", "requirepass"}, "config get requirepass"),
+		Entry("", []interface{}{"acl", "setuser", "bob", "on", ">s3cret", "~app:*", "+get"},
+			"acl setuser bob on <redacted> ~app:* +get"),
+		Entry("", []interface{}{"migrate", "h", "6379", "k", 0, 100, "auth", "s3cret"},
+			"migrate h 6379 k 0 100 auth <redacted>"),
+		Entry("", []interface{}{"migrate", "h", "6379", "", 0, 100, "keys", "auth", "k2"},
+			"migrate h 6379  0 100 keys auth k2"),
+		Entry("", []interface{}{"get", "key"}, "get key"),
+		Entry("", []interface{}{"set", "auth", "value"}, "set auth value"),
 	)
 })


### PR DESCRIPTION
AppendCmd renders every argument verbatim and is the only renderer behind redisotel's db.statement attribute and rediscensus's redis.cmd attribute. The client issues HELLO <ver> AUTH <user> <password> on every handshake and AUTH <token> on every streaming-credentials rotation, and both run through the regular hook chain, so a tracing hook sees them whether or not the caller ever issued one. redisotel avoids the exposure by dropping whole AUTH and HELLO spans in DefaultCommandFilter, but rediscensus has no filter at all, and against a fake RESP3 server I watched the handshake password land verbatim in an exported span attribute. That filter also stops at those two commands, so CONFIG SET requirepass and ACL SETUSER >password still leave both modules in the clear under default settings. Masking the credential positions here covers every consumer of the shared renderer rather than having each instrumentation module grow its own command filter. Usernames and every other argument are left as they were so traces stay readable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observability output for security-sensitive commands; behavior is narrowly scoped to credential positions with tests, but any misclassified arg could hide or over-redact trace data.
> 
> **Overview**
> **`AppendCmd`** (and thus **`CmdString`**) now replaces known credential argument positions with **`<redacted>`** instead of rendering them verbatim. That string backs **`db.statement`** in redisotel and **`redis.cmd`** in rediscensus, so handshake **`HELLO … AUTH`**, rotation **`AUTH`**, and similar client-issued commands no longer leak passwords into traces when those hooks record the full command.
> 
> Redaction is command-aware: last arg on **`AUTH`**; password on **`HELLO … AUTH`**; values for secret **`CONFIG SET`** params (`requirepass`, `masterauth`, TLS key pass options); credential-bearing **`ACL SETUSER`** rules (`>`, `<`, `#`, `!`); **`MIGRATE`** **`AUTH`** / **`AUTH2`** segments (stopping at **`KEYS`**). Usernames and non-secret args are unchanged. Tests cover these cases plus false positives (e.g. **`SET auth value`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 299376bfca58659ca76d0a891283228667ba3779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->