### PR TITLE
fix(pool): log buffered push data at debug level

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -2005,12 +2005,19 @@ func (p *ConnPool) isHealthyConn(cn *Conn, nowNs int64) bool {
 			// before the OnGet state check rejects it.
 			if replyType, err := cn.PeekReplyTypeForCheck(); err == nil && replyType == proto.RespPush {
 				// For RESP3 connections with push notifications, we allow some buffered data
-				// The client will process these notifications before using the connection
-				internal.Logger.Printf(
-					context.Background(),
-					"push: conn[%d] has buffered data, likely push notifications - will be processed by client",
-					cn.GetID(),
-				)
+				// The client will process these notifications before using the connection.
+				// This is the normal healthy path for any client with server-side
+				// invalidation or maintenance notifications (client-side caching parks
+				// an invalidate frame on idle conns after every tracked write), so it
+				// logs at debug level only — at default level it would flood the log
+				// on every pool Get under a write-heavy tracked workload.
+				if internal.LogLevel.DebugOrAbove() {
+					internal.Logger.Printf(
+						context.Background(),
+						"push: conn[%d] has buffered data, likely push notifications - will be processed by client",
+						cn.GetID(),
+					)
+				}
 
 				// Update timestamp for healthy connection
 				cn.SetUsedAtNs(nowNs)


### PR DESCRIPTION
The buffered-push-data notice in isHealthyConn fired unconditionally.
With client-side caching every tracked write parks an invalidate frame on idle pooled conns, so at default log level the line floods the log on nearly every pool Get under write-heavy workloads. It documents the normal healthy path, not a problem - gate it behind LogLevelDebug like the equivalent notices in maintnotifications.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in pool health logging; no change to connection selection or push handling.
> 
> **Overview**
> When `isHealthyConn` treats idle RESP3 connections with buffered **push** frames as healthy (client-side caching invalidations, maintenance notifications, etc.), it no longer logs that fact at the default log level.
> 
> The **"push: conn[%d] has buffered data…"** line is wrapped in `internal.LogLevel.DebugOrAbove()`, aligned with similar notices in maintnotifications. Pool health checks and connection reuse are unchanged; only log noise under write-heavy tracked workloads is reduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4367d8678f624aef910cf3382c49eba8a82aa381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->