### PR TITLE
chore(docs): point security reports at Redis VDP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,14 @@ that you are using supported versions of Docker and go.
 ### Security Vulnerabilities
 
 **NOTE**: If you find a security vulnerability, do NOT open an issue.
-Email [Redis Open Source (<oss@redis.com>)](mailto:oss@redis.com) instead.
+
+If you believe you have found a security vulnerability, to ensure proper
+review and assessment, we kindly ask vulnerability reports be submitted
+through our
+[Redis Vulnerability Disclosure Program](https://redis.io/redis-responsible-vulnerability-disclosure/).
+Alternatively reach out via email to
+[security@redis.com](mailto:security@redis.com). See
+[SECURITY.md](SECURITY.md) for the full policy.
 
 In order to determine whether you are dealing with a security issue, ask
 yourself these two questions:
@@ -83,8 +90,8 @@ yourself these two questions:
 
 If the answer to either of those two questions are *yes*, then you're
 probably dealing with a security issue. Note that even if you answer
-*no*  to both questions, you may still be dealing with a security
-issue, so if you're unsure, just email [us](mailto:oss@redis.com).
+*no* to both questions, you may still be dealing with a security
+issue, so if you're unsure, report it through the channels above.
 
 ### Everything Else
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+go-redis is generally backward compatible with very few exceptions, so we
+recommend users to always use the latest version to experience stability,
+performance and security. Security fixes are released as part of the latest
+release of the v9 line; older major versions are no longer maintained.
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability, to ensure proper
+review and assessment, we kindly ask vulnerability reports be submitted
+through our
+[Redis Vulnerability Disclosure Program](https://redis.io/redis-responsible-vulnerability-disclosure/).
+Alternatively reach out via email to
+[security@redis.com](mailto:security@redis.com).
+
+Please do **not** report security vulnerabilities through public GitHub
+issues.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes to contributor security reporting; no runtime or library behavior affected.
> 
> **Overview**
> **Security reporting** is centralized on Redis’s official channels instead of the old `oss@redis.com` contact.
> 
> `CONTRIBUTING.md` now directs reporters to the [Redis Vulnerability Disclosure Program](https://redis.io/redis-responsible-vulnerability-disclosure/) and `security@redis.com`, and links to the new policy file. The “if you’re unsure” guidance uses those same channels.
> 
> A new **`SECURITY.md`** documents supported versions (security fixes on latest v9) and repeats the VDP/email reporting rules, explicitly disallowing public GitHub issues for vulnerabilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ee7468a28c6d2ebab155151c38ee92c92ca5c69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->