### PR TITLE
feat(v9): Support fork for go-redis/v9

### DIFF
--- a/ReactiveFork.md
+++ b/ReactiveFork.md
@@ -1,0 +1,62 @@
+# Reactive Markets fork of go-redis
+
+|        |                                                                     |
+| ------ | ------------------------------------------------------------------- |
+| Date   | 2026-08-10                                                          |
+| Owner  | Marat Seifullin                                                     |
+| Status | v9 port of the v8.11.5-reactive4 changes, based on upstream v9.22.0 |
+| Ticket | [SDB-2817](https://reactivemarkets.atlassian.net/browse/SDB-2817)   |
+
+This repository is Reactive Markets' fork of [go-redis](https://github.com/redis/go-redis). It exists to cut GC pressure in hot services: stock go-redis materialises every reply as freshly allocated Go values (each bulk string becomes a new `string`, and typed commands allocate a result container on top — `HGetAll` a map, `ZRangeWithScores` a `[]Z`). For large periodic snapshot reads in `reactive-go` — reference-data IAM hashes, credit NOP limits, account/market mappings — the fork adds a zero-copy escape hatch: the caller supplies a function that parses the raw RESP reply directly into its own reusable buffers.
+
+## What the fork adds on top of upstream
+
+- `CustomCmd` (`command.go`) — a `Cmder` whose `readReply` delegates to a caller-supplied `func(*proto.Reader) error`, so the caller parses the raw reply itself. Modelled on upstream's `ZeroCopyStringCmd`: `NoRetry()` returns true (a retry would re-invoke the callback and could duplicate whatever a failed first attempt already produced), and `Clone()` returns a deliberately non-functional clone whose `readReply` drains the reply and errors.
+- `Reader` and `NewReader` (`commands.go`) — a public alias re-exporting `internal/proto.Reader`, so callbacks can be typed and exercised in tests without a live connection (the `reactive-go` mocks depend on both).
+- `HGetAllWithCustomReader` (`hash_commands.go`) and `ZRangeWithScoresWithCustomReader` / `ZRangeArgsWithScoresWithCustomReader` (`sortedset_commands.go`) — command variants that issue the normal wire command but hand the reply to the callback. Each is added to the corresponding `Cmdable` sub-interface so it works on clients and pipelines alike.
+- A module rename in `go.mod` to `github.com/reactive-go/redis/v9`. See the wiring rules below.
+
+The v8 fork also carried `Reader.ReadStringBuffered`; it was **not** ported because upstream v9 ships `Reader.ReadStringInto`, which does the same buffered read and additionally drains the payload when the buffer is too small, keeping the pooled connection aligned. Use `ReadStringInto` in callbacks. The unused extras from the v8.11.5-reactive5…7 tags (`HValsWithCustomReader`, `SMembersWithCustomReader`, plain-`ZRange` variants, `ReadStringToWriter`) were dropped — nothing consumes them, and upstream's buffer APIs cover the same ground. `CustomCmd.Result()` from reactive5 was kept.
+
+## The callback contract
+
+The reader function must consume the entire reply, exactly. The `proto.Reader` belongs to a pooled connection: bytes left unread (or read beyond the reply) desynchronise the connection for whatever command uses it next. Practical guidance:
+
+- For `HGetAllWithCustomReader`, start with `rd.ReadMapLen()` — it accepts both the RESP3 map reply and the RESP2 flat array reply and returns the pair count either way.
+- For the zset variants, start with `rd.ReadArrayLen()` and mind the protocol: RESP2 returns a flat array of member,score pairs; RESP3 an array of two-element member,score arrays (see upstream's `ZSliceCmd.readReply` for the canonical branch).
+- Read each element with `rd.ReadStringInto(buf)` into a caller-owned buffer.
+
+`custom_cmd_test.go` demonstrates the pattern under both protocols and pins the drain/no-retry behaviour.
+
+## How the module wiring works — do not "fix" it
+
+`go.mod` declares `module github.com/reactive-go/redis/v9`, while every import inside the fork still says `github.com/redis/go-redis/v9/...`. Both are required:
+
+- The declared module path must match the fork's URL so Go can fetch a tag of this repository.
+- Consumers keep importing the upstream path and map it with a replace directive, which also resolves the fork's own internal imports back into the fork: `replace github.com/redis/go-redis/v9 => github.com/reactive-go/redis/v9 <tag>`.
+
+A consequence: the fork does not build standalone once the module is renamed (its internal imports only resolve through a consumer's replace directive). To develop or run its tests locally, temporarily set the module line back to `github.com/redis/go-redis/v9`, work, then restore the rename before tagging. Rewriting the internal imports instead was tried on the v8 fork (commit `23eb2762`) and had to be reverted.
+
+## Versioning and upgrade procedure
+
+Tag every published state `v<upstream>-reactiveN` (for example `v9.22.0-reactive1`) and never move an existing tag — the Go module proxy caches tags immutably. To rebase onto a newer upstream release:
+
+```bash
+git remote add upstream https://github.com/redis/go-redis.git
+git fetch upstream --tags
+git checkout -b feature/v9.X.Y-reactive1 v9.X.Y      # the new upstream tag
+git cherry-pick <fork commits>                        # or: git rebase --onto v9.X.Y v9.OLD <fork branch>
+# resolve conflicts; the go.mod module rename must survive
+go test -run TestCustomCmd . && go test ./internal/proto/   # with go.mod temporarily un-renamed
+git tag v9.X.Y-reactive1 && git push origin HEAD --tags
+```
+
+Then bump the replace directive in the consumer's `go.mod` and run its full build and tests. Before each upgrade, check whether upstream has grown an equivalent API — this port already retired half the v8 fork (`ReadStringBuffered` → upstream `ReadStringInto`), and upstream's `GetToBuffer`/`ZeroCopyStringCmd` show the zero-allocation pattern is landing upstream piece by piece. The fork should shrink over time, not grow.
+
+## Consumers
+
+`reactive-go` is the only consumer. The fork APIs are used by `pkg/db/redis` (generic snapshot loaders and mocks), `pkg/refdata`, `pkg/creditgw`, and `pkg/clmd`. Migrating it from the v8 fork additionally requires: switching imports to `github.com/redis/go-redis/v9`, rewriting callbacks from the removed `ReadArrayReply(func(rd, n))` to `ReadMapLen`/`ReadArrayLen` loops, replacing `ReadStringBuffered` with `ReadStringInto`, and choosing a protocol (`Options.Protocol: 2` keeps the v8 wire behaviour and makes the callback port mechanical).
+
+## History
+
+The original v8 fork ([v8.11.5-reactive4](https://github.com/reactive-go/redis/commits/v8.11.5-reactive4), June 2022, SDB-2817) introduced `CustomCmd`, the `Reader` re-export, `ReadStringBuffered`, and the `HGetAll`/`ZRangeWithScores` custom-reader variants on top of upstream v8.11.5 — the last v8 release before upstream development moved to v9. The v9 port (August 2026) re-implemented the surviving pieces against upstream v9.22.0 as described above.

--- a/command.go
+++ b/command.go
@@ -1140,6 +1140,82 @@ func (cmd *ZeroCopyStringCmd) Clone() Cmder {
 
 //------------------------------------------------------------------------------
 
+// CustomCmd delegates reply parsing to a user-provided reader function,
+// allowing the raw RESP reply to be decoded directly into caller-owned
+// structures without the intermediate allocations of the typed commands.
+//
+// The reader function must consume the entire reply, exactly: the
+// proto.Reader belongs to a pooled connection, and any bytes left unread
+// (or read beyond the reply) desynchronise the connection for subsequent
+// commands.
+type CustomCmd struct {
+	baseCmd
+	customReader func(rd *proto.Reader) error
+	cloned       bool // set by Clone(); causes readReply to drain + error
+}
+
+var _ Cmder = (*CustomCmd)(nil)
+
+// NewCustomCmd returns a CustomCmd whose reply is parsed by customReader.
+func NewCustomCmd(ctx context.Context, customReader func(rd *proto.Reader) error, args ...interface{}) *CustomCmd {
+	return &CustomCmd{
+		baseCmd: baseCmd{
+			ctx:  ctx,
+			args: args,
+		},
+		customReader: customReader,
+	}
+}
+
+// Result returns any error the command failed with; the parsed value is
+// whatever the reader function produced in caller-owned state.
+func (cmd *CustomCmd) Result() error {
+	cmd.await()
+	return cmd.err
+}
+
+func (cmd *CustomCmd) String() string {
+	cmd.await()
+	return cmdString(cmd, nil)
+}
+
+func (cmd *CustomCmd) readReply(rd *proto.Reader) error {
+	if cmd.cloned {
+		// A cloned CustomCmd has no usable reader function (see Clone for
+		// the rationale). Drain the network reply so the connection stays
+		// aligned for the next command, then surface a clear error rather
+		// than silently dropping the reply.
+		if err := rd.DiscardNext(); err != nil {
+			return err
+		}
+		return fmt.Errorf("redis: CustomCmd cannot be cloned (reader function writes into caller-owned state)")
+	}
+	return cmd.customReader(rd)
+}
+
+// NoRetry returns true because the reader function typically writes into
+// caller-owned state. A retry would invoke it a second time, potentially
+// duplicating whatever a failed first attempt already produced, so the
+// caller must handle retries explicitly if needed.
+func (cmd *CustomCmd) NoRetry() bool {
+	return true
+}
+
+// Clone returns a clone that is intentionally non-functional, for the same
+// reason as ZeroCopyStringCmd: the reader function writes into caller-owned
+// state, which sibling clones can neither share safely nor replace. The
+// clone's readReply drains the network reply (keeping the connection
+// aligned) and fails with a clear error. See ZeroCopyStringCmd.Clone for
+// why this path is unreachable through normal client flows.
+func (cmd *CustomCmd) Clone() Cmder {
+	return &CustomCmd{
+		baseCmd: cmd.cloneBaseCmd(),
+		cloned:  true,
+	}
+}
+
+//------------------------------------------------------------------------------
+
 type SliceCmd struct {
 	baseCmd
 

--- a/commands.go
+++ b/commands.go
@@ -13,7 +13,19 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9/internal"
+	"github.com/redis/go-redis/v9/internal/proto"
 )
+
+// Reader is exposed to library users in order to parse raw redis replies on
+// their own, via the *WithCustomReader command variants. See CustomCmd for
+// the contract a custom reader function must honour.
+type Reader = proto.Reader
+
+// NewReader is exposed along with Reader so custom reader functions can be
+// exercised in tests without a live connection.
+func NewReader(rd io.Reader) *Reader {
+	return proto.NewReader(rd)
+}
 
 // KeepTTL is a Redis KEEPTTL option to keep existing TTL, it requires your redis-server version >= 6.0,
 // otherwise you will receive an error: (error) ERR syntax error.

--- a/custom_cmd_test.go
+++ b/custom_cmd_test.go
@@ -1,0 +1,96 @@
+package redis
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+)
+
+// hgetallReader returns a custom reader that parses an HGETALL reply into
+// dst using only caller-owned buffers, the way a zero-allocation consumer
+// would. ReadMapLen accepts both the RESP3 map reply and the RESP2 flat
+// array reply.
+func hgetallReader(dst map[string]string) func(*Reader) error {
+	return func(rd *Reader) error {
+		n, err := rd.ReadMapLen()
+		if err != nil {
+			return err
+		}
+		buf := make([]byte, 64)
+		for i := 0; i < n; i++ {
+			keyLen, err := rd.ReadStringInto(buf)
+			if err != nil {
+				return err
+			}
+			key := string(buf[:keyLen])
+			valLen, err := rd.ReadStringInto(buf)
+			if err != nil {
+				return err
+			}
+			dst[key] = string(buf[:valLen])
+		}
+		return nil
+	}
+}
+
+func TestCustomCmdReadReply(t *testing.T) {
+	replies := map[string]string{
+		"resp2 flat array": "*4\r\n$2\r\nf1\r\n$2\r\nv1\r\n$2\r\nf2\r\n$2\r\nv2\r\n",
+		"resp3 map":        "%2\r\n$2\r\nf1\r\n$2\r\nv1\r\n$2\r\nf2\r\n$2\r\nv2\r\n",
+	}
+	want := map[string]string{"f1": "v1", "f2": "v2"}
+
+	for name, reply := range replies {
+		t.Run(name, func(t *testing.T) {
+			rd := NewReader(strings.NewReader(reply))
+			got := make(map[string]string)
+			cmd := NewCustomCmd(context.Background(), hgetallReader(got), "hgetall", "key")
+
+			if err := cmd.readReply(rd); err != nil {
+				t.Fatalf("readReply: %v", err)
+			}
+			if len(got) != len(want) {
+				t.Fatalf("got %d fields, want %d", len(got), len(want))
+			}
+			for k, v := range want {
+				if got[k] != v {
+					t.Errorf("field %q: got %q, want %q", k, got[k], v)
+				}
+			}
+			// The reader must be fully consumed, or the connection would be
+			// left desynchronised for the next command.
+			if _, err := rd.ReadLine(); err != io.EOF {
+				t.Errorf("reply not fully consumed: ReadLine returned %v, want io.EOF", err)
+			}
+		})
+	}
+}
+
+func TestCustomCmdCloneDrainsReply(t *testing.T) {
+	reply := "*2\r\n$2\r\nf1\r\n$2\r\nv1\r\n"
+	rd := NewReader(strings.NewReader(reply))
+
+	got := make(map[string]string)
+	cmd := NewCustomCmd(context.Background(), hgetallReader(got), "hgetall", "key")
+	clone := cmd.Clone()
+
+	if err := clone.readReply(rd); err == nil {
+		t.Fatal("cloned CustomCmd readReply should error")
+	}
+	if len(got) != 0 {
+		t.Errorf("cloned CustomCmd must not invoke the reader function, parsed %d fields", len(got))
+	}
+	// The clone must still have drained the reply to keep the connection
+	// aligned.
+	if _, err := rd.ReadLine(); err != io.EOF {
+		t.Errorf("reply not drained: ReadLine returned %v, want io.EOF", err)
+	}
+}
+
+func TestCustomCmdNoRetry(t *testing.T) {
+	cmd := NewCustomCmd(context.Background(), func(*Reader) error { return nil }, "hgetall", "key")
+	if !cmd.NoRetry() {
+		t.Error("CustomCmd must not be retried: the reader function writes into caller-owned state")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/redis/go-redis/v9
+module github.com/reactive-go/redis/v9
 
 go 1.24
 

--- a/hash_commands.go
+++ b/hash_commands.go
@@ -12,6 +12,7 @@ type HashCmdable interface {
 	HExists(ctx context.Context, key, field string) *BoolCmd
 	HGet(ctx context.Context, key, field string) *StringCmd
 	HGetAll(ctx context.Context, key string) *MapStringStringCmd
+	HGetAllWithCustomReader(ctx context.Context, key string, customReader func(*Reader) error) *CustomCmd
 	HGetDel(ctx context.Context, key string, fields ...string) *StringSliceCmd
 	HGetEX(ctx context.Context, key string, fields ...string) *StringSliceCmd
 	HGetEXWithArgs(ctx context.Context, key string, options *HGetEXOptions, fields ...string) *StringSliceCmd
@@ -84,6 +85,17 @@ func (c cmdable) HGet(ctx context.Context, key, field string) *StringCmd {
 // See https://redis.io/commands/hgetall/
 func (c cmdable) HGetAll(ctx context.Context, key string) *MapStringStringCmd {
 	cmd := NewMapStringStringCmd(ctx, "hgetall", key)
+	_ = c(ctx, cmd)
+	return cmd
+}
+
+// HGetAllWithCustomReader executes HGETALL and delegates reply parsing to
+// customReader, avoiding the map allocation of HGetAll. Use
+// Reader.ReadMapLen to obtain the field count — it accepts both the RESP3
+// map reply and the RESP2 flat array reply. See CustomCmd for the contract
+// the reader function must honour.
+func (c cmdable) HGetAllWithCustomReader(ctx context.Context, key string, customReader func(*Reader) error) *CustomCmd {
+	cmd := NewCustomCmd(ctx, customReader, "hgetall", key)
 	_ = c(ctx, cmd)
 	return cmd
 }

--- a/sortedset_commands.go
+++ b/sortedset_commands.go
@@ -34,11 +34,13 @@ type SortedSetCmdable interface {
 	ZPopMin(ctx context.Context, key string, count ...int64) *ZSliceCmd
 	ZRange(ctx context.Context, key string, start, stop int64) *StringSliceCmd
 	ZRangeWithScores(ctx context.Context, key string, start, stop int64) *ZSliceCmd
+	ZRangeWithScoresWithCustomReader(ctx context.Context, key string, start, stop int64, customReader func(*Reader) error) *CustomCmd
 	ZRangeByScore(ctx context.Context, key string, opt *ZRangeBy) *StringSliceCmd
 	ZRangeByLex(ctx context.Context, key string, opt *ZRangeBy) *StringSliceCmd
 	ZRangeByScoreWithScores(ctx context.Context, key string, opt *ZRangeBy) *ZSliceCmd
 	ZRangeArgs(ctx context.Context, z ZRangeArgs) *StringSliceCmd
 	ZRangeArgsWithScores(ctx context.Context, z ZRangeArgs) *ZSliceCmd
+	ZRangeArgsWithScoresWithCustomReader(ctx context.Context, z ZRangeArgs, customReader func(*Reader) error) *CustomCmd
 	ZRangeStore(ctx context.Context, dst string, z ZRangeArgs) *IntCmd
 	ZRank(ctx context.Context, key, member string) *IntCmd
 	ZRankWithScore(ctx context.Context, key, member string) *RankWithScoreCmd
@@ -457,6 +459,22 @@ func (c cmdable) ZRangeArgsWithScores(ctx context.Context, z ZRangeArgs) *ZSlice
 	return cmd
 }
 
+// ZRangeArgsWithScoresWithCustomReader executes ZRANGE ... WITHSCORES and
+// delegates reply parsing to customReader, avoiding the []Z allocation of
+// ZRangeArgsWithScores. Note the reply shape differs by protocol: RESP2
+// returns a flat array of member,score pairs, RESP3 an array of two-element
+// member,score arrays. See CustomCmd for the contract the reader function
+// must honour.
+func (c cmdable) ZRangeArgsWithScoresWithCustomReader(ctx context.Context, z ZRangeArgs, customReader func(*Reader) error) *CustomCmd {
+	args := make([]interface{}, 0, 10)
+	args = append(args, "zrange")
+	args = z.appendArgs(args)
+	args = append(args, "withscores")
+	cmd := NewCustomCmd(ctx, customReader, args...)
+	_ = c(ctx, cmd)
+	return cmd
+}
+
 func (c cmdable) ZRange(ctx context.Context, key string, start, stop int64) *StringSliceCmd {
 	return c.ZRangeArgs(ctx, ZRangeArgs{
 		Key:   key,
@@ -471,6 +489,16 @@ func (c cmdable) ZRangeWithScores(ctx context.Context, key string, start, stop i
 		Start: start,
 		Stop:  stop,
 	})
+}
+
+// ZRangeWithScoresWithCustomReader is the ZRangeWithScores analogue of
+// ZRangeArgsWithScoresWithCustomReader.
+func (c cmdable) ZRangeWithScoresWithCustomReader(ctx context.Context, key string, start, stop int64, customReader func(*Reader) error) *CustomCmd {
+	return c.ZRangeArgsWithScoresWithCustomReader(ctx, ZRangeArgs{
+		Key:   key,
+		Start: start,
+		Stop:  stop,
+	}, customReader)
 }
 
 type ZRangeBy struct {


### PR DESCRIPTION
SDB-11638

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New reply-parsing APIs sit on pooled connections; incorrect callbacks can desync the client, and NoRetry shifts retry responsibility to callers—important for correctness but not security-critical.
> 
> **Overview**
> **Ports the Reactive Markets go-redis v8 fork to upstream v9.22.0** so hot-path consumers can parse large Redis replies into reusable buffers instead of allocating maps/slices per command.
> 
> Adds **`CustomCmd`** — a `Cmder` that delegates `readReply` to a caller callback (same safety model as **`ZeroCopyStringCmd`**: **`NoRetry()`**, clone drains and errors). Exposes **`Reader`** / **`NewReader`** as public aliases of **`internal/proto.Reader`** for typed callbacks and unit tests.
> 
> Adds **`HGetAllWithCustomReader`**, **`ZRangeWithScoresWithCustomReader`**, and **`ZRangeArgsWithScoresWithCustomReader`** on the relevant **`Cmdable`** interfaces. Renames **`go.mod`** to **`github.com/reactive-go/redis/v9`** (consumers use **`replace`** on **`github.com/redis/go-redis/v9`**). Documents fork wiring, callback contract, and upgrade steps in **`ReactiveFork.md`**, with **`custom_cmd_test.go`** covering RESP2/RESP3 parsing, clone drain, and no-retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83903bb651dd860ab775d7943b69885d9778ca00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->