### PR TITLE
fix(search): read the full RESP3 map reply in FTHybridCmd

### DIFF
--- a/search_commands.go
+++ b/search_commands.go
@@ -3125,9 +3125,35 @@ func parseFTHybrid(data []interface{}, withCursor bool) (FTHybridResult, *FTHybr
 }
 
 func (cmd *FTHybridCmd) readReply(rd *proto.Reader) (err error) {
-	data, err := rd.ReadSlice()
+	readType, err := rd.PeekReplyType()
 	if err != nil {
 		return err
+	}
+
+	// RESP3 returns a map, RESP2 returns an array. ReadSlice reads a map
+	// header's declared length as an element count, so it consumes only half
+	// the key/value frames and leaves the rest on the connection; ReadReply
+	// consumes the whole map. Flatten it into the key/value list parseFTHybrid
+	// expects, matching AggregateCmd/FTSearchCmd/FTSpellCheckCmd/FTSynDumpCmd.
+	var data []interface{}
+	if readType == proto.RespMap {
+		cmd.rawVal, err = rd.ReadReply()
+		if err != nil {
+			return err
+		}
+		rawMap, ok := cmd.rawVal.(map[interface{}]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected RESP3 response type: %T", cmd.rawVal)
+		}
+		data = make([]interface{}, 0, len(rawMap)*2)
+		for k, v := range rawMap {
+			data = append(data, k, v)
+		}
+	} else {
+		data, err = rd.ReadSlice()
+		if err != nil {
+			return err
+		}
 	}
 
 	result, cursorResult, err := parseFTHybrid(data, cmd.withCursor)

--- a/search_hybrid_desync_test.go
+++ b/search_hybrid_desync_test.go
@@ -1,0 +1,68 @@
+package redis
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/redis/go-redis/v9/internal/proto"
+)
+
+// FT.HYBRID replies with a RESP3 map on a RESP3 connection, like the other
+// FT.* commands. FTHybridCmd.readReply must consume the whole map: reading it
+// with ReadSlice treats the map header's declared length as an ELEMENT count,
+// so only half the key/value frames are consumed and the rest are left on the
+// connection. readReply then returns nil (success), the connection is pooled
+// desynced, and the next command reads a stray map frame as its own reply.
+func TestFTHybridRESP3MapNoDesync(t *testing.T) {
+	// A 4-pair RESP3 map, followed by the next command's reply on the wire.
+	const reply = "%4\r\n" +
+		"$13\r\ntotal_results\r\n:5\r\n" +
+		"$7\r\nresults\r\n*0\r\n" +
+		"$6\r\nformat\r\n$6\r\nSTRING\r\n" +
+		"$7\r\nwarning\r\n*0\r\n"
+	const next = ":99\r\n"
+
+	rd := proto.NewReader(strings.NewReader(reply + next))
+	cmd := newFTHybridCmd(context.Background(), nil)
+	if err := cmd.readReply(rd); err != nil {
+		t.Fatalf("readReply: %v", err)
+	}
+	if cmd.val.TotalResults != 5 {
+		t.Fatalf("TotalResults = %d, want 5", cmd.val.TotalResults)
+	}
+
+	// The whole map must have been consumed: the next reply on the wire is the
+	// following command's integer 99, not a leftover map frame.
+	got, err := rd.ReadReply()
+	if err != nil {
+		t.Fatalf("reading next reply: %v", err)
+	}
+	if n, ok := got.(int64); !ok || n != 99 {
+		t.Fatalf("connection desynced: next reply = %#v, want int64(99)", got)
+	}
+}
+
+// The RESP2 flat-array form must still parse and stay in sync.
+func TestFTHybridRESP2ArrayStillParses(t *testing.T) {
+	const reply = "*4\r\n" +
+		"$13\r\ntotal_results\r\n:7\r\n" +
+		"$7\r\nresults\r\n*0\r\n"
+	const next = ":42\r\n"
+
+	rd := proto.NewReader(strings.NewReader(reply + next))
+	cmd := newFTHybridCmd(context.Background(), nil)
+	if err := cmd.readReply(rd); err != nil {
+		t.Fatalf("readReply: %v", err)
+	}
+	if cmd.val.TotalResults != 7 {
+		t.Fatalf("TotalResults = %d, want 7", cmd.val.TotalResults)
+	}
+	got, err := rd.ReadReply()
+	if err != nil {
+		t.Fatalf("reading next reply: %v", err)
+	}
+	if n, ok := got.(int64); !ok || n != 42 {
+		t.Fatalf("connection desynced: next reply = %#v, want int64(42)", got)
+	}
+}


### PR DESCRIPTION
FTHybridCmd.readReply parsed the FT.HYBRID reply with rd.ReadSlice(). Feeding it the RESP3 map reply FT.HYBRID returns on a RESP3 connection:

    connection desynced: next reply = "format", want int64(99)

ReadSlice reads a map header's declared length as an element count, so a map of N key/value pairs (2N frames) is only half consumed and the trailing frames stay buffered. parseFTHybrid still succeeds on the half list and readReply returns nil, so the connection goes back to the pool desynced and the next command reads a stray map frame as its own reply.

FTHybridCmd was the only FT.* reply parser without the PeekReplyType/RespMap branch that AggregateCmd, FTInfoCmd, FTSpellCheckCmd, FTSearchCmd and FTSynDumpCmd already use. Read a map with ReadReply and flatten it into the key/value list parseFTHybrid expects; the RESP2 array path is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted reply-parser fix aligned with existing FT.* RESP3 handling; low blast radius beyond FT.HYBRID on RESP3 connections.
> 
> **Overview**
> Fixes **connection desync** on RESP3 when `FT.HYBRID` returns a map reply. `FTHybridCmd.readReply` no longer uses `ReadSlice` for that case; it now matches other FT parsers by peeking the reply type, reading the full map with `ReadReply`, and flattening it for `parseFTHybrid`. The RESP2 flat-array path is unchanged.
> 
> Adds unit tests that wire a synthetic RESP3 map (and RESP2 array) plus a following reply, and assert the reader stays aligned for the next command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 717d61e7b15f0a4cbf9ba166e8926f93b0385508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->