### PR TITLE
test(multidb): e2e failover tests via per-member RESP proxies

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -86,8 +86,11 @@ jobs:
           echo "Waiting for Redis to be ready..."
           timeout 30 bash -c 'until docker exec redis-standalone redis-cli ping 2>/dev/null; do sleep 1; done'
           echo "Waiting for the per-member proxies to be ready..."
+          # 127.0.0.1, not localhost: the e2e harness dials 127.0.0.1 because
+          # IPv6-first hosts resolve localhost to ::1 and can miss Docker's
+          # IPv4-published ports — the readiness probe must match.
           for port in 18120 18121 18122; do
-            timeout 30 bash -c "until curl -s http://localhost:$port/stats > /dev/null; do sleep 1; done"
+            timeout 30 bash -c "until curl -s http://127.0.0.1:$port/stats > /dev/null; do sleep 1; done"
           done
           echo "All services are ready!"
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -60,3 +60,55 @@ jobs:
           echo "=== proxy-fault-injector logs ==="
           docker logs proxy-fault-injector 2>&1 | tail -100
 
+  test-multidb-e2e:
+    name: MultiDB E2E Tests (Per-Member Proxies)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - stable
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v7
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Start Docker services for MultiDB E2E tests
+        run: docker compose --profile multidb up -d
+
+      - name: Wait for services to be ready
+        run: |
+          echo "Waiting for Redis to be ready..."
+          timeout 30 bash -c 'until docker exec redis-standalone redis-cli ping 2>/dev/null; do sleep 1; done'
+          echo "Waiting for the per-member proxies to be ready..."
+          for port in 18120 18121 18122; do
+            timeout 30 bash -c "until curl -s http://localhost:$port/stats > /dev/null; do sleep 1; done"
+          done
+          echo "All services are ready!"
+
+      - name: Run MultiDB E2E tests
+        env:
+          E2E_MULTIDB_TESTS: "true"
+        run: |
+          go test -v -race -count=1 ./multidb/e2e/ -timeout 15m
+        continue-on-error: false
+
+      - name: Stop Docker services
+        if: always()
+        run: docker compose --profile multidb down
+
+      - name: Show Docker logs on failure
+        if: failure()
+        run: |
+          echo "=== Redis logs ==="
+          docker logs redis-standalone 2>&1 | tail -100
+          for c in cae-proxy-db0 cae-proxy-db1 cae-proxy-db2; do
+            echo "=== $c logs ==="
+            docker logs "$c" 2>&1 | tail -100
+          done
+

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -95,7 +95,7 @@ jobs:
         env:
           E2E_MULTIDB_TESTS: "true"
         run: |
-          go test -v -race -count=1 ./multidb/e2e/ -timeout 15m
+          go test -v -race -count=1 -timeout 15m ./multidb/e2e/...
         continue-on-error: false
 
       # Logs BEFORE the compose down below: `down` removes the containers,

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -98,10 +98,8 @@ jobs:
           go test -v -race -count=1 ./multidb/e2e/ -timeout 15m
         continue-on-error: false
 
-      - name: Stop Docker services
-        if: always()
-        run: docker compose --profile multidb down
-
+      # Logs BEFORE the compose down below: `down` removes the containers,
+      # which would leave the diagnostics step with nothing to read.
       - name: Show Docker logs on failure
         if: failure()
         run: |
@@ -111,4 +109,8 @@ jobs:
             echo "=== $c logs ==="
             docker logs "$c" 2>&1 | tail -100
           done
+
+      - name: Stop Docker services
+        if: always()
+        run: docker compose --profile multidb down
 

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,13 @@ test.e2e.docker:
 	$(MAKE) docker.e2e.stop
 	@echo "Docker E2E tests completed!"
 
+test.multidb.e2e:
+	@echo "Running MultiDB e2e tests (per-member proxies)..."
+	docker compose --profile multidb up -d
+	@E2E_MULTIDB_TESTS=true go test -v -race -count=1 -timeout 15m ./multidb/e2e/... || (docker compose --profile multidb down && exit 1)
+	docker compose --profile multidb down
+	@echo "MultiDB e2e tests completed!"
+
 test.e2e.logic:
 	@echo "Running E2E logic tests (no proxy required)..."
 	@E2E_SCENARIO_TESTS=true \

--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,10 @@ test.e2e.docker:
 
 test.multidb.e2e:
 	@echo "Running MultiDB e2e tests (per-member proxies)..."
-	docker compose --profile multidb up -d
+	docker compose --profile multidb up -d || (docker compose --profile multidb down && exit 1)
 	@echo "Waiting for the per-member proxies to be ready..."
 	@for port in 18120 18121 18122; do \
-		timeout 30 bash -c "until curl -s http://localhost:$$port/stats > /dev/null; do sleep 1; done" || (docker compose --profile multidb down && exit 1); \
+		timeout 30 bash -c "until curl -s http://127.0.0.1:$$port/stats > /dev/null; do sleep 1; done" || (docker compose --profile multidb down && exit 1); \
 	done
 	@E2E_MULTIDB_TESTS=true go test -v -race -count=1 -timeout 15m ./multidb/e2e/... || (docker compose --profile multidb down && exit 1)
 	docker compose --profile multidb down

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,10 @@ test.e2e.docker:
 test.multidb.e2e:
 	@echo "Running MultiDB e2e tests (per-member proxies)..."
 	docker compose --profile multidb up -d
+	@echo "Waiting for the per-member proxies to be ready..."
+	@for port in 18120 18121 18122; do \
+		timeout 30 bash -c "until curl -s http://localhost:$$port/stats > /dev/null; do sleep 1; done" || (docker compose --profile multidb down && exit 1); \
+	done
 	@E2E_MULTIDB_TESTS=true go test -v -race -count=1 -timeout 15m ./multidb/e2e/... || (docker compose --profile multidb down && exit 1)
 	docker compose --profile multidb down
 	@echo "MultiDB e2e tests completed!"

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ test.multidb.e2e:
 	docker compose --profile multidb up -d || (docker compose --profile multidb down && exit 1)
 	@echo "Waiting for the per-member proxies to be ready..."
 	@for port in 18120 18121 18122; do \
-		timeout 30 bash -c "until curl -s http://127.0.0.1:$$port/stats > /dev/null; do sleep 1; done" || (docker compose --profile multidb down && exit 1); \
+		timeout 30 bash -c "until curl -s http://127.0.0.1:$$port/stats > /dev/null; do sleep 1; done" || { docker compose --profile multidb down; exit 1; }; \
 	done
 	@E2E_MULTIDB_TESTS=true go test -v -race -count=1 -timeout 15m ./multidb/e2e/... || (docker compose --profile multidb down && exit 1)
 	docker compose --profile multidb down

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ test.e2e.logic:
 		go test -v -run "TestCreateTestFaultInjectorLogic|TestFaultInjectorClientCreation" ./maintnotifications/e2e/
 	@echo "Logic tests completed!"
 
-.PHONY: all test test.ci test.ci.skip-vectorsets test.autopipeline-subjects bench fmt test.e2e test.e2e.logic docker.e2e.start docker.e2e.stop
+.PHONY: all test test.ci test.ci.skip-vectorsets test.autopipeline-subjects bench fmt test.e2e test.e2e.logic test.multidb.e2e docker.e2e.start docker.e2e.stop
 
 build:
 	export RE_CLUSTER=$(RE_CLUSTER) && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - all-stack
       - all
       - e2e
+      - multidb
 
   osscluster:
     image: *default-image
@@ -42,6 +43,64 @@ services:
     profiles:
       - cluster
       - all-stack
+      - all
+
+  # Per-member RESP proxies for MultiDB (Active-Active) e2e tests. Each proxy
+  # is one "member database" endpoint; all front the same target Redis so data
+  # written through one member is visible through the others (a converged
+  # CRDB). Faults are injected at the container level (docker stop/pause).
+  cae-proxy-db0:
+    image: redislabs/client-resp-proxy:latest
+    container_name: cae-proxy-db0
+    environment:
+      - TARGET_HOST=redis
+      - TARGET_PORT=6379
+      - LISTEN_PORT=17100
+      - LISTEN_HOST=0.0.0.0
+      - API_PORT=3000
+    ports:
+      - "17100:17100"
+      - "18120:3000"
+    depends_on:
+      - redis
+    profiles:
+      - multidb
+      - all
+
+  cae-proxy-db1:
+    image: redislabs/client-resp-proxy:latest
+    container_name: cae-proxy-db1
+    environment:
+      - TARGET_HOST=redis
+      - TARGET_PORT=6379
+      - LISTEN_PORT=17101
+      - LISTEN_HOST=0.0.0.0
+      - API_PORT=3000
+    ports:
+      - "17101:17101"
+      - "18121:3000"
+    depends_on:
+      - redis
+    profiles:
+      - multidb
+      - all
+
+  cae-proxy-db2:
+    image: redislabs/client-resp-proxy:latest
+    container_name: cae-proxy-db2
+    environment:
+      - TARGET_HOST=redis
+      - TARGET_PORT=6379
+      - LISTEN_PORT=17102
+      - LISTEN_HOST=0.0.0.0
+      - API_PORT=3000
+    ports:
+      - "17102:17102"
+      - "18122:3000"
+    depends_on:
+      - redis
+    profiles:
+      - multidb
       - all
 
   cae-resp-proxy:

--- a/multidb/e2e/harness_test.go
+++ b/multidb/e2e/harness_test.go
@@ -145,6 +145,10 @@ func memberOptions(f *proxyFarm, i int) *redis.Options {
 		// Fail fast inside a single command attempt so MultiDB's own retry
 		// and failover logic drives recovery, not the per-client retries.
 		MaxRetries: -1,
+		// Let the probe context cut socket waits short: without this a
+		// paused (hung) proxy stalls health checks for the full read
+		// timeout instead of the intended HealthCheckTimeout.
+		ContextTimeoutEnabled: true,
 	}
 }
 

--- a/multidb/e2e/harness_test.go
+++ b/multidb/e2e/harness_test.go
@@ -122,6 +122,10 @@ func fastMultiDBOptions(f *proxyFarm) *redis.MultiDBOptions {
 			{Options: memberOptions(f, 1), Weight: 2},
 			{Options: memberOptions(f, 2), Weight: 1},
 		},
+		// Every proxy must be genuinely healthy at startup: with the default
+		// majority policy a mis-wired member could slip through and scenarios
+		// that stop member 0 would silently test the wrong topology.
+		InitialDBState:      redis.InitialDBStateAllAvailable,
 		HealthCheckInterval: 500 * time.Millisecond,
 		HealthCheckTimeout:  250 * time.Millisecond,
 		CircuitBreakerConfig: &redis.MultiDBCircuitBreakerConfig{

--- a/multidb/e2e/harness_test.go
+++ b/multidb/e2e/harness_test.go
@@ -30,9 +30,11 @@ func newProxyFarm(t *testing.T) *proxyFarm {
 	f := &proxyFarm{
 		t: t,
 		members: []memberProxy{
-			{Container: "cae-proxy-db0", Addr: "localhost:17100"},
-			{Container: "cae-proxy-db1", Addr: "localhost:17101"},
-			{Container: "cae-proxy-db2", Addr: "localhost:17102"},
+			// 127.0.0.1, not localhost: docker publishes on IPv4, and hosts
+			// that resolve localhost to ::1 first would dial the wrong stack.
+			{Container: "cae-proxy-db0", Addr: "127.0.0.1:17100"},
+			{Container: "cae-proxy-db1", Addr: "127.0.0.1:17101"},
+			{Container: "cae-proxy-db2", Addr: "127.0.0.1:17102"},
 		},
 	}
 	// Whatever a test did, the next one starts from "everything running".
@@ -72,13 +74,6 @@ func (f *proxyFarm) Pause(i int) {
 	f.t.Helper()
 	if err := f.docker("pause", f.members[i].Container); err != nil {
 		f.t.Fatalf("pause member %d: %v", i, err)
-	}
-}
-
-func (f *proxyFarm) Unpause(i int) {
-	f.t.Helper()
-	if err := f.docker("unpause", f.members[i].Container); err != nil {
-		f.t.Fatalf("unpause member %d: %v", i, err)
 	}
 }
 

--- a/multidb/e2e/harness_test.go
+++ b/multidb/e2e/harness_test.go
@@ -1,0 +1,162 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// memberProxy is one MultiDB member endpoint: a cae-resp-proxy container
+// fronting the shared target Redis.
+type memberProxy struct {
+	Container string
+	Addr      string
+}
+
+// proxyFarm drives the per-member proxy containers with docker CLI faults.
+type proxyFarm struct {
+	t       *testing.T
+	members []memberProxy
+}
+
+func newProxyFarm(t *testing.T) *proxyFarm {
+	t.Helper()
+	f := &proxyFarm{
+		t: t,
+		members: []memberProxy{
+			{Container: "cae-proxy-db0", Addr: "localhost:17100"},
+			{Container: "cae-proxy-db1", Addr: "localhost:17101"},
+			{Container: "cae-proxy-db2", Addr: "localhost:17102"},
+		},
+	}
+	// Whatever a test did, the next one starts from "everything running".
+	t.Cleanup(f.RestoreAll)
+	f.RestoreAll()
+	return f
+}
+
+func (f *proxyFarm) docker(args ...string) error {
+	out, err := exec.Command("docker", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker %v: %v: %s", args, err, out)
+	}
+	return nil
+}
+
+func (f *proxyFarm) Stop(i int) {
+	f.t.Helper()
+	if err := f.docker("stop", "-t", "0", f.members[i].Container); err != nil {
+		f.t.Fatalf("stop member %d: %v", i, err)
+	}
+}
+
+func (f *proxyFarm) Start(i int) {
+	f.t.Helper()
+	if err := f.docker("start", f.members[i].Container); err != nil {
+		f.t.Fatalf("start member %d: %v", i, err)
+	}
+	f.awaitListening(i, 30*time.Second)
+}
+
+func (f *proxyFarm) Pause(i int) {
+	f.t.Helper()
+	if err := f.docker("pause", f.members[i].Container); err != nil {
+		f.t.Fatalf("pause member %d: %v", i, err)
+	}
+}
+
+func (f *proxyFarm) Unpause(i int) {
+	f.t.Helper()
+	if err := f.docker("unpause", f.members[i].Container); err != nil {
+		f.t.Fatalf("unpause member %d: %v", i, err)
+	}
+}
+
+// RestoreAll brings every member back to a running, listening state.
+func (f *proxyFarm) RestoreAll() {
+	for i, m := range f.members {
+		// unpause fails when not paused, start is a no-op when running —
+		// ignore errors and verify by dialing.
+		_ = f.docker("unpause", m.Container)
+		_ = f.docker("start", m.Container)
+		f.awaitListening(i, 30*time.Second)
+	}
+}
+
+func (f *proxyFarm) awaitListening(i int, timeout time.Duration) {
+	f.t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", f.members[i].Addr, 250*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	f.t.Fatalf("member %d (%s) never came back up", i, f.members[i].Addr)
+}
+
+// fast timings so scenarios complete in seconds while staying CI-jitter safe.
+func fastMultiDBOptions(f *proxyFarm) *redis.MultiDBOptions {
+	return &redis.MultiDBOptions{
+		Clients: []redis.MultiDBClientConfig{
+			{Options: memberOptions(f, 0), Weight: 3},
+			{Options: memberOptions(f, 1), Weight: 2},
+			{Options: memberOptions(f, 2), Weight: 1},
+		},
+		HealthCheckInterval: 500 * time.Millisecond,
+		HealthCheckTimeout:  250 * time.Millisecond,
+		CircuitBreakerConfig: &redis.MultiDBCircuitBreakerConfig{
+			FailureThreshold: 3,
+			SuccessThreshold: 1,
+			GracePeriod:      2 * time.Second,
+		},
+		CommandRetries:       3,
+		AutoFallbackInterval: 3 * time.Second,
+		MaxFailoverAttempts:  4,
+		FailoverAttemptDelay: 500 * time.Millisecond,
+	}
+}
+
+func memberOptions(f *proxyFarm, i int) *redis.Options {
+	return &redis.Options{
+		Addr:         f.members[i].Addr,
+		DialTimeout:  500 * time.Millisecond,
+		ReadTimeout:  time.Second,
+		WriteTimeout: time.Second,
+		// Fail fast inside a single command attempt so MultiDB's own retry
+		// and failover logic drives recovery, not the per-client retries.
+		MaxRetries: -1,
+	}
+}
+
+func newE2EClient(t *testing.T, opts *redis.MultiDBOptions) *redis.MultiDBClient {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	mdb, err := redis.NewMultiDBClient(ctx, opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	t.Cleanup(func() { _ = mdb.Close() })
+	return mdb
+}
+
+// eventually polls cond until it is true or the timeout elapses.
+func eventually(t *testing.T, timeout time.Duration, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/multidb/e2e/harness_test.go
+++ b/multidb/e2e/harness_test.go
@@ -42,7 +42,11 @@ func newProxyFarm(t *testing.T) *proxyFarm {
 }
 
 func (f *proxyFarm) docker(args ...string) error {
-	out, err := exec.Command("docker", args...).CombinedOutput()
+	// Bounded: a stuck docker daemon must fail the scenario, not hang the
+	// whole suite until the package timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "docker", args...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("docker %v: %v: %s", args, err, out)
 	}

--- a/multidb/e2e/harness_test.go
+++ b/multidb/e2e/harness_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -80,12 +81,19 @@ func (f *proxyFarm) Unpause(i int) {
 // RestoreAll brings every member back to a running, listening state.
 func (f *proxyFarm) RestoreAll() {
 	for i, m := range f.members {
-		// unpause fails when not paused, start is a no-op when running —
-		// ignore errors and verify by dialing.
-		_ = f.docker("unpause", m.Container)
+		// unpause fails when not paused and start is a no-op when running —
+		// those are benign. A missing container means the compose profile is
+		// not up: fail fast instead of a 30s dial timeout per member.
+		if err := f.docker("unpause", m.Container); err != nil && isMissingContainer(err) {
+			f.t.Fatalf("proxy container %s does not exist — start the stack with `docker compose --profile multidb up -d`: %v", m.Container, err)
+		}
 		_ = f.docker("start", m.Container)
 		f.awaitListening(i, 30*time.Second)
 	}
+}
+
+func isMissingContainer(err error) bool {
+	return strings.Contains(err.Error(), "No such container")
 }
 
 func (f *proxyFarm) awaitListening(i int, timeout time.Duration) {

--- a/multidb/e2e/harness_test.go
+++ b/multidb/e2e/harness_test.go
@@ -85,19 +85,33 @@ func (f *proxyFarm) Unpause(i int) {
 // RestoreAll brings every member back to a running, listening state.
 func (f *proxyFarm) RestoreAll() {
 	for i, m := range f.members {
-		// unpause fails when not paused and start is a no-op when running —
-		// those are benign. A missing container means the compose profile is
-		// not up: fail fast instead of a 30s dial timeout per member.
-		if err := f.docker("unpause", m.Container); err != nil && isMissingContainer(err) {
-			f.t.Fatalf("proxy container %s does not exist — start the stack with `docker compose --profile multidb up -d`: %v", m.Container, err)
+		// Only "is not paused" is benign for unpause (start below is a no-op
+		// when already running). A missing container means the compose
+		// profile is not up: fail fast instead of a 30s dial timeout per
+		// member. Any other unpause failure could leave the member frozen —
+		// a paused container still accepts TCP dials, so awaitListening
+		// would not catch it.
+		if err := f.docker("unpause", m.Container); err != nil {
+			switch {
+			case isMissingContainer(err):
+				f.t.Fatalf("proxy container %s does not exist — start the stack with `docker compose --profile multidb up -d`: %v", m.Container, err)
+			case !isNotPaused(err):
+				f.t.Fatalf("unpause %s: %v", m.Container, err)
+			}
 		}
-		_ = f.docker("start", m.Container)
+		if err := f.docker("start", m.Container); err != nil {
+			f.t.Fatalf("start %s: %v", m.Container, err)
+		}
 		f.awaitListening(i, 30*time.Second)
 	}
 }
 
 func isMissingContainer(err error) bool {
 	return strings.Contains(err.Error(), "No such container")
+}
+
+func isNotPaused(err error) bool {
+	return strings.Contains(err.Error(), "is not paused")
 }
 
 func (f *proxyFarm) awaitListening(i int, timeout time.Duration) {

--- a/multidb/e2e/main_test.go
+++ b/multidb/e2e/main_test.go
@@ -10,14 +10,15 @@
 package e2e
 
 import (
-	"log"
 	"os"
 	"testing"
 )
 
 func TestMain(m *testing.M) {
 	if os.Getenv("E2E_MULTIDB_TESTS") != "true" {
-		log.Println("Skipping MultiDB e2e tests, E2E_MULTIDB_TESTS is not set")
+		// Silent gated skip: the suite only runs when explicitly requested
+		// (make test.multidb.e2e), and direct logging is against repository
+		// conventions.
 		os.Exit(0)
 	}
 	os.Exit(m.Run())

--- a/multidb/e2e/main_test.go
+++ b/multidb/e2e/main_test.go
@@ -1,0 +1,24 @@
+// Package e2e contains end-to-end tests for redis.MultiDBClient driven by
+// per-member RESP proxies (docker-compose profile "multidb"). Member outages
+// are injected at the container level: docker stop (connection reset /
+// refused) and docker pause (hung connections / timeouts).
+//
+// Run via `make test.multidb.e2e`, or manually:
+//
+//	docker compose --profile multidb up -d
+//	E2E_MULTIDB_TESTS=true go test -race ./multidb/e2e/...
+package e2e
+
+import (
+	"log"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("E2E_MULTIDB_TESTS") != "true" {
+		log.Println("Skipping MultiDB e2e tests, E2E_MULTIDB_TESTS is not set")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/multidb/e2e/scenarios_test.go
+++ b/multidb/e2e/scenarios_test.go
@@ -124,8 +124,15 @@ func TestEscalationWhenAllMembersDown(t *testing.T) {
 		return errors.Is(mdb.Set(ctx, "e2e:esc", "x", 0).Err(), redis.ErrTemporarilyNotAvailable)
 	})
 	farm.Start(1)
+	// Recovery must complete WITHIN the temporary phase: reaching the
+	// terminal error while a member is already back means the attempt
+	// budget was exhausted during the documented keep-retrying window.
 	eventually(t, 20*time.Second, "recovery during the temporary phase", func() bool {
-		return mdb.Set(ctx, "e2e:esc", "y", 0).Err() == nil
+		err := mdb.Set(ctx, "e2e:esc", "y", 0).Err()
+		if errors.Is(err, redis.ErrPermanentlyNotAvailable) {
+			t.Fatalf("escalated to permanent during the temporary-phase recovery window")
+		}
+		return err == nil
 	})
 
 	// Phase 2 — escalation to the terminal error: with everything down

--- a/multidb/e2e/scenarios_test.go
+++ b/multidb/e2e/scenarios_test.go
@@ -1,0 +1,205 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// TestFailoverOnMemberOutage: traffic on the active member, then a hard stop.
+// Commands must keep succeeding via the next-weight member.
+// Spec: test_standalone_connection_failover.
+func TestFailoverOnMemberOutage(t *testing.T) {
+	farm := newProxyFarm(t)
+	opts := fastMultiDBOptions(farm)
+
+	var failoverFrom, failoverTo atomic.Int32
+	failoverFrom.Store(-1)
+	failoverTo.Store(-1)
+	opts.OnFailover = func(_ context.Context, from, to int) {
+		failoverFrom.Store(int32(from))
+		failoverTo.Store(int32(to))
+	}
+
+	mdb := newE2EClient(t, opts)
+	ctx := context.Background()
+
+	if got := mdb.ActiveIndex(); got != 0 {
+		t.Fatalf("initial active = %d, want 0 (highest weight)", got)
+	}
+	if err := mdb.Set(ctx, "e2e:failover", "before", 0).Err(); err != nil {
+		t.Fatalf("Set before outage: %v", err)
+	}
+
+	farm.Stop(0)
+
+	// Keep issuing commands; they must succeed again once failover lands.
+	eventually(t, 15*time.Second, "commands succeeding on the new active", func() bool {
+		return mdb.Set(ctx, "e2e:failover", "after", 0).Err() == nil && mdb.ActiveIndex() == 1
+	})
+
+	// Same backend behind every proxy: data written before the outage is
+	// visible through the new member (converged-CRDB approximation).
+	val, err := mdb.Get(ctx, "e2e:failover").Result()
+	if err != nil || val != "after" {
+		t.Fatalf("Get after failover: %q, %v", val, err)
+	}
+	if failoverTo.Load() != 1 {
+		t.Errorf("OnFailover to = %d, want 1", failoverTo.Load())
+	}
+}
+
+// TestBackgroundDrivenFailover: NO command traffic; a paused (hung) active
+// member must be detected by the background health checks alone.
+// Spec: Q1/D2 — background-driven failover.
+func TestBackgroundDrivenFailover(t *testing.T) {
+	farm := newProxyFarm(t)
+	mdb := newE2EClient(t, fastMultiDBOptions(farm))
+
+	farm.Pause(0)
+
+	eventually(t, 15*time.Second, "background failover with zero traffic", func() bool {
+		return mdb.ActiveIndex() == 1
+	})
+}
+
+// TestAutoFallbackToHigherWeight: after the highest-weight member recovers,
+// the client must switch back without operator action.
+// Spec: test_automatic_fallback.
+func TestAutoFallbackToHigherWeight(t *testing.T) {
+	farm := newProxyFarm(t)
+	mdb := newE2EClient(t, fastMultiDBOptions(farm))
+	ctx := context.Background()
+
+	farm.Stop(0)
+	eventually(t, 15*time.Second, "failover away from member 0", func() bool {
+		return mdb.Set(ctx, "e2e:fallback", "x", 0).Err() == nil && mdb.ActiveIndex() != 0
+	})
+
+	farm.Start(0)
+	// Recovery: grace period (2s) + health checks close the circuit +
+	// fallback interval (3s).
+	eventually(t, 30*time.Second, "fallback to the recovered member 0", func() bool {
+		return mdb.ActiveIndex() == 0
+	})
+	if err := mdb.Get(ctx, "e2e:fallback").Err(); err != nil {
+		t.Fatalf("Get after fallback: %v", err)
+	}
+}
+
+// TestEscalationWhenAllMembersDown: with every member stopped the client
+// reports temporary unavailability, then permanent after the attempt budget;
+// restarting a member during the temporary phase recovers.
+// Spec: test_all_databases_unreachable_error + escalation chain.
+func TestEscalationWhenAllMembersDown(t *testing.T) {
+	farm := newProxyFarm(t)
+	mdb := newE2EClient(t, fastMultiDBOptions(farm))
+	ctx := context.Background()
+
+	farm.Stop(0)
+	farm.Stop(1)
+	farm.Stop(2)
+
+	sawTemporary := false
+	eventually(t, 20*time.Second, "unavailability error surfacing", func() bool {
+		err := mdb.Set(ctx, "e2e:esc", "x", 0).Err()
+		if errors.Is(err, redis.ErrTemporarilyNotAvailable) {
+			sawTemporary = true
+			return true
+		}
+		return errors.Is(err, redis.ErrPermanentlyNotAvailable)
+	})
+	if !sawTemporary {
+		t.Log("note: escalated straight to permanent (attempt budget consumed by background loop)")
+	}
+
+	// Recovery: one member back is enough for one_available-style operation.
+	farm.Start(1)
+	eventually(t, 20*time.Second, "recovery after restart of member 1", func() bool {
+		return mdb.Set(ctx, "e2e:esc", "y", 0).Err() == nil
+	})
+}
+
+// TestManualFailover: SetActiveIndex refuses a stopped member with
+// ErrTargetUnhealthy; ForceActiveIndex switches unconditionally.
+// Spec: test_manual_failover_trigger / test_manual_failover_unhealthy_target.
+func TestManualFailover(t *testing.T) {
+	farm := newProxyFarm(t)
+	mdb := newE2EClient(t, fastMultiDBOptions(farm))
+	ctx := context.Background()
+
+	farm.Stop(2)
+
+	if err := mdb.SetActiveIndex(ctx, 2); !errors.Is(err, redis.ErrTargetUnhealthy) {
+		t.Fatalf("SetActiveIndex to stopped member: err = %v, want ErrTargetUnhealthy", err)
+	}
+	if got := mdb.ActiveIndex(); got != 0 {
+		t.Fatalf("active moved to %d after refused manual switch", got)
+	}
+
+	// Healthy target: probe-then-switch succeeds.
+	if err := mdb.SetActiveIndex(ctx, 1); err != nil {
+		t.Fatalf("SetActiveIndex to healthy member: %v", err)
+	}
+	if got := mdb.ActiveIndex(); got != 1 {
+		t.Fatalf("active = %d, want 1", got)
+	}
+
+	// Force onto the dead member: allowed, and the next commands drive an
+	// automatic failover away again.
+	if err := mdb.ForceActiveIndex(ctx, 2); err != nil {
+		t.Fatalf("ForceActiveIndex: %v", err)
+	}
+	eventually(t, 15*time.Second, "automatic failover away from the forced dead member", func() bool {
+		return mdb.Set(ctx, "e2e:manual", "x", 0).Err() == nil && mdb.ActiveIndex() != 2
+	})
+}
+
+// TestPubSubFollowsActive: a subscription created through the MultiDB client
+// keeps receiving messages after the active member dies, by re-dialing the
+// new active member.
+func TestPubSubFollowsActive(t *testing.T) {
+	farm := newProxyFarm(t)
+	mdb := newE2EClient(t, fastMultiDBOptions(farm))
+	ctx := context.Background()
+
+	sub := mdb.Subscribe(ctx, "e2e:channel")
+	t.Cleanup(func() { _ = sub.Close() })
+	if _, err := sub.Receive(ctx); err != nil { // wait for the subscription
+		t.Fatalf("subscribe receive: %v", err)
+	}
+	msgs := sub.Channel()
+
+	// Publisher through a member that stays alive (same backend bus).
+	pub := redis.NewClient(memberOptions(farm, 2))
+	t.Cleanup(func() { _ = pub.Close() })
+
+	publishUntilReceived := func(tag string) {
+		t.Helper()
+		deadline := time.Now().Add(20 * time.Second)
+		for time.Now().Before(deadline) {
+			_ = pub.Publish(ctx, "e2e:channel", tag).Err()
+			select {
+			case m := <-msgs:
+				if m.Payload == tag {
+					return
+				}
+			case <-time.After(250 * time.Millisecond):
+			}
+		}
+		t.Fatalf("message %q never received", tag)
+	}
+
+	publishUntilReceived("before-failover")
+
+	farm.Stop(0)
+	eventually(t, 15*time.Second, "failover away from member 0", func() bool {
+		return mdb.ActiveIndex() != 0
+	})
+
+	publishUntilReceived("after-failover")
+}

--- a/multidb/e2e/scenarios_test.go
+++ b/multidb/e2e/scenarios_test.go
@@ -109,7 +109,13 @@ func TestAutoFallbackToHigherWeight(t *testing.T) {
 // Spec: test_all_databases_unreachable_error + escalation chain.
 func TestEscalationWhenAllMembersDown(t *testing.T) {
 	farm := newProxyFarm(t)
-	mdb := newE2EClient(t, fastMultiDBOptions(farm))
+	opts := fastMultiDBOptions(farm)
+	// A larger attempt budget than the harness default: the temporary phase
+	// must comfortably outlast a docker start (~1-2s), or the strict
+	// no-permanent-during-recovery assertion below flakes on the legitimate
+	// budget-exhaustion boundary (4 x 500ms was too tight).
+	opts.MaxFailoverAttempts = 10
+	mdb := newE2EClient(t, opts)
 	ctx := context.Background()
 
 	farm.Stop(0)
@@ -354,8 +360,10 @@ func TestSetWeightSteersFallback(t *testing.T) {
 	ctx := context.Background()
 
 	farm.Stop(0)
-	eventually(t, 15*time.Second, "failover away from member 0", func() bool {
-		return mdb.Set(ctx, "e2e:weight", "x", 0).Err() == nil && mdb.ActiveIndex() != 0
+	// The failover must land on member 1 (next weight): only then does the
+	// later switch to member 2 prove the runtime weight change steered it.
+	eventually(t, 15*time.Second, "failover to member 1", func() bool {
+		return mdb.Set(ctx, "e2e:weight", "x", 0).Err() == nil && mdb.ActiveIndex() == 1
 	})
 
 	// Member 2 becomes the heaviest healthy member: the next fallback pass

--- a/multidb/e2e/scenarios_test.go
+++ b/multidb/e2e/scenarios_test.go
@@ -48,8 +48,8 @@ func TestFailoverOnMemberOutage(t *testing.T) {
 	if err != nil || val != "after" {
 		t.Fatalf("Get after failover: %q, %v", val, err)
 	}
-	if failoverTo.Load() != 1 {
-		t.Errorf("OnFailover to = %d, want 1", failoverTo.Load())
+	if failoverFrom.Load() != 0 || failoverTo.Load() != 1 {
+		t.Errorf("OnFailover(from=%d, to=%d), want (0, 1)", failoverFrom.Load(), failoverTo.Load())
 	}
 }
 
@@ -182,7 +182,11 @@ func TestPubSubFollowsActive(t *testing.T) {
 		t.Helper()
 		deadline := time.Now().Add(20 * time.Second)
 		for time.Now().Before(deadline) {
-			_ = pub.Publish(ctx, "e2e:channel", tag).Err()
+			if err := pub.Publish(ctx, "e2e:channel", tag).Err(); err != nil {
+				// The publisher uses a member that stays up; a publish error
+				// is a real problem, not an expected failover artifact.
+				t.Logf("publish error (will retry): %v", err)
+			}
 			select {
 			case m := <-msgs:
 				if m.Payload == tag {

--- a/multidb/e2e/scenarios_test.go
+++ b/multidb/e2e/scenarios_test.go
@@ -3,6 +3,8 @@ package e2e
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -243,4 +245,210 @@ func TestPubSubFollowsActive(t *testing.T) {
 	})
 
 	publishUntilReceived("after-failover")
+}
+
+// TestPSubscribeFollowsActive: the pattern-subscription variant of the test
+// above — psubscriptions must survive an active-member outage too.
+func TestPSubscribeFollowsActive(t *testing.T) {
+	farm := newProxyFarm(t)
+	mdb := newE2EClient(t, fastMultiDBOptions(farm))
+	ctx := context.Background()
+
+	sub := mdb.PSubscribe(ctx, "e2e:pat:*")
+	t.Cleanup(func() { _ = sub.Close() })
+	rctx, rcancel := context.WithTimeout(ctx, 10*time.Second)
+	_, err := sub.Receive(rctx)
+	rcancel()
+	if err != nil {
+		t.Fatalf("psubscribe receive: %v", err)
+	}
+	msgs := sub.Channel()
+
+	pub := redis.NewClient(memberOptions(farm, 2))
+	t.Cleanup(func() { _ = pub.Close() })
+
+	publishUntilReceived := func(tag string) {
+		t.Helper()
+		deadline := time.Now().Add(20 * time.Second)
+		for time.Now().Before(deadline) {
+			if err := pub.Publish(ctx, "e2e:pat:1", tag).Err(); err != nil {
+				t.Logf("publish error (will retry): %v", err)
+			}
+			select {
+			case m := <-msgs:
+				if m.Payload == tag {
+					return
+				}
+			case <-time.After(250 * time.Millisecond):
+			}
+		}
+		t.Fatalf("message %q never received", tag)
+	}
+
+	publishUntilReceived("pat-before-failover")
+
+	farm.Stop(0)
+	eventually(t, 15*time.Second, "failover away from member 0", func() bool {
+		return mdb.ActiveIndex() != 0
+	})
+
+	publishUntilReceived("pat-after-failover")
+}
+
+// TestRuntimeMembershipUnderFaults: a member added at runtime must be a real
+// failover target, and removing a (stopped, passive) member must keep the
+// shifted indexes coherent.
+// Spec: test_add_remove_database at runtime.
+func TestRuntimeMembershipUnderFaults(t *testing.T) {
+	farm := newProxyFarm(t)
+	opts := fastMultiDBOptions(farm)
+	opts.Clients = opts.Clients[:2] // start with members 0 and 1 only
+	mdb := newE2EClient(t, opts)
+	ctx := context.Background()
+
+	idx, err := mdb.AddDatabase(ctx, redis.MultiDBClientConfig{
+		Options: memberOptions(farm, 2),
+		Weight:  1,
+	})
+	if err != nil {
+		t.Fatalf("AddDatabase: %v", err)
+	}
+	if idx != 2 {
+		t.Fatalf("AddDatabase index = %d, want 2", idx)
+	}
+
+	// With both original members down, traffic must land on the member that
+	// only ever existed at runtime.
+	farm.Stop(0)
+	farm.Stop(1)
+	eventually(t, 20*time.Second, "commands succeeding on the runtime-added member", func() bool {
+		return mdb.Set(ctx, "e2e:member", "x", 0).Err() == nil && mdb.ActiveIndex() == 2
+	})
+
+	// Removing the stopped, passive member 0 shifts the slice; the active
+	// member keeps serving under its new index.
+	if err := mdb.RemoveDatabase(ctx, 0); err != nil {
+		t.Fatalf("RemoveDatabase: %v", err)
+	}
+	if got := mdb.ActiveIndex(); got != 1 {
+		t.Fatalf("active index after removal = %d, want 1 (shifted)", got)
+	}
+	if err := mdb.Set(ctx, "e2e:member", "y", 0).Err(); err != nil {
+		t.Fatalf("Set after removal: %v", err)
+	}
+}
+
+// TestSetWeightSteersFallback: a runtime weight change must redirect
+// auto-fallback to the new heaviest healthy member.
+// Spec: test_set_weight + auto-fallback interaction.
+func TestSetWeightSteersFallback(t *testing.T) {
+	farm := newProxyFarm(t)
+	mdb := newE2EClient(t, fastMultiDBOptions(farm))
+	ctx := context.Background()
+
+	farm.Stop(0)
+	eventually(t, 15*time.Second, "failover away from member 0", func() bool {
+		return mdb.Set(ctx, "e2e:weight", "x", 0).Err() == nil && mdb.ActiveIndex() != 0
+	})
+
+	// Member 2 becomes the heaviest healthy member: the next fallback pass
+	// must switch to it — not back toward the (still dead) member 0.
+	if err := mdb.SetWeight(2, 10); err != nil {
+		t.Fatalf("SetWeight: %v", err)
+	}
+	eventually(t, 30*time.Second, "fallback to the re-weighted member 2", func() bool {
+		return mdb.ActiveIndex() == 2
+	})
+	if err := mdb.Get(ctx, "e2e:weight").Err(); err != nil {
+		t.Fatalf("Get on the re-weighted member: %v", err)
+	}
+}
+
+// TestConcurrentTrafficAcrossFailover: parallel writers must all converge on
+// the new active member after an outage — no goroutine may be left behind on
+// a stale snapshot or wedged on the dead member.
+func TestConcurrentTrafficAcrossFailover(t *testing.T) {
+	farm := newProxyFarm(t)
+	mdb := newE2EClient(t, fastMultiDBOptions(farm))
+	ctx := context.Background()
+
+	const workers = 8
+	var stop atomic.Bool
+	var postFailover [workers]atomic.Int64
+	var wg sync.WaitGroup
+	for g := 0; g < workers; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			key := fmt.Sprintf("e2e:conc:%d", g)
+			for !stop.Load() {
+				if err := mdb.Set(ctx, key, "v", 0).Err(); err == nil && mdb.ActiveIndex() == 1 {
+					postFailover[g].Add(1)
+				}
+				time.Sleep(20 * time.Millisecond)
+			}
+		}(g)
+	}
+
+	time.Sleep(time.Second) // steady-state traffic on member 0 first
+	farm.Stop(0)
+
+	eventually(t, 20*time.Second, "every worker succeeding on the new active", func() bool {
+		for g := range postFailover {
+			if postFailover[g].Load() < 5 {
+				return false
+			}
+		}
+		return true
+	})
+	stop.Store(true)
+	wg.Wait()
+}
+
+// TestInitialAllAvailableRefusesDownMember: with the all_available policy and
+// no init deadline, a down member must fail construction immediately.
+// Spec: test_initialization_with_unavailable_database.
+func TestInitialAllAvailableRefusesDownMember(t *testing.T) {
+	farm := newProxyFarm(t)
+	farm.Stop(2)
+
+	opts := fastMultiDBOptions(farm)
+	mdb, err := redis.NewMultiDBClient(context.Background(), opts) // no deadline: single pass
+	if err == nil {
+		_ = mdb.Close()
+		t.Fatal("NewMultiDBClient succeeded with a down member under all_available")
+	}
+	if !errors.Is(err, redis.ErrInsufficientHealthyDatabases) {
+		t.Fatalf("err = %v, want ErrInsufficientHealthyDatabases", err)
+	}
+}
+
+// TestFailoverCallbacksObserved: an outage-driven failover must surface both
+// the active-change callback and the breaker-open callback for the dead
+// member.
+func TestFailoverCallbacksObserved(t *testing.T) {
+	farm := newProxyFarm(t)
+	var activeChanged, circuitOpened atomic.Bool
+	opts := fastMultiDBOptions(farm)
+	opts.OnActiveDatabaseChanged = func(from, to int) {
+		if from == 0 && to == 1 {
+			activeChanged.Store(true)
+		}
+	}
+	opts.OnCircuitStateChanged = func(dbIndex int, from, to string) {
+		if dbIndex == 0 && to == "open" {
+			circuitOpened.Store(true)
+		}
+	}
+	mdb := newE2EClient(t, opts)
+	ctx := context.Background()
+
+	farm.Stop(0)
+	eventually(t, 15*time.Second, "failover away from member 0", func() bool {
+		return mdb.Set(ctx, "e2e:cb", "x", 0).Err() == nil && mdb.ActiveIndex() == 1
+	})
+	// Both callbacks are delivered asynchronously — poll.
+	eventually(t, 5*time.Second, "failover callbacks", func() bool {
+		return activeChanged.Load() && circuitOpened.Load()
+	})
 }

--- a/multidb/e2e/scenarios_test.go
+++ b/multidb/e2e/scenarios_test.go
@@ -56,9 +56,11 @@ func TestFailoverOnMemberOutage(t *testing.T) {
 	if err != nil || val != "after" {
 		t.Fatalf("Get after failover: %q, %v", val, err)
 	}
-	if failoverFrom.Load() != 0 || failoverTo.Load() != 1 {
-		t.Errorf("OnFailover(from=%d, to=%d), want (0, 1)", failoverFrom.Load(), failoverTo.Load())
-	}
+	// The callback runs after the active index is published (announce fires
+	// outside the failover lock), so poll rather than assert immediately.
+	eventually(t, 5*time.Second, "OnFailover(0 -> 1) callback", func() bool {
+		return failoverFrom.Load() == 0 && failoverTo.Load() == 1
+	})
 }
 
 // TestBackgroundDrivenFailover: NO command traffic; a paused (hung) active
@@ -124,7 +126,9 @@ func TestEscalationWhenAllMembersDown(t *testing.T) {
 		return errors.Is(err, redis.ErrPermanentlyNotAvailable)
 	})
 	if !sawTemporary {
-		t.Log("note: escalated straight to permanent (attempt budget consumed by background loop)")
+		// The escalation contract is temporary-then-permanent; skipping the
+		// temporary phase means callers never got the "keep retrying" signal.
+		t.Error("escalated straight to permanent without ever reporting ErrTemporarilyNotAvailable")
 	}
 
 	// Recovery: one member back is enough for one_available-style operation.

--- a/multidb/e2e/scenarios_test.go
+++ b/multidb/e2e/scenarios_test.go
@@ -37,6 +37,14 @@ func TestFailoverOnMemberOutage(t *testing.T) {
 
 	farm.Stop(0)
 
+	// The value written through member 0 must be visible through the new
+	// active member BEFORE this test overwrites it (shared backend behind
+	// every proxy ≈ a converged CRDB).
+	eventually(t, 15*time.Second, "pre-failover data visible via the new active", func() bool {
+		val, err := mdb.Get(ctx, "e2e:failover").Result()
+		return err == nil && val == "before" && mdb.ActiveIndex() == 1
+	})
+
 	// Keep issuing commands; they must succeed again once failover lands.
 	eventually(t, 15*time.Second, "commands succeeding on the new active", func() bool {
 		return mdb.Set(ctx, "e2e:failover", "after", 0).Err() == nil && mdb.ActiveIndex() == 1

--- a/multidb/e2e/scenarios_test.go
+++ b/multidb/e2e/scenarios_test.go
@@ -104,12 +104,14 @@ func TestEscalationWhenAllMembersDown(t *testing.T) {
 	farm.Stop(1)
 	farm.Stop(2)
 
+	// Keep polling until the escalation reaches the terminal error: stopping
+	// at the first temporary error would let a regression that never
+	// increments the attempt budget pass unnoticed.
 	sawTemporary := false
-	eventually(t, 20*time.Second, "unavailability error surfacing", func() bool {
+	eventually(t, 30*time.Second, "escalation to permanent unavailability", func() bool {
 		err := mdb.Set(ctx, "e2e:esc", "x", 0).Err()
 		if errors.Is(err, redis.ErrTemporarilyNotAvailable) {
 			sawTemporary = true
-			return true
 		}
 		return errors.Is(err, redis.ErrPermanentlyNotAvailable)
 	})
@@ -169,7 +171,12 @@ func TestPubSubFollowsActive(t *testing.T) {
 
 	sub := mdb.Subscribe(ctx, "e2e:channel")
 	t.Cleanup(func() { _ = sub.Close() })
-	if _, err := sub.Receive(ctx); err != nil { // wait for the subscription
+	// Bound the subscription handshake: a hung proxy must fail the scenario
+	// promptly, not stall until the package timeout.
+	rctx, rcancel := context.WithTimeout(ctx, 10*time.Second)
+	_, err := sub.Receive(rctx)
+	rcancel()
+	if err != nil {
 		t.Fatalf("subscribe receive: %v", err)
 	}
 	msgs := sub.Channel()

--- a/multidb/e2e/scenarios_test.go
+++ b/multidb/e2e/scenarios_test.go
@@ -114,9 +114,22 @@ func TestEscalationWhenAllMembersDown(t *testing.T) {
 	farm.Stop(1)
 	farm.Stop(2)
 
-	// Keep polling until the escalation reaches the terminal error: stopping
-	// at the first temporary error would let a regression that never
-	// increments the attempt budget pass unnoticed.
+	// Phase 1 — temporary unavailability, and recovery FROM the temporary
+	// phase: "temporary" promises callers that retrying can still succeed,
+	// so a member restarted during it must bring the client back without
+	// ever reaching the terminal error.
+	eventually(t, 20*time.Second, "temporary unavailability with all members down", func() bool {
+		return errors.Is(mdb.Set(ctx, "e2e:esc", "x", 0).Err(), redis.ErrTemporarilyNotAvailable)
+	})
+	farm.Start(1)
+	eventually(t, 20*time.Second, "recovery during the temporary phase", func() bool {
+		return mdb.Set(ctx, "e2e:esc", "y", 0).Err() == nil
+	})
+
+	// Phase 2 — escalation to the terminal error: with everything down
+	// again, the attempt budget must run out and report permanent
+	// unavailability (observing the temporary phase again on the way).
+	farm.Stop(1)
 	sawTemporary := false
 	eventually(t, 30*time.Second, "escalation to permanent unavailability", func() bool {
 		err := mdb.Set(ctx, "e2e:esc", "x", 0).Err()
@@ -131,7 +144,8 @@ func TestEscalationWhenAllMembersDown(t *testing.T) {
 		t.Error("escalated straight to permanent without ever reporting ErrTemporarilyNotAvailable")
 	}
 
-	// Recovery: one member back is enough for one_available-style operation.
+	// Recovery: one member back is enough for one_available-style operation
+	// even after the terminal error was reported.
 	farm.Start(1)
 	eventually(t, 20*time.Second, "recovery after restart of member 1", func() bool {
 		return mdb.Set(ctx, "e2e:esc", "y", 0).Err() == nil

--- a/multidb/e2e/scenarios_test.go
+++ b/multidb/e2e/scenarios_test.go
@@ -30,7 +30,7 @@ func TestFailoverOnMemberOutage(t *testing.T) {
 	mdb := newE2EClient(t, opts)
 	ctx := context.Background()
 
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Fatalf("initial active = %d, want 0 (highest weight)", got)
 	}
 	if err := mdb.Set(ctx, "e2e:failover", "before", 0).Err(); err != nil {
@@ -44,12 +44,12 @@ func TestFailoverOnMemberOutage(t *testing.T) {
 	// every proxy ≈ a converged CRDB).
 	eventually(t, 15*time.Second, "pre-failover data visible via the new active", func() bool {
 		val, err := mdb.Get(ctx, "e2e:failover").Result()
-		return err == nil && val == "before" && mdb.ActiveIndex() == 1
+		return err == nil && val == "before" && mdb.ActiveDatabaseID() == 1
 	})
 
 	// Keep issuing commands; they must succeed again once failover lands.
 	eventually(t, 15*time.Second, "commands succeeding on the new active", func() bool {
-		return mdb.Set(ctx, "e2e:failover", "after", 0).Err() == nil && mdb.ActiveIndex() == 1
+		return mdb.Set(ctx, "e2e:failover", "after", 0).Err() == nil && mdb.ActiveDatabaseID() == 1
 	})
 
 	// Same backend behind every proxy: data written before the outage is
@@ -58,7 +58,7 @@ func TestFailoverOnMemberOutage(t *testing.T) {
 	if err != nil || val != "after" {
 		t.Fatalf("Get after failover: %q, %v", val, err)
 	}
-	// The callback runs after the active index is published (announce fires
+	// The callback runs after the active id is published (announce fires
 	// outside the failover lock), so poll rather than assert immediately.
 	eventually(t, 5*time.Second, "OnFailover(0 -> 1) callback", func() bool {
 		return failoverFrom.Load() == 0 && failoverTo.Load() == 1
@@ -75,7 +75,7 @@ func TestBackgroundDrivenFailover(t *testing.T) {
 	farm.Pause(0)
 
 	eventually(t, 15*time.Second, "background failover with zero traffic", func() bool {
-		return mdb.ActiveIndex() == 1
+		return mdb.ActiveDatabaseID() == 1
 	})
 }
 
@@ -89,14 +89,14 @@ func TestAutoFallbackToHigherWeight(t *testing.T) {
 
 	farm.Stop(0)
 	eventually(t, 15*time.Second, "failover away from member 0", func() bool {
-		return mdb.Set(ctx, "e2e:fallback", "x", 0).Err() == nil && mdb.ActiveIndex() != 0
+		return mdb.Set(ctx, "e2e:fallback", "x", 0).Err() == nil && mdb.ActiveDatabaseID() != 0
 	})
 
 	farm.Start(0)
 	// Recovery: grace period (2s) + health checks close the circuit +
 	// fallback interval (3s).
 	eventually(t, 30*time.Second, "fallback to the recovered member 0", func() bool {
-		return mdb.ActiveIndex() == 0
+		return mdb.ActiveDatabaseID() == 0
 	})
 	if err := mdb.Get(ctx, "e2e:fallback").Err(); err != nil {
 		t.Fatalf("Get after fallback: %v", err)
@@ -167,8 +167,8 @@ func TestEscalationWhenAllMembersDown(t *testing.T) {
 	})
 }
 
-// TestManualFailover: SetActiveIndex refuses a stopped member with
-// ErrTargetUnhealthy; ForceActiveIndex switches unconditionally.
+// TestManualFailover: SetActiveDatabase refuses a stopped member with
+// ErrTargetUnhealthy; ForceActiveDatabase switches unconditionally.
 // Spec: test_manual_failover_trigger / test_manual_failover_unhealthy_target.
 func TestManualFailover(t *testing.T) {
 	farm := newProxyFarm(t)
@@ -177,32 +177,32 @@ func TestManualFailover(t *testing.T) {
 
 	farm.Stop(2)
 
-	if err := mdb.SetActiveIndex(ctx, 2); !errors.Is(err, redis.ErrTargetUnhealthy) {
-		t.Fatalf("SetActiveIndex to stopped member: err = %v, want ErrTargetUnhealthy", err)
+	if err := mdb.SetActiveDatabase(ctx, 2); !errors.Is(err, redis.ErrTargetUnhealthy) {
+		t.Fatalf("SetActiveDatabase to stopped member: err = %v, want ErrTargetUnhealthy", err)
 	}
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Fatalf("active moved to %d after refused manual switch", got)
 	}
 
 	// Healthy target: probe-then-switch succeeds.
-	if err := mdb.SetActiveIndex(ctx, 1); err != nil {
-		t.Fatalf("SetActiveIndex to healthy member: %v", err)
+	if err := mdb.SetActiveDatabase(ctx, 1); err != nil {
+		t.Fatalf("SetActiveDatabase to healthy member: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 1 {
+	if got := mdb.ActiveDatabaseID(); got != 1 {
 		t.Fatalf("active = %d, want 1", got)
 	}
 
 	// Force onto the dead member: the switch must happen unconditionally
 	// (asserted before any traffic can fail it back over), and the next
 	// commands then drive an automatic failover away again.
-	if err := mdb.ForceActiveIndex(ctx, 2); err != nil {
-		t.Fatalf("ForceActiveIndex: %v", err)
+	if err := mdb.ForceActiveDatabase(ctx, 2); err != nil {
+		t.Fatalf("ForceActiveDatabase: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 2 {
-		t.Fatalf("active = %d immediately after ForceActiveIndex(2)", got)
+	if got := mdb.ActiveDatabaseID(); got != 2 {
+		t.Fatalf("active = %d immediately after ForceActiveDatabase(2)", got)
 	}
 	eventually(t, 15*time.Second, "automatic failover away from the forced dead member", func() bool {
-		return mdb.Set(ctx, "e2e:manual", "x", 0).Err() == nil && mdb.ActiveIndex() != 2
+		return mdb.Set(ctx, "e2e:manual", "x", 0).Err() == nil && mdb.ActiveDatabaseID() != 2
 	})
 }
 
@@ -254,7 +254,7 @@ func TestPubSubFollowsActive(t *testing.T) {
 
 	farm.Stop(0)
 	eventually(t, 15*time.Second, "failover away from member 0", func() bool {
-		return mdb.ActiveIndex() != 0
+		return mdb.ActiveDatabaseID() != 0
 	})
 
 	publishUntilReceived("after-failover")
@@ -302,15 +302,15 @@ func TestPSubscribeFollowsActive(t *testing.T) {
 
 	farm.Stop(0)
 	eventually(t, 15*time.Second, "failover away from member 0", func() bool {
-		return mdb.ActiveIndex() != 0
+		return mdb.ActiveDatabaseID() != 0
 	})
 
 	publishUntilReceived("pat-after-failover")
 }
 
 // TestRuntimeMembershipUnderFaults: a member added at runtime must be a real
-// failover target, and removing a (stopped, passive) member must keep the
-// shifted indexes coherent.
+// failover target, and removing a (stopped, passive) member must leave the
+// surviving members' ids unchanged (stable ids, no renumbering).
 // Spec: test_add_remove_database at runtime.
 func TestRuntimeMembershipUnderFaults(t *testing.T) {
 	farm := newProxyFarm(t)
@@ -319,15 +319,15 @@ func TestRuntimeMembershipUnderFaults(t *testing.T) {
 	mdb := newE2EClient(t, opts)
 	ctx := context.Background()
 
-	idx, err := mdb.AddDatabase(ctx, redis.MultiDBClientConfig{
+	id, err := mdb.AddDatabase(ctx, redis.MultiDBClientConfig{
 		Options: memberOptions(farm, 2),
 		Weight:  1,
 	})
 	if err != nil {
 		t.Fatalf("AddDatabase: %v", err)
 	}
-	if idx != 2 {
-		t.Fatalf("AddDatabase index = %d, want 2", idx)
+	if id != 2 {
+		t.Fatalf("AddDatabase id = %d, want 2", id)
 	}
 
 	// With both original members down, traffic must land on the member that
@@ -335,16 +335,16 @@ func TestRuntimeMembershipUnderFaults(t *testing.T) {
 	farm.Stop(0)
 	farm.Stop(1)
 	eventually(t, 20*time.Second, "commands succeeding on the runtime-added member", func() bool {
-		return mdb.Set(ctx, "e2e:member", "x", 0).Err() == nil && mdb.ActiveIndex() == 2
+		return mdb.Set(ctx, "e2e:member", "x", 0).Err() == nil && mdb.ActiveDatabaseID() == 2
 	})
 
-	// Removing the stopped, passive member 0 shifts the slice; the active
-	// member keeps serving under its new index.
+	// Removing the stopped, passive member 0 does not renumber survivors: ids
+	// are stable, so the active member keeps its id and keeps serving.
 	if err := mdb.RemoveDatabase(ctx, 0); err != nil {
 		t.Fatalf("RemoveDatabase: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 1 {
-		t.Fatalf("active index after removal = %d, want 1 (shifted)", got)
+	if got := mdb.ActiveDatabaseID(); got != 2 {
+		t.Fatalf("active id after removal = %d, want 2 (unchanged; ids are stable)", got)
 	}
 	if err := mdb.Set(ctx, "e2e:member", "y", 0).Err(); err != nil {
 		t.Fatalf("Set after removal: %v", err)
@@ -363,7 +363,7 @@ func TestSetWeightSteersFallback(t *testing.T) {
 	// The failover must land on member 1 (next weight): only then does the
 	// later switch to member 2 prove the runtime weight change steered it.
 	eventually(t, 15*time.Second, "failover to member 1", func() bool {
-		return mdb.Set(ctx, "e2e:weight", "x", 0).Err() == nil && mdb.ActiveIndex() == 1
+		return mdb.Set(ctx, "e2e:weight", "x", 0).Err() == nil && mdb.ActiveDatabaseID() == 1
 	})
 
 	// Member 2 becomes the heaviest healthy member: the next fallback pass
@@ -372,7 +372,7 @@ func TestSetWeightSteersFallback(t *testing.T) {
 		t.Fatalf("SetWeight: %v", err)
 	}
 	eventually(t, 30*time.Second, "fallback to the re-weighted member 2", func() bool {
-		return mdb.ActiveIndex() == 2
+		return mdb.ActiveDatabaseID() == 2
 	})
 	if err := mdb.Get(ctx, "e2e:weight").Err(); err != nil {
 		t.Fatalf("Get on the re-weighted member: %v", err)
@@ -404,7 +404,7 @@ func TestConcurrentTrafficAcrossFailover(t *testing.T) {
 			defer wg.Done()
 			key := fmt.Sprintf("e2e:conc:%d", g)
 			for !stop.Load() {
-				if err := mdb.Set(ctx, key, "v", 0).Err(); err == nil && mdb.ActiveIndex() == 1 {
+				if err := mdb.Set(ctx, key, "v", 0).Err(); err == nil && mdb.ActiveDatabaseID() == 1 {
 					postFailover[g].Add(1)
 				}
 				time.Sleep(20 * time.Millisecond)
@@ -467,7 +467,7 @@ func TestFailoverCallbacksObserved(t *testing.T) {
 
 	farm.Stop(0)
 	eventually(t, 15*time.Second, "failover away from member 0", func() bool {
-		return mdb.Set(ctx, "e2e:cb", "x", 0).Err() == nil && mdb.ActiveIndex() == 1
+		return mdb.Set(ctx, "e2e:cb", "x", 0).Err() == nil && mdb.ActiveDatabaseID() == 1
 	})
 	// Both callbacks are delivered asynchronously — poll.
 	eventually(t, 5*time.Second, "failover callbacks", func() bool {

--- a/multidb/e2e/scenarios_test.go
+++ b/multidb/e2e/scenarios_test.go
@@ -159,10 +159,14 @@ func TestManualFailover(t *testing.T) {
 		t.Fatalf("active = %d, want 1", got)
 	}
 
-	// Force onto the dead member: allowed, and the next commands drive an
-	// automatic failover away again.
+	// Force onto the dead member: the switch must happen unconditionally
+	// (asserted before any traffic can fail it back over), and the next
+	// commands then drive an automatic failover away again.
 	if err := mdb.ForceActiveIndex(ctx, 2); err != nil {
 		t.Fatalf("ForceActiveIndex: %v", err)
+	}
+	if got := mdb.ActiveIndex(); got != 2 {
+		t.Fatalf("active = %d immediately after ForceActiveIndex(2)", got)
 	}
 	eventually(t, 15*time.Second, "automatic failover away from the forced dead member", func() bool {
 		return mdb.Set(ctx, "e2e:manual", "x", 0).Err() == nil && mdb.ActiveIndex() != 2

--- a/multidb/e2e/scenarios_test.go
+++ b/multidb/e2e/scenarios_test.go
@@ -376,6 +376,13 @@ func TestConcurrentTrafficAcrossFailover(t *testing.T) {
 	var stop atomic.Bool
 	var postFailover [workers]atomic.Int64
 	var wg sync.WaitGroup
+	// Deferred (not just at the happy end): an eventually() failure calls
+	// t.Fatal, and workers still running while t.Cleanup closes the client
+	// would race the teardown.
+	defer func() {
+		stop.Store(true)
+		wg.Wait()
+	}()
 	for g := 0; g < workers; g++ {
 		wg.Add(1)
 		go func(g int) {


### PR DESCRIPTION
Stacked on the MultiDBClient orchestration PR.

End-to-end failover tests driven by the existing mock RESP proxy
(`redislabs/client-resp-proxy`), one container per member database, all
fronting the shared standalone Redis (a converged-CRDB approximation). Faults
are injected at the container level: `docker stop` for connection-reset
outages, `docker pause` for hung-connection timeouts.

- docker-compose profile `multidb` (cae-proxy-db0/1/2, ports 17100-17102)
- env-gated suite (`E2E_MULTIDB_TESTS=true`), `make test.multidb.e2e`
- scenarios: automatic failover under traffic, background-driven failover
  with zero traffic, auto-fallback to the recovered higher-weight member,
  escalation chain when all members are down (with mid-chain recovery),
  manual failover (probe-refused vs forced), and PubSub following the active
  database across a member outage

The full suite passes locally in ~21s against live proxies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Docker Compose profiles, Makefile/CI wiring, and new e2e tests; no production MultiDB client logic is modified in this diff.
> 
> **Overview**
> Adds **MultiDB end-to-end coverage** that exercises `MultiDBClient` against three separate RESP proxy containers (one per “member”), all pointing at the same standalone Redis to approximate converged Active-Active data visibility. Outages are injected with **`docker stop`** and **`docker pause`**, not HTTP fault APIs.
> 
> **Infrastructure:** a new Compose profile **`multidb`** (`cae-proxy-db0/1/2` on `127.0.0.1:17100–17102`), **`make test.multidb.e2e`**, and a **GitHub Actions** job that brings the stack up, probes proxy stats on `18120–18122`, runs `./multidb/e2e/...` with **`E2E_MULTIDB_TESTS=true`**, and dumps proxy logs on failure before `compose down`.
> 
> **Tests:** a **`proxyFarm` harness** resets members between cases; scenarios cover automatic failover under load, background health-driven failover, auto-fallback by weight, temporary vs permanent unavailability when all members are down, manual vs forced active DB selection, Pub/Sub and PSubscribe following the active member, runtime add/remove membership, weight-driven fallback, concurrent writers across failover, strict init when a member is down, and failover/circuit-breaker callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e2dfa0f077f0e73ef1d0c170a79157fbb95e2a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->