### PR TITLE
feat(multidb): pipeline, tx pipeline and autopipeline support

### DIFF
--- a/command.go
+++ b/command.go
@@ -384,6 +384,10 @@ type baseCmd struct {
 	// other point in the command's life.
 	slotCache uint16
 
+	// noRetry marks the command as never-retryable (see NoRetry). It is set
+	// before the command is handed to an execution path, never concurrently.
+	noRetry bool
+
 	// ready, when non-nil, is the batch whose done channel closes once the
 	// command has executed. It is set only by the deferred (async)
 	// autopipeliner, which hands the command back to the caller before it
@@ -568,7 +572,14 @@ func (cmd *baseCmd) readRawReply(rd *proto.Reader) (err error) {
 // io.Writer (like RawWriteToCmd) should override this to return true since
 // partial writes cannot be undone on retry.
 func (cmd *baseCmd) NoRetry() bool {
-	return false
+	return cmd.noRetry
+}
+
+// setNoRetry marks the command as never-retryable, e.g. the synthetic MULTI
+// of a MultiDB transaction whose batch must not be replayed by the member
+// client's retry loop.
+func (cmd *baseCmd) setNoRetry(v bool) {
+	cmd.noRetry = v
 }
 
 func (cmd *baseCmd) GetCmdType() CmdType {
@@ -595,6 +606,7 @@ func (cmd *baseCmd) cloneBaseCmd() baseCmd {
 		rawVal:       cmd.rawVal,
 		_readTimeout: readTimeout,
 		cmdType:      cmd.cmdType,
+		noRetry:      cmd.noRetry,
 	}
 }
 

--- a/multidb.go
+++ b/multidb.go
@@ -499,16 +499,21 @@ func (c *MultiDBClient) ForceActiveIndex(ctx context.Context, index int) error {
 }
 
 // AddDatabase implements MultiDBCtrl. Adding a cluster member is refused
-// while an autopipeliner instance exists: the cached autopipeliner was built
-// without the cluster-specific safeguards and a later failover onto the new
-// member would route merged batches around them. Close the autopipeliners
-// first, add the member, then recreate them.
+// while a live autopipeliner instance exists: the cached autopipeliner was
+// built without the cluster-specific safeguards and a later failover onto the
+// new member would route merged batches around them. Close the autopipeliners
+// first, add the member, then recreate them (closed instances do not block).
 func (c *MultiDBClient) AddDatabase(ctx context.Context, cfg MultiDBClientConfig) (int, error) {
 	if cfg.ClusterOptions != nil {
+		// Hold autopipelinerMu across the check AND the membership change so
+		// a concurrent first AutoPipeline call (which creates the pipeliner
+		// under the same mutex and re-checks membership there) cannot
+		// interleave between them.
 		c.autopipelinerMu.Lock()
-		hasAP := c.autopipeliner != nil || c.asyncAutopipeliner != nil
-		c.autopipelinerMu.Unlock()
-		if hasAP {
+		defer c.autopipelinerMu.Unlock()
+		hasLiveAP := (c.autopipeliner != nil && !c.autopipeliner.closed.Load()) ||
+			(c.asyncAutopipeliner != nil && !c.asyncAutopipeliner.closed.Load())
+		if hasLiveAP {
 			return -1, errors.New("redis: multidb: close autopipeliners before adding a cluster member database")
 		}
 	}

--- a/multidb.go
+++ b/multidb.go
@@ -415,6 +415,13 @@ type MultiDBClient struct {
 	autopipeliner       *AutoPipeliner
 	asyncAutopipeliner  *AutoPipeliner
 	autopipelinerClosed bool
+	// pendingClusterAdds counts cluster AddDatabase calls that passed the
+	// liveness check and released autopipelinerMu to run the member's initial
+	// health probe. The autopipeliner build funcs refuse to create an instance
+	// while it is > 0, which keeps the cluster-vs-autopipeliner invariant without
+	// holding the mutex across user-supplied health checks — a check that calls
+	// AutoPipeline itself would otherwise deadlock on the non-reentrant mutex.
+	pendingClusterAdds int // guarded by autopipelinerMu
 
 	// closeOnce serializes concurrent Close calls so a second caller cannot
 	// race ahead to core.close() while the first is still draining the
@@ -558,19 +565,31 @@ func (c *MultiDBClient) AddDatabase(ctx context.Context, cfg MultiDBClientConfig
 		return -1, ErrClosed
 	}
 	if cfg.ClusterOptions != nil {
-		// Hold autopipelinerMu across the liveness check AND the membership
-		// change so a concurrent first AutoPipeline call (which creates the
-		// pipeliner under the same mutex and re-checks membership there) cannot
-		// interleave between them. Once shutdown has begun the cached pointers
-		// are already cleared, so the liveness check would pass and admit the
-		// cluster member mid-drain; a batch failing over during that drain could
-		// then reach it through the unsupported unsharded autopipeline path.
-		defer c.autopipelinerMu.Unlock()
+		// A live autopipeliner and a cluster member must never coexist: the
+		// cached instance was built without the cluster-specific safeguards and a
+		// later failover onto the new member would route merged batches around
+		// them. Check liveness under the mutex, then mark the add as pending and
+		// RELEASE the mutex before core.addDatabase. That call runs the member's
+		// initial health probe synchronously, and a custom check that calls
+		// AutoPipeline()/AsyncAutoPipeline() would otherwise deadlock on the
+		// non-reentrant mutex. The pending count keeps the invariant the lock used
+		// to hold: the build funcs (see AutoPipelineWithOptions) refuse to create
+		// an instance while a cluster add is in flight, so no unsharded instance
+		// can appear between this check and the member landing.
 		hasLiveAP := (c.autopipeliner != nil && !c.autopipeliner.closed.Load()) ||
 			(c.asyncAutopipeliner != nil && !c.asyncAutopipeliner.closed.Load())
 		if hasLiveAP {
+			c.autopipelinerMu.Unlock()
 			return -1, errors.New("redis: multidb: close autopipeliners before adding a cluster member database")
 		}
+		c.pendingClusterAdds++
+		c.autopipelinerMu.Unlock()
+		// Deferred so the count is released on a panic in the member path too.
+		defer func() {
+			c.autopipelinerMu.Lock()
+			c.pendingClusterAdds--
+			c.autopipelinerMu.Unlock()
+		}()
 		return c.core.addDatabase(ctx, cfg)
 	}
 	// Standalone: a standalone member has no cluster-autopipeline hazard, so the

--- a/multidb.go
+++ b/multidb.go
@@ -582,8 +582,20 @@ func (c *MultiDBClient) SetAutoFallback(enabled bool) {
 	c.core.setAutoFallback(enabled)
 }
 
+// AddHook adds a hook to the MultiDB-level chain that wraps Process, Pipeline
+// and TxPipeline — the paths this client runs directly.
+//
+// A DialHook added here never fires: a MultiDBClient does not dial, it
+// delegates every connection to its member databases. To instrument member
+// dialing (or any other per-connection behaviour), install the hook on the
+// member with AddDatabaseHook instead.
+func (c *MultiDBClient) AddHook(hook Hook) {
+	c.hooksMixin.AddHook(hook)
+}
+
 // AddDatabaseHook installs a hook on the underlying client of the database with
-// the given id. It is mainly useful for testing and instrumentation.
+// the given id. Unlike AddHook it wraps the member connection directly, so it
+// is the way to instrument member dialing and per-connection behaviour.
 func (c *MultiDBClient) AddDatabaseHook(id int, hook Hook) error {
 	return c.core.addDatabaseHook(id, hook)
 }

--- a/multidb.go
+++ b/multidb.go
@@ -498,8 +498,20 @@ func (c *MultiDBClient) ForceActiveIndex(ctx context.Context, index int) error {
 	return c.core.setActiveIndex(ctx, index, false)
 }
 
-// AddDatabase implements MultiDBCtrl.
+// AddDatabase implements MultiDBCtrl. Adding a cluster member is refused
+// while an autopipeliner instance exists: the cached autopipeliner was built
+// without the cluster-specific safeguards and a later failover onto the new
+// member would route merged batches around them. Close the autopipeliners
+// first, add the member, then recreate them.
 func (c *MultiDBClient) AddDatabase(ctx context.Context, cfg MultiDBClientConfig) (int, error) {
+	if cfg.ClusterOptions != nil {
+		c.autopipelinerMu.Lock()
+		hasAP := c.autopipeliner != nil || c.asyncAutopipeliner != nil
+		c.autopipelinerMu.Unlock()
+		if hasAP {
+			return -1, errors.New("redis: multidb: close autopipeliners before adding a cluster member database")
+		}
+	}
 	return c.core.addDatabase(ctx, cfg)
 }
 

--- a/multidb.go
+++ b/multidb.go
@@ -551,18 +551,20 @@ func (c *MultiDBClient) AddDatabase(ctx context.Context, cfg MultiDBClientConfig
 		// interleave between them.
 		c.autopipelinerMu.Lock()
 		defer c.autopipelinerMu.Unlock()
+		// Close sets this under the same mutex before it starts draining the
+		// autopipeliners. Once shutdown has begun the cached pointers are
+		// already cleared, so the liveness check below would pass and admit the
+		// cluster member mid-drain; a batch failing over during that drain could
+		// then reach it through the unsupported unsharded autopipeline path.
+		// Reject the add instead: the client is going away.
+		if c.autopipelinerClosed {
+			return -1, ErrClosed
+		}
 		hasLiveAP := (c.autopipeliner != nil && !c.autopipeliner.closed.Load()) ||
 			(c.asyncAutopipeliner != nil && !c.asyncAutopipeliner.closed.Load())
 		if hasLiveAP {
 			return -1, errors.New("redis: multidb: close autopipeliners before adding a cluster member database")
 		}
-		// Known narrow window: AutoPipeliner.Close flips its closed flag
-		// before draining already-accepted batches, so an AddDatabase racing
-		// a direct ap.Close() can pass this check while the drain is still
-		// flushing. Those batches only reach the new cluster member if a
-		// failover selects it during that same drain. For strict guarantees,
-		// let Close return before calling AddDatabase (MultiDBClient.Close
-		// already serializes both on autopipelinerMu).
 	}
 	return c.core.addDatabase(ctx, cfg)
 }

--- a/multidb.go
+++ b/multidb.go
@@ -412,6 +412,12 @@ type MultiDBClient struct {
 	autopipeliner       *AutoPipeliner
 	asyncAutopipeliner  *AutoPipeliner
 	autopipelinerClosed bool
+
+	// closeOnce serializes concurrent Close calls so a second caller cannot
+	// race ahead to core.close() while the first is still draining the
+	// autopipeliner; closeErr carries that single close result to every caller.
+	closeOnce sync.Once
+	closeErr  error
 }
 
 // NewMultiDBClient creates a MultiDBClient for the configured member
@@ -490,23 +496,33 @@ func (c *MultiDBClient) Process(ctx context.Context, cmd Cmder) error {
 // Close stops the autopipeliners, the background loop, and every underlying
 // client.
 func (c *MultiDBClient) Close() error {
-	c.autopipelinerMu.Lock()
-	ap, async := c.autopipeliner, c.asyncAutopipeliner
-	c.autopipeliner, c.asyncAutopipeliner = nil, nil
-	c.autopipelinerClosed = true
-	c.autopipelinerMu.Unlock()
-	var firstErr error
-	for _, p := range []*AutoPipeliner{ap, async} {
-		if p != nil {
-			if err := p.Close(); err != nil && firstErr == nil {
-				firstErr = err
+	// Serialize concurrent Close calls. Without this a second caller can
+	// observe the autopipeliner pointers already cleared, skip the drain loop,
+	// and call core.close() while the first caller's AutoPipeliner.Close is
+	// still flushing queued batches — tearing down the member clients under the
+	// drain and failing those writes with ErrClosed. Once blocks the second
+	// caller until the single ordered drain-then-close completes; both return
+	// the same error.
+	c.closeOnce.Do(func() {
+		c.autopipelinerMu.Lock()
+		ap, async := c.autopipeliner, c.asyncAutopipeliner
+		c.autopipeliner, c.asyncAutopipeliner = nil, nil
+		c.autopipelinerClosed = true
+		c.autopipelinerMu.Unlock()
+		var firstErr error
+		for _, p := range []*AutoPipeliner{ap, async} {
+			if p != nil {
+				if err := p.Close(); err != nil && firstErr == nil {
+					firstErr = err
+				}
 			}
 		}
-	}
-	if err := c.core.close(); err != nil && firstErr == nil {
-		firstErr = err
-	}
-	return firstErr
+		if err := c.core.close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		c.closeErr = firstErr
+	})
+	return c.closeErr
 }
 
 // ActiveDatabaseID implements MultiDBCtrl.

--- a/multidb.go
+++ b/multidb.go
@@ -539,6 +539,13 @@ func (c *MultiDBClient) AddDatabase(ctx context.Context, cfg MultiDBClientConfig
 		if hasLiveAP {
 			return -1, errors.New("redis: multidb: close autopipeliners before adding a cluster member database")
 		}
+		// Known narrow window: AutoPipeliner.Close flips its closed flag
+		// before draining already-accepted batches, so an AddDatabase racing
+		// a direct ap.Close() can pass this check while the drain is still
+		// flushing. Those batches only reach the new cluster member if a
+		// failover selects it during that same drain. For strict guarantees,
+		// let Close return before calling AddDatabase (MultiDBClient.Close
+		// already serializes both on autopipelinerMu).
 	}
 	return c.core.addDatabase(ctx, cfg)
 }

--- a/multidb.go
+++ b/multidb.go
@@ -33,7 +33,10 @@ const (
 var (
 	// ErrTemporarilyNotAvailable is returned when no healthy database can be
 	// selected right now; the client keeps attempting failover on subsequent
-	// commands.
+	// commands. It is also returned when the member a command or batch was routed
+	// to was removed mid-flight (a concurrent RemoveDatabase or manual switch): the
+	// client is still open and the next attempt lands on the live active, so the
+	// caller should retry rather than treat it as terminal.
 	ErrTemporarilyNotAvailable = errors.New("redis: multidb: no healthy database available (temporarily)")
 	// ErrPermanentlyNotAvailable is returned once MaxFailoverAttempts
 	// consecutive failover attempts have failed; the application should stop

--- a/multidb.go
+++ b/multidb.go
@@ -521,8 +521,20 @@ func (c *MultiDBClient) ForceActiveDatabase(ctx context.Context, id int) error {
 	return c.core.setActiveDatabase(ctx, id, false)
 }
 
-// AddDatabase implements MultiDBCtrl.
+// AddDatabase implements MultiDBCtrl. Adding a cluster member is refused
+// while an autopipeliner instance exists: the cached autopipeliner was built
+// without the cluster-specific safeguards and a later failover onto the new
+// member would route merged batches around them. Close the autopipeliners
+// first, add the member, then recreate them.
 func (c *MultiDBClient) AddDatabase(ctx context.Context, cfg MultiDBClientConfig) (int, error) {
+	if cfg.ClusterOptions != nil {
+		c.autopipelinerMu.Lock()
+		hasAP := c.autopipeliner != nil || c.asyncAutopipeliner != nil
+		c.autopipelinerMu.Unlock()
+		if hasAP {
+			return -1, errors.New("redis: multidb: close autopipeliners before adding a cluster member database")
+		}
+	}
 	return c.core.addDatabase(ctx, cfg)
 }
 

--- a/multidb.go
+++ b/multidb.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	imultidb "github.com/redis/go-redis/v9/internal/multidb"
+	"github.com/redis/go-redis/v9/internal/proto"
 	"github.com/redis/go-redis/v9/maintnotifications"
 )
 
@@ -675,7 +676,11 @@ func (c *MultiDBClient) ScriptExists(ctx context.Context, hashes ...string) *Boo
 // prepared on the active member is silently missing on the member a failover
 // switches to. Until registrations fan out across members (tracked as
 // follow-up work in the design doc), rejecting loudly beats half-working.
-var errMultiDBHImport = errors.New("redis: multidb: HIMPORT commands are not supported with MultiDBClient yet (fieldset registrations are per member and would be lost on failover)")
+// A RedisError, not a plain error: the autopipeliner's sequential dispatch
+// treats a non-Redis error from one sub-batch as a fatal abort for the groups
+// behind it, and a rejected HIMPORT must fail only itself — never unrelated
+// commands that happened to be queued after it.
+var errMultiDBHImport = proto.RedisError("MULTIDB HIMPORT commands are not supported with MultiDBClient yet (fieldset registrations are per member and would be lost on failover)")
 
 // errPubSubRequiresStandalone is the retryable PubSub dial error returned when a
 // cluster member is active but the subscription needs a standalone one. It is

--- a/multidb.go
+++ b/multidb.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	imultidb "github.com/redis/go-redis/v9/internal/multidb"
+	"github.com/redis/go-redis/v9/internal/proto"
 	"github.com/redis/go-redis/v9/maintnotifications"
 )
 
@@ -645,7 +646,11 @@ func (c *MultiDBClient) ScriptExists(ctx context.Context, hashes ...string) *Boo
 // prepared on the active member is silently missing on the member a failover
 // switches to. Until registrations fan out across members (tracked as
 // follow-up work in the design doc), rejecting loudly beats half-working.
-var errMultiDBHImport = errors.New("redis: multidb: HIMPORT commands are not supported with MultiDBClient yet (fieldset registrations are per member and would be lost on failover)")
+// A RedisError, not a plain error: the autopipeliner's sequential dispatch
+// treats a non-Redis error from one sub-batch as a fatal abort for the groups
+// behind it, and a rejected HIMPORT must fail only itself — never unrelated
+// commands that happened to be queued after it.
+var errMultiDBHImport = proto.RedisError("MULTIDB HIMPORT commands are not supported with MultiDBClient yet (fieldset registrations are per member and would be lost on failover)")
 
 // HImportPrepare is not supported on MultiDBClient; see errMultiDBHImport.
 func (c *MultiDBClient) HImportPrepare(ctx context.Context, fieldsetName string, fields ...string) *StatusCmd {

--- a/multidb.go
+++ b/multidb.go
@@ -544,28 +544,35 @@ func (c *MultiDBClient) ForceActiveDatabase(ctx context.Context, id int) error {
 // new member would route merged batches around them. Close the autopipeliners
 // first, add the member, then recreate them (closed instances do not block).
 func (c *MultiDBClient) AddDatabase(ctx context.Context, cfg MultiDBClientConfig) (int, error) {
+	// Reject any add — cluster OR standalone — once Close has begun. Close sets
+	// autopipelinerClosed under autopipelinerMu before it drains the
+	// autopipeliners and calls core.close(); a member published in that window
+	// would be torn down by the completing Close, handing the caller an id for a
+	// dead member. Checked under the mutex so it cannot race the flag write.
+	c.autopipelinerMu.Lock()
+	if c.autopipelinerClosed {
+		c.autopipelinerMu.Unlock()
+		return -1, ErrClosed
+	}
 	if cfg.ClusterOptions != nil {
-		// Hold autopipelinerMu across the check AND the membership change so
-		// a concurrent first AutoPipeline call (which creates the pipeliner
-		// under the same mutex and re-checks membership there) cannot
-		// interleave between them.
-		c.autopipelinerMu.Lock()
-		defer c.autopipelinerMu.Unlock()
-		// Close sets this under the same mutex before it starts draining the
-		// autopipeliners. Once shutdown has begun the cached pointers are
-		// already cleared, so the liveness check below would pass and admit the
+		// Hold autopipelinerMu across the liveness check AND the membership
+		// change so a concurrent first AutoPipeline call (which creates the
+		// pipeliner under the same mutex and re-checks membership there) cannot
+		// interleave between them. Once shutdown has begun the cached pointers
+		// are already cleared, so the liveness check would pass and admit the
 		// cluster member mid-drain; a batch failing over during that drain could
 		// then reach it through the unsupported unsharded autopipeline path.
-		// Reject the add instead: the client is going away.
-		if c.autopipelinerClosed {
-			return -1, ErrClosed
-		}
+		defer c.autopipelinerMu.Unlock()
 		hasLiveAP := (c.autopipeliner != nil && !c.autopipeliner.closed.Load()) ||
 			(c.asyncAutopipeliner != nil && !c.asyncAutopipeliner.closed.Load())
 		if hasLiveAP {
 			return -1, errors.New("redis: multidb: close autopipeliners before adding a cluster member database")
 		}
+		return c.core.addDatabase(ctx, cfg)
 	}
+	// Standalone: a standalone member has no cluster-autopipeline hazard, so the
+	// mutex need not span the membership change as the cluster branch does.
+	c.autopipelinerMu.Unlock()
 	return c.core.addDatabase(ctx, cfg)
 }
 

--- a/multidb.go
+++ b/multidb.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	imultidb "github.com/redis/go-redis/v9/internal/multidb"
@@ -377,7 +378,15 @@ var _ MultiDBCtrl = (*MultiDBClient)(nil)
 // See the Active-Active client design for details.
 type MultiDBClient struct {
 	cmdable
+	hooksMixin
+
 	core *multidbCore
+
+	// Cached autopipeliner instances, mirroring *Client (see Client.AutoPipeline).
+	autopipelinerMu     *sync.Mutex
+	autopipeliner       *AutoPipeliner
+	asyncAutopipeliner  *AutoPipeliner
+	autopipelinerClosed bool
 }
 
 // NewMultiDBClient creates a MultiDBClient for the configured member
@@ -435,21 +444,45 @@ func NewMultiDBClient(ctx context.Context, opts *MultiDBOptions) (*MultiDBClient
 	}
 	core.startBackgroundLoop()
 
-	c := &MultiDBClient{core: core}
+	c := &MultiDBClient{core: core, autopipelinerMu: new(sync.Mutex)}
 	c.cmdable = c.Process
+	c.initHooks(hooks{
+		process:    core.process,
+		pipeline:   core.processPipeline,
+		txPipeline: core.processTxPipeline,
+	})
 	return c, nil
 }
 
 // Process routes the command to the active database, feeding the circuit
 // breaker and failure detector, and retrying against the newly selected
-// database after a failover.
+// database after a failover. MultiDB-level hooks (AddHook) wrap this path.
 func (c *MultiDBClient) Process(ctx context.Context, cmd Cmder) error {
-	return c.core.process(ctx, cmd)
+	err := c.processHook(ctx, cmd)
+	cmd.SetErr(err)
+	return err
 }
 
-// Close stops the background loop and closes every underlying client.
+// Close stops the autopipeliners, the background loop, and every underlying
+// client.
 func (c *MultiDBClient) Close() error {
-	return c.core.close()
+	c.autopipelinerMu.Lock()
+	ap, async := c.autopipeliner, c.asyncAutopipeliner
+	c.autopipeliner, c.asyncAutopipeliner = nil, nil
+	c.autopipelinerClosed = true
+	c.autopipelinerMu.Unlock()
+	var firstErr error
+	for _, p := range []*AutoPipeliner{ap, async} {
+		if p != nil {
+			if err := p.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	if err := c.core.close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
 }
 
 // ActiveIndex implements MultiDBCtrl.

--- a/multidb.go
+++ b/multidb.go
@@ -516,6 +516,13 @@ func (c *MultiDBClient) AddDatabase(ctx context.Context, cfg MultiDBClientConfig
 		if hasLiveAP {
 			return -1, errors.New("redis: multidb: close autopipeliners before adding a cluster member database")
 		}
+		// Known narrow window: AutoPipeliner.Close flips its closed flag
+		// before draining already-accepted batches, so an AddDatabase racing
+		// a direct ap.Close() can pass this check while the drain is still
+		// flushing. Those batches only reach the new cluster member if a
+		// failover selects it during that same drain. For strict guarantees,
+		// let Close return before calling AddDatabase (MultiDBClient.Close
+		// already serializes both on autopipelinerMu).
 	}
 	return c.core.addDatabase(ctx, cfg)
 }

--- a/multidb.go
+++ b/multidb.go
@@ -596,6 +596,17 @@ func (c *MultiDBClient) AddHook(hook Hook) {
 // AddDatabaseHook installs a hook on the underlying client of the database with
 // the given id. Unlike AddHook it wraps the member connection directly, so it
 // is the way to instrument member dialing and per-connection behaviour.
+//
+// A member hook must pass the context it receives — or one derived from it —
+// to next. MultiDB carries per-batch execution tracking in context values:
+// the pipeline paths attach it before entering the member's hook chain and
+// the wire path reads it back to mark commands as executed. A hook that
+// substitutes an unrelated context (context.Background() to detach
+// cancellation, a freshly built deadline context) drops that value, so a batch
+// that executed successfully is indistinguishable from one a hook served
+// locally and records no success for the circuit breaker or failure detector.
+// The effect is under-recording only — slower recovery of a half-open member,
+// failures not reset — never a phantom success or a replay.
 func (c *MultiDBClient) AddDatabaseHook(id int, hook Hook) error {
 	return c.core.addDatabaseHook(id, hook)
 }

--- a/multidb.go
+++ b/multidb.go
@@ -522,16 +522,21 @@ func (c *MultiDBClient) ForceActiveDatabase(ctx context.Context, id int) error {
 }
 
 // AddDatabase implements MultiDBCtrl. Adding a cluster member is refused
-// while an autopipeliner instance exists: the cached autopipeliner was built
-// without the cluster-specific safeguards and a later failover onto the new
-// member would route merged batches around them. Close the autopipeliners
-// first, add the member, then recreate them.
+// while a live autopipeliner instance exists: the cached autopipeliner was
+// built without the cluster-specific safeguards and a later failover onto the
+// new member would route merged batches around them. Close the autopipeliners
+// first, add the member, then recreate them (closed instances do not block).
 func (c *MultiDBClient) AddDatabase(ctx context.Context, cfg MultiDBClientConfig) (int, error) {
 	if cfg.ClusterOptions != nil {
+		// Hold autopipelinerMu across the check AND the membership change so
+		// a concurrent first AutoPipeline call (which creates the pipeliner
+		// under the same mutex and re-checks membership there) cannot
+		// interleave between them.
 		c.autopipelinerMu.Lock()
-		hasAP := c.autopipeliner != nil || c.asyncAutopipeliner != nil
-		c.autopipelinerMu.Unlock()
-		if hasAP {
+		defer c.autopipelinerMu.Unlock()
+		hasLiveAP := (c.autopipeliner != nil && !c.autopipeliner.closed.Load()) ||
+			(c.asyncAutopipeliner != nil && !c.asyncAutopipeliner.closed.Load())
+		if hasLiveAP {
 			return -1, errors.New("redis: multidb: close autopipeliners before adding a cluster member database")
 		}
 	}

--- a/multidb.go
+++ b/multidb.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"sync"
 	"time"
 
 	imultidb "github.com/redis/go-redis/v9/internal/multidb"
@@ -401,7 +402,15 @@ var _ MultiDBCtrl = (*MultiDBClient)(nil)
 // See the Active-Active client design for details.
 type MultiDBClient struct {
 	cmdable
+	hooksMixin
+
 	core *multidbCore
+
+	// Cached autopipeliner instances, mirroring *Client (see Client.AutoPipeline).
+	autopipelinerMu     *sync.Mutex
+	autopipeliner       *AutoPipeliner
+	asyncAutopipeliner  *AutoPipeliner
+	autopipelinerClosed bool
 }
 
 // NewMultiDBClient creates a MultiDBClient for the configured member
@@ -458,21 +467,45 @@ func NewMultiDBClient(ctx context.Context, opts *MultiDBOptions) (*MultiDBClient
 	}
 	core.startBackgroundLoop()
 
-	c := &MultiDBClient{core: core}
+	c := &MultiDBClient{core: core, autopipelinerMu: new(sync.Mutex)}
 	c.cmdable = c.Process
+	c.initHooks(hooks{
+		process:    core.process,
+		pipeline:   core.processPipeline,
+		txPipeline: core.processTxPipeline,
+	})
 	return c, nil
 }
 
 // Process routes the command to the active database, feeding the circuit
 // breaker and failure detector, and retrying against the newly selected
-// database after a failover.
+// database after a failover. MultiDB-level hooks (AddHook) wrap this path.
 func (c *MultiDBClient) Process(ctx context.Context, cmd Cmder) error {
-	return c.core.process(ctx, cmd)
+	err := c.processHook(ctx, cmd)
+	cmd.SetErr(err)
+	return err
 }
 
-// Close stops the background loop and closes every underlying client.
+// Close stops the autopipeliners, the background loop, and every underlying
+// client.
 func (c *MultiDBClient) Close() error {
-	return c.core.close()
+	c.autopipelinerMu.Lock()
+	ap, async := c.autopipeliner, c.asyncAutopipeliner
+	c.autopipeliner, c.asyncAutopipeliner = nil, nil
+	c.autopipelinerClosed = true
+	c.autopipelinerMu.Unlock()
+	var firstErr error
+	for _, p := range []*AutoPipeliner{ap, async} {
+		if p != nil {
+			if err := p.Close(); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	if err := c.core.close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
 }
 
 // ActiveDatabaseID implements MultiDBCtrl.

--- a/multidb_addcluster_internal_test.go
+++ b/multidb_addcluster_internal_test.go
@@ -1,0 +1,32 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// AddDatabase must refuse a cluster member once Close has begun tearing the
+// client down. Close clears the cached autopipeliner pointers and flips
+// autopipelinerClosed under autopipelinerMu before it drains the accepted
+// batches. Without the closed check the liveness guard sees no live
+// autopipeliner and would admit the cluster member while the drain is still
+// flushing, letting a failing-over batch reach it through the unsharded
+// autopipeline path the cluster member does not support.
+func TestAddClusterDatabaseRejectedAfterCloseBegan(t *testing.T) {
+	core := newMultidbCore(&MultiDBOptions{})
+	c := &MultiDBClient{core: core, autopipelinerMu: new(sync.Mutex), autopipelinerClosed: true}
+
+	before := len(core.dbs)
+	id, err := c.AddDatabase(context.Background(), MultiDBClientConfig{
+		ClusterOptions:         &ClusterOptions{Addrs: []string{"127.0.0.1:6379"}},
+		SkipInitialHealthCheck: true,
+	})
+	if !errors.Is(err, ErrClosed) {
+		t.Fatalf("cluster add during shutdown: got id=%d err=%v, want ErrClosed", id, err)
+	}
+	if got := len(core.dbs); got != before {
+		t.Fatalf("cluster add during shutdown mutated membership: %d -> %d", before, got)
+	}
+}

--- a/multidb_addcluster_internal_test.go
+++ b/multidb_addcluster_internal_test.go
@@ -30,3 +30,24 @@ func TestAddClusterDatabaseRejectedAfterCloseBegan(t *testing.T) {
 		t.Fatalf("cluster add during shutdown mutated membership: %d -> %d", before, got)
 	}
 }
+
+// AddDatabase must refuse a STANDALONE member too once Close has begun: the
+// shutdown guard is not cluster-specific. Otherwise a standalone add racing
+// Close could publish a member that the completing Close immediately tears down,
+// handing the caller an id for a dead member.
+func TestAddStandaloneDatabaseRejectedAfterCloseBegan(t *testing.T) {
+	core := newMultidbCore(&MultiDBOptions{})
+	c := &MultiDBClient{core: core, autopipelinerMu: new(sync.Mutex), autopipelinerClosed: true}
+
+	before := len(core.dbs)
+	id, err := c.AddDatabase(context.Background(), MultiDBClientConfig{
+		Options:                &Options{Addr: "127.0.0.1:6379"},
+		SkipInitialHealthCheck: true,
+	})
+	if !errors.Is(err, ErrClosed) {
+		t.Fatalf("standalone add during shutdown: got id=%d err=%v, want ErrClosed", id, err)
+	}
+	if got := len(core.dbs); got != before {
+		t.Fatalf("standalone add during shutdown mutated membership: %d -> %d", before, got)
+	}
+}

--- a/multidb_addcluster_probe_internal_test.go
+++ b/multidb_addcluster_probe_internal_test.go
@@ -1,0 +1,70 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// apCallingCheck is a health check that calls the MultiDBClient's own
+// AutoPipeline() from inside the probe — the re-entrant pattern that would
+// deadlock a cluster AddDatabase holding autopipelinerMu across the probe.
+type apCallingCheck struct {
+	mdb *MultiDBClient
+	got chan error
+}
+
+func (c *apCallingCheck) CheckHealth(context.Context, *Client) (bool, error) {
+	_, err := c.mdb.AutoPipeline()
+	c.got <- err
+	return true, nil
+}
+
+func (c *apCallingCheck) CheckClusterHealth(context.Context, *ClusterClient) (bool, error) {
+	_, err := c.mdb.AutoPipeline()
+	c.got <- err
+	return true, nil
+}
+
+// TestAddClusterDatabaseProbeMayCallAutoPipeline pins that a cluster AddDatabase
+// does not hold autopipelinerMu across the member's initial health probe: a
+// custom check that calls AutoPipeline() must not deadlock. While the add is
+// pending the call is refused (a cluster member is landing, so an unsharded
+// autopipeliner must not be created) — the invariant the lock used to protect,
+// now carried by the pending-add count.
+func TestAddClusterDatabaseProbeMayCallAutoPipeline(t *testing.T) {
+	core := newMultidbCore(&MultiDBOptions{
+		HealthCheckTimeout:   time.Second,
+		HealthCheckPolicy:    defaultMultiDBPolicy{},
+		CircuitBreakerConfig: &MultiDBCircuitBreakerConfig{FailureThreshold: 1, SuccessThreshold: 1, GracePeriod: time.Second},
+	})
+	t.Cleanup(func() { _ = core.close() })
+	mdb := &MultiDBClient{core: core, autopipelinerMu: new(sync.Mutex)}
+	got := make(chan error, 1)
+	chk := &apCallingCheck{mdb: mdb, got: got}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := mdb.AddDatabase(context.Background(), MultiDBClientConfig{
+			ClusterOptions: &ClusterOptions{Addrs: []string{"127.0.0.1:6379"}},
+			HealthChecks:   []MultiDBHealthCheck{chk},
+			Weight:         1,
+		})
+		done <- err
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("AddDatabase deadlocked: the probe's AutoPipeline() call blocked on autopipelinerMu held across the probe")
+	}
+	select {
+	case err := <-got:
+		if !errors.Is(err, errMultiDBAutoPipelineCluster) {
+			t.Fatalf("AutoPipeline() during a pending cluster add: got %v, want errMultiDBAutoPipelineCluster (refused, not created)", err)
+		}
+	default:
+		t.Fatal("health check never ran")
+	}
+}

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
+	"github.com/redis/go-redis/v9/internal/proto"
 )
 
 // MultiDBClient must be usable everywhere a UniversalClient is expected —
@@ -573,7 +574,7 @@ func TestMultiDBHookAbortedBatchNotRecordedAsSuccess(t *testing.T) {
 	mdb.TestBreakerRecordFailure(0)
 	time.Sleep(50 * time.Millisecond)
 
-	_, _ = mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+	cmds, _ := mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
 		p.Set(context.Background(), "k", "v", 0)
 		return nil
 	})
@@ -583,6 +584,111 @@ func TestMultiDBHookAbortedBatchNotRecordedAsSuccess(t *testing.T) {
 	}
 	if mdb.TestBreakerReserveHalfOpen(0) {
 		t.Error("breaker closed (or slot accounting lost) after a hook-aborted batch: unlimited admissions")
+	}
+	// The abort must also be visible on the commands themselves: leaving
+	// them nil makes per-command inspection (and cmdsFirstErr once retries
+	// are exhausted) report success for a batch that never executed.
+	for i, cmd := range cmds {
+		if cmd.Err() == nil {
+			t.Errorf("cmd %d has a nil error after a hook-aborted batch", i)
+		}
+	}
+}
+
+func TestMultiDBBatchSuccessResetsFailoverEscalation(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 1, true)
+	opts := baseOptions()
+	opts.CommandRetries = 1
+	opts.MaxFailoverAttempts = 2
+	opts.FailoverAttemptDelay = time.Millisecond
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1,
+		GracePeriod:      30 * time.Millisecond,
+	}
+	mdb := newTestMultiDB(t, opts, dbA)
+	ctx := context.Background()
+
+	// Outage one: open A's breaker and consume one failover attempt.
+	dbA.hook.fail.Store(true)
+	if err := mdb.Get(ctx, "k").Err(); !errors.Is(err, redis.ErrTemporarilyNotAvailable) {
+		t.Fatalf("first outage: err = %v, want ErrTemporarilyNotAvailable", err)
+	}
+
+	// Recovery through BATCH traffic only: a pipeline-only workload must
+	// break the consecutive-failed-attempts chain exactly like the
+	// single-command path does.
+	dbA.hook.fail.Store(false)
+	time.Sleep(50 * time.Millisecond)
+	if _, err := mdb.Pipelined(ctx, func(p redis.Pipeliner) error {
+		p.Set(ctx, "k", "v", 0)
+		return nil
+	}); err != nil {
+		t.Fatalf("recovery batch: %v", err)
+	}
+
+	time.Sleep(5 * time.Millisecond)
+	dbA.hook.fail.Store(true)
+	if err := mdb.Get(ctx, "k").Err(); !errors.Is(err, redis.ErrTemporarilyNotAvailable) {
+		t.Fatalf("second outage: err = %v, want ErrTemporarilyNotAvailable (stale escalation state)", err)
+	}
+}
+
+// partialReplyHook simulates an executed batch with a successful prefix: the
+// first command's nil error is a successfully-read reply, a later command got
+// a retryable server reply that is also the batch-level error.
+type partialReplyHook struct{}
+
+func (partialReplyHook) DialHook(next redis.DialHook) redis.DialHook          { return next }
+func (partialReplyHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook { return next }
+
+func (partialReplyHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		err := proto.RedisError("LOADING Redis is loading the dataset in memory")
+		if len(cmds) > 1 {
+			cmds[len(cmds)-1].SetErr(err)
+		}
+		return err
+	}
+}
+
+func TestMultiDBExecutedBatchKeepsSuccessfulPrefix(t *testing.T) {
+	check := newFakeHealthCheck(true)
+	opts := baseOptions()
+	opts.CommandRetries = redis.CommandRetriesNone
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+	}
+	opts.Clients = []redis.MultiDBClientConfig{{
+		Options:      &redis.Options{Addr: "127.0.0.1:1"},
+		Weight:       1,
+		HealthChecks: []redis.MultiDBHealthCheck{check},
+	}}
+	initCtx, initCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer initCancel()
+	mdb, err := redis.NewMultiDBClient(initCtx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	defer mdb.Close()
+	if err := mdb.AddDatabaseHook(0, partialReplyHook{}); err != nil {
+		t.Fatalf("AddDatabaseHook: %v", err)
+	}
+
+	// One executed batch: first command succeeded (nil), second got a
+	// retryable LOADING reply which is also the batch error. Only ONE
+	// failure may be recorded — substituting the batch error for the
+	// successful prefix would open the breaker (threshold 2) off a single
+	// partially-failed batch.
+	_, _ = mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+		p.Set(context.Background(), "k1", "v", 0)
+		p.Set(context.Background(), "k2", "v", 0)
+		return nil
+	})
+
+	if !mdb.TestBreakerReserveHalfOpen(0) {
+		t.Error("successful prefix was recorded as failures: breaker opened off one partial batch")
 	}
 }
 

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -1,0 +1,258 @@
+package redis_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// MultiDBClient must be usable everywhere a UniversalClient is expected —
+// that is also what the autopipeliner requires from its backend.
+var _ redis.UniversalClient = (*redis.MultiDBClient)(nil)
+
+// countingDetector counts detector records so tests can assert per-command
+// outcome recording for batches.
+type countingDetector struct {
+	successes atomic.Int64
+	failures  atomic.Int64
+	trip      atomic.Bool
+}
+
+func (d *countingDetector) RecordSuccess()          { d.successes.Add(1) }
+func (d *countingDetector) RecordFailure(err error) { d.failures.Add(1) }
+func (d *countingDetector) ShouldFailover() bool    { return d.trip.Load() }
+func (d *countingDetector) Reset()                  { d.trip.Store(false) }
+
+func fastBreaker() *redis.MultiDBCircuitBreakerConfig {
+	return &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1,
+		GracePeriod:      time.Hour,
+	}
+}
+
+func TestMultiDBPipelineRoutesToActive(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 2.0, true)
+	db2 := newTestDB("db2", "127.0.0.1:2", 1.0, true)
+	mdb := newTestMultiDB(t, baseOptions(), db1, db2)
+	ctx := context.Background()
+
+	pipe := mdb.Pipeline()
+	pipe.Set(ctx, "a", "1", 0)
+	pipe.Set(ctx, "b", "2", 0)
+	pipe.Get(ctx, "a")
+	if _, err := pipe.Exec(ctx); err != nil {
+		t.Fatalf("pipeline exec: %v", err)
+	}
+	if got := db1.hook.commands.Load(); got != 3 {
+		t.Errorf("active db1 saw %d commands, want 3", got)
+	}
+	if db2.hook.commands.Load() != 0 {
+		t.Error("passive db2 saw pipeline commands")
+	}
+	if db1.hook.batches.Load() != 1 {
+		t.Errorf("db1 batches = %d, want 1", db1.hook.batches.Load())
+	}
+}
+
+func TestMultiDBPipelineFailoverRetry(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 2.0, true)
+	db2 := newTestDB("db2", "127.0.0.1:2", 1.0, true)
+
+	opts := baseOptions()
+	opts.CommandRetries = 2
+	opts.CircuitBreakerConfig = fastBreaker()
+	mdb := newTestMultiDB(t, opts, db1, db2)
+	ctx := context.Background()
+
+	db1.hook.fail.Store(true)
+
+	pipe := mdb.Pipeline()
+	pipe.Set(ctx, "a", "1", 0)
+	pipe.Get(ctx, "a")
+	cmds, err := pipe.Exec(ctx)
+	if err != nil {
+		t.Fatalf("pipeline exec after active failure: %v", err)
+	}
+	for _, cmd := range cmds {
+		if cmd.Err() != nil {
+			t.Errorf("command %v error after retry: %v", cmd.Name(), cmd.Err())
+		}
+	}
+	if got := mdb.ActiveIndex(); got != 1 {
+		t.Fatalf("active index = %d after pipeline failover, want 1", got)
+	}
+	if db2.hook.batches.Load() == 0 {
+		t.Error("db2 never received the retried batch")
+	}
+}
+
+func TestMultiDBPipelinePerCommandRecording(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 2.0, true)
+	db2 := newTestDB("db2", "127.0.0.1:2", 1.0, true)
+
+	det := &countingDetector{}
+	opts := baseOptions()
+	opts.FailureDetector = det
+	opts.CommandRetries = redis.CommandRetriesNone
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 100, // stay closed; we only count
+		SuccessThreshold: 1,
+		GracePeriod:      time.Hour,
+	}
+	mdb := newTestMultiDB(t, opts, db1, db2)
+	ctx := context.Background()
+
+	db1.hook.fail.Store(true)
+	pipe := mdb.Pipeline()
+	for i := 0; i < 5; i++ {
+		pipe.Get(ctx, "k")
+	}
+	_, _ = pipe.Exec(ctx)
+
+	if got := det.failures.Load(); got != 5 {
+		t.Errorf("detector failures = %d, want 5 (one per command in the batch)", got)
+	}
+
+	db1.hook.fail.Store(false)
+	pipe = mdb.Pipeline()
+	for i := 0; i < 3; i++ {
+		pipe.Get(ctx, "k")
+	}
+	_, _ = pipe.Exec(ctx)
+	if got := det.successes.Load(); got != 3 {
+		t.Errorf("detector successes = %d, want 3", got)
+	}
+}
+
+func TestMultiDBTxPipelineNotRetried(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 2.0, true)
+	db2 := newTestDB("db2", "127.0.0.1:2", 1.0, true)
+
+	opts := baseOptions()
+	opts.CommandRetries = 3 // must be ignored for tx pipelines
+	opts.CircuitBreakerConfig = fastBreaker()
+	mdb := newTestMultiDB(t, opts, db1, db2)
+	ctx := context.Background()
+
+	db1.hook.fail.Store(true)
+
+	pipe := mdb.TxPipeline()
+	pipe.Set(ctx, "a", "1", 0)
+	_, err := pipe.Exec(ctx)
+	if err == nil {
+		t.Fatal("tx pipeline exec should surface the failure, not retry")
+	}
+	if db2.hook.batches.Load() != 0 {
+		t.Error("tx pipeline was retried on db2 — MULTI/EXEC must be at-most-once")
+	}
+}
+
+func TestMultiDBAutoPipelineRoutesAndFailsOver(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 2.0, true)
+	db2 := newTestDB("db2", "127.0.0.1:2", 1.0, true)
+
+	opts := baseOptions()
+	opts.CommandRetries = 2
+	opts.CircuitBreakerConfig = fastBreaker()
+	mdb := newTestMultiDB(t, opts, db1, db2)
+	ctx := context.Background()
+
+	ap, err := mdb.AutoPipeline()
+	if err != nil {
+		t.Fatalf("AutoPipeline: %v", err)
+	}
+
+	// Happy path: commands execute on the active member.
+	if err := ap.Set(ctx, "k", "v", 0).Err(); err != nil {
+		t.Fatalf("autopipelined Set: %v", err)
+	}
+	if db1.hook.commands.Load() == 0 {
+		t.Error("active db1 saw no autopipelined commands")
+	}
+
+	// Kill the active member: autopipelined commands must fail over and
+	// still succeed.
+	db1.hook.fail.Store(true)
+	if err := ap.Set(ctx, "k2", "v2", 0).Err(); err != nil {
+		t.Fatalf("autopipelined Set after active failure: %v", err)
+	}
+	if got := mdb.ActiveIndex(); got != 1 {
+		t.Fatalf("active index = %d after autopipeline failover, want 1", got)
+	}
+}
+
+func TestMultiDBAutoPipelineEscalation(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 2.0, true)
+	db2 := newTestDB("db2", "127.0.0.1:2", 1.0, true)
+
+	opts := baseOptions()
+	opts.CommandRetries = 1
+	opts.MaxFailoverAttempts = 2
+	opts.FailoverAttemptDelay = 5 * time.Millisecond
+	opts.CircuitBreakerConfig = fastBreaker()
+	mdb := newTestMultiDB(t, opts, db1, db2)
+	ctx := context.Background()
+
+	db1.hook.fail.Store(true)
+	db2.hook.fail.Store(true)
+
+	ap, err := mdb.AsyncAutoPipeline()
+	if err != nil {
+		t.Fatalf("AsyncAutoPipeline: %v", err)
+	}
+
+	sawUnavailable := false
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		err := ap.Get(ctx, "k").Err()
+		if errors.Is(err, redis.ErrTemporarilyNotAvailable) || errors.Is(err, redis.ErrPermanentlyNotAvailable) {
+			sawUnavailable = true
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !sawUnavailable {
+		t.Error("autopipelined commands never surfaced the escalation error")
+	}
+}
+
+func TestMultiDBAutoPipelineInstanceCachedAndClosed(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 1.0, true)
+	mdb := newTestMultiDB(t, baseOptions(), db1)
+
+	ap1, err := mdb.AutoPipeline()
+	if err != nil {
+		t.Fatalf("AutoPipeline: %v", err)
+	}
+	ap2, err := mdb.AutoPipeline()
+	if err != nil {
+		t.Fatalf("AutoPipeline second call: %v", err)
+	}
+	if ap1 != ap2 {
+		t.Error("AutoPipeline should cache and return the same instance")
+	}
+
+	if err := mdb.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := mdb.AutoPipeline(); !errors.Is(err, redis.ErrClosed) {
+		t.Errorf("AutoPipeline after Close: err = %v, want ErrClosed", err)
+	}
+}
+
+func TestMultiDBDo(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 1.0, true)
+	mdb := newTestMultiDB(t, baseOptions(), db1)
+
+	if err := mdb.Do(context.Background(), "set", "k", "v").Err(); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if db1.hook.commands.Load() == 0 {
+		t.Error("Do did not reach the active database")
+	}
+}

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -461,9 +462,42 @@ func TestMultiDBBatchRegatesAfterFailover(t *testing.T) {
 	}
 }
 
-func TestMultiDBTxPipelineMarksAllCmdsNoRetry(t *testing.T) {
-	dbA := newTestDB("a", "127.0.0.1:1", 1, true)
-	mdb := newTestMultiDB(t, baseOptions(), dbA)
+// noRetryPeekHook captures each command's NoRetry flag WHILE the member
+// executes the batch (it serves the batch locally by returning nil without
+// calling next), so a test can assert the at-most-once marker is set during
+// execution rather than after it.
+type noRetryPeekHook struct{ seen []bool }
+
+func (*noRetryPeekHook) DialHook(next redis.DialHook) redis.DialHook          { return next }
+func (*noRetryPeekHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook { return next }
+func (h *noRetryPeekHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		for _, cmd := range cmds {
+			h.seen = append(h.seen, cmd.NoRetry())
+		}
+		return nil
+	}
+}
+
+func TestMultiDBTxPipelineMarksCmdsNoRetryDuringExecOnly(t *testing.T) {
+	check := newFakeHealthCheck(true)
+	opts := baseOptions()
+	opts.Clients = []redis.MultiDBClientConfig{{
+		Options:      &redis.Options{Addr: "127.0.0.1:1"},
+		Weight:       1,
+		HealthChecks: []redis.MultiDBHealthCheck{check},
+	}}
+	initCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	mdb, err := redis.NewMultiDBClient(initCtx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	defer mdb.Close()
+	peek := &noRetryPeekHook{}
+	if err := mdb.AddDatabaseHook(0, peek); err != nil {
+		t.Fatalf("AddDatabaseHook: %v", err)
+	}
 
 	cmds, err := mdb.TxPipelined(context.Background(), func(p redis.Pipeliner) error {
 		p.Set(context.Background(), "k", "v", 0)
@@ -473,13 +507,24 @@ func TestMultiDBTxPipelineMarksAllCmdsNoRetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TxPipelined: %v", err)
 	}
-	// The cluster tx path trims the MULTI/EXEC envelope before running its
-	// retry check on the remaining user commands, so the at-most-once
-	// marker must ride on every command — a marker only on the synthetic
-	// MULTI lets a cluster member replay the transaction.
+
+	// During execution every command (including the synthetic MULTI/EXEC
+	// envelope) must carry the at-most-once marker: the cluster tx path trims
+	// the envelope before its retry check, so a marker only on the synthetic
+	// MULTI would let a cluster member replay the transaction.
+	if len(peek.seen) == 0 {
+		t.Fatal("member hook never saw the tx batch")
+	}
+	for i, nr := range peek.seen {
+		if !nr {
+			t.Errorf("cmd %d not marked NoRetry during execution — a cluster member could replay", i)
+		}
+	}
+	// After the call the caller's commands are restored to retryable, so a
+	// reused *Cmd is not left permanently non-retryable.
 	for i, cmd := range cmds {
-		if !cmd.NoRetry() {
-			t.Errorf("cmd %d (%s) not marked NoRetry — a cluster member could replay the transaction", i, cmd.Name())
+		if cmd.NoRetry() {
+			t.Errorf("cmd %d (%s) left NoRetry after TxPipeline — caller state must be restored", i, cmd.Name())
 		}
 	}
 }
@@ -1293,6 +1338,7 @@ func (*switchThenFailPipelineHook) DialHook(next redis.DialHook) redis.DialHook 
 func (*switchThenFailPipelineHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
 	return next
 }
+
 func (h *switchThenFailPipelineHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
 	return func(ctx context.Context, cmds []redis.Cmder) error {
 		h.once.Do(func() { _ = h.mdb.ForceActiveDatabase(context.Background(), h.to) })
@@ -1354,6 +1400,27 @@ func TestMultiDBPipelineStaleOutcomeNotRecordedOnDetector(t *testing.T) {
 // race ahead to close the member clients while the first is still draining the
 // autopipeliner. Run under -race, this guards the ordering (and the shared
 // close result) the sync.Once in Close provides.
+// TestMultiDBPipelineMaxIntRetriesDoesNotDropBatch pins the overflow guard:
+// CommandRetries == math.MaxInt must not make attempts = MaxInt+1 wrap to a
+// negative count, which would skip the loop and silently drop the batch
+// (Pipelined returning a nil error with nothing executed).
+func TestMultiDBPipelineMaxIntRetriesDoesNotDropBatch(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 1, true)
+	opts := baseOptions()
+	opts.CommandRetries = math.MaxInt
+	mdb := newTestMultiDB(t, opts, dbA)
+
+	if _, err := mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+		p.Set(context.Background(), "k", "v", 0)
+		return nil
+	}); err != nil {
+		t.Fatalf("Pipelined: %v", err)
+	}
+	if got := dbA.hook.batches.Load(); got == 0 {
+		t.Fatal("batch was silently dropped — attempts overflowed to a negative count")
+	}
+}
+
 func TestMultiDBConcurrentCloseSerializes(t *testing.T) {
 	check := newFakeHealthCheck(true)
 	opts := baseOptions()

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -529,6 +529,67 @@ func TestMultiDBBatchDetectorFailoverDoesNotLeakProbeSlot(t *testing.T) {
 	})
 }
 
+// mixedResultHook simulates an executed batch on a recovering member: early
+// commands succeeded, the last one hit a transport error (which is also the
+// batch-level error).
+type mixedResultHook struct{}
+
+func (mixedResultHook) DialHook(next redis.DialHook) redis.DialHook          { return next }
+func (mixedResultHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook { return next }
+
+func (mixedResultHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		if len(cmds) > 0 {
+			cmds[len(cmds)-1].SetErr(io.EOF)
+		}
+		return io.EOF
+	}
+}
+
+func TestMultiDBFailedBatchDoesNotCloseHalfOpenBreaker(t *testing.T) {
+	check := newFakeHealthCheck(true)
+	opts := baseOptions()
+	opts.CommandRetries = redis.CommandRetriesNone
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 2,
+		SuccessThreshold: 1, // one successful probe would close the circuit
+		GracePeriod:      30 * time.Millisecond,
+	}
+	opts.Clients = []redis.MultiDBClientConfig{{
+		Options:      &redis.Options{Addr: "127.0.0.1:1"},
+		Weight:       1,
+		HealthChecks: []redis.MultiDBHealthCheck{check},
+	}}
+	initCtx, initCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer initCancel()
+	mdb, err := redis.NewMultiDBClient(initCtx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	defer mdb.Close()
+	if err := mdb.AddDatabaseHook(0, mixedResultHook{}); err != nil {
+		t.Fatalf("AddDatabaseHook: %v", err)
+	}
+
+	// Half-open member admits one probe batch whose early command succeeds
+	// but whose later command fails at transport level: the batch FAILED as
+	// a recovery probe, so it must not close the circuit — failures must be
+	// recorded before successes.
+	mdb.TestBreakerRecordFailure(0)
+	mdb.TestBreakerRecordFailure(0) // -> open (threshold 2)
+	time.Sleep(50 * time.Millisecond)
+
+	_, _ = mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+		p.Set(context.Background(), "k1", "v", 0)
+		p.Set(context.Background(), "k2", "v", 0)
+		return nil
+	})
+
+	if mdb.TestBreakerReserveHalfOpen(0) {
+		t.Error("a failed recovery batch closed (or left admitting) the half-open breaker")
+	}
+}
+
 // abortHook aborts every batch with an error WITHOUT stamping the commands
 // and without calling next — the worst-case instrumentation hook.
 type abortHook struct{}

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
-	"github.com/redis/go-redis/v9/internal/proto"
 )
 
 // MultiDBClient must be usable everywhere a UniversalClient is expected —
@@ -127,8 +126,12 @@ func TestMultiDBPipelinePerCommandRecording(t *testing.T) {
 		pipe.Get(ctx, "k")
 	}
 	_, _ = pipe.Exec(ctx)
-	if got := det.successes.Load(); got != 3 {
-		t.Errorf("detector successes = %d, want 3", got)
+	// The hook serves this batch locally (nil without calling next), so no
+	// health successes may be recorded — nothing reached Redis. Executed
+	// batches' per-command success recording is covered white-box in
+	// multidb_pipeline_internal_test.go.
+	if got := det.successes.Load(); got != 0 {
+		t.Errorf("detector successes = %d for a hook-served batch, want 0", got)
 	}
 }
 
@@ -656,70 +659,75 @@ func TestMultiDBHookAbortedBatchNotRecordedAsSuccess(t *testing.T) {
 	}
 }
 
-func TestMultiDBBatchSuccessResetsFailoverEscalation(t *testing.T) {
+// (Batch successes resetting the failover escalation chain is covered
+// white-box in multidb_pipeline_internal_test.go: an executed batch success
+// sets successSinceFailover, a hook-served one does not.)
+
+// (An executed batch keeping its successful prefix — one recorded failure,
+// prefix left unstamped — is covered white-box in
+// multidb_pipeline_internal_test.go, where the execution marker can be set
+// directly.)
+
+func TestMultiDBHookServedBatchIsNeutral(t *testing.T) {
 	dbA := newTestDB("a", "127.0.0.1:1", 1, true)
 	opts := baseOptions()
-	opts.CommandRetries = 1
-	opts.MaxFailoverAttempts = 2
-	opts.FailoverAttemptDelay = time.Millisecond
+	opts.CommandRetries = redis.CommandRetriesNone
 	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
 		FailureThreshold: 1,
-		SuccessThreshold: 1,
+		SuccessThreshold: 1, // one recorded success would close the circuit
 		GracePeriod:      30 * time.Millisecond,
 	}
 	mdb := newTestMultiDB(t, opts, dbA)
-	ctx := context.Background()
 
-	// Outage one: open A's breaker and consume one failover attempt.
-	dbA.hook.fail.Store(true)
-	if err := mdb.Get(ctx, "k").Err(); !errors.Is(err, redis.ErrTemporarilyNotAvailable) {
-		t.Fatalf("first outage: err = %v, want ErrTemporarilyNotAvailable", err)
-	}
-
-	// Recovery through BATCH traffic only: a pipeline-only workload must
-	// break the consecutive-failed-attempts chain exactly like the
-	// single-command path does.
-	dbA.hook.fail.Store(false)
+	// Half-open member; the default test hook serves batches locally
+	// (returns nil without calling next). The caller gets its results, but
+	// nothing reached Redis — recording successes would close the breaker
+	// off pure client-side activity.
+	mdb.TestBreakerRecordFailure(0)
 	time.Sleep(50 * time.Millisecond)
-	if _, err := mdb.Pipelined(ctx, func(p redis.Pipeliner) error {
-		p.Set(ctx, "k", "v", 0)
+
+	if _, err := mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+		p.Set(context.Background(), "k", "v", 0)
 		return nil
 	}); err != nil {
-		t.Fatalf("recovery batch: %v", err)
+		t.Fatalf("Pipelined: %v", err)
 	}
 
-	time.Sleep(5 * time.Millisecond)
-	dbA.hook.fail.Store(true)
-	if err := mdb.Get(ctx, "k").Err(); !errors.Is(err, redis.ErrTemporarilyNotAvailable) {
-		t.Fatalf("second outage: err = %v, want ErrTemporarilyNotAvailable (stale escalation state)", err)
+	if !mdb.TestBreakerReserveHalfOpen(0) {
+		t.Fatal("expected the breaker to still be half-open with its slot free")
+	}
+	if mdb.TestBreakerReserveHalfOpen(0) {
+		t.Error("hook-served batch was recorded on the breaker (circuit closed or slot lost)")
 	}
 }
 
-// partialReplyHook simulates an executed batch with a successful prefix: the
-// first command's nil error is a successfully-read reply, a later command got
-// a retryable server reply that is also the batch-level error.
-type partialReplyHook struct{}
+// partialNeutralAbortHook aborts before next with a client-side error,
+// stamping only the LAST command — the worst-case partially-stamped abort.
+type partialNeutralAbortHook struct{}
 
-func (partialReplyHook) DialHook(next redis.DialHook) redis.DialHook          { return next }
-func (partialReplyHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook { return next }
+func (partialNeutralAbortHook) DialHook(next redis.DialHook) redis.DialHook { return next }
+func (partialNeutralAbortHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return next
+}
 
-func (partialReplyHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+func (partialNeutralAbortHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
 	return func(ctx context.Context, cmds []redis.Cmder) error {
-		err := proto.RedisError("LOADING Redis is loading the dataset in memory")
-		if len(cmds) > 1 {
+		err := errors.New("aborted by hook")
+		if len(cmds) > 0 {
 			cmds[len(cmds)-1].SetErr(err)
 		}
 		return err
 	}
 }
 
-func TestMultiDBExecutedBatchKeepsSuccessfulPrefix(t *testing.T) {
+func TestMultiDBPartiallyStampedAbortDoesNotFabricateSuccesses(t *testing.T) {
 	check := newFakeHealthCheck(true)
 	opts := baseOptions()
 	opts.CommandRetries = redis.CommandRetriesNone
 	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
-		FailureThreshold: 2,
-		SuccessThreshold: 1,
+		FailureThreshold: 1,
+		SuccessThreshold: 1, // one fabricated success would close the circuit
+		GracePeriod:      30 * time.Millisecond,
 	}
 	opts.Clients = []redis.MultiDBClientConfig{{
 		Options:      &redis.Options{Addr: "127.0.0.1:1"},
@@ -733,23 +741,64 @@ func TestMultiDBExecutedBatchKeepsSuccessfulPrefix(t *testing.T) {
 		t.Fatalf("NewMultiDBClient: %v", err)
 	}
 	defer mdb.Close()
-	if err := mdb.AddDatabaseHook(0, partialReplyHook{}); err != nil {
+	if err := mdb.AddDatabaseHook(0, partialNeutralAbortHook{}); err != nil {
 		t.Fatalf("AddDatabaseHook: %v", err)
 	}
 
-	// One executed batch: first command succeeded (nil), second got a
-	// retryable LOADING reply which is also the batch error. Only ONE
-	// failure may be recorded — substituting the batch error for the
-	// successful prefix would open the breaker (threshold 2) off a single
-	// partially-failed batch.
-	_, _ = mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+	// Half-open member; the hook aborts before execution but stamped one of
+	// the two commands. The other command's nil error is NOT a success —
+	// nothing executed — so the breaker must stay half-open.
+	mdb.TestBreakerRecordFailure(0)
+	time.Sleep(50 * time.Millisecond)
+
+	cmds, _ := mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
 		p.Set(context.Background(), "k1", "v", 0)
 		p.Set(context.Background(), "k2", "v", 0)
 		return nil
 	})
 
 	if !mdb.TestBreakerReserveHalfOpen(0) {
-		t.Error("successful prefix was recorded as failures: breaker opened off one partial batch")
+		t.Fatal("expected the breaker to still be half-open with its slot free")
+	}
+	if mdb.TestBreakerReserveHalfOpen(0) {
+		t.Error("partially-stamped abort fabricated a success (circuit closed or slot lost)")
+	}
+	for i, cmd := range cmds {
+		if cmd.Err() == nil {
+			t.Errorf("cmd %d left without an error after an aborted batch", i)
+		}
+	}
+}
+
+func TestMultiDBBatchAllHalfOpenFullReturnsUnavailable(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 2, true)
+	dbB := newTestDB("b", "127.0.0.1:2", 1, true)
+	opts := baseOptions()
+	opts.CommandRetries = 2
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1,
+		GracePeriod:      30 * time.Millisecond,
+	}
+	mdb := newTestMultiDB(t, opts, dbA, dbB)
+
+	// Every member half-open with an exhausted probe budget: the batch gate
+	// must surface ErrTemporarilyNotAvailable, not busy-loop failovers.
+	mdb.TestBreakerRecordFailure(0)
+	mdb.TestBreakerRecordFailure(1)
+	time.Sleep(50 * time.Millisecond)
+	if !mdb.TestBreakerReserveHalfOpen(0) || !mdb.TestBreakerReserveHalfOpen(1) {
+		t.Fatal("setup: expected to reserve both members' probe slots")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := mdb.Pipelined(ctx, func(p redis.Pipeliner) error {
+		p.Set(ctx, "k", "v", 0)
+		return nil
+	})
+	if !errors.Is(err, redis.ErrTemporarilyNotAvailable) {
+		t.Fatalf("Pipelined = %v, want ErrTemporarilyNotAvailable", err)
 	}
 }
 

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -1030,6 +1030,72 @@ func TestMultiDBWatchDoesNotReleaseUnreservedSlot(t *testing.T) {
 	}
 }
 
+// midflightBatchHook runs an armable callback inside batch execution and
+// then serves the batch locally (nil error, no wire I/O).
+type midflightBatchHook struct{ fn atomic.Pointer[func()] }
+
+func (h *midflightBatchHook) DialHook(next redis.DialHook) redis.DialHook { return next }
+
+func (h *midflightBatchHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error { return nil }
+}
+
+func (h *midflightBatchHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		if f := h.fn.Load(); f != nil {
+			(*f)()
+		}
+		return nil
+	}
+}
+
+func TestMultiDBBatchClosedAdmissionDoesNotFreeProbeSlot(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 1, true)
+	opts := baseOptions()
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 2, // MaxHalfOpenRequests defaults to this: two probe slots
+		GracePeriod:      30 * time.Millisecond,
+	}
+	opts.Clients = append(opts.Clients, dbA.cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	mdb, err := redis.NewMultiDBClient(ctx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	t.Cleanup(func() { _ = mdb.Close() })
+	hook := &midflightBatchHook{}
+	if err := mdb.AddDatabaseHook(0, hook); err != nil {
+		t.Fatalf("AddDatabaseHook: %v", err)
+	}
+
+	// The batch is admitted while A's breaker is CLOSED — no probe slot is
+	// reserved. While it executes, a failure opens the breaker, the grace
+	// period elapses, and recovery probes reserve both half-open slots. The
+	// hook serves the batch locally (nil, no wire I/O), which lands in the
+	// unexecuted-clean settle path — it must not free a probe's slot.
+	fn := func() {
+		mdb.TestBreakerRecordFailure(0)
+		time.Sleep(50 * time.Millisecond)
+		if !mdb.TestBreakerReserveHalfOpen(0) || !mdb.TestBreakerReserveHalfOpen(0) {
+			t.Error("setup: expected to reserve both half-open probe slots")
+		}
+	}
+	hook.fn.Store(&fn)
+	if _, err := mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+		p.Set(context.Background(), "k", "v", 0)
+		return nil
+	}); err != nil {
+		t.Fatalf("Pipelined: %v", err)
+	}
+	hook.fn.Store(nil)
+
+	if mdb.TestBreakerReserveHalfOpen(0) {
+		t.Error("a second half-open reservation succeeded — the batch released a slot it never reserved")
+	}
+}
+
 func TestMultiDBBatchAllHalfOpenFullReturnsUnavailable(t *testing.T) {
 	dbA := newTestDB("a", "127.0.0.1:1", 2, true)
 	dbB := newTestDB("b", "127.0.0.1:2", 1, true)

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -231,6 +231,42 @@ func TestMultiDBAutoPipelineRefusesClusterMembers(t *testing.T) {
 	}
 }
 
+func TestMultiDBAddClusterMemberVsAutoPipeliner(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 2.0, true)
+	mdb := newTestMultiDB(t, baseOptions(), db1)
+	ctx := context.Background()
+
+	ap, err := mdb.AutoPipeline()
+	if err != nil {
+		t.Fatalf("AutoPipeline: %v", err)
+	}
+
+	clusterCfg := redis.MultiDBClientConfig{
+		ClusterOptions:         &redis.ClusterOptions{Addrs: []string{"127.0.0.1:2"}},
+		Weight:                 1.0,
+		HealthChecks:           []redis.MultiDBHealthCheck{newFakeHealthCheck(true)},
+		SkipInitialHealthCheck: true,
+	}
+
+	// Live autopipeliner blocks cluster additions.
+	if _, err := mdb.AddDatabase(ctx, clusterCfg); err == nil {
+		t.Fatal("AddDatabase(cluster) should be refused while an autopipeliner is live")
+	}
+
+	// A CLOSED autopipeliner must not block forever.
+	if err := ap.Close(); err != nil {
+		t.Fatalf("AutoPipeliner.Close: %v", err)
+	}
+	if _, err := mdb.AddDatabase(ctx, clusterCfg); err != nil {
+		t.Fatalf("AddDatabase(cluster) after closing the autopipeliner: %v", err)
+	}
+
+	// And with a cluster member present, new autopipeliners are refused.
+	if _, err := mdb.AutoPipeline(); err == nil {
+		t.Error("AutoPipeline should be refused once a cluster member exists")
+	}
+}
+
 func TestMultiDBAutoPipelineRoutesAndFailsOver(t *testing.T) {
 	db1 := newTestDB("db1", "127.0.0.1:1", 2.0, true)
 	db2 := newTestDB("db2", "127.0.0.1:2", 1.0, true)

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -668,6 +668,99 @@ func TestMultiDBHookAbortedBatchNotRecordedAsSuccess(t *testing.T) {
 // multidb_pipeline_internal_test.go, where the execution marker can be set
 // directly.)
 
+func TestMultiDBBatchRejectsHImport(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 1, true)
+	mdb := newTestMultiDB(t, baseOptions(), dbA)
+	ctx := context.Background()
+
+	// The direct HImport* overrides reject the family, but pipeline and tx
+	// builders dispatch through their own cmdable — the batch paths must
+	// reject HIMPORT commands too, or registrations would land in a single
+	// member's registry and break after failover.
+	cmds, err := mdb.Pipelined(ctx, func(p redis.Pipeliner) error {
+		p.HImportPrepare(ctx, "fs", "f1")
+		p.Set(ctx, "k", "v", 0)
+		return nil
+	})
+	if err == nil {
+		t.Error("Pipelined with HIMPORT succeeded, want rejection")
+	}
+	for i, cmd := range cmds {
+		if cmd.Err() == nil {
+			t.Errorf("pipeline cmd %d has nil error in a rejected batch", i)
+		}
+	}
+
+	if _, err := mdb.TxPipelined(ctx, func(p redis.Pipeliner) error {
+		p.HImportSet(ctx, "k", "fs", "v")
+		return nil
+	}); err == nil {
+		t.Error("TxPipelined with HIMPORT succeeded, want rejection")
+	}
+}
+
+// nilStampAbortHook aborts before next but stamps redis.Nil (a well-formed
+// server reply sentinel) on the last command — e.g. a cache hook answering a
+// read locally while failing the rest of the batch.
+type nilStampAbortHook struct{}
+
+func (nilStampAbortHook) DialHook(next redis.DialHook) redis.DialHook          { return next }
+func (nilStampAbortHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook { return next }
+
+func (nilStampAbortHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		if len(cmds) > 0 {
+			cmds[len(cmds)-1].SetErr(redis.Nil)
+		}
+		return errors.New("aborted by hook")
+	}
+}
+
+func TestMultiDBUnexecutedBatchRecordsNoSuccesses(t *testing.T) {
+	check := newFakeHealthCheck(true)
+	opts := baseOptions()
+	opts.CommandRetries = redis.CommandRetriesNone
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1, // one fabricated success would close the circuit
+		GracePeriod:      30 * time.Millisecond,
+	}
+	opts.Clients = []redis.MultiDBClientConfig{{
+		Options:      &redis.Options{Addr: "127.0.0.1:1"},
+		Weight:       1,
+		HealthChecks: []redis.MultiDBHealthCheck{check},
+	}}
+	initCtx, initCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer initCancel()
+	mdb, err := redis.NewMultiDBClient(initCtx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	defer mdb.Close()
+	if err := mdb.AddDatabaseHook(0, nilStampAbortHook{}); err != nil {
+		t.Fatalf("AddDatabaseHook: %v", err)
+	}
+
+	// Half-open member; the hook aborts before execution but stamped
+	// redis.Nil (success-class) on one command. Nothing reached Redis, so
+	// no database success may be recorded off hook-fabricated replies.
+	mdb.TestBreakerRecordFailure(0)
+	time.Sleep(50 * time.Millisecond)
+
+	_, _ = mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+		p.Get(context.Background(), "k1")
+		p.Set(context.Background(), "k2", "v", 0)
+		return nil
+	})
+
+	if !mdb.TestBreakerReserveHalfOpen(0) {
+		t.Fatal("expected the breaker to still be half-open with its slot free")
+	}
+	if mdb.TestBreakerReserveHalfOpen(0) {
+		t.Error("hook-fabricated reply was recorded as a database success (circuit closed or slot lost)")
+	}
+}
+
 func TestMultiDBHookServedBatchIsNeutral(t *testing.T) {
 	dbA := newTestDB("a", "127.0.0.1:1", 1, true)
 	opts := baseOptions()

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -1194,6 +1194,54 @@ func TestMultiDBPipelineContextErrorOverwritesStaleErrors(t *testing.T) {
 	}
 }
 
+// TestMultiDBPipelineCallerCancelDoesNotPoisonBreaker is the regression test
+// for the canceled-batch finding: when the caller's own context ends during
+// batch execution, the failure is a client-side signal, not a database health
+// verdict, so the pipeline must record nothing on the breaker or the detector
+// (mirroring the single-command path's post-exec ctx.Err guard). FailureThreshold
+// is 1, so any recorded failure would open the breaker.
+func TestMultiDBPipelineCallerCancelDoesNotPoisonBreaker(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	det := &fakeDetector{}
+	check := newFakeHealthCheck(true)
+	opts := baseOptions()
+	opts.FailureDetector = det
+	opts.CommandRetries = 2
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1,
+	}
+	opts.Clients = []redis.MultiDBClientConfig{{
+		Options:      &redis.Options{Addr: "127.0.0.1:1"},
+		Weight:       1,
+		HealthChecks: []redis.MultiDBHealthCheck{check},
+	}}
+	initCtx, initCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer initCancel()
+	mdb, err := redis.NewMultiDBClient(initCtx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	defer mdb.Close()
+	if err := mdb.AddDatabaseHook(0, &cancelingFailHook{cancel: cancel}); err != nil {
+		t.Fatalf("AddDatabaseHook: %v", err)
+	}
+
+	_, err = mdb.Pipelined(ctx, func(p redis.Pipeliner) error {
+		p.Set(ctx, "k", "v", 0)
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Pipelined err = %v, want context.Canceled", err)
+	}
+	if got := det.failures.Load(); got != 0 {
+		t.Errorf("caller cancellation recorded %d detector failures, want 0 "+
+			"(a client-side cancel must not poison the breaker/detector)", got)
+	}
+}
+
 func TestMultiDBTxAndWatchReturnContextErrorBeforeFailover(t *testing.T) {
 	dbA := newTestDB("a", "127.0.0.1:1", 2, true)
 	dbB := newTestDB("b", "127.0.0.1:2", 1, true)

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -1150,7 +1151,7 @@ func (h *cancelingFailHook) ProcessPipelineHook(next redis.ProcessPipelineHook) 
 	}
 }
 
-func TestMultiDBPipelineContextErrorOverwritesStaleErrors(t *testing.T) {
+func TestMultiDBPipelineCallerCancelPreservesCommandResults(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1177,9 +1178,13 @@ func TestMultiDBPipelineContextErrorOverwritesStaleErrors(t *testing.T) {
 		t.Fatalf("AddDatabaseHook: %v", err)
 	}
 
-	// Attempt one fails at transport level and cancels the caller's context;
-	// the retry loop then returns the context error. The commands must carry
-	// that context error too — not the stale EOF of the failed attempt.
+	// The hook fails at transport level (io.EOF) and cancels the caller's
+	// context. The batch surfaces the cancellation as its aggregate error, but
+	// each command must keep the outcome it actually received — not be
+	// rewritten to context.Canceled. Overwriting would hide which operations
+	// completed (an applied INCR reported as canceled would prompt a replay),
+	// so the pipeline preserves command state on caller cancellation, mirroring
+	// the single-command and tx paths.
 	cmds, err := mdb.Pipelined(ctx, func(p redis.Pipeliner) error {
 		p.Set(ctx, "k", "v", 0)
 		return nil
@@ -1188,8 +1193,8 @@ func TestMultiDBPipelineContextErrorOverwritesStaleErrors(t *testing.T) {
 		t.Fatalf("Pipelined err = %v, want context.Canceled", err)
 	}
 	for i, cmd := range cmds {
-		if !errors.Is(cmd.Err(), context.Canceled) {
-			t.Errorf("cmd %d error = %v, want context.Canceled (stale transport error kept)", i, cmd.Err())
+		if !errors.Is(cmd.Err(), io.EOF) {
+			t.Errorf("cmd %d error = %v, want io.EOF (command result preserved, not overwritten)", i, cmd.Err())
 		}
 	}
 }
@@ -1272,5 +1277,118 @@ func TestMultiDBTxAndWatchReturnContextErrorBeforeFailover(t *testing.T) {
 	}
 	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Errorf("canceled operations switched the active database: active = %d", got)
+	}
+}
+
+// switchThenFailPipelineHook is the pipeline analogue of switchThenFailHook: on
+// its first batch it switches the active database and then fails that batch, so
+// the batch outcome is recorded against a member that is no longer the active.
+type switchThenFailPipelineHook struct {
+	mdb  *redis.MultiDBClient
+	to   int
+	once sync.Once
+}
+
+func (*switchThenFailPipelineHook) DialHook(next redis.DialHook) redis.DialHook { return next }
+func (*switchThenFailPipelineHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return next
+}
+func (h *switchThenFailPipelineHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		h.once.Do(func() { _ = h.mdb.ForceActiveDatabase(context.Background(), h.to) })
+		for _, cmd := range cmds {
+			cmd.SetErr(io.EOF)
+		}
+		return io.EOF
+	}
+}
+
+// TestMultiDBPipelineStaleOutcomeNotRecordedOnDetector is the batch-path
+// counterpart of TestMultiDBStaleOutcomeNotRecordedOnDetector: a batch whose
+// member is no longer the active by the time its outcome is recorded must not
+// feed the global failover detector. Otherwise a large batch failing on the
+// vacated member could immediately trip failover away from the healthy
+// replacement. The per-member breaker is still updated — that is member-scoped.
+func TestMultiDBPipelineStaleOutcomeNotRecordedOnDetector(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 2, true) // active
+	db2 := newTestDB("db2", "127.0.0.1:2", 1, true)
+	det := &fakeDetector{}
+	opts := baseOptions()
+	opts.FailureDetector = det
+	opts.CommandRetries = 1
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 100, // never opens on this test's single failure
+		SuccessThreshold: 1,
+		GracePeriod:      time.Hour,
+	}
+	opts.Clients = append(opts.Clients, db1.cfg, db2.cfg)
+	ctxInit, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	mdb, err := redis.NewMultiDBClient(ctxInit, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	t.Cleanup(func() { _ = mdb.Close() })
+
+	if err := mdb.AddDatabaseHook(0, &switchThenFailPipelineHook{mdb: mdb, to: 1}); err != nil {
+		t.Fatalf("AddDatabaseHook(0): %v", err)
+	}
+	if err := mdb.AddDatabaseHook(1, db2.hook); err != nil {
+		t.Fatalf("AddDatabaseHook(1): %v", err)
+	}
+
+	_, _ = mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+		p.Get(context.Background(), "k")
+		return nil
+	})
+
+	// db1's batch failure was recorded AFTER the hook switched the active to
+	// db2, so the global detector must not have counted it against db2's window.
+	if got := det.failures.Load(); got != 0 {
+		t.Errorf("stale batch outcome from the old active polluted the detector: failures=%d, want 0", got)
+	}
+}
+
+// TestMultiDBConcurrentCloseSerializes checks that concurrent Close calls are
+// serialized through a single drain-then-teardown: a second caller must not
+// race ahead to close the member clients while the first is still draining the
+// autopipeliner. Run under -race, this guards the ordering (and the shared
+// close result) the sync.Once in Close provides.
+func TestMultiDBConcurrentCloseSerializes(t *testing.T) {
+	check := newFakeHealthCheck(true)
+	opts := baseOptions()
+	opts.Clients = []redis.MultiDBClientConfig{{
+		Options:      &redis.Options{Addr: "127.0.0.1:1"},
+		Weight:       1,
+		HealthChecks: []redis.MultiDBHealthCheck{check},
+	}}
+	initCtx, initCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer initCancel()
+	mdb, err := redis.NewMultiDBClient(initCtx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	// Prime the cached autopipeliner so Close has a drain to run.
+	if _, err := mdb.AutoPipeline(); err != nil {
+		t.Fatalf("AutoPipeline: %v", err)
+	}
+
+	const n = 8
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = mdb.Close()
+		}(i)
+	}
+	wg.Wait()
+
+	// Every caller returns the one close's result; none observed a torn teardown.
+	for i, e := range errs {
+		if e != errs[0] {
+			t.Errorf("Close #%d = %v, want same result as #0 (%v)", i, e, errs[0])
+		}
 	}
 }

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -85,7 +85,7 @@ func TestMultiDBPipelineFailoverRetry(t *testing.T) {
 			t.Errorf("command %v error after retry: %v", cmd.Name(), cmd.Err())
 		}
 	}
-	if got := mdb.ActiveIndex(); got != 1 {
+	if got := mdb.ActiveDatabaseID(); got != 1 {
 		t.Fatalf("active index = %d after pipeline failover, want 1", got)
 	}
 	if db2.hook.batches.Load() == 0 {
@@ -301,7 +301,7 @@ func TestMultiDBAutoPipelineRoutesAndFailsOver(t *testing.T) {
 	if err := ap.Set(ctx, "k2", "v2", 0).Err(); err != nil {
 		t.Fatalf("autopipelined Set after active failure: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 1 {
+	if got := mdb.ActiveDatabaseID(); got != 1 {
 		t.Fatalf("active index = %d after autopipeline failover, want 1", got)
 	}
 }
@@ -1270,7 +1270,7 @@ func TestMultiDBTxAndWatchReturnContextErrorBeforeFailover(t *testing.T) {
 	if got := det.resets.Load(); got != 0 {
 		t.Errorf("canceled operations advanced failover state: detector resets = %d", got)
 	}
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Errorf("canceled operations switched the active database: active = %d", got)
 	}
 }

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -456,6 +456,202 @@ func TestMultiDBBatchRegatesAfterFailover(t *testing.T) {
 	}
 }
 
+func TestMultiDBTxPipelineMarksAllCmdsNoRetry(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 1, true)
+	mdb := newTestMultiDB(t, baseOptions(), dbA)
+
+	cmds, err := mdb.TxPipelined(context.Background(), func(p redis.Pipeliner) error {
+		p.Set(context.Background(), "k", "v", 0)
+		p.Get(context.Background(), "k")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("TxPipelined: %v", err)
+	}
+	// The cluster tx path trims the MULTI/EXEC envelope before running its
+	// retry check on the remaining user commands, so the at-most-once
+	// marker must ride on every command — a marker only on the synthetic
+	// MULTI lets a cluster member replay the transaction.
+	for i, cmd := range cmds {
+		if !cmd.NoRetry() {
+			t.Errorf("cmd %d (%s) not marked NoRetry — a cluster member could replay the transaction", i, cmd.Name())
+		}
+	}
+}
+
+func TestMultiDBBatchDetectorFailoverDoesNotLeakProbeSlot(t *testing.T) {
+	newClient := func(t *testing.T, det *fakeDetector) (*redis.MultiDBClient, *testDB, *testDB) {
+		dbA := newTestDB("a", "127.0.0.1:1", 2, true)
+		dbB := newTestDB("b", "127.0.0.1:2", 1, true)
+		opts := baseOptions()
+		opts.FailureDetector = det
+		opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+			FailureThreshold: 1,
+			SuccessThreshold: 1, // one bounded half-open probe slot
+			GracePeriod:      30 * time.Millisecond,
+		}
+		mdb := newTestMultiDB(t, opts, dbA, dbB)
+		// A: half-open (recovering) with its single probe slot free.
+		mdb.TestBreakerRecordFailure(0)
+		time.Sleep(50 * time.Millisecond)
+		det.tripped.Store(true)
+		return mdb, dbA, dbB
+	}
+
+	// Detector-tripped batches must fail over without reserving the old
+	// active's half-open probe slot — nothing would record or release it.
+	t.Run("pipeline", func(t *testing.T) {
+		det := &fakeDetector{}
+		mdb, _, _ := newClient(t, det)
+		if _, err := mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+			p.Set(context.Background(), "k", "v", 0)
+			return nil
+		}); err != nil {
+			t.Fatalf("Pipelined: %v", err)
+		}
+		if !mdb.TestBreakerReserveHalfOpen(0) {
+			t.Error("pipeline detector failover leaked A's half-open probe slot")
+		}
+	})
+	t.Run("tx", func(t *testing.T) {
+		det := &fakeDetector{}
+		mdb, _, _ := newClient(t, det)
+		if _, err := mdb.TxPipelined(context.Background(), func(p redis.Pipeliner) error {
+			p.Set(context.Background(), "k", "v", 0)
+			return nil
+		}); err != nil {
+			t.Fatalf("TxPipelined: %v", err)
+		}
+		if !mdb.TestBreakerReserveHalfOpen(0) {
+			t.Error("tx detector failover leaked A's half-open probe slot")
+		}
+	})
+}
+
+// abortHook aborts every batch with an error WITHOUT stamping the commands
+// and without calling next — the worst-case instrumentation hook.
+type abortHook struct{}
+
+func (abortHook) DialHook(next redis.DialHook) redis.DialHook          { return next }
+func (abortHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook { return next }
+
+func (abortHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		return errors.New("aborted by hook")
+	}
+}
+
+func TestMultiDBHookAbortedBatchNotRecordedAsSuccess(t *testing.T) {
+	check := newFakeHealthCheck(true)
+	opts := baseOptions()
+	opts.CommandRetries = redis.CommandRetriesNone
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1, // one half-open probe slot; one success closes
+		GracePeriod:      30 * time.Millisecond,
+	}
+	opts.Clients = []redis.MultiDBClientConfig{{
+		Options:      &redis.Options{Addr: "127.0.0.1:1"},
+		Weight:       1,
+		HealthChecks: []redis.MultiDBHealthCheck{check},
+	}}
+	initCtx, initCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer initCancel()
+	mdb, err := redis.NewMultiDBClient(initCtx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	defer mdb.Close()
+	if err := mdb.AddDatabaseHook(0, abortHook{}); err != nil {
+		t.Fatalf("AddDatabaseHook: %v", err)
+	}
+
+	// Half-open member: a batch aborted by a local hook (error returned,
+	// commands never stamped, Redis never contacted) must not be recorded
+	// as per-command successes — that would close the breaker off a purely
+	// client-side failure.
+	mdb.TestBreakerRecordFailure(0)
+	time.Sleep(50 * time.Millisecond)
+
+	_, _ = mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+		p.Set(context.Background(), "k", "v", 0)
+		return nil
+	})
+
+	if !mdb.TestBreakerReserveHalfOpen(0) {
+		t.Fatal("setup: expected the breaker to still hand out its half-open slot")
+	}
+	if mdb.TestBreakerReserveHalfOpen(0) {
+		t.Error("breaker closed (or slot accounting lost) after a hook-aborted batch: unlimited admissions")
+	}
+}
+
+// cancelingFailHook fails every batch AND cancels the given context, so the
+// retry loop's next iteration sees a canceled context while the commands
+// still carry the previous attempt's transport errors.
+type cancelingFailHook struct{ cancel context.CancelFunc }
+
+func (h *cancelingFailHook) DialHook(next redis.DialHook) redis.DialHook { return next }
+
+func (h *cancelingFailHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return next
+}
+
+func (h *cancelingFailHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		h.cancel()
+		err := io.EOF
+		for _, cmd := range cmds {
+			cmd.SetErr(err)
+		}
+		return err
+	}
+}
+
+func TestMultiDBPipelineContextErrorOverwritesStaleErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	check := newFakeHealthCheck(true)
+	opts := baseOptions()
+	opts.CommandRetries = 2
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 10, // stay closed so the retry stays on this member
+		SuccessThreshold: 1,
+	}
+	opts.Clients = []redis.MultiDBClientConfig{{
+		Options:      &redis.Options{Addr: "127.0.0.1:1"},
+		Weight:       1,
+		HealthChecks: []redis.MultiDBHealthCheck{check},
+	}}
+	initCtx, initCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer initCancel()
+	mdb, err := redis.NewMultiDBClient(initCtx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	defer mdb.Close()
+	if err := mdb.AddDatabaseHook(0, &cancelingFailHook{cancel: cancel}); err != nil {
+		t.Fatalf("AddDatabaseHook: %v", err)
+	}
+
+	// Attempt one fails at transport level and cancels the caller's context;
+	// the retry loop then returns the context error. The commands must carry
+	// that context error too — not the stale EOF of the failed attempt.
+	cmds, err := mdb.Pipelined(ctx, func(p redis.Pipeliner) error {
+		p.Set(ctx, "k", "v", 0)
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Pipelined err = %v, want context.Canceled", err)
+	}
+	for i, cmd := range cmds {
+		if !errors.Is(cmd.Err(), context.Canceled) {
+			t.Errorf("cmd %d error = %v, want context.Canceled (stale transport error kept)", i, cmd.Err())
+		}
+	}
+}
+
 func TestMultiDBTxAndWatchReturnContextErrorBeforeFailover(t *testing.T) {
 	dbA := newTestDB("a", "127.0.0.1:1", 2, true)
 	dbB := newTestDB("b", "127.0.0.1:2", 1, true)

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -573,6 +573,86 @@ func TestMultiDBTxPipelinePanicRestoresNoRetry(t *testing.T) {
 	}
 }
 
+// TestMultiDBBatchPanicReleasesHalfOpenProbeSlot pins the deferred release: a
+// batch admitted on a half-open member reserves its single probe slot, and a
+// panic in the member hook unwinds past recordBatchOutcomes and the cancel
+// branch. The slot must still come back, or the breaker stays wedged at
+// MaxHalfOpenRequests for good (Watch already defers the release).
+func TestMultiDBBatchPanicReleasesHalfOpenProbeSlot(t *testing.T) {
+	newClient := func(t *testing.T) *redis.MultiDBClient {
+		// Built from raw options rather than newTestMultiDB: that helper installs
+		// a per-member hookedDB which serves batches locally and would sit ahead
+		// of the panicking hook in the chain, so the panic would never fire. A
+		// single member: alone, A stays active and its half-open admission is
+		// the one the panic has to give back.
+		check := newFakeHealthCheck(true)
+		opts := baseOptions()
+		opts.Clients = []redis.MultiDBClientConfig{{
+			Options:      &redis.Options{Addr: "127.0.0.1:1"},
+			Weight:       1,
+			HealthChecks: []redis.MultiDBHealthCheck{check},
+		}}
+		opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+			FailureThreshold: 1,
+			SuccessThreshold: 1, // one bounded half-open probe slot
+			GracePeriod:      30 * time.Millisecond,
+		}
+		initCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		mdb, err := redis.NewMultiDBClient(initCtx, opts)
+		if err != nil {
+			t.Fatalf("NewMultiDBClient: %v", err)
+		}
+		t.Cleanup(func() { _ = mdb.Close() })
+		// A: half-open (recovering) with its single probe slot free.
+		mdb.TestBreakerRecordFailure(0)
+		time.Sleep(50 * time.Millisecond)
+		armed := &atomic.Bool{}
+		armed.Store(true)
+		if err := mdb.AddDatabaseHook(0, panicPipelineHook{armed: armed}); err != nil {
+			t.Fatalf("AddDatabaseHook: %v", err)
+		}
+		return mdb
+	}
+	mustPanic := func(t *testing.T, fn func() error) {
+		t.Helper()
+		var err error
+		defer func() {
+			if recover() == nil {
+				t.Fatalf("expected the member hook panic to propagate; call returned err=%v", err)
+			}
+		}()
+		err = fn()
+	}
+
+	t.Run("pipeline", func(t *testing.T) {
+		mdb := newClient(t)
+		mustPanic(t, func() error {
+			_, err := mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+				p.Set(context.Background(), "k", "v", 0)
+				return nil
+			})
+			return err
+		})
+		if !mdb.TestBreakerReserveHalfOpen(0) {
+			t.Error("pipeline panic leaked A's half-open probe slot")
+		}
+	})
+	t.Run("tx", func(t *testing.T) {
+		mdb := newClient(t)
+		mustPanic(t, func() error {
+			_, err := mdb.TxPipelined(context.Background(), func(p redis.Pipeliner) error {
+				p.Set(context.Background(), "k", "v", 0)
+				return nil
+			})
+			return err
+		})
+		if !mdb.TestBreakerReserveHalfOpen(0) {
+			t.Error("tx panic leaked A's half-open probe slot")
+		}
+	})
+}
+
 func TestMultiDBBatchDetectorFailoverDoesNotLeakProbeSlot(t *testing.T) {
 	newClient := func(t *testing.T, det *fakeDetector) (*redis.MultiDBClient, *testDB, *testDB) {
 		dbA := newTestDB("a", "127.0.0.1:1", 2, true)

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -676,19 +676,22 @@ func TestMultiDBBatchRejectsHImport(t *testing.T) {
 	// The direct HImport* overrides reject the family, but pipeline and tx
 	// builders dispatch through their own cmdable — the batch paths must
 	// reject HIMPORT commands too, or registrations would land in a single
-	// member's registry and break after failover.
-	cmds, err := mdb.Pipelined(ctx, func(p redis.Pipeliner) error {
+	// member's registry and break after failover. In plain pipelines only
+	// the HIMPORT command itself fails (see the poisoning test below); a
+	// transaction is atomic, so the whole tx is rejected.
+	cmds, _ := mdb.Pipelined(ctx, func(p redis.Pipeliner) error {
 		p.HImportPrepare(ctx, "fs", "f1")
 		p.Set(ctx, "k", "v", 0)
 		return nil
 	})
-	if err == nil {
-		t.Error("Pipelined with HIMPORT succeeded, want rejection")
+	if len(cmds) != 2 {
+		t.Fatalf("got %d cmds, want 2", len(cmds))
 	}
-	for i, cmd := range cmds {
-		if cmd.Err() == nil {
-			t.Errorf("pipeline cmd %d has nil error in a rejected batch", i)
-		}
+	if cmds[0].Err() == nil {
+		t.Error("pipelined HIMPORT command not rejected")
+	}
+	if err := cmds[1].Err(); err != nil {
+		t.Errorf("innocent pipelined command rejected: %v", err)
 	}
 
 	if _, err := mdb.TxPipelined(ctx, func(p redis.Pipeliner) error {
@@ -860,6 +863,74 @@ func TestMultiDBPartiallyStampedAbortDoesNotFabricateSuccesses(t *testing.T) {
 		if cmd.Err() == nil {
 			t.Errorf("cmd %d left without an error after an aborted batch", i)
 		}
+	}
+}
+
+func TestMultiDBBatchHImportDoesNotPoisonOtherCommands(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 1, true)
+	mdb := newTestMultiDB(t, baseOptions(), dbA)
+	ctx := context.Background()
+
+	// An unsupported HIMPORT command in a batch (e.g. coalesced by the
+	// autopipeliner with unrelated callers' commands) must fail ONLY itself:
+	// poisoning the whole flush would fail innocent commands that merely
+	// shared the batch.
+	cmds, _ := mdb.Pipelined(ctx, func(p redis.Pipeliner) error {
+		p.Set(ctx, "k1", "v", 0)
+		p.HImportPrepare(ctx, "fs", "f1")
+		p.Set(ctx, "k2", "v", 0)
+		return nil
+	})
+	if len(cmds) != 3 {
+		t.Fatalf("got %d cmds, want 3", len(cmds))
+	}
+	if err := cmds[0].Err(); err != nil {
+		t.Errorf("innocent cmd 0 poisoned by the HIMPORT rejection: %v", err)
+	}
+	if err := cmds[1].Err(); err == nil {
+		t.Error("HIMPORT command not rejected")
+	}
+	if err := cmds[2].Err(); err != nil {
+		t.Errorf("innocent cmd 2 poisoned by the HIMPORT rejection: %v", err)
+	}
+}
+
+func TestMultiDBTxRetriesAnotherMemberWhenHalfOpenFull(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 2, true)
+	dbB := newTestDB("b", "127.0.0.1:2", 1, true)
+	det := &fakeDetector{}
+	opts := baseOptions()
+	opts.FailureDetector = det
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1, // one probe slot
+		GracePeriod:      30 * time.Millisecond,
+	}
+	mdb := newTestMultiDB(t, opts, dbA, dbB)
+
+	// B: half-open with its only probe slot taken; A: healthy and closed.
+	// A detector-tripped transaction fails over to B, is denied a probe
+	// slot — and must then fail over again (back to closed A) rather than
+	// reject the transaction: no MULTI/EXEC was sent yet, so another
+	// failover cannot violate at-most-once.
+	mdb.TestBreakerRecordFailure(1)
+	time.Sleep(50 * time.Millisecond)
+	if !mdb.TestBreakerReserveHalfOpen(1) {
+		t.Fatal("setup: expected to reserve B's probe slot")
+	}
+
+	det.tripped.Store(true)
+	if _, err := mdb.TxPipelined(context.Background(), func(p redis.Pipeliner) error {
+		p.Set(context.Background(), "k", "v", 0)
+		return nil
+	}); err != nil {
+		t.Fatalf("TxPipelined = %v, want success on the closed member", err)
+	}
+	if got := dbA.hook.batches.Load(); got != 1 {
+		t.Errorf("batches on A = %d, want 1 (transaction should land back on the closed member)", got)
+	}
+	if got := dbB.hook.batches.Load(); got != 0 {
+		t.Errorf("batches on B = %d, want 0 (no probe slot available)", got)
 	}
 }
 

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -369,5 +370,121 @@ func TestMultiDBDo(t *testing.T) {
 	}
 	if db1.hook.commands.Load() == 0 {
 		t.Error("Do did not reach the active database")
+	}
+}
+
+func TestMultiDBTxPipelineNotRetriedByMemberClient(t *testing.T) {
+	var dials atomic.Int64
+	opts := baseOptions()
+	opts.Clients = []redis.MultiDBClientConfig{{
+		Weight: 1,
+		Options: &redis.Options{
+			Addr:          "127.0.0.1:1",
+			MaxRetries:    2, // member-level retries that must NOT apply to transactions
+			DialerRetries: 1, // exactly one dial per member pipeline attempt
+			DialTimeout:   200 * time.Millisecond,
+			Dialer: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				dials.Add(1)
+				return nil, io.EOF
+			},
+		},
+		HealthChecks: []redis.MultiDBHealthCheck{newFakeHealthCheck(true)},
+	}}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	mdb, err := redis.NewMultiDBClient(ctx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	defer mdb.Close()
+
+	_, err = mdb.TxPipelined(context.Background(), func(p redis.Pipeliner) error {
+		p.Set(context.Background(), "k", "v", 0)
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected the transaction to fail (no server behind the dialer)")
+	}
+	// EXEC may have committed before a transport error surfaced: the member
+	// client must not replay the transaction either — at-most-once holds for
+	// the whole stack, not only the MultiDB retry layer.
+	if got := dials.Load(); got != 1 {
+		t.Errorf("transaction dialed %d times, want 1 (member retries must be suppressed)", got)
+	}
+}
+
+func TestMultiDBBatchRegatesAfterFailover(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 2, true)
+	dbB := newTestDB("b", "127.0.0.1:2", 1, true)
+	det := &fakeDetector{}
+	opts := baseOptions()
+	opts.FailureDetector = det
+	opts.CommandRetries = 2
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1, // MaxHalfOpenRequests defaults to this: one probe slot
+		GracePeriod:      30 * time.Millisecond,
+	}
+	mdb := newTestMultiDB(t, opts, dbA, dbB)
+
+	// B: open its breaker, wait out the grace period, then occupy the only
+	// half-open probe slot — a recovering member whose probe budget a
+	// concurrent request is already using.
+	mdb.TestBreakerRecordFailure(1)
+	time.Sleep(50 * time.Millisecond)
+	if !mdb.TestBreakerReserveHalfOpen(1) {
+		t.Fatal("setup: expected to reserve B's half-open probe slot")
+	}
+
+	// Trip the gate: the batch fails over from A, and the strategy picks
+	// half-open B. With B's only probe slot taken, the batch must re-enter
+	// the admission gate (landing back on closed A) rather than execute on
+	// B without a reservation.
+	det.tripped.Store(true)
+	if _, err := mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+		p.Set(context.Background(), "k", "v", 0)
+		return nil
+	}); err != nil {
+		t.Fatalf("Pipelined: %v", err)
+	}
+
+	if got := dbB.hook.batches.Load(); got != 0 {
+		t.Errorf("batch executed on B without a half-open slot (batches = %d)", got)
+	}
+	if got := dbA.hook.batches.Load(); got != 1 {
+		t.Errorf("batches on A = %d, want 1", got)
+	}
+}
+
+func TestMultiDBTxAndWatchReturnContextErrorBeforeFailover(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 2, true)
+	dbB := newTestDB("b", "127.0.0.1:2", 1, true)
+	det := &fakeDetector{}
+	opts := baseOptions()
+	opts.FailureDetector = det
+	mdb := newTestMultiDB(t, opts, dbA, dbB)
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// With the detector tripped, a done context must be reported as the
+	// caller's own error BEFORE the failover gate runs: failing over (and
+	// resetting the detector) for an operation that cannot execute would
+	// mutate availability state for nothing.
+	det.tripped.Store(true)
+	if _, err := mdb.TxPipelined(canceled, func(p redis.Pipeliner) error {
+		p.Set(canceled, "k", "v", 0)
+		return nil
+	}); !errors.Is(err, context.Canceled) {
+		t.Errorf("TxPipelined with canceled ctx: err = %v, want context.Canceled", err)
+	}
+	if err := mdb.Watch(canceled, func(tx *redis.Tx) error { return nil }, "k"); !errors.Is(err, context.Canceled) {
+		t.Errorf("Watch with canceled ctx: err = %v, want context.Canceled", err)
+	}
+	if got := det.resets.Load(); got != 0 {
+		t.Errorf("canceled operations advanced failover state: detector resets = %d", got)
+	}
+	if got := mdb.ActiveIndex(); got != 0 {
+		t.Errorf("canceled operations switched the active database: active = %d", got)
 	}
 }

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -934,6 +934,44 @@ func TestMultiDBTxRetriesAnotherMemberWhenHalfOpenFull(t *testing.T) {
 	}
 }
 
+func TestMultiDBWatchRegatesAfterFailover(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 2, true)
+	dbB := newTestDB("b", "127.0.0.1:2", 1, true)
+	det := &fakeDetector{}
+	opts := baseOptions()
+	opts.FailureDetector = det
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1, // one probe slot
+		GracePeriod:      30 * time.Millisecond,
+	}
+	mdb := newTestMultiDB(t, opts, dbA, dbB)
+
+	// B: half-open with its only probe slot taken; A: healthy and closed.
+	// A detector-tripped Watch fails over to B, is denied a probe slot — and
+	// must then fail over again (back to closed A) like the batch gates do,
+	// rather than reject the transaction while a healthy member is still
+	// selectable: no WATCH was sent yet, so another failover is safe.
+	mdb.TestBreakerRecordFailure(1)
+	time.Sleep(50 * time.Millisecond)
+	if !mdb.TestBreakerReserveHalfOpen(1) {
+		t.Fatal("setup: expected to reserve B's probe slot")
+	}
+
+	det.tripped.Store(true)
+	if err := mdb.Watch(context.Background(), func(tx *redis.Tx) error {
+		return nil
+	}, "k"); err != nil {
+		t.Fatalf("Watch = %v, want success on the closed member", err)
+	}
+	if got := dbA.hook.commands.Load(); got == 0 {
+		t.Error("no commands on A — Watch should land back on the closed member")
+	}
+	if got := dbB.hook.commands.Load(); got != 0 {
+		t.Errorf("commands on B = %d, want 0 (no probe slot available)", got)
+	}
+}
+
 func TestMultiDBBatchAllHalfOpenFullReturnsUnavailable(t *testing.T) {
 	dbA := newTestDB("a", "127.0.0.1:1", 2, true)
 	dbB := newTestDB("b", "127.0.0.1:2", 1, true)

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -3,6 +3,7 @@ package redis_test
 import (
 	"context"
 	"errors"
+	"io"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -126,6 +127,30 @@ func TestMultiDBPipelinePerCommandRecording(t *testing.T) {
 	_, _ = pipe.Exec(ctx)
 	if got := det.successes.Load(); got != 3 {
 		t.Errorf("detector successes = %d, want 3", got)
+	}
+}
+
+func TestMultiDBPipelineNoRetryCommandDisablesRetry(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 2.0, true)
+	db2 := newTestDB("db2", "127.0.0.1:2", 1.0, true)
+
+	opts := baseOptions()
+	opts.CommandRetries = 3 // must be ignored when the batch has a NoRetry command
+	opts.CircuitBreakerConfig = fastBreaker()
+	mdb := newTestMultiDB(t, opts, db1, db2)
+	ctx := context.Background()
+
+	db1.hook.fail.Store(true)
+
+	pipe := mdb.Pipeline()
+	pipe.Get(ctx, "k")
+	_ = pipe.Process(ctx, redis.NewRawWriteToCmd(ctx, io.Discard, "get", "k"))
+	_, err := pipe.Exec(ctx)
+	if err == nil {
+		t.Fatal("batch with a NoRetry command should surface the failure, not retry")
+	}
+	if db2.hook.batches.Load() != 0 {
+		t.Error("batch containing a NoRetry command was retried on db2")
 	}
 }
 

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -1501,3 +1501,41 @@ func TestMultiDBTxPipelineCallerCancelReturnsCancellation(t *testing.T) {
 		t.Fatalf("TxPipelined caller-cancel err = %v, want context.Canceled (aggregate, not the transport error)", err)
 	}
 }
+
+// TestMultiDBPipelineRetryExitPreservesPriorAttemptResults pins that a terminal
+// exit of the retry loop after a prior attempt has run does NOT reset+restamp
+// the commands with the aggregate error: attempt 0 fails at transport level and
+// opens the member's breaker, so attempt 1 is gate-rejected into an
+// availability error, but the per-command results attempt 0 produced must
+// survive (the same preserve-on-cancel reasoning applied to every retry-loop
+// exit). A server-free fake cannot produce an executed success, so this asserts
+// attempt 0's transport error survives instead of being overwritten.
+func TestMultiDBPipelineRetryExitPreservesPriorAttemptResults(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 1, true)
+	dbA.hook.fail.Store(true) // every batch fails at transport level (wrapped io.EOF)
+	opts := baseOptions()
+	opts.CommandRetries = 1
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1, // attempt 0's failure opens the breaker
+		SuccessThreshold: 1,
+		GracePeriod:      time.Hour, // stays open, so attempt 1's gate is rejected
+	}
+	mdb := newTestMultiDB(t, opts, dbA)
+
+	cmds, err := mdb.Pipelined(context.Background(), func(p redis.Pipeliner) error {
+		p.Set(context.Background(), "k0", "v", 0)
+		p.Get(context.Background(), "k1")
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected an availability error after the member's breaker opened")
+	}
+	// attempt 1 exits via the gate (breaker open) with attempt > 0. The commands
+	// must still carry attempt 0's transport error, not be reset and overwritten
+	// with the aggregate availability error.
+	for i, cmd := range cmds {
+		if !errors.Is(cmd.Err(), io.EOF) {
+			t.Errorf("cmds[%d] err = %v, want the preserved transport error (io.EOF)", i, cmd.Err())
+		}
+	}
+}

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -1459,3 +1459,45 @@ func TestMultiDBConcurrentCloseSerializes(t *testing.T) {
 		}
 	}
 }
+
+// TestMultiDBTxPipelineCallerCancelReturnsCancellation pins that a TxPipeline
+// interrupted by the caller's own context surfaces the cancellation as its
+// aggregate error (like the non-tx pipeline path), not the underlying transport
+// error — so a caller does not mistake a deliberate cancel for a retryable
+// disconnect.
+func TestMultiDBTxPipelineCallerCancelReturnsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	check := newFakeHealthCheck(true)
+	opts := baseOptions()
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 10,
+		SuccessThreshold: 1,
+	}
+	opts.Clients = []redis.MultiDBClientConfig{{
+		Options:      &redis.Options{Addr: "127.0.0.1:1"},
+		Weight:       1,
+		HealthChecks: []redis.MultiDBHealthCheck{check},
+	}}
+	initCtx, initCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer initCancel()
+	mdb, err := redis.NewMultiDBClient(initCtx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	defer mdb.Close()
+	if err := mdb.AddDatabaseHook(0, &cancelingFailHook{cancel: cancel}); err != nil {
+		t.Fatalf("AddDatabaseHook: %v", err)
+	}
+
+	// The hook fails at transport level (io.EOF) and cancels the caller's
+	// context mid-transaction.
+	_, err = mdb.TxPipelined(ctx, func(p redis.Pipeliner) error {
+		p.Set(ctx, "k", "v", 0)
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("TxPipelined caller-cancel err = %v, want context.Canceled (aggregate, not the transport error)", err)
+	}
+}

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -895,6 +895,32 @@ func TestMultiDBBatchHImportDoesNotPoisonOtherCommands(t *testing.T) {
 	}
 }
 
+func TestMultiDBBatchEarlyExitKeepsPositionalFirstError(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 1, true)
+	mdb := newTestMultiDB(t, baseOptions(), dbA)
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// A rejected HIMPORT followed by a command whose gate exits early (the
+	// context is already canceled, so the batch never executes): Exec must
+	// still report the POSITIONALLY first error over the original slice —
+	// the HIMPORT rejection — exactly like the executed path does.
+	cmds, err := mdb.Pipelined(canceled, func(p redis.Pipeliner) error {
+		p.HImportPrepare(canceled, "fs", "f1")
+		p.Set(canceled, "k", "v", 0)
+		return nil
+	})
+	if len(cmds) != 2 {
+		t.Fatalf("got %d cmds, want 2", len(cmds))
+	}
+	if want := cmds[0].Err(); want == nil || !errors.Is(err, want) {
+		t.Errorf("Exec = %v, want the positionally first error %v", err, want)
+	}
+	if !errors.Is(cmds[1].Err(), context.Canceled) {
+		t.Errorf("cmd 1 err = %v, want context.Canceled", cmds[1].Err())
+	}
+}
+
 func TestMultiDBTxRetriesAnotherMemberWhenHalfOpenFull(t *testing.T) {
 	dbA := newTestDB("a", "127.0.0.1:1", 2, true)
 	dbB := newTestDB("b", "127.0.0.1:2", 1, true)
@@ -969,6 +995,38 @@ func TestMultiDBWatchRegatesAfterFailover(t *testing.T) {
 	}
 	if got := dbB.hook.commands.Load(); got != 0 {
 		t.Errorf("commands on B = %d, want 0 (no probe slot available)", got)
+	}
+}
+
+func TestMultiDBWatchDoesNotReleaseUnreservedSlot(t *testing.T) {
+	dbA := newTestDB("a", "127.0.0.1:1", 1, true)
+	opts := baseOptions()
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1, // one bounded half-open probe slot
+		GracePeriod:      30 * time.Millisecond,
+	}
+	mdb := newTestMultiDB(t, opts, dbA)
+
+	// Watch is admitted while A's breaker is CLOSED — no probe slot is
+	// reserved. While the transaction is open, other traffic opens the
+	// breaker, the grace period moves it to half-open, and a recovery probe
+	// takes the only slot. Watch's deferred release must not free that
+	// probe's slot: it never reserved one.
+	err := mdb.Watch(context.Background(), func(tx *redis.Tx) error {
+		mdb.TestBreakerRecordFailure(0)
+		time.Sleep(50 * time.Millisecond)
+		if !mdb.TestBreakerReserveHalfOpen(0) {
+			t.Fatal("setup: expected to reserve the half-open probe slot")
+		}
+		return nil
+	}, "k")
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	if mdb.TestBreakerReserveHalfOpen(0) {
+		t.Error("a second half-open reservation succeeded — Watch released a slot it never reserved")
 	}
 }
 

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -177,6 +177,60 @@ func TestMultiDBTxPipelineNotRetried(t *testing.T) {
 	}
 }
 
+func TestMultiDBTxPipelineRecordsOnlyUserCommands(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 2.0, true)
+	db2 := newTestDB("db2", "127.0.0.1:2", 1.0, true)
+
+	det := &countingDetector{}
+	opts := baseOptions()
+	opts.FailureDetector = det
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 100,
+		SuccessThreshold: 1,
+		GracePeriod:      time.Hour,
+	}
+	mdb := newTestMultiDB(t, opts, db1, db2)
+	ctx := context.Background()
+
+	db1.hook.fail.Store(true)
+	pipe := mdb.TxPipeline()
+	pipe.Set(ctx, "a", "1", 0)
+	_, _ = pipe.Exec(ctx)
+
+	// One user command — one failure record, not three (MULTI/EXEC excluded).
+	if got := det.failures.Load(); got != 1 {
+		t.Errorf("detector failures = %d, want 1 (synthetic MULTI/EXEC must not count)", got)
+	}
+}
+
+func TestMultiDBAutoPipelineRefusesClusterMembers(t *testing.T) {
+	standalone := newTestDB("db1", "127.0.0.1:1", 2.0, true)
+	clusterCheck := newFakeHealthCheck(true)
+
+	opts := baseOptions()
+	opts.InitialDBState = redis.InitialDBStateOneAvailable
+	opts.Clients = append(opts.Clients, standalone.cfg, redis.MultiDBClientConfig{
+		ClusterOptions: &redis.ClusterOptions{Addrs: []string{"127.0.0.1:2"}},
+		Weight:         1.0,
+		HealthChecks:   []redis.MultiDBHealthCheck{clusterCheck},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	mdb, err := redis.NewMultiDBClient(ctx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	defer mdb.Close()
+
+	if _, err := mdb.AutoPipeline(); err == nil {
+		t.Error("AutoPipeline with a cluster member should be refused")
+	}
+	if _, err := mdb.AsyncAutoPipeline(); err == nil {
+		t.Error("AsyncAutoPipeline with a cluster member should be refused")
+	}
+}
+
 func TestMultiDBAutoPipelineRoutesAndFailsOver(t *testing.T) {
 	db1 := newTestDB("db1", "127.0.0.1:1", 2.0, true)
 	db2 := newTestDB("db2", "127.0.0.1:2", 1.0, true)

--- a/multidb_autopipeline_test.go
+++ b/multidb_autopipeline_test.go
@@ -529,6 +529,50 @@ func TestMultiDBTxPipelineMarksCmdsNoRetryDuringExecOnly(t *testing.T) {
 	}
 }
 
+func TestMultiDBTxPipelinePanicRestoresNoRetry(t *testing.T) {
+	check := newFakeHealthCheck(true)
+	opts := baseOptions()
+	opts.Clients = []redis.MultiDBClientConfig{{
+		Options:      &redis.Options{Addr: "127.0.0.1:1"},
+		Weight:       1,
+		HealthChecks: []redis.MultiDBHealthCheck{check},
+	}}
+	initCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	mdb, err := redis.NewMultiDBClient(initCtx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	defer mdb.Close()
+	armed := &atomic.Bool{}
+	armed.Store(true)
+	if err := mdb.AddDatabaseHook(0, panicPipelineHook{armed: armed}); err != nil {
+		t.Fatalf("AddDatabaseHook: %v", err)
+	}
+
+	pipe := mdb.TxPipeline()
+	setCmd := pipe.Set(context.Background(), "k", "v", 0)
+	getCmd := pipe.Get(context.Background(), "k")
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected panic from member pipeline hook")
+			}
+		}()
+		_, _ = pipe.Exec(context.Background())
+	}()
+
+	// The member path unwound through a panic. The caller still holds setCmd/
+	// getCmd; the temporary at-most-once marker must have been cleared, or a
+	// reused *Cmd would be left permanently non-retryable.
+	for _, cmd := range []redis.Cmder{setCmd, getCmd} {
+		if cmd.NoRetry() {
+			t.Errorf("cmd %s left NoRetry after a panicking TxPipeline exec — restore must be panic-safe", cmd.Name())
+		}
+	}
+}
+
 func TestMultiDBBatchDetectorFailoverDoesNotLeakProbeSlot(t *testing.T) {
 	newClient := func(t *testing.T, det *fakeDetector) (*redis.MultiDBClient, *testDB, *testDB) {
 		dbA := newTestDB("a", "127.0.0.1:1", 2, true)

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -126,8 +126,10 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 			}
 			// Settle the batch's single reservation: RecordSuccessFor releases
 			// (or, at SuccessThreshold, closes on) the half-open slot at most
-			// once however many commands succeed, and records an external
-			// success for a closed admission (res.held == false).
+			// once however many commands succeed. For a closed admission
+			// (res.held == false) it clears the failure count while the circuit
+			// is still closed and never counts toward closing a later half-open
+			// episode the batch was not admitted to.
 			db.cb.RecordSuccessFor(res)
 			if cur, _ := c.activeSnapshot(); cur == db {
 				c.detector.RecordSuccess()
@@ -144,7 +146,14 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 			// marker would leave breakers closed through real outages on
 			// batch-only workloads. Successes are the asymmetric case: a
 			// genuine reply cannot exist without execution.
-			db.cb.RecordFailure()
+			//
+			// Settled through the reservation like successes: a held admission
+			// records only while its half-open episode is still current — a
+			// batch that outlived a failed recovery must not re-open the NEW
+			// episode it was never admitted to — one failure per command, as
+			// the single-command path does; a closed admission always counts
+			// toward opening.
+			db.cb.RecordFailureFor(res)
 			if cur, _ := c.activeSnapshot(); cur == db {
 				c.detector.RecordFailure(cmd.rawErr())
 			}

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -56,12 +56,16 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 		// successes for the untouched commands.
 		setCmdsErr(cmds, batchErr)
 	}
+	// Blocking commands carry their own read timeout; their local deadlines
+	// are not retryable transport failures — the same per-command rule the
+	// single-command path applies (cmd.readTimeout() == nil).
+	classify := func(cmd Cmder) outcomeKind {
+		return classifyOutcome(cmd.rawErr(), cmd.readTimeout() == nil)
+	}
 	transportFailures := 0
 	recorded := 0
 	recordOne := func(cmd Cmder) {
-		// Errors are classified with retryTimeout=true, mirroring the plain
-		// pipeline retry rule of *Client/*ClusterClient batch paths.
-		switch classifyOutcome(cmd.rawErr(), true) {
+		switch classify(cmd) {
 		case outcomeSuccess:
 			if !executed {
 				// A nil (or reply-class) error fabricated by an aborting
@@ -76,6 +80,13 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 			c.successSinceFailover.Store(true)
 			recorded++
 		case outcomeFailure:
+			// Failures record regardless of the execution marker — unlike
+			// successes: a dial failure (the canonical down-member signal)
+			// happens BEFORE the marker flips, and it is indistinguishable
+			// from a pre-execution hook abort. Guarding failures on the
+			// marker would leave breakers closed through real outages on
+			// batch-only workloads. Successes are the asymmetric case: a
+			// genuine reply cannot exist without execution.
 			db.cb.RecordFailure()
 			c.detector.RecordFailure(cmd.rawErr())
 			transportFailures++
@@ -93,12 +104,12 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 		// sequential single commands, where a success resets the closed
 		// state's failure count before a later failure increments it.
 		for _, cmd := range cmds {
-			if classifyOutcome(cmd.rawErr(), true) == outcomeFailure {
+			if classify(cmd) == outcomeFailure {
 				recordOne(cmd)
 			}
 		}
 		for _, cmd := range cmds {
-			if classifyOutcome(cmd.rawErr(), true) != outcomeFailure {
+			if classify(cmd) != outcomeFailure {
 				recordOne(cmd)
 			}
 		}
@@ -144,6 +155,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		setCmdsErr(cmds, ErrClosed)
 		return ErrClosed
 	}
+	var himportErr error
 	if cmdsContainHImport(cmds) {
 		// Reject only the HIMPORT commands themselves: the autopipeliner
 		// coalesces unrelated callers into one flush, and poisoning the
@@ -160,6 +172,10 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			return errMultiDBHImport
 		}
 		cmds = kept
+		// The batch as a whole still failed partially: callers relying on
+		// the Exec/Pipelined error must see it even when every kept command
+		// succeeds.
+		himportErr = errMultiDBHImport
 	}
 	attempts := c.opts.CommandRetries + 1
 	// A batch containing a non-retryable command (e.g. a streaming
@@ -230,10 +246,16 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		if transportFailures == 0 {
 			// Only server replies (or clean success) — done, whatever the
 			// user-level outcome is.
+			if err == nil && himportErr != nil {
+				return himportErr
+			}
 			return err
 		}
 	}
-	return cmdsFirstErr(cmds)
+	if err := cmdsFirstErr(cmds); err != nil {
+		return err
+	}
+	return himportErr
 }
 
 // processTxPipeline executes a MULTI/EXEC pipeline against the active

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -509,13 +509,16 @@ func (c *MultiDBClient) TxPipeline() Pipeliner {
 					bc.setNoRetry(true)
 				}
 			}
-			err := c.processTxPipelineHook(ctx, cmds)
-			for i, cmd := range cmds {
-				if bc, ok := cmd.(noRetrier); ok {
-					bc.setNoRetry(prev[i])
+			// Restore via defer so a panic in the hook or member path still
+			// clears the temporary noRetry on the caller-owned commands.
+			defer func() {
+				for i, cmd := range cmds {
+					if bc, ok := cmd.(noRetrier); ok {
+						bc.setNoRetry(prev[i])
+					}
 				}
-			}
-			return err
+			}()
+			return c.processTxPipelineHook(ctx, cmds)
 		},
 	}
 	pipe.init()

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -67,16 +67,12 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 	classify := func(cmd Cmder) outcomeKind {
 		return classifyOutcome(cmd.rawErr(), cmd.readTimeout() == nil)
 	}
-	// Feed the GLOBAL detector only while this batch's member is still the
-	// active: if the active switched (or this member was removed) while the
-	// batch was in flight, recording its outcomes would pollute the new
-	// active's failover window and successSinceFailover. The per-member breaker
-	// below is always updated — it is member-scoped. Mirrors the single-command
-	// path (see process). One snapshot suffices: recordBatchOutcomes runs
-	// synchronously at the end of a single attempt, the batch analogue of the
-	// single-command post-exec check.
-	cur, _ := c.activeSnapshot()
-	stillActive := cur == db
+	// The GLOBAL detector (and successSinceFailover) is fed only while this
+	// member is STILL the active — re-checked per recorded outcome, not once up
+	// front: a concurrent switchActive can vacate this member partway through
+	// recording a large batch, and outcomes recorded after that must not pollute
+	// the new active's failover window. The per-member breaker below is always
+	// updated — it is member-scoped. Mirrors the single-command path (process).
 	transportFailures := 0
 	recorded := 0
 	recordOne := func(cmd Cmder) {
@@ -94,7 +90,7 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 			// once however many commands succeed, and records an external
 			// success for a closed admission (res.held == false).
 			db.cb.RecordSuccessFor(res)
-			if stillActive {
+			if cur, _ := c.activeSnapshot(); cur == db {
 				c.detector.RecordSuccess()
 				// Recovery traffic breaks the consecutive-failed-failover chain
 				// for batch-only workloads too (see recordFailedFailoverLocked).
@@ -110,7 +106,7 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 			// batch-only workloads. Successes are the asymmetric case: a
 			// genuine reply cannot exist without execution.
 			db.cb.RecordFailure()
-			if stillActive {
+			if cur, _ := c.activeSnapshot(); cur == db {
 				c.detector.RecordFailure(cmd.rawErr())
 			}
 			transportFailures++
@@ -241,18 +237,26 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 	for attempt < attempts {
 		if c.closed.Load() {
 			// Close landed mid-retry: report the terminal state instead of
-			// escalating through the drained membership.
-			resetCmds(cmds)
-			setCmdsErr(cmds, ErrClosed)
+			// escalating through the drained membership. Only stamp the commands
+			// when no attempt has executed yet; once a prior attempt applied a
+			// prefix, its per-command results are the caller's evidence and must
+			// not be overwritten (see the post-exec cancel branch below).
+			if attempt == 0 {
+				resetCmds(cmds)
+				setCmdsErr(cmds, ErrClosed)
+			}
 			return exitErr(ErrClosed)
 		}
 		if err := ctx.Err(); err != nil {
-			// Overwrite any prior attempt's transport errors: callers that
-			// inspect per-command results must see the context error, not a
-			// stale EOF from the failed attempt (setCmdsErr fills only
-			// empty slots).
-			resetCmds(cmds)
-			setCmdsErr(cmds, err)
+			// Only stamp the cancellation when no attempt has executed yet. Once
+			// a prior attempt applied a prefix (delivery is at-least-once with
+			// retries), overwriting it would report an executed command as
+			// canceled and invite a replay — the same reasoning as the post-exec
+			// cancel branch below.
+			if attempt == 0 {
+				resetCmds(cmds)
+				setCmdsErr(cmds, err)
+			}
 			return exitErr(err)
 		}
 
@@ -269,16 +273,19 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			gateRejections++
 			if gateRejections > maxGateRejections {
 				err := ErrTemporarilyNotAvailable
-				resetCmds(cmds)
-				setCmdsErr(cmds, err)
+				if attempt == 0 {
+					resetCmds(cmds)
+					setCmdsErr(cmds, err)
+				}
 				return exitErr(err)
 			}
 			if err := c.tryFailover(ctx, idx); err != nil {
-				// Overwrite any prior attempt's transport errors so callers
-				// see the availability error, not a stale EOF (setCmdsErr
-				// only fills empty error slots).
-				resetCmds(cmds)
-				setCmdsErr(cmds, err)
+				// Stamp only when nothing has executed yet; a prior attempt's
+				// applied prefix must survive (see the ctx branch above).
+				if attempt == 0 {
+					resetCmds(cmds)
+					setCmdsErr(cmds, err)
+				}
 				return exitErr(err)
 			}
 			// Re-enter the gate on the newly selected database — mirroring

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -21,6 +21,16 @@ func resetCmds(cmds []Cmder) {
 	}
 }
 
+// cmdsHaveAnyErr reports whether at least one command carries an error.
+func cmdsHaveAnyErr(cmds []Cmder) bool {
+	for _, cmd := range cmds {
+		if cmd.rawErr() != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // recordBatchOutcomes records one breaker/detector outcome per command,
 // mirroring the single-command path: an error reply from the server proves
 // the database is reachable and counts as a success; transport-level errors
@@ -33,23 +43,31 @@ func resetCmds(cmds []Cmder) {
 // done channel closes), where Err on an async command would await the very
 // batch being completed and wedge the dispatcher.
 func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, batchErr error) int {
+	// An executed batch always stamps at least the failing command (reply
+	// errors land on their command, transport errors are stamped on every
+	// command). A batch whose batch-level call failed while NO command
+	// carries an error therefore never reached execution — e.g. a member
+	// hook aborted before calling next. Only then does the batch error
+	// stand in for the commands, and it is stamped so callers see it.
+	// Substituting it per-command when some nil errors are successfully
+	// read replies would turn a successful prefix into phantom transport
+	// failures and replay it.
+	if batchErr != nil && !cmdsHaveAnyErr(cmds) {
+		setCmdsErr(cmds, batchErr)
+	}
 	transportFailures := 0
 	recorded := 0
 	for _, cmd := range cmds {
 		err := cmd.rawErr()
-		if err == nil {
-			// An unstamped command in a failed batch (e.g. a member hook
-			// aborting before execution): nil rawErr is no proof the server
-			// answered. Classify the batch-level error instead — a local
-			// abort then records nothing rather than phantom successes.
-			err = batchErr
-		}
 		// Pipelines mirror the plain pipeline retry rule (shouldRetry with
 		// retryTimeout=true), matching *Client/*ClusterClient batch paths.
 		switch classifyOutcome(err, true) {
 		case outcomeSuccess:
 			db.cb.RecordSuccess()
 			c.detector.RecordSuccess()
+			// Recovery traffic breaks the consecutive-failed-failover chain
+			// for batch-only workloads too (see recordFailedFailoverLocked).
+			c.successSinceFailover.Store(true)
 			recorded++
 		case outcomeFailure:
 			db.cb.RecordFailure()

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -194,13 +194,27 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 	gateRejections := 0
 	maxGateRejections := c.memberCount() + 1
 
+	// exitErr picks the batch error for every exit: with a rejected HIMPORT
+	// in the batch the positionally first error over the ORIGINAL slice wins,
+	// like Pipeline.Exec reports it — including early gate exits, whose
+	// stamped error would otherwise displace a rejection that precedes the
+	// stamped commands positionally.
+	exitErr := func(err error) error {
+		if himportRejected {
+			if ferr := cmdsFirstErr(orig); ferr != nil {
+				return ferr
+			}
+		}
+		return err
+	}
+
 	for attempt < attempts {
 		if c.closed.Load() {
 			// Close landed mid-retry: report the terminal state instead of
 			// escalating through the drained membership.
 			resetCmds(cmds)
 			setCmdsErr(cmds, ErrClosed)
-			return ErrClosed
+			return exitErr(ErrClosed)
 		}
 		if err := ctx.Err(); err != nil {
 			// Overwrite any prior attempt's transport errors: callers that
@@ -209,7 +223,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			// empty slots).
 			resetCmds(cmds)
 			setCmdsErr(cmds, err)
-			return err
+			return exitErr(err)
 		}
 
 		// Detector before IsAllowed: IsAllowed reserves a bounded half-open
@@ -222,7 +236,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 				err := ErrTemporarilyNotAvailable
 				resetCmds(cmds)
 				setCmdsErr(cmds, err)
-				return err
+				return exitErr(err)
 			}
 			if err := c.tryFailover(ctx, idx); err != nil {
 				// Overwrite any prior attempt's transport errors so callers
@@ -230,7 +244,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 				// only fills empty error slots).
 				resetCmds(cmds)
 				setCmdsErr(cmds, err)
-				return err
+				return exitErr(err)
 			}
 			// Re-enter the gate on the newly selected database — mirroring
 			// the single-command path: its breaker may be half-open and the
@@ -253,15 +267,8 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 
 		if transportFailures == 0 {
 			// Only server replies (or clean success) — done, whatever the
-			// user-level outcome is. With a rejected HIMPORT in the batch
-			// the positionally first error over the ORIGINAL slice wins,
-			// like Pipeline.Exec reports it.
-			if himportRejected {
-				if ferr := cmdsFirstErr(orig); ferr != nil {
-					return ferr
-				}
-			}
-			return err
+			// user-level outcome is.
+			return exitErr(err)
 		}
 	}
 	return cmdsFirstErr(orig)
@@ -452,17 +459,18 @@ func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	// The gate loops like the batch paths (detector before IsAllowed; a
-	// denied member triggers another failover, bounded by the rejection cap),
-	// so a half-open candidate with an exhausted probe budget does not fail
-	// the call while a healthy member is still selectable — no WATCH has been
-	// sent while the gate is still choosing. IsAllowed reserves, so a
-	// half-open member's MaxHalfOpenRequests bounds concurrent WATCH
-	// transactions too; the slot is released after the call because the WATCH
-	// outcome deliberately never records on the breaker.
+	// The gate loops like the batch paths (detector before the breaker
+	// admission; a denied member triggers another failover, bounded by the
+	// rejection cap), so a half-open candidate with an exhausted probe budget
+	// does not fail the call while a healthy member is still selectable — no
+	// WATCH has been sent while the gate is still choosing. A half-open
+	// admission reserves a probe slot, so MaxHalfOpenRequests bounds
+	// concurrent WATCH transactions too; the slot is released after the call
+	// because the WATCH outcome deliberately never records on the breaker.
 	gateRejections := 0
 	maxGateRejections := c.core.memberCount() + 1
 	var db *multidbDatabase
+	var reserved bool
 	for {
 		if c.core.closed.Load() {
 			return ErrClosed
@@ -472,7 +480,11 @@ func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 		}
 		var idx int
 		db, idx = c.core.activeSnapshot()
-		if db == nil || c.core.detector.ShouldFailover() || !db.cb.IsAllowed() {
+		admitted := false
+		if db != nil && !c.core.detector.ShouldFailover() {
+			admitted, reserved = db.cb.Allow()
+		}
+		if !admitted {
 			gateRejections++
 			if gateRejections > maxGateRejections {
 				return ErrTemporarilyNotAvailable
@@ -484,7 +496,13 @@ func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 		}
 		break
 	}
-	defer db.cb.ReleaseHalfOpen()
+	if reserved {
+		// Only a half-open admission holds a probe slot. A closed-state
+		// admission must not release later: the transaction can outlive an
+		// open -> half-open transition, and the release would free a slot a
+		// real recovery probe is holding.
+		defer db.cb.ReleaseHalfOpen()
+	}
 	if db.cc != nil {
 		return db.cc.Watch(ctx, fn, keys...)
 	}

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -218,7 +218,6 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 	// failover keeps handing back members the gate rejects — surface
 	// unavailability instead of busy-looping the active index.
 	gateRejections := 0
-	maxGateRejections := c.memberCount() + 1
 
 	// exitErr picks the batch error for every exit: with a rejected HIMPORT
 	// in the batch the positionally first error over the ORIGINAL slice wins,
@@ -271,7 +270,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		}
 		if !admitted {
 			gateRejections++
-			if gateRejections > maxGateRejections {
+			if gateRejections > c.memberCount()+1 {
 				err := ErrTemporarilyNotAvailable
 				if attempt == 0 {
 					resetCmds(cmds)
@@ -365,7 +364,6 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	// cap) — only the EXECUTION below stays single-shot, so at-most-once
 	// holds: no MULTI/EXEC has been sent while the gate is still choosing.
 	gateRejections := 0
-	maxGateRejections := c.memberCount() + 1
 	var db *multidbDatabase
 	var res imultidb.Reservation
 	for {
@@ -387,7 +385,7 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 		}
 		if !admitted {
 			gateRejections++
-			if gateRejections > maxGateRejections {
+			if gateRejections > c.memberCount()+1 {
 				err := ErrTemporarilyNotAvailable
 				resetCmds(cmds)
 				setCmdsErr(cmds, err)
@@ -559,7 +557,6 @@ func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 	// concurrent WATCH transactions too; the slot is released after the call
 	// because the WATCH outcome deliberately never records on the breaker.
 	gateRejections := 0
-	maxGateRejections := c.core.memberCount() + 1
 	var db *multidbDatabase
 	var res imultidb.Reservation
 	for {
@@ -577,7 +574,7 @@ func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 		}
 		if !admitted {
 			gateRejections++
-			if gateRejections > maxGateRejections {
+			if gateRejections > c.core.memberCount()+1 {
 				return ErrTemporarilyNotAvailable
 			}
 			if err := c.core.tryFailover(ctx, idx); err != nil {

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -272,6 +272,20 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		return err
 	}
 
+	// The current attempt's admission, released on any exit that did not
+	// settle it: a panic in a member hook or the member path unwinds past
+	// recordBatchOutcomes and the cancel branch, and a leaked half-open slot
+	// would wedge the breaker at MaxHalfOpenRequests. ReleaseFor settles at
+	// most once and no-ops for a closed admission, so it is harmless after a
+	// normal settle too (Watch uses the same defer).
+	var pendingDB *multidbDatabase
+	var pendingRes imultidb.Reservation
+	defer func() {
+		if pendingDB != nil {
+			pendingDB.cb.ReleaseFor(pendingRes)
+		}
+	}()
+
 	for attempt < attempts {
 		if c.closed.Load() {
 			// Close landed mid-retry: report the terminal state instead of
@@ -333,6 +347,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			continue
 		}
 		gateRejections = 0
+		pendingDB, pendingRes = db, res
 
 		if attempt > 0 {
 			resetCmds(cmds)
@@ -440,6 +455,11 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 		break
 	}
 
+	// Release the admission on any exit that did not settle it: a panic in a
+	// member hook or the member path skips both recordBatchOutcomes and the
+	// cancel branch. ReleaseFor settles at most once and no-ops for a closed
+	// admission — the same defer Watch uses.
+	defer db.cb.ReleaseFor(res)
 	executed := newExecutedCmds(len(cmds))
 	err := db.processTxPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
 	if err != nil && ctx.Err() != nil {

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -64,8 +64,47 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 	// Blocking commands carry their own read timeout; their local deadlines
 	// are not retryable transport failures — the same per-command rule the
 	// single-command path applies (cmd.readTimeout() == nil).
+	//
+	// The pipeline reader stops at the first transport error and stamps that
+	// SAME error onto every unread follower (pipelineReadCmds; the cluster
+	// path does the same per node). When the originating command is a
+	// blocking command whose local deadline is neutral, the followers carry
+	// a propagation of that one neutral event, not N transport failures of
+	// their own: counting them would charge the breaker and detector N times
+	// and replay the whole batch — blocking command included — off a
+	// deadline the blocker itself does not retry. The first carrier of an
+	// error in slice order is its originator: stamping only ever reaches
+	// later commands, and a node sub-batch keeps the original order.
+	var neutralPropagated []error
+	var seen []error
+	for _, cmd := range cmds {
+		err := cmd.rawErr()
+		if err == nil || isRedisError(err) {
+			continue
+		}
+		known := false
+		for _, s := range seen {
+			if errors.Is(err, s) {
+				known = true
+				break
+			}
+		}
+		if known {
+			continue
+		}
+		seen = append(seen, err)
+		if cmd.readTimeout() != nil && classifyOutcome(err, false) == outcomeNeutral {
+			neutralPropagated = append(neutralPropagated, err)
+		}
+	}
 	classify := func(cmd Cmder) outcomeKind {
-		return classifyOutcome(cmd.rawErr(), cmd.readTimeout() == nil)
+		err := cmd.rawErr()
+		for _, origin := range neutralPropagated {
+			if errors.Is(err, origin) {
+				return outcomeNeutral
+			}
+		}
+		return classifyOutcome(err, cmd.readTimeout() == nil)
 	}
 	// The GLOBAL detector (and successSinceFailover) is fed only while this
 	// member is STILL the active — re-checked per recorded outcome, not once up

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -401,12 +401,22 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		transportFailures := c.recordBatchOutcomes(db, cmds, err, executed, res)
 
 		if transportFailures == 0 {
-			if errors.Is(err, ErrClosed) && db.removed.Load() {
+			if errors.Is(err, ErrClosed) && db.removed.Load() && !executed.any() {
 				// A concurrent control op removed the snapshotted member (closing
 				// its client) between the gate and execution, so its pool returned
 				// the terminal ErrClosed, classified neutral. The MultiDBClient is
 				// still open: re-enter the gate on the live active instead of
 				// surfacing ErrClosed, mirroring the single-command process() path.
+				//
+				// Guarded on !executed.any(), like the tx path: a cluster fan-out
+				// can have one node apply its commands while another node's
+				// connection acquisition returns ErrClosed after the member was
+				// switched away and removed. transportFailures is still 0 (the
+				// applied commands are successes, the ErrClosed is neutral), but the
+				// batch DID partially execute — re-gating and replaying it would
+				// duplicate the completed node's non-idempotent writes. When any
+				// shard executed, fall through and return the batch as-is instead.
+				//
 				// recordBatchOutcomes released the reservation (nothing recorded);
 				// the batch never executed, so don't spend a retry attempt. Bound
 				// the re-gates separately from gate rejections (which reset on

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -22,16 +22,6 @@ func resetCmds(cmds []Cmder) {
 	}
 }
 
-// cmdsHaveAnyErr reports whether at least one command carries an error.
-func cmdsHaveAnyErr(cmds []Cmder) bool {
-	for _, cmd := range cmds {
-		if cmd.rawErr() != nil {
-			return true
-		}
-	}
-	return false
-}
-
 // recordBatchOutcomes records one breaker/detector outcome per command,
 // mirroring the single-command path: an error reply from the server proves
 // the database is reachable and counts as a success; transport-level errors
@@ -44,16 +34,24 @@ func cmdsHaveAnyErr(cmds []Cmder) bool {
 // done channel closes), where Err on an async command would await the very
 // batch being completed and wedge the dispatcher.
 func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, batchErr error, executed bool) int {
-	// A batch whose batch-level call failed while execution never started
-	// (the marker was not flipped — e.g. a member hook aborted before
-	// calling next) has no per-command verdicts: the batch error stands in
-	// for the commands and is stamped so callers see it. `executed` comes
-	// from the execution marker, not from inspecting command state: an
-	// executed all-success batch whose error was injected by a post-exec
-	// hook looks identical on the commands, and stamping it would turn
-	// already-applied writes into phantom transport failures and replay
-	// them.
-	if batchErr != nil && !executed && !cmdsHaveAnyErr(cmds) {
+	// `executed` comes from the execution marker, not from inspecting
+	// command state: an executed all-success batch whose error was injected
+	// by a post-exec hook looks identical on the commands, and stamping it
+	// would turn already-applied writes into phantom transport failures and
+	// replay them.
+	if !executed {
+		if batchErr == nil {
+			// A member hook served the batch locally (returned nil without
+			// calling next): the results are valid for the caller, but
+			// nothing reached Redis — record no health signal and give the
+			// gate's probe slot back.
+			db.cb.ReleaseHalfOpen()
+			return 0
+		}
+		// Execution never started: the batch error stands in for every
+		// command the aborting hook did not stamp itself (setCmdsErr fills
+		// only empty slots), so a partially-stamped abort cannot fabricate
+		// successes for the untouched commands.
 		setCmdsErr(cmds, batchErr)
 	}
 	// Failures first, successes second: on a half-open breaker a batch's
@@ -121,6 +119,13 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 	}
 
 	attempt := 0
+	// Bound consecutive gate rejections, mirroring the single-command path:
+	// with every selectable member half-open and probe budgets exhausted,
+	// failover keeps handing back members the gate rejects — surface
+	// unavailability instead of busy-looping the active index.
+	gateRejections := 0
+	maxGateRejections := c.memberCount() + 1
+
 	for attempt < attempts {
 		if err := ctx.Err(); err != nil {
 			// Overwrite any prior attempt's transport errors: callers that
@@ -137,6 +142,13 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		// executing the batch — the reservation would leak.
 		db, idx := c.activeSnapshot()
 		if db == nil || c.detector.ShouldFailover() || !db.cb.IsAllowed() {
+			gateRejections++
+			if gateRejections > maxGateRejections {
+				err := ErrTemporarilyNotAvailable
+				resetCmds(cmds)
+				setCmdsErr(cmds, err)
+				return err
+			}
 			if err := c.tryFailover(ctx, idx); err != nil {
 				// Overwrite any prior attempt's transport errors so callers
 				// see the availability error, not a stale EOF (setCmdsErr
@@ -151,6 +163,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			// Re-gating does not consume a retry attempt.
 			continue
 		}
+		gateRejections = 0
 
 		if attempt > 0 {
 			resetCmds(cmds)

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -643,10 +643,15 @@ func (c *MultiDBClient) TxPipeline() Pipeliner {
 				}
 			}
 			// Restore via defer so a panic in the hook or member path still
-			// clears the temporary noRetry on the caller-owned commands.
+			// clears the temporary noRetry on the caller-owned commands. Restore
+			// in REVERSE order: if the same Cmder was queued twice, its second
+			// occurrence snapshotted prev=true (already set by the first), so a
+			// forward restore would end on that value and leave the shared command
+			// permanently non-retryable. Reversing makes the first occurrence's
+			// genuine original state the last write.
 			defer func() {
-				for i, cmd := range cmds {
-					if bc, ok := cmd.(noRetrier); ok {
+				for i := len(cmds) - 1; i >= 0; i-- {
+					if bc, ok := cmds[i].(noRetrier); ok {
 						bc.setNoRetry(prev[i])
 					}
 				}

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -452,19 +452,37 @@ func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	// IsAllowed (reserving) so a half-open member's MaxHalfOpenRequests
-	// bounds concurrent WATCH transactions too; the slot is released after
-	// the call because the WATCH outcome deliberately never records on the
-	// breaker.
-	db, idx := c.core.activeSnapshot()
-	if db == nil || c.core.detector.ShouldFailover() || !db.cb.IsAllowed() {
-		if err := c.core.tryFailover(ctx, idx); err != nil {
+	// The gate loops like the batch paths (detector before IsAllowed; a
+	// denied member triggers another failover, bounded by the rejection cap),
+	// so a half-open candidate with an exhausted probe budget does not fail
+	// the call while a healthy member is still selectable — no WATCH has been
+	// sent while the gate is still choosing. IsAllowed reserves, so a
+	// half-open member's MaxHalfOpenRequests bounds concurrent WATCH
+	// transactions too; the slot is released after the call because the WATCH
+	// outcome deliberately never records on the breaker.
+	gateRejections := 0
+	maxGateRejections := c.core.memberCount() + 1
+	var db *multidbDatabase
+	for {
+		if c.core.closed.Load() {
+			return ErrClosed
+		}
+		if err := ctx.Err(); err != nil {
 			return err
 		}
-		db, _ = c.core.activeSnapshot()
-		if db == nil || !db.cb.IsAllowed() {
-			return ErrTemporarilyNotAvailable
+		var idx int
+		db, idx = c.core.activeSnapshot()
+		if db == nil || c.core.detector.ShouldFailover() || !db.cb.IsAllowed() {
+			gateRejections++
+			if gateRejections > maxGateRejections {
+				return ErrTemporarilyNotAvailable
+			}
+			if err := c.core.tryFailover(ctx, idx); err != nil {
+				return err
+			}
+			continue
 		}
+		break
 	}
 	defer db.cb.ReleaseHalfOpen()
 	if db.cc != nil {

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -34,21 +34,32 @@ func resetCmds(cmds []Cmder) {
 // batch being completed and wedge the dispatcher.
 func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder) int {
 	transportFailures := 0
+	recorded := 0
 	for _, cmd := range cmds {
 		err := cmd.rawErr()
-		switch classifyOutcome(err) {
+		// Pipelines mirror the plain pipeline retry rule (shouldRetry with
+		// retryTimeout=true), matching *Client/*ClusterClient batch paths.
+		switch classifyOutcome(err, true) {
 		case outcomeSuccess:
 			db.cb.RecordSuccess()
 			c.detector.RecordSuccess()
+			recorded++
 		case outcomeFailure:
 			db.cb.RecordFailure()
 			c.detector.RecordFailure(err)
 			transportFailures++
+			recorded++
 		case outcomeNeutral:
 			// Not a database-health signal (client-side error or a locally
 			// synthesized Redis error such as ErrCrossSlot); surfaced to the
 			// caller as-is.
 		}
+	}
+	if recorded == 0 {
+		// The whole batch was neutral (e.g. a local ErrCrossSlot rejection):
+		// nothing was recorded on the breaker, so give back the half-open
+		// probe slot the caller's IsAllowed gate may have reserved.
+		db.cb.ReleaseHalfOpen()
 	}
 	return transportFailures
 }
@@ -62,6 +73,10 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder) int
 func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 	if len(cmds) == 0 {
 		return nil
+	}
+	if c.closed.Load() {
+		setCmdsErr(cmds, ErrClosed)
+		return ErrClosed
 	}
 	attempts := c.opts.CommandRetries + 1
 	// A batch containing a non-retryable command (e.g. a streaming
@@ -116,6 +131,10 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error {
 	if len(cmds) == 0 {
 		return nil
+	}
+	if c.closed.Load() {
+		setCmdsErr(cmds, ErrClosed)
+		return ErrClosed
 	}
 	db, idx := c.activeSnapshot()
 	if db == nil || !db.cb.IsAllowed() || c.detector.ShouldFailover() {
@@ -235,8 +254,14 @@ func (c *MultiDBClient) TxPipelined(ctx context.Context, fn func(Pipeliner) erro
 // the Tx runs on the member client, so install member-level hooks via
 // AddDatabaseHook when WATCH traffic must be instrumented.
 func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {
+	if c.core.closed.Load() {
+		return ErrClosed
+	}
+	// selectable (non-reserving) rather than IsAllowed: the WATCH path does
+	// not feed the breaker, so it must not consume a bounded half-open probe
+	// slot it would never record or release.
 	db, idx := c.core.activeSnapshot()
-	if db == nil || !db.cb.IsAllowed() || c.core.detector.ShouldFailover() {
+	if db == nil || !db.selectable() || c.core.detector.ShouldFailover() {
 		if err := c.core.tryFailover(ctx, idx); err != nil {
 			return err
 		}

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -155,7 +155,11 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		setCmdsErr(cmds, ErrClosed)
 		return ErrClosed
 	}
-	var himportErr error
+	// orig keeps the caller's slice for the final error: rejected HIMPORT
+	// commands stay in it, so cmdsFirstErr reports the POSITIONALLY first
+	// failure like Pipeline.Exec would.
+	orig := cmds
+	himportRejected := false
 	if cmdsContainHImport(cmds) {
 		// Reject only the HIMPORT commands themselves: the autopipeliner
 		// coalesces unrelated callers into one flush, and poisoning the
@@ -172,10 +176,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			return errMultiDBHImport
 		}
 		cmds = kept
-		// The batch as a whole still failed partially: callers relying on
-		// the Exec/Pipelined error must see it even when every kept command
-		// succeeds.
-		himportErr = errMultiDBHImport
+		himportRejected = true
 	}
 	attempts := c.opts.CommandRetries + 1
 	// A batch containing a non-retryable command (e.g. a streaming
@@ -245,17 +246,18 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 
 		if transportFailures == 0 {
 			// Only server replies (or clean success) — done, whatever the
-			// user-level outcome is.
-			if err == nil && himportErr != nil {
-				return himportErr
+			// user-level outcome is. With a rejected HIMPORT in the batch
+			// the positionally first error over the ORIGINAL slice wins,
+			// like Pipeline.Exec reports it.
+			if himportRejected {
+				if ferr := cmdsFirstErr(orig); ferr != nil {
+					return ferr
+				}
 			}
 			return err
 		}
 	}
-	if err := cmdsFirstErr(cmds); err != nil {
-		return err
-	}
-	return himportErr
+	return cmdsFirstErr(orig)
 }
 
 // processTxPipeline executes a MULTI/EXEC pipeline against the active
@@ -461,15 +463,27 @@ func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 // call time. Unlike Subscribe/PSubscribe, sharded subscriptions do not follow
 // the active database across failovers yet.
 func (c *MultiDBClient) SSubscribe(ctx context.Context, channels ...string) *PubSub {
-	db, _ := c.core.activeSnapshot()
-	if db != nil && db.cc != nil {
-		return db.cc.SSubscribe(ctx, channels...)
+	// The closed check keeps a Close race from delegating to a member that
+	// is being torn down: the MultiDB PubSub path below fails dials with
+	// the terminal ErrClosed instead.
+	if !c.core.closed.Load() {
+		db, _ := c.core.activeSnapshot()
+		if db != nil && db.cc != nil {
+			return db.cc.SSubscribe(ctx, channels...)
+		}
+		if db != nil {
+			return db.c.SSubscribe(ctx, channels...)
+		}
 	}
-	if db != nil {
-		return db.c.SSubscribe(ctx, channels...)
+	// No active database (or closed): return a PubSub that fails to
+	// connect — with the requested channels registered, like Subscribe and
+	// PSubscribe, so the failure surfaces on use instead of silently
+	// subscribing to nothing.
+	pubsub := c.core.newPubSub()
+	if len(channels) > 0 {
+		_ = pubsub.SSubscribe(ctx, channels...)
 	}
-	// No active database: return a PubSub that fails to connect.
-	return c.core.newPubSub()
+	return pubsub
 }
 
 // PoolStats returns the connection pool statistics of the active database.

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -51,6 +51,12 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		return nil
 	}
 	attempts := c.opts.CommandRetries + 1
+	// A batch containing a non-retryable command (e.g. a streaming
+	// RawWriteToCmd) must be executed at most once: retrying it after a
+	// transport failure could duplicate execution or corrupt a partial write.
+	if cmdsContainNoRetry(cmds) {
+		attempts = 1
+	}
 
 	for attempt := 0; attempt < attempts; attempt++ {
 		if err := ctx.Err(); err != nil {
@@ -180,9 +186,11 @@ func (c *MultiDBClient) TxPipelined(ctx context.Context, fn func(Pipeliner) erro
 }
 
 // Watch runs a WATCH/MULTI/EXEC transaction on the database that is active
-// when Watch is called. WATCH state is connection-bound: a failover while the
-// transaction is open aborts it with an error, and it is never automatically
-// retried on another database.
+// when Watch is called. The transaction is bound to that member for its whole
+// lifetime: it does NOT follow a MultiDB failover, and it is never
+// automatically retried on another database. If the bound member fails while
+// the transaction is open, the transaction errors like it would on a plain
+// client; MultiDB moves only subsequent operations to the new active member.
 func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {
 	db, _ := c.core.activeSnapshot()
 	if db == nil {

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -1,0 +1,259 @@
+package redis
+
+import (
+	"context"
+)
+
+// This file makes MultiDBClient a full UniversalClient and wires pipelines
+// and autopipelining through the MultiDB core, per the MultiDB × AutoPipeline
+// design: batches resolve the active database at exec time, feed the circuit
+// breaker and failure detector per command, and are retried against the newly
+// selected database after a failover.
+
+var _ UniversalClient = (*MultiDBClient)(nil)
+
+// resetCmds clears per-command errors from a previous attempt so a retried
+// batch does not report stale failures.
+func resetCmds(cmds []Cmder) {
+	for _, cmd := range cmds {
+		cmd.SetErr(nil)
+	}
+}
+
+// recordBatchOutcomes records one breaker/detector outcome per command,
+// mirroring the single-command path: an error reply from the server proves
+// the database is reachable and counts as a success; transport-level errors
+// count as failures. It returns the number of transport-level failures.
+func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder) int {
+	transportFailures := 0
+	for _, cmd := range cmds {
+		err := cmd.Err()
+		if err == nil || isRedisReplyError(err) {
+			db.cb.RecordSuccess()
+			c.detector.RecordSuccess()
+			continue
+		}
+		db.cb.RecordFailure()
+		c.detector.RecordFailure(err)
+		transportFailures++
+	}
+	return transportFailures
+}
+
+// processPipeline is the batch analogue of process: an attempt loop bounded
+// by CommandRetries that snapshots the active database, executes the whole
+// batch through the member's hook-wrapped pipeline path, records per-command
+// outcomes, and retries the batch against the newly selected database after
+// a failover. Delivery is at-least-once when retries are enabled: a
+// connection that broke mid-pipeline may have executed a prefix server-side.
+func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
+	if len(cmds) == 0 {
+		return nil
+	}
+	attempts := c.opts.CommandRetries + 1
+
+	for attempt := 0; attempt < attempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			setCmdsErr(cmds, err)
+			return err
+		}
+
+		db, idx := c.activeSnapshot()
+		if db == nil || !db.cb.IsAllowed() || c.detector.ShouldFailover() {
+			if err := c.tryFailover(ctx, idx); err != nil {
+				setCmdsErr(cmds, err)
+				return err
+			}
+			db, _ = c.activeSnapshot()
+			if db == nil {
+				continue
+			}
+		}
+
+		if attempt > 0 {
+			resetCmds(cmds)
+		}
+		err := db.processPipelineHook(ctx, cmds)
+		transportFailures := c.recordBatchOutcomes(db, cmds)
+
+		if transportFailures == 0 {
+			// Only server replies (or clean success) — done, whatever the
+			// user-level outcome is.
+			return err
+		}
+	}
+	return cmdsFirstErr(cmds)
+}
+
+// processTxPipeline executes a MULTI/EXEC pipeline against the active
+// database exactly once: EXEC may have committed before a connection broke,
+// so a blind retry could double-apply the transaction. Failures are still
+// recorded so the breaker and detector can move traffic for subsequent
+// operations.
+func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error {
+	if len(cmds) == 0 {
+		return nil
+	}
+	db, idx := c.activeSnapshot()
+	if db == nil || !db.cb.IsAllowed() || c.detector.ShouldFailover() {
+		if err := c.tryFailover(ctx, idx); err != nil {
+			setCmdsErr(cmds, err)
+			return err
+		}
+		db, _ = c.activeSnapshot()
+		if db == nil {
+			err := ErrTemporarilyNotAvailable
+			setCmdsErr(cmds, err)
+			return err
+		}
+	}
+
+	err := db.processTxPipelineHook(ctx, cmds)
+	c.recordBatchOutcomes(db, cmds)
+	return err
+}
+
+func (db *multidbDatabase) processPipelineHook(ctx context.Context, cmds []Cmder) error {
+	if db.cc != nil {
+		return db.cc.processPipelineHook(ctx, cmds)
+	}
+	return db.c.processPipelineHook(ctx, cmds)
+}
+
+func (db *multidbDatabase) processTxPipelineHook(ctx context.Context, cmds []Cmder) error {
+	if db.cc != nil {
+		return db.cc.processTxPipelineHook(ctx, cmds)
+	}
+	return db.c.processTxPipelineHook(ctx, cmds)
+}
+
+// process / processPipeline are the unhooked base entry points required by
+// the autopipeliner's backend interface (cmdableClient); the hook-wrapped
+// variants come from hooksMixin.
+func (c *MultiDBClient) process(ctx context.Context, cmd Cmder) error {
+	return c.core.process(ctx, cmd)
+}
+
+func (c *MultiDBClient) processPipeline(ctx context.Context, cmds []Cmder) error {
+	return c.core.processPipeline(ctx, cmds)
+}
+
+// Do creates a Cmd from the args and routes it through Process.
+func (c *MultiDBClient) Do(ctx context.Context, args ...interface{}) *Cmd {
+	cmd := NewCmd(ctx, args...)
+	_ = c.Process(ctx, cmd)
+	return cmd
+}
+
+// Pipeline returns a pipeline whose Exec routes the whole batch to the active
+// database, with failover and retry semantics (see the MultiDB design).
+func (c *MultiDBClient) Pipeline() Pipeliner {
+	pipe := Pipeline{
+		exec: pipelineExecer(c.processPipelineHook),
+	}
+	pipe.init()
+	return &pipe
+}
+
+// Pipelined executes fn inside a Pipeline and returns the queued commands.
+func (c *MultiDBClient) Pipelined(ctx context.Context, fn func(Pipeliner) error) ([]Cmder, error) {
+	return c.Pipeline().Pipelined(ctx, fn)
+}
+
+// TxPipeline returns a MULTI/EXEC pipeline against the active database.
+// Transactions are executed at most once: they are never automatically
+// retried on another database after a failure.
+func (c *MultiDBClient) TxPipeline() Pipeliner {
+	pipe := Pipeline{
+		exec: func(ctx context.Context, cmds []Cmder) error {
+			cmds = wrapMultiExec(ctx, cmds)
+			return c.processTxPipelineHook(ctx, cmds)
+		},
+	}
+	pipe.init()
+	return &pipe
+}
+
+// TxPipelined executes fn inside a TxPipeline.
+func (c *MultiDBClient) TxPipelined(ctx context.Context, fn func(Pipeliner) error) ([]Cmder, error) {
+	return c.TxPipeline().Pipelined(ctx, fn)
+}
+
+// Watch runs a WATCH/MULTI/EXEC transaction on the database that is active
+// when Watch is called. WATCH state is connection-bound: a failover while the
+// transaction is open aborts it with an error, and it is never automatically
+// retried on another database.
+func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {
+	db, _ := c.core.activeSnapshot()
+	if db == nil {
+		return ErrTemporarilyNotAvailable
+	}
+	if db.cc != nil {
+		return db.cc.Watch(ctx, fn, keys...)
+	}
+	return db.c.Watch(ctx, fn, keys...)
+}
+
+// SSubscribe subscribes to shard channels on the database that is active at
+// call time. Unlike Subscribe/PSubscribe, sharded subscriptions do not follow
+// the active database across failovers yet.
+func (c *MultiDBClient) SSubscribe(ctx context.Context, channels ...string) *PubSub {
+	db, _ := c.core.activeSnapshot()
+	if db != nil && db.cc != nil {
+		return db.cc.SSubscribe(ctx, channels...)
+	}
+	if db != nil {
+		return db.c.SSubscribe(ctx, channels...)
+	}
+	// No active database: return a PubSub that fails to connect.
+	return c.core.newPubSub()
+}
+
+// PoolStats returns the connection pool statistics of the active database.
+func (c *MultiDBClient) PoolStats() *PoolStats {
+	db, _ := c.core.activeSnapshot()
+	if db == nil {
+		return &PoolStats{}
+	}
+	if db.cc != nil {
+		return db.cc.PoolStats()
+	}
+	return db.c.PoolStats()
+}
+
+// AutoPipeline returns the blocking autopipeliner for this MultiDB client:
+// batches are flushed against whichever database is active at exec time, and
+// a batch that fails at transport level is retried against the newly selected
+// database (bounded by CommandRetries). The instance is cached and shared; the
+// first call's config wins.
+//
+// EXPERIMENTAL: this API is subject to change, use with caution.
+func (c *MultiDBClient) AutoPipeline() (*AutoPipeliner, error) {
+	return c.AutoPipelineWithOptions(nil)
+}
+
+// AutoPipelineWithOptions is AutoPipeline with explicit options.
+//
+// EXPERIMENTAL: this API is subject to change, use with caution.
+func (c *MultiDBClient) AutoPipelineWithOptions(config *AutoPipelineOptions) (*AutoPipeliner, error) {
+	return getOrCreateAutoPipeliner(c.autopipelinerMu, &c.autopipeliner, &c.autopipelinerClosed, nil, config,
+		DefaultBlockingAutoPipelineOptions,
+		func(cfg *AutoPipelineOptions) (*AutoPipeliner, error) { return newAutoPipeliner(c, cfg, true) })
+}
+
+// AsyncAutoPipeline returns the deferred autopipeliner for this MultiDB
+// client (see AutoPipeline for the failover semantics).
+//
+// EXPERIMENTAL: this API is subject to change, use with caution.
+func (c *MultiDBClient) AsyncAutoPipeline() (*AutoPipeliner, error) {
+	return c.AsyncAutoPipelineWithOptions(nil)
+}
+
+// AsyncAutoPipelineWithOptions is AsyncAutoPipeline with explicit options.
+//
+// EXPERIMENTAL: this API is subject to change, use with caution.
+func (c *MultiDBClient) AsyncAutoPipelineWithOptions(config *AutoPipelineOptions) (*AutoPipeliner, error) {
+	return getOrCreateAutoPipeliner(c.autopipelinerMu, &c.asyncAutopipeliner, &c.autopipelinerClosed, nil, config,
+		DefaultAutoPipelineOptions,
+		func(cfg *AutoPipelineOptions) (*AutoPipeliner, error) { return newAutoPipeliner(c, cfg, false) })
+}

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"errors"
+	"math"
 	"sync/atomic"
 
 	imultidb "github.com/redis/go-redis/v9/internal/multidb"
@@ -35,24 +36,22 @@ func resetCmds(cmds []Cmder) {
 // path (including the autopipeliner's batch dispatcher, before the batch's
 // done channel closes), where Err on an async command would await the very
 // batch being completed and wedge the dispatcher.
-func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, batchErr error, executed, reserved bool) int {
+func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, batchErr error, executed bool, res imultidb.Reservation) int {
 	// `executed` comes from the execution marker, not from inspecting
 	// command state: an executed all-success batch whose error was injected
 	// by a post-exec hook looks identical on the commands, and stamping it
 	// would turn already-applied writes into phantom transport failures and
-	// replay them. `reserved` is the gate admission's half-open reservation:
-	// a closed-state admission holds no probe slot, and a batch outliving a
-	// later open -> half-open transition must not free the slot a real
-	// recovery probe is holding.
+	// replay them. `res` is the gate admission's half-open reservation: the
+	// whole batch is ONE admission, so RecordSuccessFor / ReleaseFor settle the
+	// breaker's half-open slot exactly once however many commands succeed, and a
+	// closed-state admission (res.held == false) holds no slot to settle.
 	if !executed {
 		if batchErr == nil {
 			// A member hook served the batch locally (returned nil without
 			// calling next): the results are valid for the caller, but
 			// nothing reached Redis — record no health signal and give the
-			// gate's probe slot back if it reserved one.
-			if reserved {
-				db.cb.ReleaseHalfOpen()
-			}
+			// gate's probe slot back (ReleaseFor no-ops for a closed admission).
+			db.cb.ReleaseFor(res)
 			return 0
 		}
 		// Execution never started: the batch error stands in for every
@@ -88,13 +87,11 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 				// caller, record nothing.
 				return
 			}
-			if reserved {
-				db.cb.RecordSuccess()
-			} else {
-				// Unreserved admission: the success counts toward closing,
-				// but must not release a half-open slot the batch never held.
-				db.cb.RecordExternalSuccess()
-			}
+			// Settle the batch's single reservation: RecordSuccessFor releases
+			// (or, at SuccessThreshold, closes on) the half-open slot at most
+			// once however many commands succeed, and records an external
+			// success for a closed admission (res.held == false).
+			db.cb.RecordSuccessFor(res)
 			if stillActive {
 				c.detector.RecordSuccess()
 				// Recovery traffic breaks the consecutive-failed-failover chain
@@ -143,11 +140,11 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 			recordOne(cmd)
 		}
 	}
-	if recorded == 0 && reserved {
+	if recorded == 0 {
 		// The whole batch was neutral (e.g. a local ErrCrossSlot rejection):
 		// nothing was recorded on the breaker, so give back the half-open
-		// probe slot the gate admission reserved.
-		db.cb.ReleaseHalfOpen()
+		// probe slot the admission reserved (ReleaseFor no-ops otherwise).
+		db.cb.ReleaseFor(res)
 	}
 	return transportFailures
 }
@@ -204,6 +201,12 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		himportRejected = true
 	}
 	attempts := c.opts.CommandRetries + 1
+	if c.opts.CommandRetries == math.MaxInt {
+		// Guard the +1 against wrapping to a negative attempt count — which
+		// would skip the loop and silently drop the batch (returning nil).
+		// Mirrors the single-command path in process().
+		attempts = math.MaxInt
+	}
 	// A batch containing a non-retryable command (e.g. a streaming
 	// RawWriteToCmd) must be executed at most once: retrying it after a
 	// transport failure could duplicate execution or corrupt a partial write.
@@ -255,9 +258,10 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		// reserves a bounded probe slot, and a tripped detector routes to
 		// failover without executing the batch — the reservation would leak.
 		db, idx := c.activeSnapshot()
-		admitted, reserved := false, false
+		admitted := false
+		var res imultidb.Reservation
 		if db != nil && !c.detector.ShouldFailover() {
-			admitted, reserved = db.cb.Allow()
+			admitted, res = db.cb.AllowReserve()
 		}
 		if !admitted {
 			gateRejections++
@@ -277,7 +281,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			}
 			// Re-enter the gate on the newly selected database — mirroring
 			// the single-command path: its breaker may be half-open and the
-			// Allow call above is what reserves the bounded probe slot.
+			// AllowReserve call above is what reserves the bounded probe slot.
 			// Re-gating does not consume a retry attempt.
 			continue
 		}
@@ -298,9 +302,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			// classifier would otherwise score as a member failure. That is a
 			// client-side signal, not a health verdict: release any half-open
 			// reservation and return WITHOUT recording.
-			if reserved {
-				db.cb.ReleaseHalfOpen()
-			}
+			db.cb.ReleaseFor(res)
 			// Do NOT reset or overwrite the commands. The deadline may have
 			// interrupted reading a LATER reply while earlier commands already
 			// received definitive results, and those are the caller's only
@@ -313,7 +315,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			// return without touching command state on caller cancellation.
 			return exitErr(ctx.Err())
 		}
-		transportFailures := c.recordBatchOutcomes(db, cmds, err, executed.Load(), reserved)
+		transportFailures := c.recordBatchOutcomes(db, cmds, err, executed.Load(), res)
 
 		if transportFailures == 0 {
 			// Only server replies (or clean success) — done, whatever the
@@ -356,7 +358,7 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	gateRejections := 0
 	maxGateRejections := c.memberCount() + 1
 	var db *multidbDatabase
-	var reserved bool
+	var res imultidb.Reservation
 	for {
 		if c.closed.Load() {
 			resetCmds(cmds)
@@ -372,7 +374,7 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 		db, idx = c.activeSnapshot()
 		admitted := false
 		if db != nil && !c.detector.ShouldFailover() {
-			admitted, reserved = db.cb.Allow()
+			admitted, res = db.cb.AllowReserve()
 		}
 		if !admitted {
 			gateRejections++
@@ -400,9 +402,7 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 		// reservation and return without recording. Do NOT reset the commands
 		// here — EXEC may have committed, and their state is the caller's only
 		// evidence of that.
-		if reserved {
-			db.cb.ReleaseHalfOpen()
-		}
+		db.cb.ReleaseFor(res)
 		return err
 	}
 	// Record outcomes only for the user's commands: cmds arrives wrapped by
@@ -412,7 +412,7 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	if len(cmds) >= 3 {
 		user = cmds[1 : len(cmds)-1]
 	}
-	c.recordBatchOutcomes(db, user, err, executed.Load(), reserved)
+	c.recordBatchOutcomes(db, user, err, executed.Load(), res)
 	return err
 }
 
@@ -486,13 +486,27 @@ func (c *MultiDBClient) TxPipeline() Pipeliner {
 			// whole stack, not only the MultiDB retry layer. Every command
 			// is marked — cluster members trim the MULTI/EXEC envelope
 			// before their retry check, so a marker only on the synthetic
-			// MULTI would be lost there.
-			for _, cmd := range cmds {
-				if bc, ok := cmd.(interface{ setNoRetry(bool) }); ok {
+			// MULTI would be lost there. The prior NoRetry is restored after
+			// execution: cmds are caller-owned and may be reused, and a plain
+			// client's TxPipeline does not leave them permanently non-retryable.
+			type noRetrier interface {
+				setNoRetry(bool)
+				NoRetry() bool
+			}
+			prev := make([]bool, len(cmds))
+			for i, cmd := range cmds {
+				if bc, ok := cmd.(noRetrier); ok {
+					prev[i] = bc.NoRetry()
 					bc.setNoRetry(true)
 				}
 			}
-			return c.processTxPipelineHook(ctx, cmds)
+			err := c.processTxPipelineHook(ctx, cmds)
+			for i, cmd := range cmds {
+				if bc, ok := cmd.(noRetrier); ok {
+					bc.setNoRetry(prev[i])
+				}
+			}
+			return err
 		},
 	}
 	pipe.init()
@@ -536,7 +550,7 @@ func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 	gateRejections := 0
 	maxGateRejections := c.core.memberCount() + 1
 	var db *multidbDatabase
-	var reserved bool
+	var res imultidb.Reservation
 	for {
 		if c.core.closed.Load() {
 			return ErrClosed
@@ -548,7 +562,7 @@ func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 		db, idx = c.core.activeSnapshot()
 		admitted := false
 		if db != nil && !c.core.detector.ShouldFailover() {
-			admitted, reserved = db.cb.Allow()
+			admitted, res = db.cb.AllowReserve()
 		}
 		if !admitted {
 			gateRejections++
@@ -562,13 +576,12 @@ func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 		}
 		break
 	}
-	if reserved {
-		// Only a half-open admission holds a probe slot. A closed-state
-		// admission must not release later: the transaction can outlive an
-		// open -> half-open transition, and the release would free a slot a
-		// real recovery probe is holding.
-		defer db.cb.ReleaseHalfOpen()
-	}
+	// Release the reservation after the call: the WATCH outcome deliberately
+	// never records on the breaker. ReleaseFor settles once and only within the
+	// reservation's own half-open episode — so a closed-state admission (no
+	// slot) is a no-op, and a transaction that outlives an open -> half-open
+	// cycle cannot free a slot a real recovery probe is holding in the new one.
+	defer db.cb.ReleaseFor(res)
 	if db.cc != nil {
 		return db.cc.Watch(ctx, fn, keys...)
 	}

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -32,11 +32,18 @@ func resetCmds(cmds []Cmder) {
 // path (including the autopipeliner's batch dispatcher, before the batch's
 // done channel closes), where Err on an async command would await the very
 // batch being completed and wedge the dispatcher.
-func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder) int {
+func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, batchErr error) int {
 	transportFailures := 0
 	recorded := 0
 	for _, cmd := range cmds {
 		err := cmd.rawErr()
+		if err == nil {
+			// An unstamped command in a failed batch (e.g. a member hook
+			// aborting before execution): nil rawErr is no proof the server
+			// answered. Classify the batch-level error instead — a local
+			// abort then records nothing rather than phantom successes.
+			err = batchErr
+		}
 		// Pipelines mirror the plain pipeline retry rule (shouldRetry with
 		// retryTimeout=true), matching *Client/*ClusterClient batch paths.
 		switch classifyOutcome(err, true) {
@@ -89,12 +96,20 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 	attempt := 0
 	for attempt < attempts {
 		if err := ctx.Err(); err != nil {
+			// Overwrite any prior attempt's transport errors: callers that
+			// inspect per-command results must see the context error, not a
+			// stale EOF from the failed attempt (setCmdsErr fills only
+			// empty slots).
+			resetCmds(cmds)
 			setCmdsErr(cmds, err)
 			return err
 		}
 
+		// Detector before IsAllowed: IsAllowed reserves a bounded half-open
+		// probe slot, and a tripped detector routes to failover without
+		// executing the batch — the reservation would leak.
 		db, idx := c.activeSnapshot()
-		if db == nil || !db.cb.IsAllowed() || c.detector.ShouldFailover() {
+		if db == nil || c.detector.ShouldFailover() || !db.cb.IsAllowed() {
 			if err := c.tryFailover(ctx, idx); err != nil {
 				// Overwrite any prior attempt's transport errors so callers
 				// see the availability error, not a stale EOF (setCmdsErr
@@ -115,7 +130,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		}
 		attempt++
 		err := db.processPipelineHook(ctx, cmds)
-		transportFailures := c.recordBatchOutcomes(db, cmds)
+		transportFailures := c.recordBatchOutcomes(db, cmds, err)
 
 		if transportFailures == 0 {
 			// Only server replies (or clean success) — done, whatever the
@@ -147,8 +162,10 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 		setCmdsErr(cmds, err)
 		return err
 	}
+	// Detector before IsAllowed, as in the other gates: a tripped detector
+	// routes to failover, and a probe slot reserved on the way out would leak.
 	db, idx := c.activeSnapshot()
-	if db == nil || !db.cb.IsAllowed() || c.detector.ShouldFailover() {
+	if db == nil || c.detector.ShouldFailover() || !db.cb.IsAllowed() {
 		if err := c.tryFailover(ctx, idx); err != nil {
 			resetCmds(cmds)
 			setCmdsErr(cmds, err)
@@ -175,7 +192,7 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	if len(cmds) >= 3 {
 		user = cmds[1 : len(cmds)-1]
 	}
-	c.recordBatchOutcomes(db, user)
+	c.recordBatchOutcomes(db, user, err)
 	return err
 }
 
@@ -246,10 +263,14 @@ func (c *MultiDBClient) TxPipeline() Pipeliner {
 			// Suppress the member client's own retry loop for the wrapped
 			// batch (cmdsContainNoRetry): EXEC may have committed before a
 			// transport error surfaced, and at-most-once must hold for the
-			// whole stack, not only the MultiDB retry layer. The marker
-			// rides on the synthetic MULTI so user commands stay untouched.
-			if multi, ok := cmds[0].(*StatusCmd); ok {
-				multi.setNoRetry(true)
+			// whole stack, not only the MultiDB retry layer. Every command
+			// is marked — cluster members trim the MULTI/EXEC envelope
+			// before their retry check, so a marker only on the synthetic
+			// MULTI would be lost there.
+			for _, cmd := range cmds {
+				if bc, ok := cmd.(interface{ setNoRetry(bool) }); ok {
+					bc.setNoRetry(true)
+				}
 			}
 			return c.processTxPipelineHook(ctx, cmds)
 		},

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -145,8 +145,21 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		return ErrClosed
 	}
 	if cmdsContainHImport(cmds) {
-		setCmdsErr(cmds, errMultiDBHImport)
-		return errMultiDBHImport
+		// Reject only the HIMPORT commands themselves: the autopipeliner
+		// coalesces unrelated callers into one flush, and poisoning the
+		// whole batch would fail innocent commands that merely shared it.
+		kept := make([]Cmder, 0, len(cmds))
+		for _, cmd := range cmds {
+			if _, ok := cmd.(interface{ himportCmd() }); ok {
+				cmd.SetErr(errMultiDBHImport)
+				continue
+			}
+			kept = append(kept, cmd)
+		}
+		if len(kept) == 0 {
+			return errMultiDBHImport
+		}
+		cmds = kept
 	}
 	attempts := c.opts.CommandRetries + 1
 	// A batch containing a non-retryable command (e.g. a streaming
@@ -248,26 +261,37 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 		setCmdsErr(cmds, err)
 		return err
 	}
-	// Detector before IsAllowed, as in the other gates: a tripped detector
-	// routes to failover, and a probe slot reserved on the way out would leak.
-	db, idx := c.activeSnapshot()
-	if db == nil || c.detector.ShouldFailover() || !db.cb.IsAllowed() {
-		if err := c.tryFailover(ctx, idx); err != nil {
+	// The gate loops like the other paths (detector before IsAllowed; a
+	// denied member triggers another failover, bounded by the rejection
+	// cap) — only the EXECUTION below stays single-shot, so at-most-once
+	// holds: no MULTI/EXEC has been sent while the gate is still choosing.
+	gateRejections := 0
+	maxGateRejections := c.memberCount() + 1
+	var db *multidbDatabase
+	for {
+		if err := ctx.Err(); err != nil {
 			resetCmds(cmds)
 			setCmdsErr(cmds, err)
 			return err
 		}
-		// Re-run the admission gate on the newly selected database: its
-		// breaker may be half-open, and executing without IsAllowed would
-		// bypass the bounded probe-slot accounting. Transactions run at
-		// most once, so a denied slot fails the call rather than looping.
-		db, _ = c.activeSnapshot()
-		if db == nil || !db.cb.IsAllowed() {
-			err := ErrTemporarilyNotAvailable
-			resetCmds(cmds)
-			setCmdsErr(cmds, err)
-			return err
+		var idx int
+		db, idx = c.activeSnapshot()
+		if db == nil || c.detector.ShouldFailover() || !db.cb.IsAllowed() {
+			gateRejections++
+			if gateRejections > maxGateRejections {
+				err := ErrTemporarilyNotAvailable
+				resetCmds(cmds)
+				setCmdsErr(cmds, err)
+				return err
+			}
+			if err := c.tryFailover(ctx, idx); err != nil {
+				resetCmds(cmds)
+				setCmdsErr(cmds, err)
+				return err
+			}
+			continue
 		}
+		break
 	}
 
 	executed := new(atomic.Bool)

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -413,8 +413,12 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 		return ErrClosed
 	}
 	if cmdsContainHImport(cmds) {
+		// Reject the whole transaction (MULTI/EXEC is all-or-nothing). Report
+		// the positionally-first error like Pipeline.Exec: setCmdsErr fills only
+		// empty slots, so a command the caller queued with a pre-existing error
+		// keeps it and must win over errMultiDBHImport when it comes first.
 		setCmdsErr(cmds, errMultiDBHImport)
-		return errMultiDBHImport
+		return cmdsFirstErr(cmds)
 	}
 	// A context that is already done must not reach the failover gate: with
 	// ProbeTargetBeforeFailover the doomed probes would damage candidate

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -808,12 +808,16 @@ func (c *MultiDBClient) AutoPipeline() (*AutoPipeliner, error) {
 // EXPERIMENTAL: this API is subject to change, use with caution.
 func (c *MultiDBClient) AutoPipelineWithOptions(config *AutoPipelineOptions) (*AutoPipeliner, error) {
 	// The cluster-member check runs inside the build function, under
-	// autopipelinerMu: AddDatabase performs its cluster-vs-autopipeliner
-	// check under the same mutex, so the two cannot interleave.
+	// autopipelinerMu: AddDatabase performs its cluster-vs-autopipeliner check
+	// under the same mutex, so the two cannot interleave. AddDatabase releases
+	// the mutex before running the new member's health probe (so a probe that
+	// calls AutoPipeline cannot deadlock) and leaves pendingClusterAdds > 0 for
+	// that window; the build func refuses then too, so no unsharded instance is
+	// created while a cluster member is landing.
 	return getOrCreateAutoPipeliner(c.autopipelinerMu, &c.autopipeliner, &c.autopipelinerClosed, nil, config,
 		DefaultBlockingAutoPipelineOptions,
 		func(cfg *AutoPipelineOptions) (*AutoPipeliner, error) {
-			if c.core.hasClusterMember() {
+			if c.core.hasClusterMember() || c.pendingClusterAdds > 0 {
 				return nil, errMultiDBAutoPipelineCluster
 			}
 			return newAutoPipeliner(c, cfg, true)
@@ -835,7 +839,7 @@ func (c *MultiDBClient) AsyncAutoPipelineWithOptions(config *AutoPipelineOptions
 	return getOrCreateAutoPipeliner(c.autopipelinerMu, &c.asyncAutopipeliner, &c.autopipelinerClosed, nil, config,
 		DefaultAutoPipelineOptions,
 		func(cfg *AutoPipelineOptions) (*AutoPipeliner, error) {
-			if c.core.hasClusterMember() {
+			if c.core.hasClusterMember() || c.pendingClusterAdds > 0 {
 				return nil, errMultiDBAutoPipelineCluster
 			}
 			return newAutoPipeliner(c, cfg, false)

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -266,6 +266,10 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 	// failover keeps handing back members the gate rejects — surface
 	// unavailability instead of busy-looping the active index.
 	gateRejections := 0
+	// Separate bound for re-gates caused by a removed former active: those pass
+	// the gate (so gateRejections is reset on admission) and must not busy-loop
+	// if a rapid add/remove keeps handing back a closed member. Mirrors process().
+	removedActiveRegates := 0
 
 	// exitErr picks the batch error for every exit: with a rejected HIMPORT
 	// in the batch the positionally first error over the ORIGINAL slice wins,
@@ -366,14 +370,6 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		// per-command errors setCmdsErr refuses to overwrite. The rejected
 		// HIMPORT stamps live in orig, not in cmds (kept is a fresh slice), so
 		// this cannot clear them.
-		// Clear any per-command error before executing. On a retry this drops
-		// the previous attempt's stamps; on the first attempt it drops an error
-		// a caller left on a reused command, so a batch that aborts before
-		// execution (e.g. a connection-acquire failure) still records the
-		// transport failure through setCmdsErr instead of being masked by stale
-		// per-command errors setCmdsErr refuses to overwrite. The rejected
-		// HIMPORT stamps live in orig, not in cmds (kept is a fresh slice), so
-		// this cannot clear them.
 		resetCmds(cmds)
 		attempt++
 		// The marker tells recordBatchOutcomes whether execution started
@@ -405,6 +401,28 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		transportFailures := c.recordBatchOutcomes(db, cmds, err, executed, res)
 
 		if transportFailures == 0 {
+			if errors.Is(err, ErrClosed) && db.removed.Load() {
+				// A concurrent control op removed the snapshotted member (closing
+				// its client) between the gate and execution, so its pool returned
+				// the terminal ErrClosed, classified neutral. The MultiDBClient is
+				// still open: re-enter the gate on the live active instead of
+				// surfacing ErrClosed, mirroring the single-command process() path.
+				// recordBatchOutcomes released the reservation (nothing recorded);
+				// the batch never executed, so don't spend a retry attempt. Bound
+				// the re-gates separately from gate rejections (which reset on
+				// admission); a genuine Close is caught by c.closed next iteration.
+				removedActiveRegates++
+				if removedActiveRegates > c.memberCount()+1 {
+					// Pathological rapid add/remove: surface the retryable
+					// unavailable error rather than the removed member's terminal
+					// ErrClosed. Leave the per-command state as recorded — the
+					// attempt counter cannot cleanly tell whether an earlier attempt
+					// applied a prefix, so do not risk overwriting it here.
+					return exitErr(ErrTemporarilyNotAvailable)
+				}
+				attempt--
+				continue
+			}
 			// Only server replies (or clean success) — done, whatever the
 			// user-level outcome is.
 			return exitErr(err)
@@ -456,80 +474,109 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	// denied member triggers another failover, bounded by the rejection
 	// cap) — only the EXECUTION below stays single-shot, so at-most-once
 	// holds: no MULTI/EXEC has been sent while the gate is still choosing.
-	gateRejections := 0
+	// Separate bound for re-gates caused by a removed former active (see
+	// processPipeline): they pass the gate, so gateRejections cannot bound them.
+	removedActiveRegates := 0
 	var db *multidbDatabase
 	var res imultidb.Reservation
+	// Release the current admission on any exit that did not settle it: a panic
+	// in a member hook skips recordBatchOutcomes and the cancel branch. The
+	// closure reads the latest res/db (the outer loop may re-admit) and ReleaseFor
+	// settles once, so an explicit release before a re-gate plus this final one
+	// never double-count. Guarded against a never-admitted exit.
+	defer func() {
+		if db != nil {
+			db.cb.ReleaseFor(res)
+		}
+	}()
 	for {
-		if c.closed.Load() {
-			resetCmds(cmds)
-			setCmdsErr(cmds, ErrClosed)
-			return ErrClosed
-		}
-		if err := ctx.Err(); err != nil {
-			resetCmds(cmds)
-			setCmdsErr(cmds, err)
-			return err
-		}
-		var idx int
-		db, idx = c.activeSnapshot()
-		admitted := false
-		if db != nil && !c.detector.ShouldFailover() {
-			admitted, res = db.cb.AllowReserve()
-		}
-		if !admitted {
-			gateRejections++
-			if gateRejections > c.memberCount()+1 {
-				err := ErrTemporarilyNotAvailable
+		gateRejections := 0
+		// The gate loops like the other paths (detector before IsAllowed; a
+		// denied member triggers another failover, bounded by the rejection cap)
+		// — only the EXECUTION below stays single-shot, so at-most-once holds:
+		// no MULTI/EXEC has been sent while the gate is still choosing.
+		for {
+			if c.closed.Load() {
+				resetCmds(cmds)
+				setCmdsErr(cmds, ErrClosed)
+				return ErrClosed
+			}
+			if err := ctx.Err(); err != nil {
 				resetCmds(cmds)
 				setCmdsErr(cmds, err)
 				return err
 			}
-			if err := c.tryFailover(ctx, idx); err != nil {
+			var idx int
+			db, idx = c.activeSnapshot()
+			admitted := false
+			if db != nil && !c.detector.ShouldFailover() {
+				admitted, res = db.cb.AllowReserve()
+			}
+			if !admitted {
+				gateRejections++
+				if gateRejections > c.memberCount()+1 {
+					err := ErrTemporarilyNotAvailable
+					resetCmds(cmds)
+					setCmdsErr(cmds, err)
+					return err
+				}
+				if err := c.tryFailover(ctx, idx); err != nil {
+					resetCmds(cmds)
+					setCmdsErr(cmds, err)
+					return err
+				}
+				continue
+			}
+			break
+		}
+
+		// Record outcomes only for the user's commands: cmds arrives wrapped by
+		// wrapMultiExec (MULTI ... EXEC), and counting the synthetic envelope
+		// would advance the breaker by three per single-command transaction.
+		user := cmds
+		if len(cmds) >= 3 {
+			user = cmds[1 : len(cmds)-1]
+		}
+		// Clear any error a caller left on a reused command — or the stale
+		// ErrClosed from a previous re-gate — before executing, so a transaction
+		// that aborts before execution is recorded as a transport failure instead
+		// of being masked by stale per-command errors setCmdsErr refuses to
+		// overwrite. Only the user slice can carry caller staleness; the MULTI/EXEC
+		// envelope is built fresh per call.
+		resetCmds(user)
+		// The execution marker rides on the context (see processPipeline and
+		// AddDatabaseHook): a member hook must pass the received ctx to next.
+		executed := newExecutedCmds(len(cmds))
+		err := db.processTxPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
+		if err != nil && ctx.Err() != nil {
+			// Caller's context ended mid-transaction (see processPipeline): a
+			// client-side signal, not a health verdict. Return without recording;
+			// the deferred release frees the reservation. Do NOT reset the
+			// commands — EXEC may have committed, and their state is the caller's
+			// only evidence of that. Return the cancellation as the aggregate
+			// error (like processPipeline) rather than the stale transport error.
+			return ctx.Err()
+		}
+		if errors.Is(err, ErrClosed) && db.removed.Load() && !executed.any() {
+			// The snapshotted member was removed (its client closed) before the
+			// transaction executed, so its pool returned the terminal ErrClosed
+			// though the MultiDBClient is still open. The execution marker is empty
+			// — nothing ran — so re-gating is at-most-once-safe: release this
+			// admission and re-enter the gate on the live active. Bounded
+			// separately from gate rejections; a genuine Close is caught by the
+			// c.closed check at the top of the next iteration.
+			db.cb.ReleaseFor(res)
+			removedActiveRegates++
+			if removedActiveRegates > c.memberCount()+1 {
 				resetCmds(cmds)
-				setCmdsErr(cmds, err)
-				return err
+				setCmdsErr(cmds, ErrTemporarilyNotAvailable)
+				return ErrTemporarilyNotAvailable
 			}
 			continue
 		}
-		break
+		c.recordBatchOutcomes(db, user, err, executed, res)
+		return err
 	}
-
-	// Release the admission on any exit that did not settle it: a panic in a
-	// member hook or the member path skips both recordBatchOutcomes and the
-	// cancel branch. ReleaseFor settles at most once and no-ops for a closed
-	// admission — the same defer Watch uses.
-	defer db.cb.ReleaseFor(res)
-	// Record outcomes only for the user's commands: cmds arrives wrapped by
-	// wrapMultiExec (MULTI ... EXEC), and counting the synthetic envelope
-	// would advance the breaker by three per single-command transaction.
-	user := cmds
-	if len(cmds) >= 3 {
-		user = cmds[1 : len(cmds)-1]
-	}
-	// Clear any error a caller left on a reused command before executing, so a
-	// transaction that aborts before execution (e.g. a connection-acquire
-	// failure) is recorded as a transport failure instead of being masked by
-	// stale per-command errors setCmdsErr refuses to overwrite. Only the user
-	// slice can carry caller staleness; the MULTI/EXEC envelope is built fresh
-	// per call.
-	resetCmds(user)
-	// The execution marker rides on the context (see processPipeline and
-	// AddDatabaseHook): a member hook must pass the received ctx to next.
-	executed := newExecutedCmds(len(cmds))
-	err := db.processTxPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
-	if err != nil && ctx.Err() != nil {
-		// Caller's context ended mid-transaction (see processPipeline): a
-		// client-side signal, not a health verdict. Release any half-open
-		// reservation and return without recording. Do NOT reset the commands
-		// here — EXEC may have committed, and their state is the caller's only
-		// evidence of that. Return the cancellation as the aggregate error (like
-		// processPipeline) rather than the stale transport error, so a caller
-		// does not mistake a deliberate cancel for a retryable disconnect.
-		db.cb.ReleaseFor(res)
-		return ctx.Err()
-	}
-	c.recordBatchOutcomes(db, user, err, executed, res)
-	return err
 }
 
 func (db *multidbDatabase) processPipelineHook(ctx context.Context, cmds []Cmder) error {

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"math"
-	"sync/atomic"
 
 	imultidb "github.com/redis/go-redis/v9/internal/multidb"
 )
@@ -36,16 +35,18 @@ func resetCmds(cmds []Cmder) {
 // path (including the autopipeliner's batch dispatcher, before the batch's
 // done channel closes), where Err on an async command would await the very
 // batch being completed and wedge the dispatcher.
-func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, batchErr error, executed bool, res imultidb.Reservation) int {
-	// `executed` comes from the execution marker, not from inspecting
-	// command state: an executed all-success batch whose error was injected
-	// by a post-exec hook looks identical on the commands, and stamping it
-	// would turn already-applied writes into phantom transport failures and
-	// replay them. `res` is the gate admission's half-open reservation: the
-	// whole batch is ONE admission, so RecordSuccessFor / ReleaseFor settle the
-	// breaker's half-open slot exactly once however many commands succeed, and a
-	// closed-state admission (res.held == false) holds no slot to settle.
-	if !executed {
+func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, batchErr error, executed *executedCmds, res imultidb.Reservation) int {
+	// `executed` is the per-command execution marker, not inferred from command
+	// state: an executed all-success batch whose error was injected by a
+	// post-exec hook looks identical on the commands, and stamping it would turn
+	// already-applied writes into phantom transport failures and replay them.
+	// It is per-command because a cluster batch fans out into independent node
+	// sub-batches — one node executing must not make another node's untouched
+	// commands look served. `res` is the gate admission's half-open reservation:
+	// the whole batch is ONE admission, so RecordSuccessFor / ReleaseFor settle
+	// the breaker's half-open slot exactly once however many commands succeed,
+	// and a closed-state admission (res.held == false) holds no slot to settle.
+	if !executed.any() {
 		if batchErr == nil {
 			// A member hook served the batch locally (returned nil without
 			// calling next): the results are valid for the caller, but
@@ -81,10 +82,11 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 	recordOne := func(cmd Cmder) {
 		switch classify(cmd) {
 		case outcomeSuccess:
-			if !executed {
-				// A nil (or reply-class) error fabricated by an aborting
-				// hook is no proof the database answered: surface it to the
-				// caller, record nothing.
+			if !executed.has(cmd) {
+				// This command never reached the server — a hook served it
+				// locally, or (cluster fan-out) its node short-circuited while
+				// another node executed. Its nil error is no proof the database
+				// answered: surface it to the caller, record nothing.
 				return
 			}
 			// Settle the batch's single reservation: RecordSuccessFor releases
@@ -294,7 +296,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		// The marker tells recordBatchOutcomes whether execution started
 		// (fresh per attempt): command state alone cannot distinguish a
 		// pre-execution hook abort from a post-execution hook error.
-		executed := new(atomic.Bool)
+		executed := newExecutedCmds(len(cmds))
 		err := db.processPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
 		if err != nil && ctx.Err() != nil {
 			// The caller's own context ended (deadline/cancel) while the batch
@@ -315,7 +317,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			// return without touching command state on caller cancellation.
 			return exitErr(ctx.Err())
 		}
-		transportFailures := c.recordBatchOutcomes(db, cmds, err, executed.Load(), res)
+		transportFailures := c.recordBatchOutcomes(db, cmds, err, executed, res)
 
 		if transportFailures == 0 {
 			// Only server replies (or clean success) — done, whatever the
@@ -394,16 +396,18 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 		break
 	}
 
-	executed := new(atomic.Bool)
+	executed := newExecutedCmds(len(cmds))
 	err := db.processTxPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
 	if err != nil && ctx.Err() != nil {
 		// Caller's context ended mid-transaction (see processPipeline): a
 		// client-side signal, not a health verdict. Release any half-open
 		// reservation and return without recording. Do NOT reset the commands
 		// here — EXEC may have committed, and their state is the caller's only
-		// evidence of that.
+		// evidence of that. Return the cancellation as the aggregate error (like
+		// processPipeline) rather than the stale transport error, so a caller
+		// does not mistake a deliberate cancel for a retryable disconnect.
 		db.cb.ReleaseFor(res)
-		return err
+		return ctx.Err()
 	}
 	// Record outcomes only for the user's commands: cmds arrives wrapped by
 	// wrapMultiExec (MULTI ... EXEC), and counting the synthetic envelope
@@ -412,7 +416,7 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	if len(cmds) >= 3 {
 		user = cmds[1 : len(cmds)-1]
 	}
-	c.recordBatchOutcomes(db, user, err, executed.Load(), res)
+	c.recordBatchOutcomes(db, user, err, executed, res)
 	return err
 }
 

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -364,7 +364,9 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		attempt++
 		// The marker tells recordBatchOutcomes whether execution started
 		// (fresh per attempt): command state alone cannot distinguish a
-		// pre-execution hook abort from a post-execution hook error.
+		// pre-execution hook abort from a post-execution hook error. It rides
+		// on the context, so a member hook must pass the received ctx (or a
+		// child of it) to next — see AddDatabaseHook.
 		executed := newExecutedCmds(len(cmds))
 		err := db.processPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
 		if err != nil && ctx.Err() != nil {
@@ -469,6 +471,8 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	// cancel branch. ReleaseFor settles at most once and no-ops for a closed
 	// admission — the same defer Watch uses.
 	defer db.cb.ReleaseFor(res)
+	// The execution marker rides on the context (see processPipeline and
+	// AddDatabaseHook): a member hook must pass the received ctx to next.
 	executed := newExecutedCmds(len(cmds))
 	err := db.processTxPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
 	if err != nil && ctx.Err() != nil {

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -67,6 +67,16 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 	classify := func(cmd Cmder) outcomeKind {
 		return classifyOutcome(cmd.rawErr(), cmd.readTimeout() == nil)
 	}
+	// Feed the GLOBAL detector only while this batch's member is still the
+	// active: if the active switched (or this member was removed) while the
+	// batch was in flight, recording its outcomes would pollute the new
+	// active's failover window and successSinceFailover. The per-member breaker
+	// below is always updated — it is member-scoped. Mirrors the single-command
+	// path (see process). One snapshot suffices: recordBatchOutcomes runs
+	// synchronously at the end of a single attempt, the batch analogue of the
+	// single-command post-exec check.
+	cur, _ := c.activeSnapshot()
+	stillActive := cur == db
 	transportFailures := 0
 	recorded := 0
 	recordOne := func(cmd Cmder) {
@@ -85,10 +95,12 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 				// but must not release a half-open slot the batch never held.
 				db.cb.RecordExternalSuccess()
 			}
-			c.detector.RecordSuccess()
-			// Recovery traffic breaks the consecutive-failed-failover chain
-			// for batch-only workloads too (see recordFailedFailoverLocked).
-			c.successSinceFailover.Store(true)
+			if stillActive {
+				c.detector.RecordSuccess()
+				// Recovery traffic breaks the consecutive-failed-failover chain
+				// for batch-only workloads too (see recordFailedFailoverLocked).
+				c.successSinceFailover.Store(true)
+			}
 			recorded++
 		case outcomeFailure:
 			// Failures record regardless of the execution marker — unlike
@@ -99,7 +111,9 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 			// batch-only workloads. Successes are the asymmetric case: a
 			// genuine reply cannot exist without execution.
 			db.cb.RecordFailure()
-			c.detector.RecordFailure(cmd.rawErr())
+			if stillActive {
+				c.detector.RecordFailure(cmd.rawErr())
+			}
 			transportFailures++
 			recorded++
 		case outcomeNeutral:
@@ -283,16 +297,21 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			// ran — typically a dial cut short, surfacing as a net timeout the
 			// classifier would otherwise score as a member failure. That is a
 			// client-side signal, not a health verdict: release any half-open
-			// reservation and return WITHOUT recording. Surface the context
-			// error, overwriting the stale transport error, exactly as the
-			// pre-execution gate check does.
+			// reservation and return WITHOUT recording.
 			if reserved {
 				db.cb.ReleaseHalfOpen()
 			}
-			ctxErr := ctx.Err()
-			resetCmds(cmds)
-			setCmdsErr(cmds, ctxErr)
-			return exitErr(ctxErr)
+			// Do NOT reset or overwrite the commands. The deadline may have
+			// interrupted reading a LATER reply while earlier commands already
+			// received definitive results, and those are the caller's only
+			// evidence of what applied — an already-executed INCR must not
+			// resurface as canceled and prompt a replay. The member pipeline
+			// stamped the interrupted/unread commands itself. Unlike the
+			// pre-execution gate checks above (which reset because nothing ran,
+			// so no result can exist), execution here may have produced
+			// results; this mirrors the tx and single-command paths, which also
+			// return without touching command state on caller cancellation.
+			return exitErr(ctx.Err())
 		}
 		transportFailures := c.recordBatchOutcomes(db, cmds, err, executed.Load(), reserved)
 

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -278,6 +278,22 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		// pre-execution hook abort from a post-execution hook error.
 		executed := new(atomic.Bool)
 		err := db.processPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
+		if err != nil && ctx.Err() != nil {
+			// The caller's own context ended (deadline/cancel) while the batch
+			// ran — typically a dial cut short, surfacing as a net timeout the
+			// classifier would otherwise score as a member failure. That is a
+			// client-side signal, not a health verdict: release any half-open
+			// reservation and return WITHOUT recording. Surface the context
+			// error, overwriting the stale transport error, exactly as the
+			// pre-execution gate check does.
+			if reserved {
+				db.cb.ReleaseHalfOpen()
+			}
+			ctxErr := ctx.Err()
+			resetCmds(cmds)
+			setCmdsErr(cmds, ctxErr)
+			return exitErr(ctxErr)
+		}
 		transportFailures := c.recordBatchOutcomes(db, cmds, err, executed.Load(), reserved)
 
 		if transportFailures == 0 {
@@ -359,6 +375,17 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 
 	executed := new(atomic.Bool)
 	err := db.processTxPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
+	if err != nil && ctx.Err() != nil {
+		// Caller's context ended mid-transaction (see processPipeline): a
+		// client-side signal, not a health verdict. Release any half-open
+		// reservation and return without recording. Do NOT reset the commands
+		// here — EXEC may have committed, and their state is the caller's only
+		// evidence of that.
+		if reserved {
+			db.cb.ReleaseHalfOpen()
+		}
+		return err
+	}
 	// Record outcomes only for the user's commands: cmds arrives wrapped by
 	// wrapMultiExec (MULTI ... EXEC), and counting the synthetic envelope
 	// would advance the breaker by three per single-command transaction.

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -427,12 +427,22 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 		return ErrClosed
 	}
 	if cmdsContainHImport(cmds) {
-		// Reject the whole transaction (MULTI/EXEC is all-or-nothing). Report
-		// the positionally-first error like Pipeline.Exec: setCmdsErr fills only
-		// empty slots, so a command the caller queued with a pre-existing error
-		// keeps it and must win over errMultiDBHImport when it comes first.
-		setCmdsErr(cmds, errMultiDBHImport)
-		return cmdsFirstErr(cmds)
+		// Reject the whole transaction (MULTI/EXEC is all-or-nothing) and report
+		// the positionally-first error over the USER commands, like Pipeline.Exec
+		// — not the synthetic MULTI that wrapMultiExec prepends. cmds is always
+		// the wrapped [MULTI, user..., EXEC]: TxPipeline().Exec is the only caller
+		// and wraps before dispatch, and transactions are never autopipelined, so
+		// the user commands are cmds[1:len-1] (the minimum wrapped length is 3).
+		// setCmdsErr fills only empty slots, so a user command the caller queued
+		// with a pre-existing error keeps it and wins over errMultiDBHImport when
+		// it comes first — stamping the fresh MULTI (index 0) instead would let it
+		// win every time.
+		user := cmds
+		if len(cmds) >= 3 {
+			user = cmds[1 : len(cmds)-1]
+		}
+		setCmdsErr(user, errMultiDBHImport)
+		return cmdsFirstErr(user)
 	}
 	// A context that is already done must not reach the failover gate: with
 	// ProbeTargetBeforeFailover the doomed probes would damage candidate

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -266,10 +266,6 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 	// failover keeps handing back members the gate rejects — surface
 	// unavailability instead of busy-looping the active index.
 	gateRejections := 0
-	// Separate bound for re-gates caused by a removed former active: those pass
-	// the gate (so gateRejections is reset on admission) and must not busy-loop
-	// if a rapid add/remove keeps handing back a closed member. Mirrors process().
-	removedActiveRegates := 0
 
 	// exitErr picks the batch error for every exit: with a rejected HIMPORT
 	// in the batch the positionally first error over the ORIGINAL slice wins,
@@ -401,37 +397,23 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		transportFailures := c.recordBatchOutcomes(db, cmds, err, executed, res)
 
 		if transportFailures == 0 {
-			if errors.Is(err, ErrClosed) && db.removed.Load() && !executed.any() {
+			if errors.Is(err, ErrClosed) && db.removed.Load() {
 				// A concurrent control op removed the snapshotted member (closing
 				// its client) between the gate and execution, so its pool returned
 				// the terminal ErrClosed, classified neutral. The MultiDBClient is
-				// still open: re-enter the gate on the live active instead of
-				// surfacing ErrClosed, mirroring the single-command process() path.
-				//
-				// Guarded on !executed.any(), like the tx path: a cluster fan-out
-				// can have one node apply its commands while another node's
-				// connection acquisition returns ErrClosed after the member was
-				// switched away and removed. transportFailures is still 0 (the
-				// applied commands are successes, the ErrClosed is neutral), but the
-				// batch DID partially execute — re-gating and replaying it would
-				// duplicate the completed node's non-idempotent writes. When any
-				// shard executed, fall through and return the batch as-is instead.
-				//
-				// recordBatchOutcomes released the reservation (nothing recorded);
-				// the batch never executed, so don't spend a retry attempt. Bound
-				// the re-gates separately from gate rejections (which reset on
-				// admission); a genuine Close is caught by c.closed next iteration.
-				removedActiveRegates++
-				if removedActiveRegates > c.memberCount()+1 {
-					// Pathological rapid add/remove: surface the retryable
-					// unavailable error rather than the removed member's terminal
-					// ErrClosed. Leave the per-command state as recorded — the
-					// attempt counter cannot cleanly tell whether an earlier attempt
-					// applied a prefix, so do not risk overwriting it here.
-					return exitErr(ErrTemporarilyNotAvailable)
+				// still open: surface the retryable ErrTemporarilyNotAvailable
+				// instead of a client-closed sentinel, as process() does, and let
+				// the caller retry as it would for a transport failure. Nothing is
+				// replayed here — a cluster fan-out may have applied one node's
+				// commands while another node's connection acquisition hit the
+				// removed member, and replaying would duplicate those writes. Only
+				// when nothing executed are the per-command stand-in errors rewritten
+				// to match the aggregate; a partially executed batch keeps its results.
+				if !executed.any() {
+					resetCmds(cmds)
+					setCmdsErr(cmds, ErrTemporarilyNotAvailable)
 				}
-				attempt--
-				continue
+				return exitErr(ErrTemporarilyNotAvailable)
 			}
 			// Only server replies (or clean success) — done, whatever the
 			// user-level outcome is.
@@ -484,109 +466,96 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	// denied member triggers another failover, bounded by the rejection
 	// cap) — only the EXECUTION below stays single-shot, so at-most-once
 	// holds: no MULTI/EXEC has been sent while the gate is still choosing.
-	// Separate bound for re-gates caused by a removed former active (see
-	// processPipeline): they pass the gate, so gateRejections cannot bound them.
-	removedActiveRegates := 0
+	gateRejections := 0
 	var db *multidbDatabase
 	var res imultidb.Reservation
-	// Release the current admission on any exit that did not settle it: a panic
-	// in a member hook skips recordBatchOutcomes and the cancel branch. The
-	// closure reads the latest res/db (the outer loop may re-admit) and ReleaseFor
-	// settles once, so an explicit release before a re-gate plus this final one
-	// never double-count. Guarded against a never-admitted exit.
-	defer func() {
-		if db != nil {
-			db.cb.ReleaseFor(res)
-		}
-	}()
 	for {
-		gateRejections := 0
-		// The gate loops like the other paths (detector before IsAllowed; a
-		// denied member triggers another failover, bounded by the rejection cap)
-		// — only the EXECUTION below stays single-shot, so at-most-once holds:
-		// no MULTI/EXEC has been sent while the gate is still choosing.
-		for {
-			if c.closed.Load() {
-				resetCmds(cmds)
-				setCmdsErr(cmds, ErrClosed)
-				return ErrClosed
-			}
-			if err := ctx.Err(); err != nil {
+		if c.closed.Load() {
+			resetCmds(cmds)
+			setCmdsErr(cmds, ErrClosed)
+			return ErrClosed
+		}
+		if err := ctx.Err(); err != nil {
+			resetCmds(cmds)
+			setCmdsErr(cmds, err)
+			return err
+		}
+		var idx int
+		db, idx = c.activeSnapshot()
+		admitted := false
+		if db != nil && !c.detector.ShouldFailover() {
+			admitted, res = db.cb.AllowReserve()
+		}
+		if !admitted {
+			gateRejections++
+			if gateRejections > c.memberCount()+1 {
+				err := ErrTemporarilyNotAvailable
 				resetCmds(cmds)
 				setCmdsErr(cmds, err)
 				return err
 			}
-			var idx int
-			db, idx = c.activeSnapshot()
-			admitted := false
-			if db != nil && !c.detector.ShouldFailover() {
-				admitted, res = db.cb.AllowReserve()
-			}
-			if !admitted {
-				gateRejections++
-				if gateRejections > c.memberCount()+1 {
-					err := ErrTemporarilyNotAvailable
-					resetCmds(cmds)
-					setCmdsErr(cmds, err)
-					return err
-				}
-				if err := c.tryFailover(ctx, idx); err != nil {
-					resetCmds(cmds)
-					setCmdsErr(cmds, err)
-					return err
-				}
-				continue
-			}
-			break
-		}
-
-		// Record outcomes only for the user's commands: cmds arrives wrapped by
-		// wrapMultiExec (MULTI ... EXEC), and counting the synthetic envelope
-		// would advance the breaker by three per single-command transaction.
-		user := cmds
-		if len(cmds) >= 3 {
-			user = cmds[1 : len(cmds)-1]
-		}
-		// Clear any error a caller left on a reused command — or the stale
-		// ErrClosed from a previous re-gate — before executing, so a transaction
-		// that aborts before execution is recorded as a transport failure instead
-		// of being masked by stale per-command errors setCmdsErr refuses to
-		// overwrite. Only the user slice can carry caller staleness; the MULTI/EXEC
-		// envelope is built fresh per call.
-		resetCmds(user)
-		// The execution marker rides on the context (see processPipeline and
-		// AddDatabaseHook): a member hook must pass the received ctx to next.
-		executed := newExecutedCmds(len(cmds))
-		err := db.processTxPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
-		if err != nil && ctx.Err() != nil {
-			// Caller's context ended mid-transaction (see processPipeline): a
-			// client-side signal, not a health verdict. Return without recording;
-			// the deferred release frees the reservation. Do NOT reset the
-			// commands — EXEC may have committed, and their state is the caller's
-			// only evidence of that. Return the cancellation as the aggregate
-			// error (like processPipeline) rather than the stale transport error.
-			return ctx.Err()
-		}
-		if errors.Is(err, ErrClosed) && db.removed.Load() && !executed.any() {
-			// The snapshotted member was removed (its client closed) before the
-			// transaction executed, so its pool returned the terminal ErrClosed
-			// though the MultiDBClient is still open. The execution marker is empty
-			// — nothing ran — so re-gating is at-most-once-safe: release this
-			// admission and re-enter the gate on the live active. Bounded
-			// separately from gate rejections; a genuine Close is caught by the
-			// c.closed check at the top of the next iteration.
-			db.cb.ReleaseFor(res)
-			removedActiveRegates++
-			if removedActiveRegates > c.memberCount()+1 {
+			if err := c.tryFailover(ctx, idx); err != nil {
 				resetCmds(cmds)
-				setCmdsErr(cmds, ErrTemporarilyNotAvailable)
-				return ErrTemporarilyNotAvailable
+				setCmdsErr(cmds, err)
+				return err
 			}
 			continue
 		}
-		c.recordBatchOutcomes(db, user, err, executed, res)
-		return err
+		break
 	}
+
+	// Release the admission on any exit that did not settle it: a panic in a
+	// member hook or the member path skips both recordBatchOutcomes and the
+	// cancel branch. ReleaseFor settles at most once and no-ops for a closed
+	// admission — the same defer Watch uses.
+	defer db.cb.ReleaseFor(res)
+	// Record outcomes only for the user's commands: cmds arrives wrapped by
+	// wrapMultiExec (MULTI ... EXEC), and counting the synthetic envelope
+	// would advance the breaker by three per single-command transaction.
+	user := cmds
+	if len(cmds) >= 3 {
+		user = cmds[1 : len(cmds)-1]
+	}
+	// Clear any error a caller left on a reused command before executing, so a
+	// transaction that aborts before execution (e.g. a connection-acquire
+	// failure) is recorded as a transport failure instead of being masked by
+	// stale per-command errors setCmdsErr refuses to overwrite. Only the user
+	// slice can carry caller staleness; the MULTI/EXEC envelope is built fresh
+	// per call.
+	resetCmds(user)
+	// The execution marker rides on the context (see processPipeline and
+	// AddDatabaseHook): a member hook must pass the received ctx to next.
+	executed := newExecutedCmds(len(cmds))
+	err := db.processTxPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
+	if err != nil && ctx.Err() != nil {
+		// Caller's context ended mid-transaction (see processPipeline): a
+		// client-side signal, not a health verdict. Release any half-open
+		// reservation and return without recording. Do NOT reset the commands
+		// here — EXEC may have committed, and their state is the caller's only
+		// evidence of that. Return the cancellation as the aggregate error (like
+		// processPipeline) rather than the stale transport error, so a caller
+		// does not mistake a deliberate cancel for a retryable disconnect.
+		db.cb.ReleaseFor(res)
+		return ctx.Err()
+	}
+	c.recordBatchOutcomes(db, user, err, executed, res)
+	if errors.Is(err, ErrClosed) && db.removed.Load() {
+		// A concurrent control op removed the snapshotted member (closing its
+		// client) between the gate and execution, so its pool returned the
+		// terminal ErrClosed though the MultiDBClient is still open. Surface the
+		// retryable ErrTemporarilyNotAvailable instead of a client-closed
+		// sentinel, as process() does. Nothing is replayed here — EXEC may have
+		// committed, so at-most-once forbids it — and recordBatchOutcomes
+		// recorded no health outcome for the neutral ErrClosed. Only when nothing
+		// executed are the per-command stand-in errors rewritten to match the
+		// aggregate; a partially executed transaction keeps its evidence.
+		if !executed.any() {
+			resetCmds(user)
+			setCmdsErr(user, ErrTemporarilyNotAvailable)
+		}
+		return ErrTemporarilyNotAvailable
+	}
+	return err
 }
 
 func (db *multidbDatabase) processPipelineHook(ctx context.Context, cmds []Cmder) error {

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -358,9 +358,23 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		gateRejections = 0
 		pendingDB, pendingRes = db, res
 
-		if attempt > 0 {
-			resetCmds(cmds)
-		}
+		// Clear any per-command error before executing. On a retry this drops
+		// the previous attempt's stamps; on the first attempt it drops an error
+		// a caller left on a reused command, so a batch that aborts before
+		// execution (e.g. a connection-acquire failure) still records the
+		// transport failure through setCmdsErr instead of being masked by stale
+		// per-command errors setCmdsErr refuses to overwrite. The rejected
+		// HIMPORT stamps live in orig, not in cmds (kept is a fresh slice), so
+		// this cannot clear them.
+		// Clear any per-command error before executing. On a retry this drops
+		// the previous attempt's stamps; on the first attempt it drops an error
+		// a caller left on a reused command, so a batch that aborts before
+		// execution (e.g. a connection-acquire failure) still records the
+		// transport failure through setCmdsErr instead of being masked by stale
+		// per-command errors setCmdsErr refuses to overwrite. The rejected
+		// HIMPORT stamps live in orig, not in cmds (kept is a fresh slice), so
+		// this cannot clear them.
+		resetCmds(cmds)
 		attempt++
 		// The marker tells recordBatchOutcomes whether execution started
 		// (fresh per attempt): command state alone cannot distinguish a
@@ -475,6 +489,20 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	// cancel branch. ReleaseFor settles at most once and no-ops for a closed
 	// admission — the same defer Watch uses.
 	defer db.cb.ReleaseFor(res)
+	// Record outcomes only for the user's commands: cmds arrives wrapped by
+	// wrapMultiExec (MULTI ... EXEC), and counting the synthetic envelope
+	// would advance the breaker by three per single-command transaction.
+	user := cmds
+	if len(cmds) >= 3 {
+		user = cmds[1 : len(cmds)-1]
+	}
+	// Clear any error a caller left on a reused command before executing, so a
+	// transaction that aborts before execution (e.g. a connection-acquire
+	// failure) is recorded as a transport failure instead of being masked by
+	// stale per-command errors setCmdsErr refuses to overwrite. Only the user
+	// slice can carry caller staleness; the MULTI/EXEC envelope is built fresh
+	// per call.
+	resetCmds(user)
 	// The execution marker rides on the context (see processPipeline and
 	// AddDatabaseHook): a member hook must pass the received ctx to next.
 	executed := newExecutedCmds(len(cmds))
@@ -489,13 +517,6 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 		// does not mistake a deliberate cancel for a retryable disconnect.
 		db.cb.ReleaseFor(res)
 		return ctx.Err()
-	}
-	// Record outcomes only for the user's commands: cmds arrives wrapped by
-	// wrapMultiExec (MULTI ... EXEC), and counting the synthetic envelope
-	// would advance the breaker by three per single-command transaction.
-	user := cmds
-	if len(cmds) >= 3 {
-		user = cmds[1 : len(cmds)-1]
 	}
 	c.recordBatchOutcomes(db, user, err, executed, res)
 	return err

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -86,7 +86,8 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		attempts = 1
 	}
 
-	for attempt := 0; attempt < attempts; attempt++ {
+	attempt := 0
+	for attempt < attempts {
 		if err := ctx.Err(); err != nil {
 			setCmdsErr(cmds, err)
 			return err
@@ -102,15 +103,17 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 				setCmdsErr(cmds, err)
 				return err
 			}
-			db, _ = c.activeSnapshot()
-			if db == nil {
-				continue
-			}
+			// Re-enter the gate on the newly selected database — mirroring
+			// the single-command path: its breaker may be half-open and the
+			// IsAllowed call above is what reserves the bounded probe slot.
+			// Re-gating does not consume a retry attempt.
+			continue
 		}
 
 		if attempt > 0 {
 			resetCmds(cmds)
 		}
+		attempt++
 		err := db.processPipelineHook(ctx, cmds)
 		transportFailures := c.recordBatchOutcomes(db, cmds)
 
@@ -136,6 +139,14 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 		setCmdsErr(cmds, ErrClosed)
 		return ErrClosed
 	}
+	// A context that is already done must not reach the failover gate: with
+	// ProbeTargetBeforeFailover the doomed probes would damage candidate
+	// breakers and advance the escalation state, and without it the active
+	// database could be switched for an operation that cannot run anyway.
+	if err := ctx.Err(); err != nil {
+		setCmdsErr(cmds, err)
+		return err
+	}
 	db, idx := c.activeSnapshot()
 	if db == nil || !db.cb.IsAllowed() || c.detector.ShouldFailover() {
 		if err := c.tryFailover(ctx, idx); err != nil {
@@ -143,8 +154,12 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 			setCmdsErr(cmds, err)
 			return err
 		}
+		// Re-run the admission gate on the newly selected database: its
+		// breaker may be half-open, and executing without IsAllowed would
+		// bypass the bounded probe-slot accounting. Transactions run at
+		// most once, so a denied slot fails the call rather than looping.
 		db, _ = c.activeSnapshot()
-		if db == nil {
+		if db == nil || !db.cb.IsAllowed() {
 			err := ErrTemporarilyNotAvailable
 			resetCmds(cmds)
 			setCmdsErr(cmds, err)
@@ -228,6 +243,14 @@ func (c *MultiDBClient) TxPipeline() Pipeliner {
 	pipe := Pipeline{
 		exec: func(ctx context.Context, cmds []Cmder) error {
 			cmds = wrapMultiExec(ctx, cmds)
+			// Suppress the member client's own retry loop for the wrapped
+			// batch (cmdsContainNoRetry): EXEC may have committed before a
+			// transport error surfaced, and at-most-once must hold for the
+			// whole stack, not only the MultiDB retry layer. The marker
+			// rides on the synthetic MULTI so user commands stay untouched.
+			if multi, ok := cmds[0].(*StatusCmd); ok {
+				multi.setNoRetry(true)
+			}
 			return c.processTxPipelineHook(ctx, cmds)
 		},
 	}
@@ -257,6 +280,10 @@ func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 	if c.core.closed.Load() {
 		return ErrClosed
 	}
+	// A done context must not reach the failover gate (see processTxPipeline).
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	// selectable (non-reserving) rather than IsAllowed: the WATCH path does
 	// not feed the breaker, so it must not consume a bounded half-open probe
 	// slot it would never record or release.
@@ -266,7 +293,7 @@ func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 			return err
 		}
 		db, _ = c.core.activeSnapshot()
-		if db == nil {
+		if db == nil || !db.selectable() {
 			return ErrTemporarilyNotAvailable
 		}
 	}

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -36,18 +36,19 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder) int
 	transportFailures := 0
 	for _, cmd := range cmds {
 		err := cmd.rawErr()
-		if err == nil || isRedisReplyError(err) {
+		switch classifyOutcome(err) {
+		case outcomeSuccess:
 			db.cb.RecordSuccess()
 			c.detector.RecordSuccess()
-			continue
+		case outcomeFailure:
+			db.cb.RecordFailure()
+			c.detector.RecordFailure(err)
+			transportFailures++
+		case outcomeNeutral:
+			// Not a database-health signal (client-side error or a locally
+			// synthesized Redis error such as ErrCrossSlot); surfaced to the
+			// caller as-is.
 		}
-		if !shouldRetry(err, true) {
-			// Not a database-health signal; surfaced to the caller as-is.
-			continue
-		}
-		db.cb.RecordFailure()
-		c.detector.RecordFailure(err)
-		transportFailures++
 	}
 	return transportFailures
 }
@@ -79,6 +80,10 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		db, idx := c.activeSnapshot()
 		if db == nil || !db.cb.IsAllowed() || c.detector.ShouldFailover() {
 			if err := c.tryFailover(ctx, idx); err != nil {
+				// Overwrite any prior attempt's transport errors so callers
+				// see the availability error, not a stale EOF (setCmdsErr
+				// only fills empty error slots).
+				resetCmds(cmds)
 				setCmdsErr(cmds, err)
 				return err
 			}
@@ -115,12 +120,14 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	db, idx := c.activeSnapshot()
 	if db == nil || !db.cb.IsAllowed() || c.detector.ShouldFailover() {
 		if err := c.tryFailover(ctx, idx); err != nil {
+			resetCmds(cmds)
 			setCmdsErr(cmds, err)
 			return err
 		}
 		db, _ = c.activeSnapshot()
 		if db == nil {
 			err := ErrTemporarilyNotAvailable
+			resetCmds(cmds)
 			setCmdsErr(cmds, err)
 			return err
 		}

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 )
 
 // This file makes MultiDBClient a full UniversalClient and wires pipelines
@@ -42,26 +43,37 @@ func cmdsHaveAnyErr(cmds []Cmder) bool {
 // path (including the autopipeliner's batch dispatcher, before the batch's
 // done channel closes), where Err on an async command would await the very
 // batch being completed and wedge the dispatcher.
-func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, batchErr error) int {
-	// An executed batch always stamps at least the failing command (reply
-	// errors land on their command, transport errors are stamped on every
-	// command). A batch whose batch-level call failed while NO command
-	// carries an error therefore never reached execution — e.g. a member
-	// hook aborted before calling next. Only then does the batch error
-	// stand in for the commands, and it is stamped so callers see it.
-	// Substituting it per-command when some nil errors are successfully
-	// read replies would turn a successful prefix into phantom transport
-	// failures and replay it.
-	if batchErr != nil && !cmdsHaveAnyErr(cmds) {
+func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, batchErr error, executed bool) int {
+	// A batch whose batch-level call failed while execution never started
+	// (the marker was not flipped — e.g. a member hook aborted before
+	// calling next) has no per-command verdicts: the batch error stands in
+	// for the commands and is stamped so callers see it. `executed` comes
+	// from the execution marker, not from inspecting command state: an
+	// executed all-success batch whose error was injected by a post-exec
+	// hook looks identical on the commands, and stamping it would turn
+	// already-applied writes into phantom transport failures and replay
+	// them.
+	if batchErr != nil && !executed && !cmdsHaveAnyErr(cmds) {
 		setCmdsErr(cmds, batchErr)
 	}
+	// Failures first, successes second: on a half-open breaker a batch's
+	// early successful replies could otherwise close the circuit before its
+	// own later failure is recorded, marking a failed recovery probe as a
+	// recovered database.
 	transportFailures := 0
 	recorded := 0
 	for _, cmd := range cmds {
-		err := cmd.rawErr()
-		// Pipelines mirror the plain pipeline retry rule (shouldRetry with
-		// retryTimeout=true), matching *Client/*ClusterClient batch paths.
-		switch classifyOutcome(err, true) {
+		// Errors are classified with retryTimeout=true, mirroring the plain
+		// pipeline retry rule of *Client/*ClusterClient batch paths.
+		if classifyOutcome(cmd.rawErr(), true) == outcomeFailure {
+			db.cb.RecordFailure()
+			c.detector.RecordFailure(cmd.rawErr())
+			transportFailures++
+			recorded++
+		}
+	}
+	for _, cmd := range cmds {
+		switch classifyOutcome(cmd.rawErr(), true) {
 		case outcomeSuccess:
 			db.cb.RecordSuccess()
 			c.detector.RecordSuccess()
@@ -70,10 +82,7 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 			c.successSinceFailover.Store(true)
 			recorded++
 		case outcomeFailure:
-			db.cb.RecordFailure()
-			c.detector.RecordFailure(err)
-			transportFailures++
-			recorded++
+			// Recorded in the first pass.
 		case outcomeNeutral:
 			// Not a database-health signal (client-side error or a locally
 			// synthesized Redis error such as ErrCrossSlot); surfaced to the
@@ -147,8 +156,12 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			resetCmds(cmds)
 		}
 		attempt++
-		err := db.processPipelineHook(ctx, cmds)
-		transportFailures := c.recordBatchOutcomes(db, cmds, err)
+		// The marker tells recordBatchOutcomes whether execution started
+		// (fresh per attempt): command state alone cannot distinguish a
+		// pre-execution hook abort from a post-execution hook error.
+		executed := new(atomic.Bool)
+		err := db.processPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
+		transportFailures := c.recordBatchOutcomes(db, cmds, err, executed.Load())
 
 		if transportFailures == 0 {
 			// Only server replies (or clean success) — done, whatever the
@@ -202,7 +215,8 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 		}
 	}
 
-	err := db.processTxPipelineHook(ctx, cmds)
+	executed := new(atomic.Bool)
+	err := db.processTxPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
 	// Record outcomes only for the user's commands: cmds arrives wrapped by
 	// wrapMultiExec (MULTI ... EXEC), and counting the synthetic envelope
 	// would advance the breaker by three per single-command transaction.
@@ -210,7 +224,7 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	if len(cmds) >= 3 {
 		user = cmds[1 : len(cmds)-1]
 	}
-	c.recordBatchOutcomes(db, user, err)
+	c.recordBatchOutcomes(db, user, err, executed.Load())
 	return err
 }
 

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -195,6 +195,13 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 	maxGateRejections := c.memberCount() + 1
 
 	for attempt < attempts {
+		if c.closed.Load() {
+			// Close landed mid-retry: report the terminal state instead of
+			// escalating through the drained membership.
+			resetCmds(cmds)
+			setCmdsErr(cmds, ErrClosed)
+			return ErrClosed
+		}
 		if err := ctx.Err(); err != nil {
 			// Overwrite any prior attempt's transport errors: callers that
 			// inspect per-command results must see the context error, not a
@@ -293,6 +300,11 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	maxGateRejections := c.memberCount() + 1
 	var db *multidbDatabase
 	for {
+		if c.closed.Load() {
+			resetCmds(cmds)
+			setCmdsErr(cmds, ErrClosed)
+			return ErrClosed
+		}
 		if err := ctx.Err(); err != nil {
 			resetCmds(cmds)
 			setCmdsErr(cmds, err)

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 )
 
 // This file makes MultiDBClient a full UniversalClient and wires pipelines
@@ -23,14 +24,25 @@ func resetCmds(cmds []Cmder) {
 // recordBatchOutcomes records one breaker/detector outcome per command,
 // mirroring the single-command path: an error reply from the server proves
 // the database is reachable and counts as a success; transport-level errors
-// count as failures. It returns the number of transport-level failures.
+// count as failures; client-side errors (context cancellation, deterministic
+// local rejections per shouldRetry) record nothing and do not trigger
+// failover. It returns the number of transport-level failures.
+//
+// Errors are read via rawErr, never Err: this runs on the pipeline execution
+// path (including the autopipeliner's batch dispatcher, before the batch's
+// done channel closes), where Err on an async command would await the very
+// batch being completed and wedge the dispatcher.
 func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder) int {
 	transportFailures := 0
 	for _, cmd := range cmds {
-		err := cmd.Err()
+		err := cmd.rawErr()
 		if err == nil || isRedisReplyError(err) {
 			db.cb.RecordSuccess()
 			c.detector.RecordSuccess()
+			continue
+		}
+		if !shouldRetry(err, true) {
+			// Not a database-health signal; surfaced to the caller as-is.
 			continue
 		}
 		db.cb.RecordFailure()
@@ -115,7 +127,14 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	}
 
 	err := db.processTxPipelineHook(ctx, cmds)
-	c.recordBatchOutcomes(db, cmds)
+	// Record outcomes only for the user's commands: cmds arrives wrapped by
+	// wrapMultiExec (MULTI ... EXEC), and counting the synthetic envelope
+	// would advance the breaker by three per single-command transaction.
+	user := cmds
+	if len(cmds) >= 3 {
+		user = cmds[1 : len(cmds)-1]
+	}
+	c.recordBatchOutcomes(db, user)
 	return err
 }
 
@@ -138,6 +157,16 @@ func (db *multidbDatabase) processTxPipelineHook(ctx context.Context, cmds []Cmd
 // variants come from hooksMixin.
 func (c *MultiDBClient) process(ctx context.Context, cmd Cmder) error {
 	return c.core.process(ctx, cmd)
+}
+
+// hookCount reports one more hook than are installed on the MultiDBClient
+// itself: member clients can carry their own hooks (AddDatabaseHook), which
+// the autopipeliner cannot see, and its async dispatcher only arms the
+// batch-executor self-deadlock guards when hookCount is non-zero. Always
+// reporting at least one keeps those guards armed for member-level hooks
+// that read command results.
+func (c *MultiDBClient) hookCount() int {
+	return c.hooksMixin.hookCount() + 1
 }
 
 func (c *MultiDBClient) processPipeline(ctx context.Context, cmds []Cmder) error {
@@ -186,15 +215,28 @@ func (c *MultiDBClient) TxPipelined(ctx context.Context, fn func(Pipeliner) erro
 }
 
 // Watch runs a WATCH/MULTI/EXEC transaction on the database that is active
-// when Watch is called. The transaction is bound to that member for its whole
-// lifetime: it does NOT follow a MultiDB failover, and it is never
-// automatically retried on another database. If the bound member fails while
-// the transaction is open, the transaction errors like it would on a plain
-// client; MultiDB moves only subsequent operations to the new active member.
+// when Watch is called; if the active database's circuit is open or the
+// failure detector has tripped, a failover is attempted first so the
+// transaction does not start on a known-unhealthy member. The transaction is
+// then bound to that member for its whole lifetime: it does NOT follow a
+// MultiDB failover, its outcome does not feed the breaker or detector, and it
+// is never automatically retried on another database. If the bound member
+// fails while the transaction is open, the transaction errors like it would
+// on a plain client; MultiDB moves only subsequent operations.
+//
+// MultiDB-level hooks (AddHook on MultiDBClient) do not wrap the transaction:
+// the Tx runs on the member client, so install member-level hooks via
+// AddDatabaseHook when WATCH traffic must be instrumented.
 func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {
-	db, _ := c.core.activeSnapshot()
-	if db == nil {
-		return ErrTemporarilyNotAvailable
+	db, idx := c.core.activeSnapshot()
+	if db == nil || !db.cb.IsAllowed() || c.core.detector.ShouldFailover() {
+		if err := c.core.tryFailover(ctx, idx); err != nil {
+			return err
+		}
+		db, _ = c.core.activeSnapshot()
+		if db == nil {
+			return ErrTemporarilyNotAvailable
+		}
 	}
 	if db.cc != nil {
 		return db.cc.Watch(ctx, fn, keys...)
@@ -229,11 +271,32 @@ func (c *MultiDBClient) PoolStats() *PoolStats {
 	return db.c.PoolStats()
 }
 
+// errMultiDBAutoPipelineCluster is returned when an autopipeliner is
+// requested while a cluster member database is configured: the MultiDB
+// autopipeliner would bypass the cluster-specific autopipeline wiring
+// (command preflight, diversion and slot sharding), so cluster members are
+// not supported yet.
+var errMultiDBAutoPipelineCluster = errors.New("redis: multidb: autopipeline does not support cluster member databases yet")
+
+func (c *multidbCore) hasClusterMember() bool {
+	c.dbMu.RLock()
+	defer c.dbMu.RUnlock()
+	for _, db := range c.dbs {
+		if db.cc != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // AutoPipeline returns the blocking autopipeliner for this MultiDB client:
 // batches are flushed against whichever database is active at exec time, and
 // a batch that fails at transport level is retried against the newly selected
 // database (bounded by CommandRetries). The instance is cached and shared; the
 // first call's config wins.
+//
+// Cluster member databases are not supported yet (checked at call time): the
+// cluster-specific autopipeline safeguards would be bypassed.
 //
 // EXPERIMENTAL: this API is subject to change, use with caution.
 func (c *MultiDBClient) AutoPipeline() (*AutoPipeliner, error) {
@@ -244,6 +307,9 @@ func (c *MultiDBClient) AutoPipeline() (*AutoPipeliner, error) {
 //
 // EXPERIMENTAL: this API is subject to change, use with caution.
 func (c *MultiDBClient) AutoPipelineWithOptions(config *AutoPipelineOptions) (*AutoPipeliner, error) {
+	if c.core.hasClusterMember() {
+		return nil, errMultiDBAutoPipelineCluster
+	}
 	return getOrCreateAutoPipeliner(c.autopipelinerMu, &c.autopipeliner, &c.autopipelinerClosed, nil, config,
 		DefaultBlockingAutoPipelineOptions,
 		func(cfg *AutoPipelineOptions) (*AutoPipeliner, error) { return newAutoPipeliner(c, cfg, true) })
@@ -261,6 +327,9 @@ func (c *MultiDBClient) AsyncAutoPipeline() (*AutoPipeliner, error) {
 //
 // EXPERIMENTAL: this API is subject to change, use with caution.
 func (c *MultiDBClient) AsyncAutoPipelineWithOptions(config *AutoPipelineOptions) (*AutoPipeliner, error) {
+	if c.core.hasClusterMember() {
+		return nil, errMultiDBAutoPipelineCluster
+	}
 	return getOrCreateAutoPipeliner(c.autopipelinerMu, &c.asyncAutopipeliner, &c.autopipelinerClosed, nil, config,
 		DefaultAutoPipelineOptions,
 		func(cfg *AutoPipelineOptions) (*AutoPipeliner, error) { return newAutoPipeliner(c, cfg, false) })

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -35,19 +35,24 @@ func resetCmds(cmds []Cmder) {
 // path (including the autopipeliner's batch dispatcher, before the batch's
 // done channel closes), where Err on an async command would await the very
 // batch being completed and wedge the dispatcher.
-func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, batchErr error, executed bool) int {
+func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, batchErr error, executed, reserved bool) int {
 	// `executed` comes from the execution marker, not from inspecting
 	// command state: an executed all-success batch whose error was injected
 	// by a post-exec hook looks identical on the commands, and stamping it
 	// would turn already-applied writes into phantom transport failures and
-	// replay them.
+	// replay them. `reserved` is the gate admission's half-open reservation:
+	// a closed-state admission holds no probe slot, and a batch outliving a
+	// later open -> half-open transition must not free the slot a real
+	// recovery probe is holding.
 	if !executed {
 		if batchErr == nil {
 			// A member hook served the batch locally (returned nil without
 			// calling next): the results are valid for the caller, but
 			// nothing reached Redis — record no health signal and give the
-			// gate's probe slot back.
-			db.cb.ReleaseHalfOpen()
+			// gate's probe slot back if it reserved one.
+			if reserved {
+				db.cb.ReleaseHalfOpen()
+			}
 			return 0
 		}
 		// Execution never started: the batch error stands in for every
@@ -73,7 +78,13 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 				// caller, record nothing.
 				return
 			}
-			db.cb.RecordSuccess()
+			if reserved {
+				db.cb.RecordSuccess()
+			} else {
+				// Unreserved admission: the success counts toward closing,
+				// but must not release a half-open slot the batch never held.
+				db.cb.RecordExternalSuccess()
+			}
 			c.detector.RecordSuccess()
 			// Recovery traffic breaks the consecutive-failed-failover chain
 			// for batch-only workloads too (see recordFailedFailoverLocked).
@@ -118,10 +129,10 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 			recordOne(cmd)
 		}
 	}
-	if recorded == 0 {
+	if recorded == 0 && reserved {
 		// The whole batch was neutral (e.g. a local ErrCrossSlot rejection):
 		// nothing was recorded on the breaker, so give back the half-open
-		// probe slot the caller's IsAllowed gate may have reserved.
+		// probe slot the gate admission reserved.
 		db.cb.ReleaseHalfOpen()
 	}
 	return transportFailures
@@ -226,11 +237,15 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			return exitErr(err)
 		}
 
-		// Detector before IsAllowed: IsAllowed reserves a bounded half-open
-		// probe slot, and a tripped detector routes to failover without
-		// executing the batch — the reservation would leak.
+		// Detector before the breaker admission: a half-open admission
+		// reserves a bounded probe slot, and a tripped detector routes to
+		// failover without executing the batch — the reservation would leak.
 		db, idx := c.activeSnapshot()
-		if db == nil || c.detector.ShouldFailover() || !db.cb.IsAllowed() {
+		admitted, reserved := false, false
+		if db != nil && !c.detector.ShouldFailover() {
+			admitted, reserved = db.cb.Allow()
+		}
+		if !admitted {
 			gateRejections++
 			if gateRejections > maxGateRejections {
 				err := ErrTemporarilyNotAvailable
@@ -248,7 +263,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 			}
 			// Re-enter the gate on the newly selected database — mirroring
 			// the single-command path: its breaker may be half-open and the
-			// IsAllowed call above is what reserves the bounded probe slot.
+			// Allow call above is what reserves the bounded probe slot.
 			// Re-gating does not consume a retry attempt.
 			continue
 		}
@@ -263,7 +278,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		// pre-execution hook abort from a post-execution hook error.
 		executed := new(atomic.Bool)
 		err := db.processPipelineHook(context.WithValue(ctx, pipelineExecutedKey{}, executed), cmds)
-		transportFailures := c.recordBatchOutcomes(db, cmds, err, executed.Load())
+		transportFailures := c.recordBatchOutcomes(db, cmds, err, executed.Load(), reserved)
 
 		if transportFailures == 0 {
 			// Only server replies (or clean success) — done, whatever the
@@ -306,6 +321,7 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	gateRejections := 0
 	maxGateRejections := c.memberCount() + 1
 	var db *multidbDatabase
+	var reserved bool
 	for {
 		if c.closed.Load() {
 			resetCmds(cmds)
@@ -319,7 +335,11 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 		}
 		var idx int
 		db, idx = c.activeSnapshot()
-		if db == nil || c.detector.ShouldFailover() || !db.cb.IsAllowed() {
+		admitted := false
+		if db != nil && !c.detector.ShouldFailover() {
+			admitted, reserved = db.cb.Allow()
+		}
+		if !admitted {
 			gateRejections++
 			if gateRejections > maxGateRejections {
 				err := ErrTemporarilyNotAvailable
@@ -346,7 +366,7 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	if len(cmds) >= 3 {
 		user = cmds[1 : len(cmds)-1]
 	}
-	c.recordBatchOutcomes(db, user, err, executed.Load())
+	c.recordBatchOutcomes(db, user, err, executed.Load(), reserved)
 	return err
 }
 

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"sync/atomic"
+
+	imultidb "github.com/redis/go-redis/v9/internal/multidb"
 )
 
 // This file makes MultiDBClient a full UniversalClient and wires pipelines
@@ -54,25 +56,19 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 		// successes for the untouched commands.
 		setCmdsErr(cmds, batchErr)
 	}
-	// Failures first, successes second: on a half-open breaker a batch's
-	// early successful replies could otherwise close the circuit before its
-	// own later failure is recorded, marking a failed recovery probe as a
-	// recovered database.
 	transportFailures := 0
 	recorded := 0
-	for _, cmd := range cmds {
+	recordOne := func(cmd Cmder) {
 		// Errors are classified with retryTimeout=true, mirroring the plain
 		// pipeline retry rule of *Client/*ClusterClient batch paths.
-		if classifyOutcome(cmd.rawErr(), true) == outcomeFailure {
-			db.cb.RecordFailure()
-			c.detector.RecordFailure(cmd.rawErr())
-			transportFailures++
-			recorded++
-		}
-	}
-	for _, cmd := range cmds {
 		switch classifyOutcome(cmd.rawErr(), true) {
 		case outcomeSuccess:
+			if !executed {
+				// A nil (or reply-class) error fabricated by an aborting
+				// hook is no proof the database answered: surface it to the
+				// caller, record nothing.
+				return
+			}
 			db.cb.RecordSuccess()
 			c.detector.RecordSuccess()
 			// Recovery traffic breaks the consecutive-failed-failover chain
@@ -80,11 +76,35 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 			c.successSinceFailover.Store(true)
 			recorded++
 		case outcomeFailure:
-			// Recorded in the first pass.
+			db.cb.RecordFailure()
+			c.detector.RecordFailure(cmd.rawErr())
+			transportFailures++
+			recorded++
 		case outcomeNeutral:
 			// Not a database-health signal (client-side error or a locally
 			// synthesized Redis error such as ErrCrossSlot); surfaced to the
 			// caller as-is.
+		}
+	}
+	if db.cb.State() == imultidb.CircuitHalfOpen {
+		// Recovery probe: record failures BEFORE successes, so a batch that
+		// ultimately failed cannot close the circuit off its own successful
+		// prefix. Everywhere else the arrival order stands — mirroring
+		// sequential single commands, where a success resets the closed
+		// state's failure count before a later failure increments it.
+		for _, cmd := range cmds {
+			if classifyOutcome(cmd.rawErr(), true) == outcomeFailure {
+				recordOne(cmd)
+			}
+		}
+		for _, cmd := range cmds {
+			if classifyOutcome(cmd.rawErr(), true) != outcomeFailure {
+				recordOne(cmd)
+			}
+		}
+	} else {
+		for _, cmd := range cmds {
+			recordOne(cmd)
 		}
 	}
 	if recorded == 0 {
@@ -94,6 +114,20 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 		db.cb.ReleaseHalfOpen()
 	}
 	return transportFailures
+}
+
+// errMultiDBHImportCmd matches the HIMPORT command family, which is rejected
+// on MultiDBClient (see errMultiDBHImport): the direct methods are overridden,
+// and the batch paths below must reject them too — pipeline builders dispatch
+// through their own cmdable and would otherwise hand the command to a single
+// member's registry.
+func cmdsContainHImport(cmds []Cmder) bool {
+	for _, cmd := range cmds {
+		if _, ok := cmd.(interface{ himportCmd() }); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // processPipeline is the batch analogue of process: an attempt loop bounded
@@ -109,6 +143,10 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 	if c.closed.Load() {
 		setCmdsErr(cmds, ErrClosed)
 		return ErrClosed
+	}
+	if cmdsContainHImport(cmds) {
+		setCmdsErr(cmds, errMultiDBHImport)
+		return errMultiDBHImport
 	}
 	attempts := c.opts.CommandRetries + 1
 	// A batch containing a non-retryable command (e.g. a streaming
@@ -197,6 +235,10 @@ func (c *multidbCore) processTxPipeline(ctx context.Context, cmds []Cmder) error
 	if c.closed.Load() {
 		setCmdsErr(cmds, ErrClosed)
 		return ErrClosed
+	}
+	if cmdsContainHImport(cmds) {
+		setCmdsErr(cmds, errMultiDBHImport)
+		return errMultiDBHImport
 	}
 	// A context that is already done must not reach the failover gate: with
 	// ProbeTargetBeforeFailover the doomed probes would damage candidate

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -314,12 +314,17 @@ func (c *MultiDBClient) AutoPipeline() (*AutoPipeliner, error) {
 //
 // EXPERIMENTAL: this API is subject to change, use with caution.
 func (c *MultiDBClient) AutoPipelineWithOptions(config *AutoPipelineOptions) (*AutoPipeliner, error) {
-	if c.core.hasClusterMember() {
-		return nil, errMultiDBAutoPipelineCluster
-	}
+	// The cluster-member check runs inside the build function, under
+	// autopipelinerMu: AddDatabase performs its cluster-vs-autopipeliner
+	// check under the same mutex, so the two cannot interleave.
 	return getOrCreateAutoPipeliner(c.autopipelinerMu, &c.autopipeliner, &c.autopipelinerClosed, nil, config,
 		DefaultBlockingAutoPipelineOptions,
-		func(cfg *AutoPipelineOptions) (*AutoPipeliner, error) { return newAutoPipeliner(c, cfg, true) })
+		func(cfg *AutoPipelineOptions) (*AutoPipeliner, error) {
+			if c.core.hasClusterMember() {
+				return nil, errMultiDBAutoPipelineCluster
+			}
+			return newAutoPipeliner(c, cfg, true)
+		})
 }
 
 // AsyncAutoPipeline returns the deferred autopipeliner for this MultiDB
@@ -334,10 +339,12 @@ func (c *MultiDBClient) AsyncAutoPipeline() (*AutoPipeliner, error) {
 //
 // EXPERIMENTAL: this API is subject to change, use with caution.
 func (c *MultiDBClient) AsyncAutoPipelineWithOptions(config *AutoPipelineOptions) (*AutoPipeliner, error) {
-	if c.core.hasClusterMember() {
-		return nil, errMultiDBAutoPipelineCluster
-	}
 	return getOrCreateAutoPipeliner(c.autopipelinerMu, &c.asyncAutopipeliner, &c.autopipelinerClosed, nil, config,
 		DefaultAutoPipelineOptions,
-		func(cfg *AutoPipelineOptions) (*AutoPipeliner, error) { return newAutoPipeliner(c, cfg, false) })
+		func(cfg *AutoPipelineOptions) (*AutoPipeliner, error) {
+			if c.core.hasClusterMember() {
+				return nil, errMultiDBAutoPipelineCluster
+			}
+			return newAutoPipeliner(c, cfg, false)
+		})
 }

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -134,7 +134,7 @@ func (c *multidbCore) recordBatchOutcomes(db *multidbDatabase, cmds []Cmder, bat
 // member's registry.
 func cmdsContainHImport(cmds []Cmder) bool {
 	for _, cmd := range cmds {
-		if _, ok := cmd.(interface{ himportCmd() }); ok {
+		if isHImportCmd(cmd) {
 			return true
 		}
 	}
@@ -166,7 +166,7 @@ func (c *multidbCore) processPipeline(ctx context.Context, cmds []Cmder) error {
 		// whole batch would fail innocent commands that merely shared it.
 		kept := make([]Cmder, 0, len(cmds))
 		for _, cmd := range cmds {
-			if _, ok := cmd.(interface{ himportCmd() }); ok {
+			if isHImportCmd(cmd) {
 				cmd.SetErr(errMultiDBHImport)
 				continue
 			}
@@ -452,19 +452,21 @@ func (c *MultiDBClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...s
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	// selectable (non-reserving) rather than IsAllowed: the WATCH path does
-	// not feed the breaker, so it must not consume a bounded half-open probe
-	// slot it would never record or release.
+	// IsAllowed (reserving) so a half-open member's MaxHalfOpenRequests
+	// bounds concurrent WATCH transactions too; the slot is released after
+	// the call because the WATCH outcome deliberately never records on the
+	// breaker.
 	db, idx := c.core.activeSnapshot()
-	if db == nil || !db.selectable() || c.core.detector.ShouldFailover() {
+	if db == nil || c.core.detector.ShouldFailover() || !db.cb.IsAllowed() {
 		if err := c.core.tryFailover(ctx, idx); err != nil {
 			return err
 		}
 		db, _ = c.core.activeSnapshot()
-		if db == nil || !db.selectable() {
+		if db == nil || !db.cb.IsAllowed() {
 			return ErrTemporarilyNotAvailable
 		}
 	}
+	defer db.cb.ReleaseHalfOpen()
 	if db.cc != nil {
 		return db.cc.Watch(ctx, fn, keys...)
 	}

--- a/multidb_pipeline_internal_test.go
+++ b/multidb_pipeline_internal_test.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -205,6 +206,23 @@ func TestRecordBatchOutcomesStaleReservationFailureDoesNotReopen(t *testing.T) {
 			t.Errorf("breaker %v, want open", st)
 		}
 	})
+}
+
+// TestProcessTxPipelineHImportPreservesFirstError pins that a rejected HIMPORT
+// transaction reports the positionally-first error (Pipeline.Exec semantics):
+// a command the caller queued with a pre-existing error, before the HIMPORT,
+// must win over errMultiDBHImport.
+func TestProcessTxPipelineHImportPreservesFirstError(t *testing.T) {
+	core := newMultidbCore(&MultiDBOptions{})
+	prior := errors.New("prior error")
+	preErr := NewStatusCmd(context.Background(), "set", "k", "v")
+	preErr.SetErr(prior)
+	him := NewStatusCmd(context.Background(), "himport", "fs")
+
+	err := core.processTxPipeline(context.Background(), []Cmder{preErr, him})
+	if !errors.Is(err, prior) {
+		t.Fatalf("processTxPipeline = %v, want the positionally-first pre-existing error %v", err, prior)
+	}
 }
 
 func TestRecordBatchOutcomesPostExecHookError(t *testing.T) {

--- a/multidb_pipeline_internal_test.go
+++ b/multidb_pipeline_internal_test.go
@@ -128,6 +128,85 @@ func TestRecordBatchOutcomesPropagatedBlockingTimeoutIsNeutral(t *testing.T) {
 	})
 }
 
+// TestRecordBatchOutcomesStaleReservationFailureDoesNotReopen pins the failure
+// path's reservation binding: a half-open batch that outlives its recovery
+// episode must not apply its failure to the NEW half-open episode another
+// request has since opened (that would abort a recovery it was never admitted
+// to). A current admission still re-opens, and a closed admission still counts
+// toward opening.
+func TestRecordBatchOutcomesStaleReservationFailureDoesNotReopen(t *testing.T) {
+	newHalfOpen := func(t *testing.T) *multidbDatabase {
+		t.Helper()
+		db := &multidbDatabase{cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{
+			FailureThreshold: 1,
+			SuccessThreshold: 1,
+			GracePeriod:      20 * time.Millisecond,
+		})}
+		db.cb.RecordFailure() // open
+		time.Sleep(30 * time.Millisecond)
+		if st := db.cb.CheckState(); st != imultidb.CircuitHalfOpen {
+			t.Fatalf("state after grace = %v, want half-open", st)
+		}
+		return db
+	}
+	failedBatch := func() []Cmder {
+		cmd := NewStatusCmd(context.Background(), "set", "k", "v")
+		cmd.SetErr(io.EOF)
+		return []Cmder{cmd}
+	}
+
+	t.Run("stale half-open admission records nothing", func(t *testing.T) {
+		core := newMultidbCore(&MultiDBOptions{})
+		db := newHalfOpen(t)
+		ok, stale := db.cb.AllowReserve() // episode 1 probe slot
+		if !ok {
+			t.Fatal("AllowReserve on a half-open breaker with a free slot was rejected")
+		}
+		// The recovery fails elsewhere and a NEW half-open episode begins.
+		db.cb.ForceOpen()
+		time.Sleep(30 * time.Millisecond)
+		if st := db.cb.CheckState(); st != imultidb.CircuitHalfOpen {
+			t.Fatalf("state after second grace = %v, want half-open", st)
+		}
+
+		cmds := failedBatch()
+		got := core.recordBatchOutcomes(db, cmds, io.EOF, execAll(cmds), stale)
+		if got != 1 {
+			t.Errorf("transportFailures = %d, want 1: the caller still sees a transport failure", got)
+		}
+		if st := db.cb.State(); st != imultidb.CircuitHalfOpen {
+			t.Errorf("breaker %v, want half-open: a stale batch must not re-open the new episode", st)
+		}
+	})
+
+	t.Run("current half-open admission re-opens", func(t *testing.T) {
+		core := newMultidbCore(&MultiDBOptions{})
+		db := newHalfOpen(t)
+		ok, cur := db.cb.AllowReserve()
+		if !ok {
+			t.Fatal("AllowReserve on a half-open breaker with a free slot was rejected")
+		}
+		cmds := failedBatch()
+		core.recordBatchOutcomes(db, cmds, io.EOF, execAll(cmds), cur)
+		if st := db.cb.State(); st != imultidb.CircuitOpen {
+			t.Errorf("breaker %v, want open: a live probe's failure aborts the recovery", st)
+		}
+	})
+
+	t.Run("closed admission counts toward opening", func(t *testing.T) {
+		core := newMultidbCore(&MultiDBOptions{})
+		db := &multidbDatabase{cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{
+			FailureThreshold: 1,
+			SuccessThreshold: 1,
+		})}
+		cmds := failedBatch()
+		core.recordBatchOutcomes(db, cmds, io.EOF, execAll(cmds), imultidb.Reservation{})
+		if st := db.cb.State(); st != imultidb.CircuitOpen {
+			t.Errorf("breaker %v, want open", st)
+		}
+	})
+}
+
 func TestRecordBatchOutcomesPostExecHookError(t *testing.T) {
 	core := newMultidbCore(&MultiDBOptions{})
 	db := &multidbDatabase{cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{

--- a/multidb_pipeline_internal_test.go
+++ b/multidb_pipeline_internal_test.go
@@ -104,6 +104,31 @@ func TestRecordBatchOutcomesFailuresBeforeSuccesses(t *testing.T) {
 	}
 }
 
+func TestRecordBatchOutcomesClosedStateKeepsArrivalOrder(t *testing.T) {
+	core := newMultidbCore(&MultiDBOptions{})
+	db := &multidbDatabase{cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+	})}
+	db.cb.RecordFailure() // one stale failure below the threshold
+
+	// Closed breaker: the batch's successful reply arrived BEFORE its EOF,
+	// exactly like sequential single commands, whose ordering would reset
+	// the stale failure count. Failure-first recording here would combine
+	// the stale failure with the batch failure and open a healthy member's
+	// circuit; that ordering is only for half-open recovery probes.
+	cmds := []Cmder{
+		NewStatusCmd(context.Background(), "set", "k1", "v"),
+		NewStatusCmd(context.Background(), "set", "k2", "v"),
+	}
+	cmds[1].SetErr(io.EOF)
+	core.recordBatchOutcomes(db, cmds, io.EOF, true)
+
+	if got := db.cb.State(); got != imultidb.CircuitClosed {
+		t.Errorf("breaker state = %v, want closed (stale failure must be reset by the earlier success)", got)
+	}
+}
+
 func TestRecordBatchOutcomesSuccessSinceFailover(t *testing.T) {
 	core := newMultidbCore(&MultiDBOptions{})
 	db := &multidbDatabase{cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{

--- a/multidb_pipeline_internal_test.go
+++ b/multidb_pipeline_internal_test.go
@@ -23,7 +23,7 @@ func TestRecordBatchOutcomesPostExecHookError(t *testing.T) {
 	// Executed batch, every reply read fine, then a post-exec hook injected
 	// a retryable error without stamping the commands: the commands are
 	// authoritative — no phantom failures, no stamping, no replay signal.
-	if got := core.recordBatchOutcomes(db, cmds, io.EOF, true, true); got != 0 {
+	if got := core.recordBatchOutcomes(db, cmds, io.EOF, true, imultidb.Reservation{}); got != 0 {
 		t.Errorf("transportFailures = %d for an executed all-success batch, want 0", got)
 	}
 	if err := cmds[0].Err(); err != nil {
@@ -33,7 +33,7 @@ func TestRecordBatchOutcomesPostExecHookError(t *testing.T) {
 	// Not executed (hook aborted before next): the batch error stands in
 	// for the commands and is stamped so callers see it.
 	resetCmds(cmds)
-	if got := core.recordBatchOutcomes(db, cmds, io.EOF, false, true); got != 1 {
+	if got := core.recordBatchOutcomes(db, cmds, io.EOF, false, imultidb.Reservation{}); got != 1 {
 		t.Errorf("transportFailures = %d for an unexecuted batch, want 1", got)
 	}
 	if err := cmds[0].Err(); err == nil {
@@ -69,7 +69,7 @@ func TestRecordBatchOutcomesExecutedBatchKeepsSuccessfulPrefix(t *testing.T) {
 	}
 	cmds[1].SetErr(loading)
 
-	if got := core.recordBatchOutcomes(db, cmds, loading, true, true); got != 1 {
+	if got := core.recordBatchOutcomes(db, cmds, loading, true, imultidb.Reservation{}); got != 1 {
 		t.Errorf("transportFailures = %d, want 1 (prefix must not count)", got)
 	}
 	if err := cmds[0].Err(); err != nil {
@@ -97,7 +97,8 @@ func TestRecordBatchOutcomesFailuresBeforeSuccesses(t *testing.T) {
 		NewStatusCmd(context.Background(), "set", "k2", "v"),
 	}
 	cmds[1].SetErr(io.EOF)
-	core.recordBatchOutcomes(db, cmds, io.EOF, true, true)
+	_, res := db.cb.AllowReserve() // authentic half-open admission for this batch
+	core.recordBatchOutcomes(db, cmds, io.EOF, true, res)
 
 	if got := db.cb.State(); got != imultidb.CircuitOpen {
 		t.Errorf("breaker state = %v after a failed recovery batch, want open", got)
@@ -122,7 +123,7 @@ func TestRecordBatchOutcomesClosedStateKeepsArrivalOrder(t *testing.T) {
 		NewStatusCmd(context.Background(), "set", "k2", "v"),
 	}
 	cmds[1].SetErr(io.EOF)
-	core.recordBatchOutcomes(db, cmds, io.EOF, true, true)
+	core.recordBatchOutcomes(db, cmds, io.EOF, true, imultidb.Reservation{})
 
 	if got := db.cb.State(); got != imultidb.CircuitClosed {
 		t.Errorf("breaker state = %v, want closed (stale failure must be reset by the earlier success)", got)
@@ -135,11 +136,16 @@ func TestRecordBatchOutcomesSuccessSinceFailover(t *testing.T) {
 		FailureThreshold: 2,
 		SuccessThreshold: 1,
 	})}
+	// Make db the active member: recordBatchOutcomes marks recovery traffic
+	// (and feeds the detector) only while the batch's member is still the
+	// active, mirroring the single-command path.
+	core.dbs[0] = db
+	core.active.Store(0)
 
 	// An executed batch success is recovery traffic: it breaks the
 	// consecutive-failed-failover escalation chain.
 	cmds := []Cmder{NewStatusCmd(context.Background(), "set", "k", "v")}
-	core.recordBatchOutcomes(db, cmds, nil, true, true)
+	core.recordBatchOutcomes(db, cmds, nil, true, imultidb.Reservation{})
 	if !core.successSinceFailover.Load() {
 		t.Error("executed batch success did not mark recovery traffic")
 	}
@@ -147,7 +153,7 @@ func TestRecordBatchOutcomesSuccessSinceFailover(t *testing.T) {
 	// A hook-served batch (nil without execution) is not.
 	core.successSinceFailover.Store(false)
 	resetCmds(cmds)
-	core.recordBatchOutcomes(db, cmds, nil, false, true)
+	core.recordBatchOutcomes(db, cmds, nil, false, imultidb.Reservation{})
 	if core.successSinceFailover.Load() {
 		t.Error("hook-served batch counted as recovery traffic")
 	}

--- a/multidb_pipeline_internal_test.go
+++ b/multidb_pipeline_internal_test.go
@@ -18,6 +18,116 @@ func execAll(cmds []Cmder) *executedCmds {
 	return ec
 }
 
+// batchTimeoutErr is a pointer-typed local read timeout: shouldRetry treats it
+// as retryable only when retryTimeout is set, so it is neutral for a blocking
+// command and a transport failure for an ordinary one — the asymmetry the
+// propagation rule below has to reconcile. Pointer identity mirrors the real
+// *net.OpError the reader stamps onto unread followers; the padding byte keeps
+// distinct allocations at distinct addresses (zero-size values may alias).
+type batchTimeoutErr struct{ _ byte }
+
+func (*batchTimeoutErr) Error() string { return "i/o timeout" }
+func (*batchTimeoutErr) Timeout() bool { return true }
+
+// TestRecordBatchOutcomesPropagatedBlockingTimeoutIsNeutral pins the reader
+// stamping rule: pipelineReadCmds stops at the first transport error and stamps
+// that same error onto every unread follower. When the originator is a blocking
+// command whose local deadline is neutral, the followers are propagations of
+// that one event — not N transport failures that would charge the breaker and
+// replay the batch (blocking command included).
+func TestRecordBatchOutcomesPropagatedBlockingTimeoutIsNeutral(t *testing.T) {
+	newDB := func() *multidbDatabase {
+		return &multidbDatabase{cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{
+			FailureThreshold: 1,
+			SuccessThreshold: 1,
+		})}
+	}
+	blocking := func() *StatusCmd {
+		b := NewStatusCmd(context.Background(), "blpop", "k", "5")
+		b.setReadTimeout(5 * time.Second)
+		return b
+	}
+	ordinary := func(name string) *StatusCmd {
+		return NewStatusCmd(context.Background(), name, "k", "v")
+	}
+	stamp := func(err error, cmds ...Cmder) {
+		for _, c := range cmds {
+			c.SetErr(err)
+		}
+	}
+
+	t.Run("blocking origin: followers are neutral, batch not replayed", func(t *testing.T) {
+		core := newMultidbCore(&MultiDBOptions{})
+		db := newDB()
+		e := &batchTimeoutErr{}
+		cmds := []Cmder{blocking(), ordinary("set"), ordinary("get")}
+		stamp(e, cmds...) // reader: origin + identical instance on followers
+
+		got := core.recordBatchOutcomes(db, cmds, e, execAll(cmds), imultidb.Reservation{})
+		if got != 0 {
+			t.Errorf("transportFailures = %d, want 0: the followers carry the blocker's neutral deadline", got)
+		}
+		if st := db.cb.State(); st != imultidb.CircuitClosed {
+			t.Errorf("breaker %v, want closed: one neutral event must not be charged N times", st)
+		}
+		for i, c := range cmds {
+			if c.rawErr() != e {
+				t.Errorf("cmd %d error %v, want the propagated timeout surfaced to the caller", i, c.rawErr())
+			}
+		}
+	})
+
+	t.Run("ordinary origin: propagation stays a transport failure", func(t *testing.T) {
+		core := newMultidbCore(&MultiDBOptions{})
+		db := newDB()
+		e := &batchTimeoutErr{}
+		cmds := []Cmder{ordinary("set"), ordinary("get"), ordinary("incr")}
+		stamp(e, cmds...)
+
+		if got := core.recordBatchOutcomes(db, cmds, e, execAll(cmds), imultidb.Reservation{}); got != 3 {
+			t.Errorf("transportFailures = %d, want 3: an ordinary command's timeout is a real transport failure", got)
+		}
+		if st := db.cb.State(); st != imultidb.CircuitOpen {
+			t.Errorf("breaker %v, want open", st)
+		}
+	})
+
+	t.Run("blocking origin but followers carry a different error", func(t *testing.T) {
+		core := newMultidbCore(&MultiDBOptions{})
+		db := newDB()
+		origin, other := &batchTimeoutErr{}, &batchTimeoutErr{}
+		cmds := []Cmder{blocking(), ordinary("set"), ordinary("get")}
+		stamp(origin, cmds[0])
+		stamp(other, cmds[1], cmds[2]) // distinct instance: not a propagation
+
+		if got := core.recordBatchOutcomes(db, cmds, origin, execAll(cmds), imultidb.Reservation{}); got != 2 {
+			t.Errorf("transportFailures = %d, want 2: only an identical stamped error is a propagation", got)
+		}
+		if st := db.cb.State(); st != imultidb.CircuitOpen {
+			t.Errorf("breaker %v, want open", st)
+		}
+	})
+
+	t.Run("ordinary origin stamps a later blocking command", func(t *testing.T) {
+		// The first carrier in slice order is the originator. A blocking
+		// command that merely RECEIVED an ordinary command's timeout must not
+		// retroactively neutralize it.
+		core := newMultidbCore(&MultiDBOptions{})
+		db := newDB()
+		e := &batchTimeoutErr{}
+		cmds := []Cmder{ordinary("set"), blocking(), ordinary("get")}
+		stamp(e, cmds...)
+
+		// set: failure (origin); blpop: neutral (its own rule); get: failure.
+		if got := core.recordBatchOutcomes(db, cmds, e, execAll(cmds), imultidb.Reservation{}); got != 2 {
+			t.Errorf("transportFailures = %d, want 2: the ordinary originator's timeout is real", got)
+		}
+		if st := db.cb.State(); st != imultidb.CircuitOpen {
+			t.Errorf("breaker %v, want open", st)
+		}
+	})
+}
+
 func TestRecordBatchOutcomesPostExecHookError(t *testing.T) {
 	core := newMultidbCore(&MultiDBOptions{})
 	db := &multidbDatabase{cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{

--- a/multidb_pipeline_internal_test.go
+++ b/multidb_pipeline_internal_test.go
@@ -5,8 +5,10 @@ import (
 	"io"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	imultidb "github.com/redis/go-redis/v9/internal/multidb"
+	"github.com/redis/go-redis/v9/internal/proto"
 )
 
 func TestRecordBatchOutcomesPostExecHookError(t *testing.T) {
@@ -47,4 +49,81 @@ func TestMarkPipelineExecuted(t *testing.T) {
 	}
 	// Without a marker in the context it must be a no-op, not a panic.
 	markPipelineExecuted(context.Background())
+}
+
+func TestRecordBatchOutcomesExecutedBatchKeepsSuccessfulPrefix(t *testing.T) {
+	core := newMultidbCore(&MultiDBOptions{})
+	db := &multidbDatabase{cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+	})}
+
+	// Executed batch: the first command's nil error is a successfully-read
+	// reply, the second carries a retryable server reply that is also the
+	// batch error. Exactly one failure may be recorded, and the successful
+	// prefix must stay unstamped — otherwise the batch would be replayed.
+	loading := proto.RedisError("LOADING Redis is loading the dataset in memory")
+	cmds := []Cmder{
+		NewStatusCmd(context.Background(), "set", "k1", "v"),
+		NewStatusCmd(context.Background(), "set", "k2", "v"),
+	}
+	cmds[1].SetErr(loading)
+
+	if got := core.recordBatchOutcomes(db, cmds, loading, true); got != 1 {
+		t.Errorf("transportFailures = %d, want 1 (prefix must not count)", got)
+	}
+	if err := cmds[0].Err(); err != nil {
+		t.Errorf("successful prefix was stamped with %v", err)
+	}
+}
+
+func TestRecordBatchOutcomesFailuresBeforeSuccesses(t *testing.T) {
+	core := newMultidbCore(&MultiDBOptions{})
+	db := &multidbDatabase{cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1,
+		GracePeriod:      time.Nanosecond,
+	})}
+	db.cb.RecordFailure() // -> open; 1ns grace has already elapsed
+	if db.cb.CheckState() != imultidb.CircuitHalfOpen {
+		t.Fatal("setup: expected a half-open breaker")
+	}
+
+	// Executed mixed batch on a half-open breaker: the failure must be
+	// recorded before the success, so a failed recovery batch re-opens the
+	// circuit instead of its own successful prefix closing it.
+	cmds := []Cmder{
+		NewStatusCmd(context.Background(), "set", "k1", "v"),
+		NewStatusCmd(context.Background(), "set", "k2", "v"),
+	}
+	cmds[1].SetErr(io.EOF)
+	core.recordBatchOutcomes(db, cmds, io.EOF, true)
+
+	if got := db.cb.State(); got != imultidb.CircuitOpen {
+		t.Errorf("breaker state = %v after a failed recovery batch, want open", got)
+	}
+}
+
+func TestRecordBatchOutcomesSuccessSinceFailover(t *testing.T) {
+	core := newMultidbCore(&MultiDBOptions{})
+	db := &multidbDatabase{cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+	})}
+
+	// An executed batch success is recovery traffic: it breaks the
+	// consecutive-failed-failover escalation chain.
+	cmds := []Cmder{NewStatusCmd(context.Background(), "set", "k", "v")}
+	core.recordBatchOutcomes(db, cmds, nil, true)
+	if !core.successSinceFailover.Load() {
+		t.Error("executed batch success did not mark recovery traffic")
+	}
+
+	// A hook-served batch (nil without execution) is not.
+	core.successSinceFailover.Store(false)
+	resetCmds(cmds)
+	core.recordBatchOutcomes(db, cmds, nil, false)
+	if core.successSinceFailover.Load() {
+		t.Error("hook-served batch counted as recovery traffic")
+	}
 }

--- a/multidb_pipeline_internal_test.go
+++ b/multidb_pipeline_internal_test.go
@@ -3,13 +3,20 @@ package redis
 import (
 	"context"
 	"io"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	imultidb "github.com/redis/go-redis/v9/internal/multidb"
 	"github.com/redis/go-redis/v9/internal/proto"
 )
+
+// execAll marks every command as executed — the per-command marker a fully
+// executed batch produces (see executedCmds / markPipelineExecuted).
+func execAll(cmds []Cmder) *executedCmds {
+	ec := newExecutedCmds(len(cmds))
+	ec.mark(cmds)
+	return ec
+}
 
 func TestRecordBatchOutcomesPostExecHookError(t *testing.T) {
 	core := newMultidbCore(&MultiDBOptions{})
@@ -23,7 +30,7 @@ func TestRecordBatchOutcomesPostExecHookError(t *testing.T) {
 	// Executed batch, every reply read fine, then a post-exec hook injected
 	// a retryable error without stamping the commands: the commands are
 	// authoritative — no phantom failures, no stamping, no replay signal.
-	if got := core.recordBatchOutcomes(db, cmds, io.EOF, true, imultidb.Reservation{}); got != 0 {
+	if got := core.recordBatchOutcomes(db, cmds, io.EOF, execAll(cmds), imultidb.Reservation{}); got != 0 {
 		t.Errorf("transportFailures = %d for an executed all-success batch, want 0", got)
 	}
 	if err := cmds[0].Err(); err != nil {
@@ -33,7 +40,7 @@ func TestRecordBatchOutcomesPostExecHookError(t *testing.T) {
 	// Not executed (hook aborted before next): the batch error stands in
 	// for the commands and is stamped so callers see it.
 	resetCmds(cmds)
-	if got := core.recordBatchOutcomes(db, cmds, io.EOF, false, imultidb.Reservation{}); got != 1 {
+	if got := core.recordBatchOutcomes(db, cmds, io.EOF, newExecutedCmds(0), imultidb.Reservation{}); got != 1 {
 		t.Errorf("transportFailures = %d for an unexecuted batch, want 1", got)
 	}
 	if err := cmds[0].Err(); err == nil {
@@ -42,13 +49,17 @@ func TestRecordBatchOutcomesPostExecHookError(t *testing.T) {
 }
 
 func TestMarkPipelineExecuted(t *testing.T) {
-	flag := new(atomic.Bool)
-	markPipelineExecuted(context.WithValue(context.Background(), pipelineExecutedKey{}, flag))
-	if !flag.Load() {
-		t.Error("marker did not flip the flag")
+	cmd := NewStatusCmd(context.Background(), "ping")
+	ec := newExecutedCmds(1)
+	markPipelineExecuted(context.WithValue(context.Background(), pipelineExecutedKey{}, ec), []Cmder{cmd})
+	if !ec.has(cmd) {
+		t.Error("marker did not record the executed command")
+	}
+	if !ec.any() {
+		t.Error("marker did not report any executed command")
 	}
 	// Without a marker in the context it must be a no-op, not a panic.
-	markPipelineExecuted(context.Background())
+	markPipelineExecuted(context.Background(), []Cmder{cmd})
 }
 
 func TestRecordBatchOutcomesExecutedBatchKeepsSuccessfulPrefix(t *testing.T) {
@@ -69,7 +80,7 @@ func TestRecordBatchOutcomesExecutedBatchKeepsSuccessfulPrefix(t *testing.T) {
 	}
 	cmds[1].SetErr(loading)
 
-	if got := core.recordBatchOutcomes(db, cmds, loading, true, imultidb.Reservation{}); got != 1 {
+	if got := core.recordBatchOutcomes(db, cmds, loading, execAll(cmds), imultidb.Reservation{}); got != 1 {
 		t.Errorf("transportFailures = %d, want 1 (prefix must not count)", got)
 	}
 	if err := cmds[0].Err(); err != nil {
@@ -98,7 +109,7 @@ func TestRecordBatchOutcomesFailuresBeforeSuccesses(t *testing.T) {
 	}
 	cmds[1].SetErr(io.EOF)
 	_, res := db.cb.AllowReserve() // authentic half-open admission for this batch
-	core.recordBatchOutcomes(db, cmds, io.EOF, true, res)
+	core.recordBatchOutcomes(db, cmds, io.EOF, execAll(cmds), res)
 
 	if got := db.cb.State(); got != imultidb.CircuitOpen {
 		t.Errorf("breaker state = %v after a failed recovery batch, want open", got)
@@ -123,7 +134,7 @@ func TestRecordBatchOutcomesClosedStateKeepsArrivalOrder(t *testing.T) {
 		NewStatusCmd(context.Background(), "set", "k2", "v"),
 	}
 	cmds[1].SetErr(io.EOF)
-	core.recordBatchOutcomes(db, cmds, io.EOF, true, imultidb.Reservation{})
+	core.recordBatchOutcomes(db, cmds, io.EOF, execAll(cmds), imultidb.Reservation{})
 
 	if got := db.cb.State(); got != imultidb.CircuitClosed {
 		t.Errorf("breaker state = %v, want closed (stale failure must be reset by the earlier success)", got)
@@ -145,7 +156,7 @@ func TestRecordBatchOutcomesSuccessSinceFailover(t *testing.T) {
 	// An executed batch success is recovery traffic: it breaks the
 	// consecutive-failed-failover escalation chain.
 	cmds := []Cmder{NewStatusCmd(context.Background(), "set", "k", "v")}
-	core.recordBatchOutcomes(db, cmds, nil, true, imultidb.Reservation{})
+	core.recordBatchOutcomes(db, cmds, nil, execAll(cmds), imultidb.Reservation{})
 	if !core.successSinceFailover.Load() {
 		t.Error("executed batch success did not mark recovery traffic")
 	}
@@ -153,8 +164,53 @@ func TestRecordBatchOutcomesSuccessSinceFailover(t *testing.T) {
 	// A hook-served batch (nil without execution) is not.
 	core.successSinceFailover.Store(false)
 	resetCmds(cmds)
-	core.recordBatchOutcomes(db, cmds, nil, false, imultidb.Reservation{})
+	core.recordBatchOutcomes(db, cmds, nil, newExecutedCmds(0), imultidb.Reservation{})
 	if core.successSinceFailover.Load() {
 		t.Error("hook-served batch counted as recovery traffic")
+	}
+}
+
+// countingFD counts detector outcomes for the recordBatchOutcomes tests.
+type countingFD struct {
+	successes int
+	failures  int
+}
+
+func (d *countingFD) RecordSuccess()       { d.successes++ }
+func (d *countingFD) RecordFailure(error)  { d.failures++ }
+func (d *countingFD) ShouldFailover() bool { return false }
+func (d *countingFD) Reset()               {}
+
+// TestRecordBatchOutcomesPartialExecutionDoesNotCountUntouched pins the
+// per-command execution marker: in a cluster fan-out one node can execute while
+// another short-circuits, leaving its commands untouched (nil error). Only the
+// commands that actually executed may be recorded — an untouched nil-error
+// command must not be counted as a database success.
+func TestRecordBatchOutcomesPartialExecutionDoesNotCountUntouched(t *testing.T) {
+	det := &countingFD{}
+	core := newMultidbCore(&MultiDBOptions{FailureDetector: det})
+	db := &multidbDatabase{cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+	})}
+	core.dbs[0] = db
+	core.active.Store(0)
+
+	cmds := []Cmder{
+		NewStatusCmd(context.Background(), "set", "k1", "v"),
+		NewStatusCmd(context.Background(), "set", "k2", "v"),
+	}
+	// Both commands look successful (nil error), but only the first actually
+	// executed — the second's node short-circuited.
+	ec := newExecutedCmds(len(cmds))
+	ec.mark(cmds[:1])
+
+	core.recordBatchOutcomes(db, cmds, nil, ec, imultidb.Reservation{})
+
+	if det.successes != 1 {
+		t.Errorf("detector successes = %d, want 1 (an untouched command must not count as a success)", det.successes)
+	}
+	if det.failures != 0 {
+		t.Errorf("detector failures = %d, want 0 (an untouched command must not count at all)", det.failures)
 	}
 }

--- a/multidb_pipeline_internal_test.go
+++ b/multidb_pipeline_internal_test.go
@@ -23,7 +23,7 @@ func TestRecordBatchOutcomesPostExecHookError(t *testing.T) {
 	// Executed batch, every reply read fine, then a post-exec hook injected
 	// a retryable error without stamping the commands: the commands are
 	// authoritative — no phantom failures, no stamping, no replay signal.
-	if got := core.recordBatchOutcomes(db, cmds, io.EOF, true); got != 0 {
+	if got := core.recordBatchOutcomes(db, cmds, io.EOF, true, true); got != 0 {
 		t.Errorf("transportFailures = %d for an executed all-success batch, want 0", got)
 	}
 	if err := cmds[0].Err(); err != nil {
@@ -33,7 +33,7 @@ func TestRecordBatchOutcomesPostExecHookError(t *testing.T) {
 	// Not executed (hook aborted before next): the batch error stands in
 	// for the commands and is stamped so callers see it.
 	resetCmds(cmds)
-	if got := core.recordBatchOutcomes(db, cmds, io.EOF, false); got != 1 {
+	if got := core.recordBatchOutcomes(db, cmds, io.EOF, false, true); got != 1 {
 		t.Errorf("transportFailures = %d for an unexecuted batch, want 1", got)
 	}
 	if err := cmds[0].Err(); err == nil {
@@ -69,7 +69,7 @@ func TestRecordBatchOutcomesExecutedBatchKeepsSuccessfulPrefix(t *testing.T) {
 	}
 	cmds[1].SetErr(loading)
 
-	if got := core.recordBatchOutcomes(db, cmds, loading, true); got != 1 {
+	if got := core.recordBatchOutcomes(db, cmds, loading, true, true); got != 1 {
 		t.Errorf("transportFailures = %d, want 1 (prefix must not count)", got)
 	}
 	if err := cmds[0].Err(); err != nil {
@@ -97,7 +97,7 @@ func TestRecordBatchOutcomesFailuresBeforeSuccesses(t *testing.T) {
 		NewStatusCmd(context.Background(), "set", "k2", "v"),
 	}
 	cmds[1].SetErr(io.EOF)
-	core.recordBatchOutcomes(db, cmds, io.EOF, true)
+	core.recordBatchOutcomes(db, cmds, io.EOF, true, true)
 
 	if got := db.cb.State(); got != imultidb.CircuitOpen {
 		t.Errorf("breaker state = %v after a failed recovery batch, want open", got)
@@ -122,7 +122,7 @@ func TestRecordBatchOutcomesClosedStateKeepsArrivalOrder(t *testing.T) {
 		NewStatusCmd(context.Background(), "set", "k2", "v"),
 	}
 	cmds[1].SetErr(io.EOF)
-	core.recordBatchOutcomes(db, cmds, io.EOF, true)
+	core.recordBatchOutcomes(db, cmds, io.EOF, true, true)
 
 	if got := db.cb.State(); got != imultidb.CircuitClosed {
 		t.Errorf("breaker state = %v, want closed (stale failure must be reset by the earlier success)", got)
@@ -139,7 +139,7 @@ func TestRecordBatchOutcomesSuccessSinceFailover(t *testing.T) {
 	// An executed batch success is recovery traffic: it breaks the
 	// consecutive-failed-failover escalation chain.
 	cmds := []Cmder{NewStatusCmd(context.Background(), "set", "k", "v")}
-	core.recordBatchOutcomes(db, cmds, nil, true)
+	core.recordBatchOutcomes(db, cmds, nil, true, true)
 	if !core.successSinceFailover.Load() {
 		t.Error("executed batch success did not mark recovery traffic")
 	}
@@ -147,7 +147,7 @@ func TestRecordBatchOutcomesSuccessSinceFailover(t *testing.T) {
 	// A hook-served batch (nil without execution) is not.
 	core.successSinceFailover.Store(false)
 	resetCmds(cmds)
-	core.recordBatchOutcomes(db, cmds, nil, false)
+	core.recordBatchOutcomes(db, cmds, nil, false, true)
 	if core.successSinceFailover.Load() {
 		t.Error("hook-served batch counted as recovery traffic")
 	}

--- a/multidb_pipeline_internal_test.go
+++ b/multidb_pipeline_internal_test.go
@@ -1,0 +1,50 @@
+package redis
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+	"testing"
+
+	imultidb "github.com/redis/go-redis/v9/internal/multidb"
+)
+
+func TestRecordBatchOutcomesPostExecHookError(t *testing.T) {
+	core := newMultidbCore(&MultiDBOptions{})
+	db := &multidbDatabase{cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{
+		FailureThreshold: 2,
+		SuccessThreshold: 1,
+	})}
+
+	cmds := []Cmder{NewStatusCmd(context.Background(), "set", "k", "v")}
+
+	// Executed batch, every reply read fine, then a post-exec hook injected
+	// a retryable error without stamping the commands: the commands are
+	// authoritative — no phantom failures, no stamping, no replay signal.
+	if got := core.recordBatchOutcomes(db, cmds, io.EOF, true); got != 0 {
+		t.Errorf("transportFailures = %d for an executed all-success batch, want 0", got)
+	}
+	if err := cmds[0].Err(); err != nil {
+		t.Errorf("executed batch had its successful command stamped with %v", err)
+	}
+
+	// Not executed (hook aborted before next): the batch error stands in
+	// for the commands and is stamped so callers see it.
+	resetCmds(cmds)
+	if got := core.recordBatchOutcomes(db, cmds, io.EOF, false); got != 1 {
+		t.Errorf("transportFailures = %d for an unexecuted batch, want 1", got)
+	}
+	if err := cmds[0].Err(); err == nil {
+		t.Error("unexecuted batch left the command unstamped")
+	}
+}
+
+func TestMarkPipelineExecuted(t *testing.T) {
+	flag := new(atomic.Bool)
+	markPipelineExecuted(context.WithValue(context.Background(), pipelineExecutedKey{}, flag))
+	if !flag.Load() {
+		t.Error("marker did not flip the flag")
+	}
+	// Without a marker in the context it must be a no-op, not a panic.
+	markPipelineExecuted(context.Background())
+}

--- a/multidb_pipeline_internal_test.go
+++ b/multidb_pipeline_internal_test.go
@@ -403,3 +403,34 @@ func TestRecordBatchOutcomesPartialExecutionDoesNotCountUntouched(t *testing.T) 
 		t.Errorf("detector failures = %d, want 0 (an untouched command must not count at all)", det.failures)
 	}
 }
+
+// unhashableCmd is a value-type Cmder (methods promoted from the embedded
+// *StatusCmd) made non-comparable by a slice field — a legal Cmder that would
+// panic as a map key.
+type unhashableCmd struct {
+	*StatusCmd
+	extra []int
+}
+
+// TestExecutedCmdsSkipsNonComparableCommand pins that executedCmds does not
+// panic on a non-comparable command (Cmder imposes no comparability contract):
+// it goes untracked rather than being hashed as a map key.
+func TestExecutedCmdsSkipsNonComparableCommand(t *testing.T) {
+	e := newExecutedCmds(2)
+	cmd := unhashableCmd{StatusCmd: NewStatusCmd(context.Background(), "ping"), extra: []int{1}}
+
+	e.mark([]Cmder{cmd}) // must not panic ("hash of unhashable type")
+	if e.has(cmd) {
+		t.Error("non-comparable command reported executed; want untracked")
+	}
+	if e.any() {
+		t.Error("a non-comparable-only batch marked something; want none")
+	}
+
+	// A normal pointer command is still tracked.
+	normal := NewStatusCmd(context.Background(), "get", "k")
+	e.mark([]Cmder{normal})
+	if !e.has(normal) {
+		t.Error("normal command not tracked")
+	}
+}

--- a/multidb_pipeline_internal_test.go
+++ b/multidb_pipeline_internal_test.go
@@ -219,9 +219,18 @@ func TestProcessTxPipelineHImportPreservesFirstError(t *testing.T) {
 	preErr.SetErr(prior)
 	him := NewStatusCmd(context.Background(), "himport", "fs")
 
-	err := core.processTxPipeline(context.Background(), []Cmder{preErr, him})
+	// Wrap like TxPipeline().Exec does before dispatch. The synthetic MULTI at
+	// index 0 must not win the first-error ordering over a user command the
+	// caller pre-stamped.
+	wrapped := wrapMultiExec(context.Background(), []Cmder{preErr, him})
+	err := core.processTxPipeline(context.Background(), wrapped)
 	if !errors.Is(err, prior) {
 		t.Fatalf("processTxPipeline = %v, want the positionally-first pre-existing error %v", err, prior)
+	}
+	// The HIMPORT command itself is stamped — proving the envelope was stripped
+	// and the user slice stamped, not that stamping was skipped altogether.
+	if !errors.Is(him.Err(), errMultiDBHImport) {
+		t.Fatalf("HIMPORT command err = %v, want errMultiDBHImport", him.Err())
 	}
 }
 

--- a/multidb_pipeline_removed_internal_test.go
+++ b/multidb_pipeline_removed_internal_test.go
@@ -1,0 +1,57 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	imultidb "github.com/redis/go-redis/v9/internal/multidb"
+)
+
+func newRemovedActiveCore(t *testing.T) *multidbCore {
+	t.Helper()
+	core := newMultidbCore(&MultiDBOptions{})
+	// A closed client's pool returns ErrClosed from its hooks without dialing.
+	a := NewClient(&Options{Addr: "127.0.0.1:6379", MaxRetries: -1})
+	t.Cleanup(func() { _ = a.Close() })
+	_ = a.Close()
+	db := &multidbDatabase{id: 0, weight: 1, c: a, cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1,
+	})}
+	db.removed.Store(true)
+	core.dbs[0] = db
+	core.active.Store(0)
+	return core
+}
+
+// TestProcessPipelineRemovedActiveDoesNotSurfaceErrClosed is the batch analogue
+// of the single-command re-gate: a pipeline whose snapshotted member was removed
+// mid-flight must not surface the terminal ErrClosed while the client is open.
+// It re-enters the gate; with no live member the re-gates are bounded and it
+// reports the retryable ErrTemporarilyNotAvailable.
+func TestProcessPipelineRemovedActiveDoesNotSurfaceErrClosed(t *testing.T) {
+	core := newRemovedActiveCore(t)
+	err := core.processPipeline(context.Background(), []Cmder{NewStatusCmd(context.Background(), "ping")})
+	if errors.Is(err, ErrClosed) {
+		t.Fatalf("processPipeline surfaced terminal ErrClosed for a removed former active: %v", err)
+	}
+	if !errors.Is(err, ErrTemporarilyNotAvailable) {
+		t.Fatalf("got %v, want ErrTemporarilyNotAvailable after the bounded re-gate", err)
+	}
+}
+
+// TestProcessTxPipelineRemovedActiveDoesNotSurfaceErrClosed is the same for the
+// transaction path. Re-gating is at-most-once-safe because the execution marker
+// is empty (the removed member's pool returned ErrClosed before anything ran).
+func TestProcessTxPipelineRemovedActiveDoesNotSurfaceErrClosed(t *testing.T) {
+	core := newRemovedActiveCore(t)
+	wrapped := wrapMultiExec(context.Background(), []Cmder{NewStatusCmd(context.Background(), "ping")})
+	err := core.processTxPipeline(context.Background(), wrapped)
+	if errors.Is(err, ErrClosed) {
+		t.Fatalf("processTxPipeline surfaced terminal ErrClosed for a removed former active: %v", err)
+	}
+	if !errors.Is(err, ErrTemporarilyNotAvailable) {
+		t.Fatalf("got %v, want ErrTemporarilyNotAvailable after the bounded re-gate", err)
+	}
+}

--- a/multidb_pipeline_removed_internal_test.go
+++ b/multidb_pipeline_removed_internal_test.go
@@ -3,10 +3,27 @@ package redis
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	imultidb "github.com/redis/go-redis/v9/internal/multidb"
 )
+
+// markThenCloseHook marks the batch executed, then returns ErrClosed without
+// calling next — simulating a cluster fan-out where one shard applied its
+// commands before another shard's connection acquisition failed against a
+// member that was switched away and removed.
+type markThenCloseHook struct{ calls *int32 }
+
+func (markThenCloseHook) DialHook(next DialHook) DialHook          { return next }
+func (markThenCloseHook) ProcessHook(next ProcessHook) ProcessHook { return next }
+func (h markThenCloseHook) ProcessPipelineHook(ProcessPipelineHook) ProcessPipelineHook {
+	return func(ctx context.Context, cmds []Cmder) error {
+		atomic.AddInt32(h.calls, 1)
+		markPipelineExecuted(ctx, cmds)
+		return ErrClosed
+	}
+}
 
 func newRemovedActiveCore(t *testing.T) *multidbCore {
 	t.Helper()
@@ -53,5 +70,38 @@ func TestProcessTxPipelineRemovedActiveDoesNotSurfaceErrClosed(t *testing.T) {
 	}
 	if !errors.Is(err, ErrTemporarilyNotAvailable) {
 		t.Fatalf("got %v, want ErrTemporarilyNotAvailable after the bounded re-gate", err)
+	}
+}
+
+// TestProcessPipelinePartiallyExecutedRemovedMemberNotReplayed pins that a batch
+// which PARTIALLY executed (execution marker set) before hitting ErrClosed on a
+// removed member is NOT re-gated and replayed — replaying would duplicate the
+// applied writes from the completed shard. Only a wholly-unexecuted batch
+// re-gates (the !executed.any() guard, mirroring the tx path).
+func TestProcessPipelinePartiallyExecutedRemovedMemberNotReplayed(t *testing.T) {
+	core := newMultidbCore(&MultiDBOptions{})
+	var calls int32
+	a := NewClient(&Options{Addr: "127.0.0.1:6379", MaxRetries: -1})
+	t.Cleanup(func() { _ = a.Close() })
+	a.AddHook(markThenCloseHook{calls: &calls})
+	db := &multidbDatabase{id: 0, weight: 1, c: a, cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1,
+	})}
+	db.removed.Store(true)
+	core.dbs[0] = db
+	core.active.Store(0)
+
+	err := core.processPipeline(context.Background(), []Cmder{
+		NewStatusCmd(context.Background(), "set", "k", "v"),
+		NewStatusCmd(context.Background(), "get", "k"),
+	})
+	// The batch executed, so it must surface ErrClosed as-is (not re-gate to the
+	// retryable ErrTemporarilyNotAvailable), and it must run exactly once.
+	if !errors.Is(err, ErrClosed) {
+		t.Fatalf("partially-executed removed-member batch was re-gated instead of surfacing ErrClosed: %v", err)
+	}
+	if n := atomic.LoadInt32(&calls); n != 1 {
+		t.Fatalf("batch executed %d times, want 1 — it was replayed (duplicating applied writes)", n)
 	}
 }

--- a/multidb_pipeline_removed_internal_test.go
+++ b/multidb_pipeline_removed_internal_test.go
@@ -43,10 +43,10 @@ func newRemovedActiveCore(t *testing.T) *multidbCore {
 }
 
 // TestProcessPipelineRemovedActiveDoesNotSurfaceErrClosed is the batch analogue
-// of the single-command re-gate: a pipeline whose snapshotted member was removed
+// of the single-command path: a pipeline whose snapshotted member was removed
 // mid-flight must not surface the terminal ErrClosed while the client is open.
-// It re-enters the gate; with no live member the re-gates are bounded and it
-// reports the retryable ErrTemporarilyNotAvailable.
+// It reports the retryable ErrTemporarilyNotAvailable instead, so the caller
+// retries; nothing is replayed by the client itself.
 func TestProcessPipelineRemovedActiveDoesNotSurfaceErrClosed(t *testing.T) {
 	core := newRemovedActiveCore(t)
 	err := core.processPipeline(context.Background(), []Cmder{NewStatusCmd(context.Background(), "ping")})
@@ -59,8 +59,8 @@ func TestProcessPipelineRemovedActiveDoesNotSurfaceErrClosed(t *testing.T) {
 }
 
 // TestProcessTxPipelineRemovedActiveDoesNotSurfaceErrClosed is the same for the
-// transaction path. Re-gating is at-most-once-safe because the execution marker
-// is empty (the removed member's pool returned ErrClosed before anything ran).
+// transaction path: the retryable error is surfaced, never a replay — EXEC may
+// have committed, so at-most-once forbids re-running it.
 func TestProcessTxPipelineRemovedActiveDoesNotSurfaceErrClosed(t *testing.T) {
 	core := newRemovedActiveCore(t)
 	wrapped := wrapMultiExec(context.Background(), []Cmder{NewStatusCmd(context.Background(), "ping")})
@@ -75,9 +75,9 @@ func TestProcessTxPipelineRemovedActiveDoesNotSurfaceErrClosed(t *testing.T) {
 
 // TestProcessPipelinePartiallyExecutedRemovedMemberNotReplayed pins that a batch
 // which PARTIALLY executed (execution marker set) before hitting ErrClosed on a
-// removed member is NOT re-gated and replayed — replaying would duplicate the
-// applied writes from the completed shard. Only a wholly-unexecuted batch
-// re-gates (the !executed.any() guard, mirroring the tx path).
+// removed member is NOT replayed — replaying would duplicate the applied writes
+// from the completed shard. It surfaces the retryable error exactly once and
+// keeps the executed commands' results (they are not rewritten).
 func TestProcessPipelinePartiallyExecutedRemovedMemberNotReplayed(t *testing.T) {
 	core := newMultidbCore(&MultiDBOptions{})
 	var calls int32
@@ -92,16 +92,23 @@ func TestProcessPipelinePartiallyExecutedRemovedMemberNotReplayed(t *testing.T) 
 	core.dbs[0] = db
 	core.active.Store(0)
 
-	err := core.processPipeline(context.Background(), []Cmder{
+	cmds := []Cmder{
 		NewStatusCmd(context.Background(), "set", "k", "v"),
 		NewStatusCmd(context.Background(), "get", "k"),
-	})
-	// The batch executed, so it must surface ErrClosed as-is (not re-gate to the
-	// retryable ErrTemporarilyNotAvailable), and it must run exactly once.
-	if !errors.Is(err, ErrClosed) {
-		t.Fatalf("partially-executed removed-member batch was re-gated instead of surfacing ErrClosed: %v", err)
+	}
+	err := core.processPipeline(context.Background(), cmds)
+	// The batch executed: the retryable error is surfaced (never a replay), the
+	// batch runs exactly once, and the executed commands keep their results —
+	// they are not rewritten with the aggregate error.
+	if !errors.Is(err, ErrTemporarilyNotAvailable) {
+		t.Fatalf("partially-executed removed-member batch: got %v, want ErrTemporarilyNotAvailable", err)
 	}
 	if n := atomic.LoadInt32(&calls); n != 1 {
 		t.Fatalf("batch executed %d times, want 1 — it was replayed (duplicating applied writes)", n)
+	}
+	for i, cmd := range cmds {
+		if cmd.rawErr() != nil {
+			t.Fatalf("executed command %d had its result rewritten to %v", i, cmd.rawErr())
+		}
 	}
 }

--- a/multidb_pipeline_reset_internal_test.go
+++ b/multidb_pipeline_reset_internal_test.go
@@ -1,0 +1,77 @@
+package redis
+
+import (
+	"context"
+	"testing"
+
+	imultidb "github.com/redis/go-redis/v9/internal/multidb"
+	"github.com/redis/go-redis/v9/internal/proto"
+)
+
+// TestProcessPipelineReusedCmdErrorsDoNotMaskTransportFailure pins the reset
+// before execution. A caller may hand the batch a command that still carries a
+// Redis error from a prior use. When connection acquisition then fails before
+// anything executes, the stale per-command errors must not mask the transport
+// failure: setCmdsErr fills only empty slots, so without the reset it never
+// stamps the batch error, every command classifies as an unexecuted success,
+// transportFailures stays 0, and the outage is neither recorded on the detector
+// nor failed over. The reset clears the stale errors so the connection-acquire
+// failure is recorded.
+func TestProcessPipelineReusedCmdErrorsDoNotMaskTransportFailure(t *testing.T) {
+	det := &countingFD{}
+	core := newMultidbCore(&MultiDBOptions{FailureDetector: det, CommandRetries: 0})
+	dead := NewClient(&Options{Addr: "127.0.0.1:1", MaxRetries: -1})
+	defer dead.Close()
+	core.dbs[0] = &multidbDatabase{id: 0, weight: 1, c: dead, cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1,
+	})}
+	core.active.Store(0)
+
+	cmds := []Cmder{
+		NewStatusCmd(context.Background(), "set", "k", "v"),
+		NewStatusCmd(context.Background(), "get", "k"),
+	}
+	// Reused commands still carrying a Redis error from a prior batch.
+	for _, cmd := range cmds {
+		cmd.SetErr(proto.RedisError("ERR from a prior use"))
+	}
+
+	_ = core.processPipeline(context.Background(), cmds)
+
+	if det.failures == 0 {
+		t.Fatalf("transport failure not recorded: stale per-command errors masked the connection-acquire failure, so no failover would trigger")
+	}
+}
+
+// TestProcessTxPipelineReusedCmdErrorsDoNotMaskTransportFailure is the tx
+// analogue: processTxPipeline classifies only the user slice inside the
+// MULTI/EXEC envelope, and a reused user command carrying a stale Redis error
+// would otherwise mask a connection-acquire failure exactly as in the plain
+// pipeline path. The reset targets the user slice; the envelope is clean.
+func TestProcessTxPipelineReusedCmdErrorsDoNotMaskTransportFailure(t *testing.T) {
+	det := &countingFD{}
+	core := newMultidbCore(&MultiDBOptions{FailureDetector: det, CommandRetries: 0})
+	dead := NewClient(&Options{Addr: "127.0.0.1:1", MaxRetries: -1})
+	defer dead.Close()
+	core.dbs[0] = &multidbDatabase{id: 0, weight: 1, c: dead, cb: imultidb.NewCircuitBreaker(imultidb.CircuitBreakerConfig{
+		FailureThreshold: 1,
+		SuccessThreshold: 1,
+	})}
+	core.active.Store(0)
+
+	// [MULTI, set, get, EXEC]: the user slice is the middle two commands, and
+	// they are the reused ones carrying a stale Redis error.
+	multi := NewStatusCmd(context.Background(), "multi")
+	exec := NewSliceCmd(context.Background(), "exec")
+	set := NewStatusCmd(context.Background(), "set", "k", "v")
+	get := NewStatusCmd(context.Background(), "get", "k")
+	set.SetErr(proto.RedisError("ERR from a prior use"))
+	get.SetErr(proto.RedisError("ERR from a prior use"))
+
+	_ = core.processTxPipeline(context.Background(), []Cmder{multi, set, get, exec})
+
+	if det.failures == 0 {
+		t.Fatalf("transport failure not recorded: stale user-command errors masked the connection-acquire failure inside the transaction")
+	}
+}

--- a/multidb_test.go
+++ b/multidb_test.go
@@ -63,6 +63,7 @@ type hookedDB struct {
 	fail     atomic.Bool
 	custom   atomic.Pointer[customErr]
 	commands atomic.Int64
+	batches  atomic.Int64
 }
 
 func (h *hookedDB) DialHook(next redis.DialHook) redis.DialHook { return next }
@@ -86,7 +87,18 @@ func (h *hookedDB) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
 }
 
 func (h *hookedDB) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
-	return next
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		h.commands.Add(int64(len(cmds)))
+		h.batches.Add(1)
+		if h.fail.Load() {
+			err := errors.New("hooked: " + h.name + " down")
+			for _, cmd := range cmds {
+				cmd.SetErr(err)
+			}
+			return err
+		}
+		return nil
+	}
 }
 
 // testDB bundles one fake database: config + hook + health check.

--- a/multidb_test.go
+++ b/multidb_test.go
@@ -91,7 +91,8 @@ func (h *hookedDB) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.Pro
 		h.commands.Add(int64(len(cmds)))
 		h.batches.Add(1)
 		if h.fail.Load() {
-			err := errors.New("hooked: " + h.name + " down")
+			// Wrap io.EOF so the failure classifies as a transport error.
+			err := fmt.Errorf("hooked: %s down: %w", h.name, io.EOF)
 			for _, cmd := range cmds {
 				cmd.SetErr(err)
 			}

--- a/multidb_test.go
+++ b/multidb_test.go
@@ -89,7 +89,8 @@ func (h *hookedDB) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.Pro
 		h.commands.Add(int64(len(cmds)))
 		h.batches.Add(1)
 		if h.fail.Load() {
-			err := errors.New("hooked: " + h.name + " down")
+			// Wrap io.EOF so the failure classifies as a transport error.
+			err := fmt.Errorf("hooked: %s down: %w", h.name, io.EOF)
 			for _, cmd := range cmds {
 				cmd.SetErr(err)
 			}

--- a/multidb_test.go
+++ b/multidb_test.go
@@ -61,6 +61,7 @@ type hookedDB struct {
 	fail     atomic.Bool
 	custom   atomic.Pointer[customErr]
 	commands atomic.Int64
+	batches  atomic.Int64
 }
 
 func (h *hookedDB) DialHook(next redis.DialHook) redis.DialHook { return next }
@@ -84,7 +85,18 @@ func (h *hookedDB) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
 }
 
 func (h *hookedDB) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
-	return next
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		h.commands.Add(int64(len(cmds)))
+		h.batches.Add(1)
+		if h.fail.Load() {
+			err := errors.New("hooked: " + h.name + " down")
+			for _, cmd := range cmds {
+				cmd.SetErr(err)
+			}
+			return err
+		}
+		return nil
+	}
 }
 
 // testDB bundles one fake database: config + hook + health check.

--- a/multidb_txnoretry_internal_test.go
+++ b/multidb_txnoretry_internal_test.go
@@ -1,0 +1,35 @@
+package redis
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestTxPipelineRestoresNoRetryForDuplicateCommand pins that the temporary
+// NoRetry marker TxPipeline sets on the wrapped batch is restored correctly even
+// when the SAME Cmder is queued twice. The second occurrence snapshots the
+// already-set marker, so a forward-order restore would end on prev=true and
+// leave the shared command permanently non-retryable for later ordinary use.
+func TestTxPipelineRestoresNoRetryForDuplicateCommand(t *testing.T) {
+	core := newRemovedActiveCore(t) // exec returns fast; the deferred restore still runs
+	mdb := &MultiDBClient{core: core, autopipelinerMu: new(sync.Mutex)}
+	mdb.initHooks(hooks{
+		process:    core.process,
+		pipeline:   core.processPipeline,
+		txPipeline: core.processTxPipeline,
+	})
+
+	cmd := NewStatusCmd(context.Background(), "set", "k", "v")
+	if cmd.NoRetry() {
+		t.Fatal("precondition: fresh command must be retryable")
+	}
+	pipe := mdb.TxPipeline()
+	_ = pipe.Process(context.Background(), cmd)
+	_ = pipe.Process(context.Background(), cmd) // same object queued twice
+	_, _ = pipe.Exec(context.Background())      // error expected; restore must still run
+
+	if cmd.NoRetry() {
+		t.Fatal("NoRetry left set on a command queued twice in a TxPipeline — a later ordinary request would silently lose retries")
+	}
+}

--- a/osscluster.go
+++ b/osscluster.go
@@ -1996,6 +1996,7 @@ func (c *ClusterClient) processPipelineNode(
 func (c *ClusterClient) processPipelineNodeConn(
 	ctx context.Context, node *clusterNode, cn *pool.Conn, cmds []Cmder, failedCmds *cmdsMap,
 ) error {
+	markPipelineExecuted(ctx)
 	// HIMPORT bookkeeping: pending discards for this session and PREPAREs
 	// for registered fieldsets the batch references get written ahead of
 	// the batch (see himport.go).
@@ -2434,6 +2435,7 @@ func (c *ClusterClient) processTxPipelineNode(
 func (c *ClusterClient) processTxPipelineNodeConn(
 	ctx context.Context, node *clusterNode, cn *pool.Conn, wire []Cmder, cmds []Cmder, asking bool,
 ) *txOutcome {
+	markPipelineExecuted(ctx)
 	// HIMPORT bookkeeping: pending discards and PREPAREs for registered
 	// fieldsets the transaction references get written ahead of the wire
 	// batch (before ASKING/MULTI; the session state is visible at EXEC).

--- a/osscluster.go
+++ b/osscluster.go
@@ -1996,7 +1996,7 @@ func (c *ClusterClient) processPipelineNode(
 func (c *ClusterClient) processPipelineNodeConn(
 	ctx context.Context, node *clusterNode, cn *pool.Conn, cmds []Cmder, failedCmds *cmdsMap,
 ) error {
-	markPipelineExecuted(ctx)
+	markPipelineExecuted(ctx, cmds)
 	// HIMPORT bookkeeping: pending discards for this session and PREPAREs
 	// for registered fieldsets the batch references get written ahead of
 	// the batch (see himport.go).
@@ -2435,7 +2435,7 @@ func (c *ClusterClient) processTxPipelineNode(
 func (c *ClusterClient) processTxPipelineNodeConn(
 	ctx context.Context, node *clusterNode, cn *pool.Conn, wire []Cmder, cmds []Cmder, asking bool,
 ) *txOutcome {
-	markPipelineExecuted(ctx)
+	markPipelineExecuted(ctx, cmds)
 	// HIMPORT bookkeeping: pending discards and PREPAREs for registered
 	// fieldsets the transaction references get written ahead of the wire
 	// batch (before ASKING/MULTI; the session state is visible at EXEC).

--- a/redis.go
+++ b/redis.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1724,12 +1725,28 @@ func newExecutedCmds(size int) *executedCmds {
 func (e *executedCmds) mark(cmds []Cmder) {
 	e.mu.Lock()
 	for _, cmd := range cmds {
-		e.done[cmd] = struct{}{}
+		// Cmder carries no comparability contract: a value-type command that
+		// embeds a builtin cmd plus a slice/map field is not comparable and
+		// would panic ("hash of unhashable type") as a map key. Skip those —
+		// they go untracked (has == false), which is conservative: an untracked
+		// successful command records no health signal (recordBatchOutcomes'
+		// success path guards on the marker), and failures record regardless.
+		// A batch of ONLY non-comparable commands leaves any() == false, so a
+		// batch-level error would stamp them via the never-executed path — a
+		// documented corner the eventual per-command marker on baseCmd removes
+		// by dropping the map entirely. A nil dynamic type (t == nil) is the
+		// comparable nil interface and is tracked as before.
+		if t := reflect.TypeOf(cmd); t == nil || t.Comparable() {
+			e.done[cmd] = struct{}{}
+		}
 	}
 	e.mu.Unlock()
 }
 
 func (e *executedCmds) has(cmd Cmder) bool {
+	if t := reflect.TypeOf(cmd); t != nil && !t.Comparable() {
+		return false // never tracked (see mark) — treat as not executed
+	}
 	e.mu.Lock()
 	_, ok := e.done[cmd]
 	e.mu.Unlock()

--- a/redis.go
+++ b/redis.go
@@ -1699,9 +1699,24 @@ func (c *baseClient) generalProcessPipeline(
 	return lastErr
 }
 
+// pipelineExecutedKey carries an *atomic.Bool that execution paths flip the
+// moment a batch may have reached the server. MultiDBClient uses it to
+// distinguish "a hook aborted before execution" from "the batch executed and
+// a hook then replaced the error": command state alone cannot tell those
+// apart, and confusing them either fabricates phantom outcomes or replays
+// writes that already applied.
+type pipelineExecutedKey struct{}
+
+func markPipelineExecuted(ctx context.Context) {
+	if flag, ok := ctx.Value(pipelineExecutedKey{}).(*atomic.Bool); ok {
+		flag.Store(true)
+	}
+}
+
 func (c *baseClient) pipelineProcessCmds(
 	ctx context.Context, cn *pool.Conn, cmds []Cmder,
 ) (bool, error) {
+	markPipelineExecuted(ctx)
 	// Process any pending push notifications before executing the pipeline
 	if err := c.processPushNotifications(ctx, cn); err != nil {
 		internal.Logger.Printf(ctx, "push: error processing pending notifications before writing pipeline: %v", err)
@@ -1794,6 +1809,7 @@ func (c *baseClient) pipelineReadCmds(ctx context.Context, cn *pool.Conn, rd *pr
 func (c *baseClient) txPipelineProcessCmds(
 	ctx context.Context, cn *pool.Conn, cmds []Cmder,
 ) (bool, error) {
+	markPipelineExecuted(ctx)
 	// Process any pending push notifications before executing the transaction pipeline
 	if err := c.processPushNotifications(ctx, cn); err != nil {
 		internal.Logger.Printf(ctx, "push: error processing pending notifications before transaction: %v", err)

--- a/redis.go
+++ b/redis.go
@@ -1699,24 +1699,63 @@ func (c *baseClient) generalProcessPipeline(
 	return lastErr
 }
 
-// pipelineExecutedKey carries an *atomic.Bool that execution paths flip the
-// moment a batch may have reached the server. MultiDBClient uses it to
-// distinguish "a hook aborted before execution" from "the batch executed and
-// a hook then replaced the error": command state alone cannot tell those
+// pipelineExecutedKey carries an *executedCmds that execution paths populate
+// the moment a batch's commands may have reached the server. MultiDBClient uses
+// it to distinguish "a hook aborted before execution" from "the batch executed
+// and a hook then replaced the error": command state alone cannot tell those
 // apart, and confusing them either fabricates phantom outcomes or replays
 // writes that already applied.
 type pipelineExecutedKey struct{}
 
-func markPipelineExecuted(ctx context.Context) {
-	if flag, ok := ctx.Value(pipelineExecutedKey{}).(*atomic.Bool); ok {
-		flag.Store(true)
+// executedCmds records which commands of a batch actually reached (or
+// attempted) the server. It is per-command, not a single flag, because a
+// cluster pipeline fans one batch out into independent node sub-batches: one
+// node executing must not make another node's short-circuited (untouched,
+// nil-error) commands look like served database successes.
+type executedCmds struct {
+	mu   sync.Mutex
+	done map[Cmder]struct{}
+}
+
+func newExecutedCmds(size int) *executedCmds {
+	return &executedCmds{done: make(map[Cmder]struct{}, size)}
+}
+
+func (e *executedCmds) mark(cmds []Cmder) {
+	e.mu.Lock()
+	for _, cmd := range cmds {
+		e.done[cmd] = struct{}{}
+	}
+	e.mu.Unlock()
+}
+
+func (e *executedCmds) has(cmd Cmder) bool {
+	e.mu.Lock()
+	_, ok := e.done[cmd]
+	e.mu.Unlock()
+	return ok
+}
+
+func (e *executedCmds) any() bool {
+	e.mu.Lock()
+	n := len(e.done)
+	e.mu.Unlock()
+	return n > 0
+}
+
+// markPipelineExecuted records that cmds reached (or attempted) the server for
+// the batch tracked in ctx, if any. Safe to call from multiple cluster-node
+// goroutines concurrently.
+func markPipelineExecuted(ctx context.Context, cmds []Cmder) {
+	if ec, ok := ctx.Value(pipelineExecutedKey{}).(*executedCmds); ok {
+		ec.mark(cmds)
 	}
 }
 
 func (c *baseClient) pipelineProcessCmds(
 	ctx context.Context, cn *pool.Conn, cmds []Cmder,
 ) (bool, error) {
-	markPipelineExecuted(ctx)
+	markPipelineExecuted(ctx, cmds)
 	// Process any pending push notifications before executing the pipeline
 	if err := c.processPushNotifications(ctx, cn); err != nil {
 		internal.Logger.Printf(ctx, "push: error processing pending notifications before writing pipeline: %v", err)
@@ -1809,7 +1848,7 @@ func (c *baseClient) pipelineReadCmds(ctx context.Context, cn *pool.Conn, rd *pr
 func (c *baseClient) txPipelineProcessCmds(
 	ctx context.Context, cn *pool.Conn, cmds []Cmder,
 ) (bool, error) {
-	markPipelineExecuted(ctx)
+	markPipelineExecuted(ctx, cmds)
 	// Process any pending push notifications before executing the transaction pipeline
 	if err := c.processPushNotifications(ctx, cn); err != nil {
 		internal.Logger.Printf(ctx, "push: error processing pending notifications before transaction: %v", err)
@@ -2622,7 +2661,8 @@ func (c *baseClient) drainPushNotifications(cn *pool.Conn) (processorSucceeded b
 	err = cn.WithReaderHardDeadline(cscDrainHardReadCap, func(rd *proto.Reader) error {
 		if processor, ok := c.pushProcessor.(*push.Processor); ok {
 			return processor.ProcessPendingNotificationsBuffered(
-				context.Background(), handlerCtx, rd)
+				context.Background(), handlerCtx, rd,
+			)
 		}
 		return c.pushProcessor.ProcessPendingNotifications(context.Background(), handlerCtx, rd)
 	})


### PR DESCRIPTION
Stacked on the MultiDBClient orchestration PR.

Makes `MultiDBClient` a full `UniversalClient` and wires batching through the
MultiDB core:

- `hooksMixin` on `MultiDBClient` (MultiDB-level `AddHook`), satisfying the
  autopipeliner's backend interface — one `AutoPipeliner` instance survives
  failover; every flushed batch resolves the active database at exec time
- `processPipeline`: batch attempt loop bounded by `CommandRetries`;
  per-command outcome recording (server error replies count as healthy);
  transport-failed batches are retried against the newly selected database
- `processTxPipeline`: MULTI/EXEC executed at most once, never auto-retried
  (EXEC may have committed before the connection broke)
- `Pipeline`/`Pipelined`, `TxPipeline`/`TxPipelined`, `Do`, `Watch`
  (active-bound, aborts on failover), `SSubscribe`, `PoolStats`
- `AutoPipeline`/`AsyncAutoPipeline` (+`WithOptions`) with the same cached
  instance semantics as `*Client`; `Close` drains pipeliners before member
  clients shut down

Known trade-off: batches reaching a cluster member are split per node by the
member's own pipeline path (correct, not slot-shard-optimized).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core MultiDB failover, circuit-breaker admission, and at-most-once transaction semantics across pipelines and autopipeline; incorrect recording or retry behavior could duplicate writes or wedge breakers under concurrency.
> 
> **Overview**
> **`MultiDBClient` now implements the full `UniversalClient` surface** — pipelines, transactions, `Do`, `Watch`, `PoolStats`, and cached blocking/async **autopipeliners** — with batches routed through the MultiDB core (failover, circuit breaker, per-command health recording) instead of only single-command `Process`.
> 
> **Batch execution** adds `processPipeline` (retry bounded by `CommandRetries`, at-least-once delivery) and `processTxPipeline` (gate + single-shot MULTI/EXEC, no MultiDB replay). Outcomes use a context-carried **`executedCmds` marker** (wired from standalone/cluster wire paths via `markPipelineExecuted`) so hook-served or partially applied batches do not fake successes or replay writes. **`baseCmd.noRetry` / `setNoRetry`** temporarily marks tx batches so member-level retries cannot replay EXEC; HIMPORT in batches is rejected per-command (or whole tx) using a **`proto.RedisError`** so autopipeline coalescing does not abort unrelated commands.
> 
> **Client lifecycle and autopipeline safety**: `Close` uses **`sync.Once`** to drain autopipeliners before tearing down members; **`AddHook`** wraps MultiDB paths; cluster members cannot coexist with a live autopipeliner (and **`pendingClusterAdds`** avoids deadlock when health probes call `AutoPipeline`). Mid-flight removal of a member surfaces **`ErrTemporarilyNotAvailable`** instead of terminal `ErrClosed` where appropriate.
> 
> Large integration/unit test suites cover failover, half-open probe slots, cancellation, and concurrent close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce9bcc1244e2e92207756ed80908502fe21aa0e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->