### PR TITLE
chore(refactor): move per-connection CLIENT commands to statefulCmdable

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
+          go-version: "stable"
           cache: true
 
       - name: Install govulncheck

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -1064,36 +1064,58 @@ func (ap *AutoPipeliner) HImportDiscardAll(ctx context.Context) *IntCmd {
 	return ap.pipeliner.HImportDiscardAll(ctx)
 }
 
-// Watch runs a transactional function on the underlying client (not batched).
 // ClientTracking and friends are per-connection commands (statefulCmdable);
 // through the autopipeliner they fail with guidance exactly as on the
 // underlying pooled client — a batch executes on an arbitrary pool
-// connection. Use a dedicated connection (Client.Conn), a Pipeline/Tx, or
-// the built-in client-side cache.
+// connection. Use a dedicated connection (Client.Conn) or the built-in
+// client-side cache. On a closed autopipeliner they return ErrClosed, like
+// every other dispatch path.
 func (ap *AutoPipeliner) ClientTracking(ctx context.Context, on bool, opt *ClientTrackingOptions) *StatusCmd {
-	arg := "off"
-	if on {
-		arg = "on"
+	if !on {
+		return ap.ClientTrackingOff(ctx)
 	}
-	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", arg)
+	return ap.ClientTrackingOn(ctx, opt)
 }
 
 // ClientTrackingOn through the autopipeliner fails with guidance; see ClientTracking.
 func (ap *AutoPipeliner) ClientTrackingOn(ctx context.Context, opt *ClientTrackingOptions) *StatusCmd {
-	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "on")
+	args := []interface{}{"client", "tracking", "on"}
+	if opt != nil {
+		args = appendClientTrackingOptions(args, opt)
+	}
+	if ap.isClosed() {
+		return pooledConnStateCmd(ctx, ErrClosed, args...)
+	}
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, args...)
 }
 
 // ClientTrackingOff through the autopipeliner fails with guidance; see ClientTracking.
 func (ap *AutoPipeliner) ClientTrackingOff(ctx context.Context) *StatusCmd {
+	if ap.isClosed() {
+		return pooledConnStateCmd(ctx, ErrClosed, "client", "tracking", "off")
+	}
 	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "off")
 }
 
 // ClientMaintNotifications through the autopipeliner fails with guidance;
-// set Options.MaintNotificationsConfig instead.
+// set the MaintNotificationsConfig option instead.
 func (ap *AutoPipeliner) ClientMaintNotifications(ctx context.Context, enabled bool, endpointType string) *StatusCmd {
-	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, "client", "maint_notifications")
+	args := []interface{}{"client", "maint_notifications"}
+	if enabled {
+		if endpointType == "" {
+			endpointType = "none"
+		}
+		args = append(args, "on", "moving-endpoint-type", endpointType)
+	} else {
+		args = append(args, "off")
+	}
+	if ap.isClosed() {
+		return pooledConnStateCmd(ctx, ErrClosed, args...)
+	}
+	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, args...)
 }
 
+// Watch runs a transactional function on the underlying client (not batched).
 func (ap *AutoPipeliner) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {
 	return ap.pipeliner.Watch(ctx, fn, keys...)
 }

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -1065,6 +1065,35 @@ func (ap *AutoPipeliner) HImportDiscardAll(ctx context.Context) *IntCmd {
 }
 
 // Watch runs a transactional function on the underlying client (not batched).
+// ClientTracking and friends are per-connection commands (statefulCmdable);
+// through the autopipeliner they fail with guidance exactly as on the
+// underlying pooled client — a batch executes on an arbitrary pool
+// connection. Use a dedicated connection (Client.Conn), a Pipeline/Tx, or
+// the built-in client-side cache.
+func (ap *AutoPipeliner) ClientTracking(ctx context.Context, on bool, opt *ClientTrackingOptions) *StatusCmd {
+	arg := "off"
+	if on {
+		arg = "on"
+	}
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", arg)
+}
+
+// ClientTrackingOn through the autopipeliner fails with guidance; see ClientTracking.
+func (ap *AutoPipeliner) ClientTrackingOn(ctx context.Context, opt *ClientTrackingOptions) *StatusCmd {
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "on")
+}
+
+// ClientTrackingOff through the autopipeliner fails with guidance; see ClientTracking.
+func (ap *AutoPipeliner) ClientTrackingOff(ctx context.Context) *StatusCmd {
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "off")
+}
+
+// ClientMaintNotifications through the autopipeliner fails with guidance;
+// set Options.MaintNotificationsConfig instead.
+func (ap *AutoPipeliner) ClientMaintNotifications(ctx context.Context, enabled bool, endpointType string) *StatusCmd {
+	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, "client", "maint_notifications")
+}
+
 func (ap *AutoPipeliner) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {
 	return ap.pipeliner.Watch(ctx, fn, keys...)
 }

--- a/client_tracking_pooled_test.go
+++ b/client_tracking_pooled_test.go
@@ -1,0 +1,75 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// TestPooledClientTrackingPreservesArgs verifies the pooled-client CLIENT
+// TRACKING / MAINT_NOTIFICATIONS wrappers build the full argument list (mirroring
+// the stateful command) before failing with guidance, instead of dropping the
+// caller's options (#3961). The command is pre-failed without dispatch, so no
+// server is needed.
+func TestPooledClientTrackingPreservesArgs(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(&Options{Addr: ":6379"})
+	defer c.Close()
+
+	opt := &ClientTrackingOptions{Redirect: 42, Bcast: true, Prefixes: []string{"foo"}, NoLoop: true}
+
+	cases := []struct {
+		name string
+		cmd  *StatusCmd
+		err  error
+		want []interface{}
+	}{
+		{
+			name: "ClientTrackingOn",
+			cmd:  c.ClientTrackingOn(ctx, opt),
+			err:  errClientTrackingOnPooledClient,
+			want: []interface{}{"client", "tracking", "on", "redirect", int64(42), "bcast", "prefix", "foo", "noloop"},
+		},
+		{
+			name: "ClientTracking(on)",
+			cmd:  c.ClientTracking(ctx, true, opt),
+			err:  errClientTrackingOnPooledClient,
+			want: []interface{}{"client", "tracking", "on", "redirect", int64(42), "bcast", "prefix", "foo", "noloop"},
+		},
+		{
+			name: "ClientMaintNotifications(on)",
+			cmd:  c.ClientMaintNotifications(ctx, true, "external"),
+			err:  errClientMaintNotificationsOnPooledClient,
+			want: []interface{}{"client", "maint_notifications", "on", "moving-endpoint-type", "external"},
+		},
+		{
+			name: "ClientMaintNotifications(off)",
+			cmd:  c.ClientMaintNotifications(ctx, false, ""),
+			err:  errClientMaintNotificationsOnPooledClient,
+			want: []interface{}{"client", "maint_notifications", "off"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !errors.Is(tc.cmd.Err(), tc.err) {
+				t.Fatalf("Err() = %v, want %v", tc.cmd.Err(), tc.err)
+			}
+			if got := tc.cmd.Args(); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("Args() = %v, want %v (options dropped)", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPooledClientMaintNotificationsDefaultEndpoint verifies the empty endpoint
+// type defaults to "none", matching the stateful command.
+func TestPooledClientMaintNotificationsDefaultEndpoint(t *testing.T) {
+	c := NewClient(&Options{Addr: ":6379"})
+	defer c.Close()
+	cmd := c.ClientMaintNotifications(context.Background(), true, "")
+	want := []interface{}{"client", "maint_notifications", "on", "moving-endpoint-type", "none"}
+	if got := cmd.Args(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Args() = %v, want %v", got, want)
+	}
+}

--- a/client_tracking_pooled_test.go
+++ b/client_tracking_pooled_test.go
@@ -138,12 +138,9 @@ func TestPipelineRejectsStateCommandsWhenPooled(t *testing.T) {
 	}
 }
 
-// TestClusterPipelineRejectsStateCommands pins the cluster-side gap (#3961
-// review): ClusterClient.processPipeline/processTxPipeline bypass
-// baseClient.generalProcessPipeline, so they must check stateRejectedErr
-// themselves — otherwise the queued CLIENT TRACKING runs on a borrowed node
-// connection and the server reply overwrites the guidance error. The guard
-// fires before any node mapping, so no cluster (or dial) is needed.
+// TestClusterPipelineRejectsStateCommands: cluster pipeline entries bypass
+// baseClient.generalProcessPipeline, so they must surface a queued pooled-state
+// rejection themselves. Dial-free: the guard fires before any node mapping.
 func TestClusterPipelineRejectsStateCommands(t *testing.T) {
 	ctx := context.Background()
 	cc := NewClusterClient(&ClusterOptions{Addrs: []string{"localhost:1"}})
@@ -164,12 +161,9 @@ func TestClusterPipelineRejectsStateCommands(t *testing.T) {
 	}
 }
 
-// TestRingPipelineRejectsStateCommands pins the Ring-side gap (#3961 review):
-// Ring.generalProcessPipeline shards concurrently, so it must surface a queued
-// pooled-state rejection BEFORE sharding — otherwise the other shard groups
-// execute while only the rejected command's group fails. The guard fires before
-// any shard lookup, so no server is needed; mixing a keyed command in the same
-// batch pins that it is NOT dispatched either.
+// TestRingPipelineRejectsStateCommands: Ring shards dispatch concurrently, so
+// the rejection must surface BEFORE sharding or other shard groups execute. The
+// keyed command in the same batch pins fail-before-dispatch. Dial-free.
 func TestRingPipelineRejectsStateCommands(t *testing.T) {
 	ctx := context.Background()
 	ring := NewRing(&RingOptions{Addrs: map[string]string{"a": "localhost:1"}})
@@ -197,10 +191,9 @@ func TestRingPipelineRejectsStateCommands(t *testing.T) {
 	}
 }
 
-// TestTxPipelineAllowsStateCommands pins that a Tx pipeline is sticky: WATCH
-// pins one connection for the whole Tx, so CLIENT TRACKING queues there instead
-// of being rejected as pooled (#3961 regression flagged by review). Needs a
-// server because Watch dials.
+// TestTxPipelineAllowsStateCommands: Tx pipelines are sticky (WATCH pins one
+// connection until Close), so state commands queue instead of being rejected.
+// Needs a server (Watch dials).
 func TestTxPipelineAllowsStateCommands(t *testing.T) {
 	ctx := context.Background()
 	c := NewClient(&Options{Addr: ":6379"})

--- a/client_tracking_pooled_test.go
+++ b/client_tracking_pooled_test.go
@@ -73,3 +73,40 @@ func TestPooledClientMaintNotificationsDefaultEndpoint(t *testing.T) {
 		t.Fatalf("Args() = %v, want %v", got, want)
 	}
 }
+
+// TestPipelineRejectsStateCommandsWhenPooled verifies per-connection state
+// commands (CLIENT TRACKING / MAINT_NOTIFICATIONS) are rejected in a POOLED
+// pipeline — whose borrowed connection returns to the pool after Exec — but
+// allowed (queued) in a pipeline from a dedicated *Conn (#3961). No server needed:
+// rejections are pre-failed, and the Conn pipeline only queues.
+func TestPipelineRejectsStateCommandsWhenPooled(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(&Options{Addr: ":6379"})
+	defer c.Close()
+
+	// Pooled pipeline: rejected, and NOT queued.
+	pp := c.Pipeline()
+	if cmd := pp.ClientTrackingOn(ctx, &ClientTrackingOptions{Bcast: true}); !errors.Is(cmd.Err(), errClientTrackingOnPooledClient) {
+		t.Fatalf("pooled Pipeline ClientTrackingOn err = %v, want errClientTrackingOnPooledClient", cmd.Err())
+	}
+	if cmd := pp.ClientTrackingOff(ctx); !errors.Is(cmd.Err(), errClientTrackingOnPooledClient) {
+		t.Fatalf("pooled Pipeline ClientTrackingOff err = %v, want reject", cmd.Err())
+	}
+	if cmd := pp.ClientMaintNotifications(ctx, true, "none"); !errors.Is(cmd.Err(), errClientMaintNotificationsOnPooledClient) {
+		t.Fatalf("pooled Pipeline ClientMaintNotifications err = %v, want reject", cmd.Err())
+	}
+	if pp.Len() != 0 {
+		t.Fatalf("pooled Pipeline queued %d rejected state commands, want 0", pp.Len())
+	}
+
+	// Dedicated-Conn pipeline: allowed → queued.
+	conn := c.Conn()
+	defer conn.Close()
+	cp := conn.Pipeline()
+	if cmd := cp.ClientTrackingOn(ctx, &ClientTrackingOptions{Bcast: true}); errors.Is(cmd.Err(), errClientTrackingOnPooledClient) {
+		t.Fatalf("Conn Pipeline wrongly rejected ClientTrackingOn: %v", cmd.Err())
+	}
+	if cp.Len() != 1 {
+		t.Fatalf("Conn Pipeline queued %d, want 1 (state command should be queued on a dedicated conn)", cp.Len())
+	}
+}

--- a/client_tracking_pooled_test.go
+++ b/client_tracking_pooled_test.go
@@ -81,10 +81,15 @@ func TestPooledClientMaintNotificationsDefaultEndpoint(t *testing.T) {
 // rejections are pre-failed, and the Conn pipeline only queues.
 func TestPipelineRejectsStateCommandsWhenPooled(t *testing.T) {
 	ctx := context.Background()
-	c := NewClient(&Options{Addr: ":6379"})
+	// localhost:1 is never dialed: the pooled-pipeline guard in
+	// generalProcessPipeline fires before any connection is acquired.
+	c := NewClient(&Options{Addr: "localhost:1"})
 	defer c.Close()
 
-	// Pooled pipeline: rejected, and NOT queued.
+	// Pooled pipeline: the returned command carries the guidance error AND the
+	// command is queued, so Exec surfaces the rejection even when the caller
+	// ignores the returned command. The command must never be sent to a borrowed
+	// pooled connection.
 	pp := c.Pipeline()
 	if cmd := pp.ClientTrackingOn(ctx, &ClientTrackingOptions{Bcast: true}); !errors.Is(cmd.Err(), errClientTrackingOnPooledClient) {
 		t.Fatalf("pooled Pipeline ClientTrackingOn err = %v, want errClientTrackingOnPooledClient", cmd.Err())
@@ -95,11 +100,33 @@ func TestPipelineRejectsStateCommandsWhenPooled(t *testing.T) {
 	if cmd := pp.ClientMaintNotifications(ctx, true, "none"); !errors.Is(cmd.Err(), errClientMaintNotificationsOnPooledClient) {
 		t.Fatalf("pooled Pipeline ClientMaintNotifications err = %v, want reject", cmd.Err())
 	}
-	if pp.Len() != 0 {
-		t.Fatalf("pooled Pipeline queued %d rejected state commands, want 0", pp.Len())
+	if pp.Len() != 3 {
+		t.Fatalf("pooled Pipeline queued %d state commands, want 3 (queued so Exec surfaces the rejection)", pp.Len())
+	}
+	// Exec surfaces the rejection through the guard, before any dial (this would
+	// otherwise fail dialing localhost:1 with a different error).
+	if _, err := pp.Exec(ctx); !errors.Is(err, errClientTrackingOnPooledClient) {
+		t.Fatalf("pooled Pipeline Exec err = %v, want errClientTrackingOnPooledClient (guarded before dial)", err)
 	}
 
-	// Dedicated-Conn pipeline: allowed → queued.
+	// The common Pipelined pattern — callback ignores the returned command — must
+	// still fail rather than silently reporting success (the dropped-error bug).
+	if _, err := c.Pipelined(ctx, func(pipe Pipeliner) error {
+		pipe.ClientTrackingOff(ctx)
+		return nil
+	}); !errors.Is(err, errClientTrackingOnPooledClient) {
+		t.Fatalf("Pipelined ClientTrackingOff err = %v, want errClientTrackingOnPooledClient", err)
+	}
+
+	// Discard drops queued rejections like any other queued command.
+	pp2 := c.Pipeline()
+	pp2.ClientTrackingOff(ctx)
+	pp2.Discard()
+	if _, err := pp2.Exec(ctx); err != nil {
+		t.Fatalf("after Discard, Exec err = %v, want nil (empty pipeline)", err)
+	}
+
+	// Dedicated-Conn pipeline: sticky → allowed → queued (state stays on the conn).
 	conn := c.Conn()
 	defer conn.Close()
 	cp := conn.Pipeline()
@@ -108,5 +135,34 @@ func TestPipelineRejectsStateCommandsWhenPooled(t *testing.T) {
 	}
 	if cp.Len() != 1 {
 		t.Fatalf("Conn Pipeline queued %d, want 1 (state command should be queued on a dedicated conn)", cp.Len())
+	}
+}
+
+// TestTxPipelineAllowsStateCommands pins that a Tx pipeline is sticky: WATCH
+// pins one connection for the whole Tx, so CLIENT TRACKING queues there instead
+// of being rejected as pooled (#3961 regression flagged by review). Needs a
+// server because Watch dials.
+func TestTxPipelineAllowsStateCommands(t *testing.T) {
+	ctx := context.Background()
+	c := NewClient(&Options{Addr: ":6379"})
+	defer c.Close()
+	if err := c.Ping(ctx).Err(); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
+
+	err := c.Watch(ctx, func(tx *Tx) error {
+		for _, p := range []Pipeliner{tx.Pipeline(), tx.TxPipeline()} {
+			cmd := p.ClientTrackingOn(ctx, nil)
+			if errors.Is(cmd.Err(), errClientTrackingOnPooledClient) {
+				t.Fatalf("Tx pipeline wrongly rejected CLIENT TRACKING (should be sticky): %v", cmd.Err())
+			}
+			if p.Len() != 1 {
+				t.Fatalf("Tx pipeline queued %d, want 1 (state command allowed on the pinned conn)", p.Len())
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
 	}
 }

--- a/client_tracking_pooled_test.go
+++ b/client_tracking_pooled_test.go
@@ -138,6 +138,32 @@ func TestPipelineRejectsStateCommandsWhenPooled(t *testing.T) {
 	}
 }
 
+// TestClusterPipelineRejectsStateCommands pins the cluster-side gap (#3961
+// review): ClusterClient.processPipeline/processTxPipeline bypass
+// baseClient.generalProcessPipeline, so they must check stateRejectedErr
+// themselves — otherwise the queued CLIENT TRACKING runs on a borrowed node
+// connection and the server reply overwrites the guidance error. The guard
+// fires before any node mapping, so no cluster (or dial) is needed.
+func TestClusterPipelineRejectsStateCommands(t *testing.T) {
+	ctx := context.Background()
+	cc := NewClusterClient(&ClusterOptions{Addrs: []string{"localhost:1"}})
+	defer cc.Close()
+
+	if _, err := cc.Pipelined(ctx, func(pipe Pipeliner) error {
+		pipe.ClientTrackingOff(ctx)
+		return nil
+	}); !errors.Is(err, errClientTrackingOnPooledClient) {
+		t.Fatalf("cluster Pipelined ClientTrackingOff err = %v, want errClientTrackingOnPooledClient", err)
+	}
+
+	if _, err := cc.TxPipelined(ctx, func(pipe Pipeliner) error {
+		pipe.ClientMaintNotifications(ctx, true, "none")
+		return nil
+	}); !errors.Is(err, errClientMaintNotificationsOnPooledClient) {
+		t.Fatalf("cluster TxPipelined ClientMaintNotifications err = %v, want errClientMaintNotificationsOnPooledClient", err)
+	}
+}
+
 // TestTxPipelineAllowsStateCommands pins that a Tx pipeline is sticky: WATCH
 // pins one connection for the whole Tx, so CLIENT TRACKING queues there instead
 // of being rejected as pooled (#3961 regression flagged by review). Needs a

--- a/client_tracking_pooled_test.go
+++ b/client_tracking_pooled_test.go
@@ -164,6 +164,39 @@ func TestClusterPipelineRejectsStateCommands(t *testing.T) {
 	}
 }
 
+// TestRingPipelineRejectsStateCommands pins the Ring-side gap (#3961 review):
+// Ring.generalProcessPipeline shards concurrently, so it must surface a queued
+// pooled-state rejection BEFORE sharding — otherwise the other shard groups
+// execute while only the rejected command's group fails. The guard fires before
+// any shard lookup, so no server is needed; mixing a keyed command in the same
+// batch pins that it is NOT dispatched either.
+func TestRingPipelineRejectsStateCommands(t *testing.T) {
+	ctx := context.Background()
+	ring := NewRing(&RingOptions{Addrs: map[string]string{"a": "localhost:1"}})
+	defer ring.Close()
+
+	var keyed *StatusCmd
+	if _, err := ring.Pipelined(ctx, func(pipe Pipeliner) error {
+		keyed = pipe.Set(ctx, "rk", "v", 0)
+		pipe.ClientTrackingOff(ctx)
+		return nil
+	}); !errors.Is(err, errClientTrackingOnPooledClient) {
+		t.Fatalf("Ring Pipelined ClientTrackingOff err = %v, want errClientTrackingOnPooledClient", err)
+	}
+	// The whole batch must fail-before-dispatch: the keyed command carries the
+	// same guidance error (a dial error would mean its shard group was executed).
+	if err := keyed.Err(); !errors.Is(err, errClientTrackingOnPooledClient) {
+		t.Fatalf("keyed command in the same batch err = %v, want errClientTrackingOnPooledClient (must not dispatch)", err)
+	}
+
+	if _, err := ring.TxPipelined(ctx, func(pipe Pipeliner) error {
+		pipe.ClientMaintNotifications(ctx, true, "none")
+		return nil
+	}); !errors.Is(err, errClientMaintNotificationsOnPooledClient) {
+		t.Fatalf("Ring TxPipelined ClientMaintNotifications err = %v, want errClientMaintNotificationsOnPooledClient", err)
+	}
+}
+
 // TestTxPipelineAllowsStateCommands pins that a Tx pipeline is sticky: WATCH
 // pins one connection for the whole Tx, so CLIENT TRACKING queues there instead
 // of being rejected as pooled (#3961 regression flagged by review). Needs a

--- a/command.go
+++ b/command.go
@@ -235,6 +235,11 @@ type Cmder interface {
 	SetErr(error)
 	Err() error
 
+	// markStateRejected/isStateRejected flag a per-connection state command a
+	// pooled pipeline queued only to surface a rejection through Exec.
+	markStateRejected()
+	isStateRejected() bool
+
 	// setReady marks a command as asynchronously pending (autopipeline async
 	// faces); await blocks the public accessors until it has executed; rawErr
 	// reads the error without awaiting (internal execution path).
@@ -374,6 +379,11 @@ type baseCmd struct {
 	rawVal       interface{}
 	_readTimeout *time.Duration
 	cmdType      CmdType
+	// stateRejected marks a per-connection state command that a pooled
+	// *Pipeline queued only to surface a rejection through Exec (see
+	// markStateRejected). generalProcessPipeline returns its pre-set error
+	// without sending it.
+	stateRejected bool
 	// slotCache memoizes the cluster slot once computed, so the cluster
 	// autopipeline shard router and the pipeline flush router don't each
 	// recompute it. 0 = not computed; it stores slot+1 so a real slot of 0 is
@@ -548,6 +558,20 @@ func (cmd *baseCmd) SetErr(e error) {
 func (cmd *baseCmd) Err() error {
 	cmd.await()
 	return cmd.err
+}
+
+// markStateRejected / isStateRejected carry the "queued only to be rejected"
+// signal from a pooled *Pipeline to generalProcessPipeline. A pooled pipeline
+// queues a per-connection state command (CLIENT TRACKING / MAINT_NOTIFICATIONS)
+// carrying a pre-set guidance error and this flag, so Exec surfaces the error
+// instead of the command being sent to an arbitrary pooled connection. A sticky
+// (dedicated-connection) pipeline never sets it, so those commands run normally.
+func (cmd *baseCmd) markStateRejected() {
+	cmd.stateRejected = true
+}
+
+func (cmd *baseCmd) isStateRejected() bool {
+	return cmd.stateRejected
 }
 
 func (cmd *baseCmd) readTimeout() *time.Duration {

--- a/command.go
+++ b/command.go
@@ -256,6 +256,22 @@ type Cmder interface {
 	GetCmdType() CmdType
 }
 
+// stateRejectedErr returns the pre-set guidance error of the first
+// state-rejected command in cmds (a per-connection state command a pooled
+// *Pipeline queued only to surface its rejection through Exec — see
+// Pipeline.rejectPooledState), or nil when none is present. Every pipeline
+// execution entry point must check it BEFORE dispatching, so the command is
+// never sent to a borrowed connection and the server reply cannot overwrite
+// the guidance error.
+func stateRejectedErr(cmds []Cmder) error {
+	for _, cmd := range cmds {
+		if cmd.isStateRejected() {
+			return cmd.Err()
+		}
+	}
+	return nil
+}
+
 func setCmdsErr(cmds []Cmder, e error) {
 	for _, cmd := range cmds {
 		// rawErr: this runs on the execution path; never await here.

--- a/command.go
+++ b/command.go
@@ -257,12 +257,10 @@ type Cmder interface {
 }
 
 // stateRejectedErr returns the pre-set guidance error of the first
-// state-rejected command in cmds (a per-connection state command a pooled
-// *Pipeline queued only to surface its rejection through Exec — see
-// Pipeline.rejectPooledState), or nil when none is present. Every pipeline
-// execution entry point must check it BEFORE dispatching, so the command is
-// never sent to a borrowed connection and the server reply cannot overwrite
-// the guidance error.
+// state-rejected command in cmds (see Pipeline.rejectPooledState), or nil.
+// EVERY pipeline execution entry point must check it BEFORE dispatching:
+// otherwise the command runs on a borrowed connection and the server reply
+// overwrites the guidance error.
 func stateRejectedErr(cmds []Cmder) error {
 	for _, cmd := range cmds {
 		if cmd.isStateRejected() {
@@ -395,10 +393,8 @@ type baseCmd struct {
 	rawVal       interface{}
 	_readTimeout *time.Duration
 	cmdType      CmdType
-	// stateRejected marks a per-connection state command that a pooled
-	// *Pipeline queued only to surface a rejection through Exec (see
-	// markStateRejected). generalProcessPipeline returns its pre-set error
-	// without sending it.
+	// stateRejected marks a state command a pooled *Pipeline queued only to
+	// surface its rejection through Exec (see stateRejectedErr).
 	stateRejected bool
 	// slotCache memoizes the cluster slot once computed, so the cluster
 	// autopipeline shard router and the pipeline flush router don't each
@@ -577,11 +573,9 @@ func (cmd *baseCmd) Err() error {
 }
 
 // markStateRejected / isStateRejected carry the "queued only to be rejected"
-// signal from a pooled *Pipeline to generalProcessPipeline. A pooled pipeline
-// queues a per-connection state command (CLIENT TRACKING / MAINT_NOTIFICATIONS)
-// carrying a pre-set guidance error and this flag, so Exec surfaces the error
-// instead of the command being sent to an arbitrary pooled connection. A sticky
-// (dedicated-connection) pipeline never sets it, so those commands run normally.
+// signal from a pooled *Pipeline to the pipeline executors (stateRejectedErr):
+// Exec surfaces the pre-set guidance error instead of sending the command to a
+// borrowed connection. Sticky pipelines never set it.
 func (cmd *baseCmd) markStateRejected() {
 	cmd.stateRejected = true
 }

--- a/command.go
+++ b/command.go
@@ -629,6 +629,9 @@ func (cmd *baseCmd) cloneBaseCmd() baseCmd {
 		rawVal:       cmd.rawVal,
 		_readTimeout: readTimeout,
 		cmdType:      cmd.cmdType,
+		// A hook that rebuilds the command slice via Clone must not launder a
+		// queued pooled-state rejection into a sendable command.
+		stateRejected: cmd.stateRejected,
 	}
 }
 

--- a/commands.go
+++ b/commands.go
@@ -554,7 +554,15 @@ func (c cmdable) ClientInfo(ctx context.Context) *ClientInfoCmd {
 
 // ClientMaintNotifications enables or disables maintenance notifications for maintenance upgrades.
 // When enabled, the client will receive push notifications about Redis maintenance events.
-func (c cmdable) ClientMaintNotifications(ctx context.Context, enabled bool, endpointType string) *StatusCmd {
+//
+// CLIENT MAINT_NOTIFICATIONS is per-connection state, exactly like CLIENT
+// TRACKING: it lives on statefulCmdable and is directly usable on a dedicated
+// connection (Client.Conn) and inside Pipeline/Tx. The library enables it on
+// every connection automatically during connection init when
+// Options.MaintNotificationsConfig is set — that is the supported way to turn
+// it on for a whole client. The pooled clients keep a same-named method for
+// interface compatibility that returns an explanatory error.
+func (c statefulCmdable) ClientMaintNotifications(ctx context.Context, enabled bool, endpointType string) *StatusCmd {
 	args := []interface{}{"client", "maint_notifications"}
 	if enabled {
 		if endpointType == "" {
@@ -591,7 +599,16 @@ type ClientTrackingOptions struct {
 // configured with Options.ClientSideCache or ClientSideCacheConfig this
 // command is rejected, because changing a pool connection's tracking state
 // would silently break the cache's invalidation.
-func (c cmdable) ClientTracking(ctx context.Context, on bool, opt *ClientTrackingOptions) *StatusCmd {
+//
+// CLIENT TRACKING is per-connection state, so this lives on statefulCmdable
+// next to ClientSetName/ClientSetInfo: it is directly usable on a dedicated
+// connection (Client.Conn) and inside Pipeline/Tx. The pooled clients keep
+// same-named methods for interface compatibility, but those return an error
+// explaining that the command must target a specific connection — on a pooled
+// client it would land on an arbitrary connection that is immediately
+// returned to the pool, so subsequent reads run on other connections and the
+// invalidation pushes arrive on a connection nothing is reading.
+func (c statefulCmdable) ClientTracking(ctx context.Context, on bool, opt *ClientTrackingOptions) *StatusCmd {
 	if !on {
 		return c.ClientTrackingOff(ctx)
 	}
@@ -600,7 +617,7 @@ func (c cmdable) ClientTracking(ctx context.Context, on bool, opt *ClientTrackin
 
 // ClientTrackingOn enables tracking on the serving connection. See
 // ClientTracking for the pooled-client and built-in-CSC caveats.
-func (c cmdable) ClientTrackingOn(ctx context.Context, opt *ClientTrackingOptions) *StatusCmd {
+func (c statefulCmdable) ClientTrackingOn(ctx context.Context, opt *ClientTrackingOptions) *StatusCmd {
 	args := []interface{}{"client", "tracking", "on"}
 	if opt != nil {
 		if err := validateClientTrackingOptions(opt); err != nil {
@@ -617,7 +634,7 @@ func (c cmdable) ClientTrackingOn(ctx context.Context, opt *ClientTrackingOption
 
 // ClientTrackingOff disables tracking on the serving connection. See
 // ClientTracking for the pooled-client and built-in-CSC caveats.
-func (c cmdable) ClientTrackingOff(ctx context.Context) *StatusCmd {
+func (c statefulCmdable) ClientTrackingOff(ctx context.Context) *StatusCmd {
 	cmd := NewStatusCmd(ctx, "client", "tracking", "off")
 	_ = c(ctx, cmd)
 	return cmd

--- a/commands_test.go
+++ b/commands_test.go
@@ -494,7 +494,10 @@ var _ = Describe("Commands", func() {
 			Expect(client.ClientMaintNotifications(ctx, true, "none").Err()).
 				To(MatchError(ContainSubstring("per-connection state")))
 
-			// The dedicated-connection variant keeps working.
+			// The dedicated-connection variant keeps working — gated, since
+			// CLIENT TRACKING may be unavailable on RE/ACL-restricted targets
+			// (the pooled-rejection assertions above are client-side, no gate).
+			skipIfClientTrackingUnavailable(ctx, rawClient)
 			conn := rawClient.Conn()
 			defer conn.Close()
 			Expect(conn.ClientTrackingOn(ctx, nil).Err()).NotTo(HaveOccurred())

--- a/commands_test.go
+++ b/commands_test.go
@@ -453,22 +453,52 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("should reject invalid ClientTracking option combinations", func() {
-			err := client.ClientTrackingOn(ctx, &redis.ClientTrackingOptions{
+			// Option validation lives on the per-connection (statefulCmdable)
+			// variant: the pooled-client methods reject the command outright
+			// (per-connection state), so validation is only reachable on a
+			// dedicated connection or in a pipeline.
+			conn := rawClient.Conn()
+			defer conn.Close()
+
+			err := conn.ClientTrackingOn(ctx, &redis.ClientTrackingOptions{
 				OptIn:  true,
 				OptOut: true,
 			}).Err()
 			Expect(err).To(MatchError(ContainSubstring("OPTIN and OPTOUT")))
 
-			err = client.ClientTrackingOn(ctx, &redis.ClientTrackingOptions{
+			err = conn.ClientTrackingOn(ctx, &redis.ClientTrackingOptions{
 				Bcast: true,
 				OptIn: true,
 			}).Err()
 			Expect(err).To(MatchError(ContainSubstring("BCAST cannot be combined")))
 
-			err = client.ClientTrackingOn(ctx, &redis.ClientTrackingOptions{
+			err = conn.ClientTrackingOn(ctx, &redis.ClientTrackingOptions{
 				Prefixes: []string{"k:"},
 			}).Err()
 			Expect(err).To(MatchError(ContainSubstring("PREFIX requires BCAST")))
+		})
+
+		It("should reject per-connection commands on pooled clients", func() {
+			// CLIENT TRACKING and CLIENT MAINT_NOTIFICATIONS are per-connection
+			// state: through a pool they would land on an arbitrary connection,
+			// so the pooled-client methods fail with guidance instead. The
+			// subject may be the raw client or an autopipeliner face — both
+			// must reject identically.
+			for _, cmd := range []*redis.StatusCmd{
+				client.ClientTracking(ctx, true, nil),
+				client.ClientTrackingOn(ctx, nil),
+				client.ClientTrackingOff(ctx),
+			} {
+				Expect(cmd.Err()).To(MatchError(ContainSubstring("per-connection state")))
+			}
+			Expect(client.ClientMaintNotifications(ctx, true, "none").Err()).
+				To(MatchError(ContainSubstring("per-connection state")))
+
+			// The dedicated-connection variant keeps working.
+			conn := rawClient.Conn()
+			defer conn.Close()
+			Expect(conn.ClientTrackingOn(ctx, nil).Err()).NotTo(HaveOccurred())
+			Expect(conn.ClientTrackingOff(ctx).Err()).NotTo(HaveOccurred())
 		})
 
 		It("should ConfigGet", func() {

--- a/csc_test.go
+++ b/csc_test.go
@@ -957,25 +957,27 @@ func TestIsClientTrackingCmd(t *testing.T) {
 	}
 }
 
-// TestClientTrackingRejectedWithCSC: on a client with the built-in cache
-// configured, CLIENT TRACKING must be rejected before it reaches a connection —
-// it would flip an arbitrary pool conn's tracking state and leave it filling
-// the cache with entries the server never invalidates. The guard fires without
-// dialing, so no server is needed.
+// TestClientTrackingRejectedWithCSC: CLIENT TRACKING on a CSC client is
+// rejected in two layers, and this pins both. The pooled-client methods are
+// rejected FIRST as per-connection state (they would flip an arbitrary pool
+// conn's tracking state regardless of CSC); the CSC-specific guard remains the
+// backstop on the paths that actually reach a connection — the raw Do escape
+// hatch here, and pipelines in the _Pipeline test below. Both guards fire
+// without dialing, so no server is needed.
 func TestClientTrackingRejectedWithCSC(t *testing.T) {
 	ctx := context.Background()
 	c := NewClient(&Options{
-		Addr:                  "localhost:1", // never dialed: the guard fires first
+		Addr:                  "localhost:1", // never dialed: the guards fire first
 		Protocol:              3,
 		ClientSideCacheConfig: &ClientSideCacheConfig{MaxEntries: 16},
 	})
 	t.Cleanup(func() { _ = c.Close() })
 
-	if err := c.ClientTrackingOff(ctx).Err(); !errors.Is(err, errClientTrackingWithCSC) {
-		t.Fatalf("ClientTrackingOff must be rejected with CSC enabled, got %v", err)
+	if err := c.ClientTrackingOff(ctx).Err(); !errors.Is(err, errClientTrackingOnPooledClient) {
+		t.Fatalf("pooled ClientTrackingOff must be rejected as per-connection state, got %v", err)
 	}
-	if err := c.ClientTrackingOn(ctx, nil).Err(); !errors.Is(err, errClientTrackingWithCSC) {
-		t.Fatalf("ClientTrackingOn must be rejected with CSC enabled, got %v", err)
+	if err := c.ClientTrackingOn(ctx, nil).Err(); !errors.Is(err, errClientTrackingOnPooledClient) {
+		t.Fatalf("pooled ClientTrackingOn must be rejected as per-connection state, got %v", err)
 	}
 	// The raw escape hatch is caught too: the guard matches leading args.
 	// (Non-tracking CLIENT subcommands are covered by TestIsClientTrackingCmd's

--- a/osscluster.go
+++ b/osscluster.go
@@ -1767,6 +1767,14 @@ func (c *ClusterClient) Pipelined(ctx context.Context, fn func(Pipeliner) error)
 }
 
 func (c *ClusterClient) processPipeline(ctx context.Context, cmds []Cmder) error {
+	// Cluster pipelines do not pass through baseClient.generalProcessPipeline, so
+	// surface a queued pooled-state rejection here (see Pipeline.rejectPooledState)
+	// before any command is mapped to a node — otherwise the state command runs on
+	// a borrowed node connection and its reply overwrites the guidance error.
+	if err := stateRejectedErr(cmds); err != nil {
+		setCmdsErr(cmds, err)
+		return err
+	}
 	// Only call time.Now() if pipeline operation duration callback is set to avoid overhead
 	var operationStart time.Time
 	pipelineOpDurationCallback := otel.GetPipelineOperationDurationCallback()
@@ -2250,6 +2258,13 @@ func (c *ClusterClient) processTxPipeline(ctx context.Context, cmds []Cmder) (re
 	cmds = cmds[1 : len(cmds)-1]
 	if len(cmds) == 0 {
 		return nil
+	}
+
+	// Same pooled-state rejection surfacing as processPipeline: cluster tx
+	// pipelines bypass baseClient.generalProcessPipeline too.
+	if err := stateRejectedErr(cmds); err != nil {
+		setCmdsErr(cmds, err)
+		return err
 	}
 
 	state, err := c.state.Get(ctx)

--- a/osscluster.go
+++ b/osscluster.go
@@ -2626,6 +2626,34 @@ func (c *ClusterClient) classifyExecError(execErr error, firstRedirect *txRedire
 	return &txOutcome{kind: txFatal, err: execErr}
 }
 
+// ClientTracking and friends are per-connection commands (statefulCmdable);
+// on a pooled cluster client they fail with guidance. Use a dedicated
+// connection of the relevant node client, a Pipeline/Tx, or the built-in
+// client-side cache.
+func (c *ClusterClient) ClientTracking(ctx context.Context, on bool, opt *ClientTrackingOptions) *StatusCmd {
+	arg := "off"
+	if on {
+		arg = "on"
+	}
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", arg)
+}
+
+// ClientTrackingOn on a pooled cluster client fails with guidance; see ClientTracking.
+func (c *ClusterClient) ClientTrackingOn(ctx context.Context, opt *ClientTrackingOptions) *StatusCmd {
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "on")
+}
+
+// ClientTrackingOff on a pooled cluster client fails with guidance; see ClientTracking.
+func (c *ClusterClient) ClientTrackingOff(ctx context.Context) *StatusCmd {
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "off")
+}
+
+// ClientMaintNotifications on a pooled cluster client fails with guidance;
+// set ClusterOptions.MaintNotificationsConfig instead.
+func (c *ClusterClient) ClientMaintNotifications(ctx context.Context, enabled bool, endpointType string) *StatusCmd {
+	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, "client", "maint_notifications")
+}
+
 func (c *ClusterClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {
 	if len(keys) == 0 {
 		return errNoWatchKeys

--- a/osscluster.go
+++ b/osscluster.go
@@ -1767,10 +1767,8 @@ func (c *ClusterClient) Pipelined(ctx context.Context, fn func(Pipeliner) error)
 }
 
 func (c *ClusterClient) processPipeline(ctx context.Context, cmds []Cmder) error {
-	// Cluster pipelines do not pass through baseClient.generalProcessPipeline, so
-	// surface a queued pooled-state rejection here (see Pipeline.rejectPooledState)
-	// before any command is mapped to a node — otherwise the state command runs on
-	// a borrowed node connection and its reply overwrites the guidance error.
+	// Cluster pipelines bypass baseClient.generalProcessPipeline: surface a
+	// queued pooled-state rejection before any node mapping (fail-before-dispatch).
 	if err := stateRejectedErr(cmds); err != nil {
 		setCmdsErr(cmds, err)
 		return err
@@ -2260,8 +2258,7 @@ func (c *ClusterClient) processTxPipeline(ctx context.Context, cmds []Cmder) (re
 		return nil
 	}
 
-	// Same pooled-state rejection surfacing as processPipeline: cluster tx
-	// pipelines bypass baseClient.generalProcessPipeline too.
+	// Same fail-before-dispatch surfacing as processPipeline.
 	if err := stateRejectedErr(cmds); err != nil {
 		setCmdsErr(cmds, err)
 		return err

--- a/osscluster.go
+++ b/osscluster.go
@@ -2628,19 +2628,21 @@ func (c *ClusterClient) classifyExecError(execErr error, firstRedirect *txRedire
 
 // ClientTracking and friends are per-connection commands (statefulCmdable);
 // on a pooled cluster client they fail with guidance. Use a dedicated
-// connection of the relevant node client, a Pipeline/Tx, or the built-in
-// client-side cache.
+// connection of the relevant node client, or the built-in client-side cache.
 func (c *ClusterClient) ClientTracking(ctx context.Context, on bool, opt *ClientTrackingOptions) *StatusCmd {
-	arg := "off"
-	if on {
-		arg = "on"
+	if !on {
+		return c.ClientTrackingOff(ctx)
 	}
-	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", arg)
+	return c.ClientTrackingOn(ctx, opt)
 }
 
 // ClientTrackingOn on a pooled cluster client fails with guidance; see ClientTracking.
 func (c *ClusterClient) ClientTrackingOn(ctx context.Context, opt *ClientTrackingOptions) *StatusCmd {
-	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "on")
+	args := []interface{}{"client", "tracking", "on"}
+	if opt != nil {
+		args = appendClientTrackingOptions(args, opt)
+	}
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, args...)
 }
 
 // ClientTrackingOff on a pooled cluster client fails with guidance; see ClientTracking.
@@ -2651,7 +2653,16 @@ func (c *ClusterClient) ClientTrackingOff(ctx context.Context) *StatusCmd {
 // ClientMaintNotifications on a pooled cluster client fails with guidance;
 // set ClusterOptions.MaintNotificationsConfig instead.
 func (c *ClusterClient) ClientMaintNotifications(ctx context.Context, enabled bool, endpointType string) *StatusCmd {
-	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, "client", "maint_notifications")
+	args := []interface{}{"client", "maint_notifications"}
+	if enabled {
+		if endpointType == "" {
+			endpointType = "none"
+		}
+		args = append(args, "on", "moving-endpoint-type", endpointType)
+	} else {
+		args = append(args, "off")
+	}
+	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, args...)
 }
 
 func (c *ClusterClient) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {

--- a/pipeline.go
+++ b/pipeline.go
@@ -57,11 +57,69 @@ type Pipeline struct {
 
 	exec pipelineExecer
 	cmds []Cmder
+	// sticky is true only for a Pipeline created from a dedicated *Conn (a
+	// persistent, caller-owned connection). Per-connection state commands
+	// (CLIENT TRACKING / MAINT_NOTIFICATIONS) are then allowed. On a pooled
+	// Pipeline (from a Client/Ring/ClusterClient, or a Tx) the connection is
+	// borrowed for Exec and returned to the pool afterwards, so queuing those
+	// commands would leave per-connection state on an arbitrary connection — the
+	// overrides below reject them there (matching the pooled-client wrappers).
+	sticky bool
 }
 
 func (c *Pipeline) init() {
 	c.cmdable = c.Process
 	c.statefulCmdable = c.Process
+}
+
+// ClientTracking / ClientTrackingOn / ClientTrackingOff / ClientMaintNotifications
+// are per-connection state. On a POOLED pipeline (from a Client/Ring/ClusterClient,
+// or a Tx) the connection is borrowed for Exec and returned to the pool afterwards,
+// so queuing these would leave state on an arbitrary connection — reject them with
+// guidance, exactly like the pooled-client wrappers. On a pipeline from a dedicated
+// *Conn (sticky) they are queued normally, since the state stays on that connection.
+func (c *Pipeline) ClientTracking(ctx context.Context, on bool, opt *ClientTrackingOptions) *StatusCmd {
+	if c.sticky {
+		return c.statefulCmdable.ClientTracking(ctx, on, opt)
+	}
+	if !on {
+		return c.ClientTrackingOff(ctx)
+	}
+	return c.ClientTrackingOn(ctx, opt)
+}
+
+func (c *Pipeline) ClientTrackingOn(ctx context.Context, opt *ClientTrackingOptions) *StatusCmd {
+	if c.sticky {
+		return c.statefulCmdable.ClientTrackingOn(ctx, opt)
+	}
+	args := []interface{}{"client", "tracking", "on"}
+	if opt != nil {
+		args = appendClientTrackingOptions(args, opt)
+	}
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, args...)
+}
+
+func (c *Pipeline) ClientTrackingOff(ctx context.Context) *StatusCmd {
+	if c.sticky {
+		return c.statefulCmdable.ClientTrackingOff(ctx)
+	}
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "off")
+}
+
+func (c *Pipeline) ClientMaintNotifications(ctx context.Context, enabled bool, endpointType string) *StatusCmd {
+	if c.sticky {
+		return c.statefulCmdable.ClientMaintNotifications(ctx, enabled, endpointType)
+	}
+	args := []interface{}{"client", "maint_notifications"}
+	if enabled {
+		if endpointType == "" {
+			endpointType = "none"
+		}
+		args = append(args, "on", "moving-endpoint-type", endpointType)
+	} else {
+		args = append(args, "off")
+	}
+	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, args...)
 }
 
 // Len returns the number of queued commands.

--- a/pipeline.go
+++ b/pipeline.go
@@ -57,15 +57,12 @@ type Pipeline struct {
 
 	exec pipelineExecer
 	cmds []Cmder
-	// sticky is true for a Pipeline created on a connection pinned for the
-	// pipeline's whole lifetime: a dedicated *Conn, or a *Tx (WATCH pins one
-	// connection until the Tx is closed). Per-connection state commands (CLIENT
-	// TRACKING / MAINT_NOTIFICATIONS) are then allowed, since the state stays on
-	// the connection the caller keeps using. On a pooled Pipeline (from a
-	// Client/Ring/ClusterClient, or a Client's TxPipeline) the connection is
-	// borrowed for Exec and returned to the pool afterwards, so queuing those
-	// commands would leave per-connection state on an arbitrary connection — the
-	// overrides below reject them there (matching the pooled-client wrappers).
+	// sticky marks a Pipeline whose connection is pinned for its whole lifetime
+	// (a dedicated *Conn, or a *Tx — WATCH pins until Close). Per-connection
+	// state commands (CLIENT TRACKING / MAINT_NOTIFICATIONS) are allowed only
+	// then: on a pooled Pipeline the conn is borrowed for Exec and returned, so
+	// queuing them would strand state on an arbitrary pool connection — the
+	// overrides below reject them there.
 	sticky bool
 }
 
@@ -74,12 +71,9 @@ func (c *Pipeline) init() {
 	c.statefulCmdable = c.Process
 }
 
-// ClientTracking / ClientTrackingOn / ClientTrackingOff / ClientMaintNotifications
-// are per-connection state. On a POOLED pipeline (from a Client/Ring/ClusterClient,
-// or a Tx) the connection is borrowed for Exec and returned to the pool afterwards,
-// so queuing these would leave state on an arbitrary connection — reject them with
-// guidance, exactly like the pooled-client wrappers. On a pipeline from a dedicated
-// *Conn (sticky) they are queued normally, since the state stays on that connection.
+// ClientTracking / ClientTrackingOn / ClientTrackingOff / ClientMaintNotifications:
+// queued normally on a sticky pipeline, rejected with guidance on a pooled one
+// (see the sticky field doc).
 func (c *Pipeline) ClientTracking(ctx context.Context, on bool, opt *ClientTrackingOptions) *StatusCmd {
 	if c.sticky {
 		return c.statefulCmdable.ClientTracking(ctx, on, opt)
@@ -124,13 +118,11 @@ func (c *Pipeline) ClientMaintNotifications(ctx context.Context, enabled bool, e
 	return c.rejectPooledState(ctx, errClientMaintNotificationsOnPooledClient, args...)
 }
 
-// rejectPooledState queues a pre-failed per-connection state command on a pooled
-// pipeline so Exec/Pipelined surfaces the guidance error even when the caller
-// ignores the returned command (the common Pipelined pattern), and returns it
-// for callers that inspect it directly. The command is flagged so
-// generalProcessPipeline returns its error instead of sending it to a borrowed
-// connection. Queuing (not a pipeline-level pending error) means Discard clears
-// it like any other queued command.
+// rejectPooledState queues a pre-failed state command (flagged stateRejected)
+// so Exec/Pipelined surface the guidance error even when the caller ignores the
+// returned command, and the pipeline executors return it without dispatching.
+// Queuing — rather than a pipeline-level pending error — lets Discard clear it
+// like any other queued command.
 func (c *Pipeline) rejectPooledState(ctx context.Context, err error, args ...interface{}) *StatusCmd {
 	cmd := pooledConnStateCmd(ctx, err, args...)
 	cmd.markStateRejected()

--- a/pipeline.go
+++ b/pipeline.go
@@ -57,10 +57,12 @@ type Pipeline struct {
 
 	exec pipelineExecer
 	cmds []Cmder
-	// sticky is true only for a Pipeline created from a dedicated *Conn (a
-	// persistent, caller-owned connection). Per-connection state commands
-	// (CLIENT TRACKING / MAINT_NOTIFICATIONS) are then allowed. On a pooled
-	// Pipeline (from a Client/Ring/ClusterClient, or a Tx) the connection is
+	// sticky is true for a Pipeline created on a connection pinned for the
+	// pipeline's whole lifetime: a dedicated *Conn, or a *Tx (WATCH pins one
+	// connection until the Tx is closed). Per-connection state commands (CLIENT
+	// TRACKING / MAINT_NOTIFICATIONS) are then allowed, since the state stays on
+	// the connection the caller keeps using. On a pooled Pipeline (from a
+	// Client/Ring/ClusterClient, or a Client's TxPipeline) the connection is
 	// borrowed for Exec and returned to the pool afterwards, so queuing those
 	// commands would leave per-connection state on an arbitrary connection — the
 	// overrides below reject them there (matching the pooled-client wrappers).
@@ -96,14 +98,14 @@ func (c *Pipeline) ClientTrackingOn(ctx context.Context, opt *ClientTrackingOpti
 	if opt != nil {
 		args = appendClientTrackingOptions(args, opt)
 	}
-	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, args...)
+	return c.rejectPooledState(ctx, errClientTrackingOnPooledClient, args...)
 }
 
 func (c *Pipeline) ClientTrackingOff(ctx context.Context) *StatusCmd {
 	if c.sticky {
 		return c.statefulCmdable.ClientTrackingOff(ctx)
 	}
-	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "off")
+	return c.rejectPooledState(ctx, errClientTrackingOnPooledClient, "client", "tracking", "off")
 }
 
 func (c *Pipeline) ClientMaintNotifications(ctx context.Context, enabled bool, endpointType string) *StatusCmd {
@@ -119,7 +121,21 @@ func (c *Pipeline) ClientMaintNotifications(ctx context.Context, enabled bool, e
 	} else {
 		args = append(args, "off")
 	}
-	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, args...)
+	return c.rejectPooledState(ctx, errClientMaintNotificationsOnPooledClient, args...)
+}
+
+// rejectPooledState queues a pre-failed per-connection state command on a pooled
+// pipeline so Exec/Pipelined surfaces the guidance error even when the caller
+// ignores the returned command (the common Pipelined pattern), and returns it
+// for callers that inspect it directly. The command is flagged so
+// generalProcessPipeline returns its error instead of sending it to a borrowed
+// connection. Queuing (not a pipeline-level pending error) means Discard clears
+// it like any other queued command.
+func (c *Pipeline) rejectPooledState(ctx context.Context, err error, args ...interface{}) *StatusCmd {
+	cmd := pooledConnStateCmd(ctx, err, args...)
+	cmd.markStateRejected()
+	_ = c.Process(ctx, cmd)
+	return cmd
 }
 
 // Len returns the number of queued commands.

--- a/redis.go
+++ b/redis.go
@@ -1607,12 +1607,10 @@ type pipelineProcessor func(context.Context, *pool.Conn, []Cmder) (bool, error)
 func (c *baseClient) generalProcessPipeline(
 	ctx context.Context, cmds []Cmder, p pipelineProcessor, operationName string,
 ) error {
-	// Pipeline commands never pass through process, so apply the same CSC state
-	// guard here. initConn's internal client is exempt. The CSC guard runs first
-	// so a CSC client rejects CLIENT TRACKING with the CSC-specific error; the
-	// pooled-state check then surfaces a per-connection state command a pooled
-	// pipeline queued only to be rejected (see Pipeline.rejectPooledState) —
-	// returning its guidance error rather than sending it to a borrowed conn.
+	// Pipelines bypass process, so apply the CSC state guard here (initConn's
+	// internal client is exempt); it runs first so a CSC client gets the
+	// CSC-specific error. Then surface any queued pooled-state rejection
+	// (stateRejectedErr) before dispatch.
 	for _, cmd := range cmds {
 		if err := c.cscCommandError(cmd); err != nil {
 			setCmdsErr(cmds, err)

--- a/redis.go
+++ b/redis.go
@@ -2133,11 +2133,11 @@ func (c *Client) Close() error {
 var (
 	errClientTrackingOnPooledClient = errors.New(
 		"redis: CLIENT TRACKING is per-connection state and cannot be applied through a connection pool; " +
-			"use a dedicated connection (Client.Conn) or a Pipeline/Tx, " +
-			"or configure the built-in client-side cache (Options.ClientSideCacheConfig) instead")
+			"use a dedicated connection (Client.Conn), " +
+			"or configure the built-in client-side cache (the ClientSideCacheConfig option) instead")
 	errClientMaintNotificationsOnPooledClient = errors.New(
 		"redis: CLIENT MAINT_NOTIFICATIONS is per-connection state and cannot be applied through a connection pool; " +
-			"set Options.MaintNotificationsConfig to enable it on every connection automatically, " +
+			"set the MaintNotificationsConfig option to enable it on every connection automatically, " +
 			"or use a dedicated connection (Client.Conn) for manual control")
 )
 
@@ -2154,16 +2154,19 @@ func pooledConnStateCmd(ctx context.Context, err error, args ...interface{}) *St
 // per-connection state. Use Client.Conn, a Pipeline/Tx, or the built-in
 // client-side cache. See the statefulCmdable method for the working variant.
 func (c *Client) ClientTracking(ctx context.Context, on bool, opt *ClientTrackingOptions) *StatusCmd {
-	arg := "off"
-	if on {
-		arg = "on"
+	if !on {
+		return c.ClientTrackingOff(ctx)
 	}
-	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", arg)
+	return c.ClientTrackingOn(ctx, opt)
 }
 
 // ClientTrackingOn on a pooled client fails with guidance; see ClientTracking.
 func (c *Client) ClientTrackingOn(ctx context.Context, opt *ClientTrackingOptions) *StatusCmd {
-	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "on")
+	args := []interface{}{"client", "tracking", "on"}
+	if opt != nil {
+		args = appendClientTrackingOptions(args, opt)
+	}
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, args...)
 }
 
 // ClientTrackingOff on a pooled client fails with guidance; see ClientTracking.
@@ -2177,7 +2180,16 @@ func (c *Client) ClientTrackingOff(ctx context.Context) *StatusCmd {
 // during connection init. See the statefulCmdable method for the working
 // per-connection variant.
 func (c *Client) ClientMaintNotifications(ctx context.Context, enabled bool, endpointType string) *StatusCmd {
-	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, "client", "maint_notifications")
+	args := []interface{}{"client", "maint_notifications"}
+	if enabled {
+		if endpointType == "" {
+			endpointType = "none"
+		}
+		args = append(args, "on", "moving-endpoint-type", endpointType)
+	} else {
+		args = append(args, "off")
+	}
+	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, args...)
 }
 
 func (c *Client) Conn() *Conn {

--- a/redis.go
+++ b/redis.go
@@ -1618,11 +1618,10 @@ func (c *baseClient) generalProcessPipeline(
 			setCmdsErr(cmds, err)
 			return err
 		}
-		if cmd.isStateRejected() {
-			err := cmd.Err()
-			setCmdsErr(cmds, err)
-			return err
-		}
+	}
+	if err := stateRejectedErr(cmds); err != nil {
+		setCmdsErr(cmds, err)
+		return err
 	}
 	// Only call time.Now() if pipeline operation duration callback is set to avoid overhead
 	var operationStart time.Time

--- a/redis.go
+++ b/redis.go
@@ -2122,6 +2122,64 @@ func (c *Client) Close() error {
 	return firstErr
 }
 
+// errClientTrackingOnPooledClient and errClientMaintNotificationsOnPooledClient
+// reject the per-connection commands on pooled clients. Both commands mutate
+// connection state: issued through a pool they would land on an arbitrary
+// connection that is immediately returned to the pool, so the flag applies to
+// a connection the caller cannot address again (and, for CLIENT TRACKING, the
+// invalidation pushes arrive on a connection nothing is reading). The methods
+// exist on the pooled clients only to keep the Cmdable interface intact; they
+// fail with guidance instead of silently misconfiguring one random connection.
+var (
+	errClientTrackingOnPooledClient = errors.New(
+		"redis: CLIENT TRACKING is per-connection state and cannot be applied through a connection pool; " +
+			"use a dedicated connection (Client.Conn) or a Pipeline/Tx, " +
+			"or configure the built-in client-side cache (Options.ClientSideCacheConfig) instead")
+	errClientMaintNotificationsOnPooledClient = errors.New(
+		"redis: CLIENT MAINT_NOTIFICATIONS is per-connection state and cannot be applied through a connection pool; " +
+			"set Options.MaintNotificationsConfig to enable it on every connection automatically, " +
+			"or use a dedicated connection (Client.Conn) for manual control")
+)
+
+// pooledConnStateCmd builds the pre-failed StatusCmd the pooled-client
+// variants of the per-connection commands return. The args mirror the real
+// command so instrumentation that inspects command names still sees them.
+func pooledConnStateCmd(ctx context.Context, err error, args ...interface{}) *StatusCmd {
+	cmd := NewStatusCmd(ctx, args...)
+	cmd.SetErr(err)
+	return cmd
+}
+
+// ClientTracking on a pooled client fails with guidance: CLIENT TRACKING is
+// per-connection state. Use Client.Conn, a Pipeline/Tx, or the built-in
+// client-side cache. See the statefulCmdable method for the working variant.
+func (c *Client) ClientTracking(ctx context.Context, on bool, opt *ClientTrackingOptions) *StatusCmd {
+	arg := "off"
+	if on {
+		arg = "on"
+	}
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", arg)
+}
+
+// ClientTrackingOn on a pooled client fails with guidance; see ClientTracking.
+func (c *Client) ClientTrackingOn(ctx context.Context, opt *ClientTrackingOptions) *StatusCmd {
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "on")
+}
+
+// ClientTrackingOff on a pooled client fails with guidance; see ClientTracking.
+func (c *Client) ClientTrackingOff(ctx context.Context) *StatusCmd {
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "off")
+}
+
+// ClientMaintNotifications on a pooled client fails with guidance: the
+// supported way to enable maintenance notifications for a whole client is
+// Options.MaintNotificationsConfig, which applies it to every connection
+// during connection init. See the statefulCmdable method for the working
+// per-connection variant.
+func (c *Client) ClientMaintNotifications(ctx context.Context, enabled bool, endpointType string) *StatusCmd {
+	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, "client", "maint_notifications")
+}
+
 func (c *Client) Conn() *Conn {
 	// Share the HIMPORT fieldset registry: the sticky pool borrows
 	// connections from this client's pool, so fieldsets prepared on them

--- a/redis.go
+++ b/redis.go
@@ -1608,9 +1608,18 @@ func (c *baseClient) generalProcessPipeline(
 	ctx context.Context, cmds []Cmder, p pipelineProcessor, operationName string,
 ) error {
 	// Pipeline commands never pass through process, so apply the same CSC state
-	// guard here. initConn's internal client is exempt.
+	// guard here. initConn's internal client is exempt. The CSC guard runs first
+	// so a CSC client rejects CLIENT TRACKING with the CSC-specific error; the
+	// pooled-state check then surfaces a per-connection state command a pooled
+	// pipeline queued only to be rejected (see Pipeline.rejectPooledState) —
+	// returning its guidance error rather than sending it to a borrowed conn.
 	for _, cmd := range cmds {
 		if err := c.cscCommandError(cmd); err != nil {
+			setCmdsErr(cmds, err)
+			return err
+		}
+		if cmd.isStateRejected() {
+			err := cmd.Err()
 			setCmdsErr(cmds, err)
 			return err
 		}

--- a/redis.go
+++ b/redis.go
@@ -2540,7 +2540,8 @@ func (c *Conn) Pipelined(ctx context.Context, fn func(Pipeliner) error) ([]Cmder
 
 func (c *Conn) Pipeline() Pipeliner {
 	pipe := Pipeline{
-		exec: c.processPipelineHook,
+		exec:   c.processPipelineHook,
+		sticky: true, // dedicated connection: per-connection state commands are allowed
 	}
 	pipe.init()
 	return &pipe
@@ -2557,6 +2558,7 @@ func (c *Conn) TxPipeline() Pipeliner {
 			cmds = wrapMultiExec(ctx, cmds)
 			return c.processTxPipelineHook(ctx, cmds)
 		},
+		sticky: true, // dedicated connection: per-connection state commands are allowed
 	}
 	pipe.init()
 	return &pipe

--- a/redis.go
+++ b/redis.go
@@ -1613,6 +1613,10 @@ func (c *baseClient) generalProcessPipeline(
 	// (stateRejectedErr) before dispatch.
 	for _, cmd := range cmds {
 		if err := c.cscCommandError(cmd); err != nil {
+			// Overwrite a queued pooled-state rejection's pre-set error: on a CSC
+			// client the CSC-specific error wins, and Exec's return and the
+			// command's Err() must agree (setCmdsErr skips already-errored cmds).
+			cmd.SetErr(err)
 			setCmdsErr(cmds, err)
 			return err
 		}

--- a/ring.go
+++ b/ring.go
@@ -914,12 +914,9 @@ func (c *Ring) generalProcessPipeline(
 		cmds = cmds[1 : len(cmds)-1]
 	}
 
-	// Surface a queued pooled-state rejection BEFORE sharding (see
-	// Pipeline.rejectPooledState): the per-shard dispatch below runs shard groups
-	// concurrently, so without this check the group holding the rejected CLIENT
-	// command fails while the other shards' commands still execute — breaking the
-	// fail-before-dispatch contract that baseClient.generalProcessPipeline and the
-	// cluster pipeline entries enforce.
+	// Surface a queued pooled-state rejection BEFORE sharding: shard groups run
+	// concurrently, so a later check would let the other shards execute while
+	// only the rejected command's group fails (fail-before-dispatch contract).
 	if err := stateRejectedErr(cmds); err != nil {
 		setCmdsErr(cmds, err)
 		return err

--- a/ring.go
+++ b/ring.go
@@ -960,6 +960,33 @@ func (c *Ring) generalProcessPipeline(
 	return cmdsFirstErr(cmds)
 }
 
+// ClientTracking and friends are per-connection commands (statefulCmdable);
+// on a pooled ring client they fail with guidance. Use a dedicated connection
+// of the relevant shard client, a Pipeline/Tx, or the built-in client-side cache.
+func (c *Ring) ClientTracking(ctx context.Context, on bool, opt *ClientTrackingOptions) *StatusCmd {
+	arg := "off"
+	if on {
+		arg = "on"
+	}
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", arg)
+}
+
+// ClientTrackingOn on a pooled ring client fails with guidance; see ClientTracking.
+func (c *Ring) ClientTrackingOn(ctx context.Context, opt *ClientTrackingOptions) *StatusCmd {
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "on")
+}
+
+// ClientTrackingOff on a pooled ring client fails with guidance; see ClientTracking.
+func (c *Ring) ClientTrackingOff(ctx context.Context) *StatusCmd {
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "off")
+}
+
+// ClientMaintNotifications on a pooled ring client fails with guidance;
+// set RingOptions.MaintNotificationsConfig instead.
+func (c *Ring) ClientMaintNotifications(ctx context.Context, enabled bool, endpointType string) *StatusCmd {
+	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, "client", "maint_notifications")
+}
+
 func (c *Ring) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {
 	if len(keys) == 0 {
 		return fmt.Errorf("redis: Watch requires at least one key")

--- a/ring.go
+++ b/ring.go
@@ -962,18 +962,21 @@ func (c *Ring) generalProcessPipeline(
 
 // ClientTracking and friends are per-connection commands (statefulCmdable);
 // on a pooled ring client they fail with guidance. Use a dedicated connection
-// of the relevant shard client, a Pipeline/Tx, or the built-in client-side cache.
+// of the relevant shard client, or the built-in client-side cache.
 func (c *Ring) ClientTracking(ctx context.Context, on bool, opt *ClientTrackingOptions) *StatusCmd {
-	arg := "off"
-	if on {
-		arg = "on"
+	if !on {
+		return c.ClientTrackingOff(ctx)
 	}
-	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", arg)
+	return c.ClientTrackingOn(ctx, opt)
 }
 
 // ClientTrackingOn on a pooled ring client fails with guidance; see ClientTracking.
 func (c *Ring) ClientTrackingOn(ctx context.Context, opt *ClientTrackingOptions) *StatusCmd {
-	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "on")
+	args := []interface{}{"client", "tracking", "on"}
+	if opt != nil {
+		args = appendClientTrackingOptions(args, opt)
+	}
+	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, args...)
 }
 
 // ClientTrackingOff on a pooled ring client fails with guidance; see ClientTracking.
@@ -981,10 +984,19 @@ func (c *Ring) ClientTrackingOff(ctx context.Context) *StatusCmd {
 	return pooledConnStateCmd(ctx, errClientTrackingOnPooledClient, "client", "tracking", "off")
 }
 
-// ClientMaintNotifications on a pooled ring client fails with guidance;
-// set RingOptions.MaintNotificationsConfig instead.
+// ClientMaintNotifications on a pooled ring client fails with guidance; set
+// MaintNotificationsConfig on the per-shard Options (RingOptions.NewClient) instead.
 func (c *Ring) ClientMaintNotifications(ctx context.Context, enabled bool, endpointType string) *StatusCmd {
-	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, "client", "maint_notifications")
+	args := []interface{}{"client", "maint_notifications"}
+	if enabled {
+		if endpointType == "" {
+			endpointType = "none"
+		}
+		args = append(args, "on", "moving-endpoint-type", endpointType)
+	} else {
+		args = append(args, "off")
+	}
+	return pooledConnStateCmd(ctx, errClientMaintNotificationsOnPooledClient, args...)
 }
 
 func (c *Ring) Watch(ctx context.Context, fn func(*Tx) error, keys ...string) error {

--- a/ring.go
+++ b/ring.go
@@ -914,6 +914,17 @@ func (c *Ring) generalProcessPipeline(
 		cmds = cmds[1 : len(cmds)-1]
 	}
 
+	// Surface a queued pooled-state rejection BEFORE sharding (see
+	// Pipeline.rejectPooledState): the per-shard dispatch below runs shard groups
+	// concurrently, so without this check the group holding the rejected CLIENT
+	// command fails while the other shards' commands still execute — breaking the
+	// fail-before-dispatch contract that baseClient.generalProcessPipeline and the
+	// cluster pipeline entries enforce.
+	if err := stateRejectedErr(cmds); err != nil {
+		setCmdsErr(cmds, err)
+		return err
+	}
+
 	cmdsMap := make(map[string][]Cmder)
 
 	for _, cmd := range cmds {

--- a/tx.go
+++ b/tx.go
@@ -148,6 +148,9 @@ func (c *Tx) Pipeline() Pipeliner {
 		exec: func(ctx context.Context, cmds []Cmder) error {
 			return c.processPipelineHook(ctx, cmds)
 		},
+		// A Tx pins one connection (WATCH) until it is closed, so per-connection
+		// state commands stay on the connection the caller keeps using.
+		sticky: true,
 	}
 	pipe.init()
 	return &pipe
@@ -191,6 +194,9 @@ func (c *Tx) TxPipeline() Pipeliner {
 			}
 			return err
 		},
+		// A Tx pins one connection (WATCH) until it is closed, so per-connection
+		// state commands stay on the connection the caller keeps using.
+		sticky: true,
 	}
 	pipe.init()
 	return &pipe

--- a/tx.go
+++ b/tx.go
@@ -148,8 +148,7 @@ func (c *Tx) Pipeline() Pipeliner {
 		exec: func(ctx context.Context, cmds []Cmder) error {
 			return c.processPipelineHook(ctx, cmds)
 		},
-		// A Tx pins one connection (WATCH) until it is closed, so per-connection
-		// state commands stay on the connection the caller keeps using.
+		// A Tx pins one connection until Close: state commands are safe here.
 		sticky: true,
 	}
 	pipe.init()
@@ -194,8 +193,7 @@ func (c *Tx) TxPipeline() Pipeliner {
 			}
 			return err
 		},
-		// A Tx pins one connection (WATCH) until it is closed, so per-connection
-		// state commands stay on the connection the caller keeps using.
+		// A Tx pins one connection until Close: state commands are safe here.
 		sticky: true,
 	}
 	pipe.init()


### PR DESCRIPTION
CLIENT TRACKING (and its On/Off variants) and CLIENT MAINT_NOTIFICATIONS mutate per-connection state, exactly like CLIENT SETNAME/SETINFO, but lived on cmdable: on a pooled client they executed on an arbitrary pool connection that was immediately returned to the pool, so the flag applied to a connection the caller could not address again — and for CLIENT TRACKING the invalidation pushes arrived on a connection nothing was reading. They now live on statefulCmdable, next to ClientSetName, where the connection is pinned: usable on *redis.Conn (Client.Conn), Pipeline and Tx.

The pooled clients — Client, ClusterClient, Ring and AutoPipeliner — keep same-named methods so the Cmdable and UniversalClient interfaces are unchanged and existing code still compiles. Those methods now return a pre-failed StatusCmd with guidance instead of silently misconfiguring one random connection: CLIENT TRACKING points at Client.Conn, Pipeline/Tx or the built-in client-side cache (Options.ClientSideCacheConfig); CLIENT MAINT_NOTIFICATIONS points at Options.MaintNotificationsConfig, which the library already applies to every connection during connection init. The returned command carries the real command name and arguments so instrumentation that inspects commands still sees them.

The library's own uses were already per-connection (the connection-init handshake issues CLIENT TRACKING ON through the pinned init pipeline and CLIENT MAINT_NOTIFICATIONS through the pinned init wrapper) and are unaffected. The option-validation spec moves to a dedicated connection, and a new spec pins the pooled-client rejection on the raw client and both autopipeliner faces, plus the working Conn path.

### Review refinements

On a POOLED Pipeline/TxPipeline the rejected state command is now QUEUED
(flagged internally) so `Exec`/`Pipelined` surface the guidance error even when
the callback ignores the returned command — enforced fail-before-dispatch in
every pipeline entry point (standalone, ClusterClient, Ring; a batch mixing
keyed commands never partially executes). Pipelines from a dedicated `*Conn`
AND from a `*Tx` are sticky (WATCH pins one connection for the Tx lifetime),
so state commands queue there normally, matching the direct `tx.ClientTracking*`
face.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pipeline execution paths across client types and changes observable errors for pooled CLIENT TRACKING/MAINT_NOTIFICATIONS callers, but behavior is intentionally stricter with broad test coverage and interface compatibility preserved.
> 
> **Overview**
> **CLIENT TRACKING** and **CLIENT MAINT_NOTIFICATIONS** move to `statefulCmdable` for real execution on pinned connections (`Conn`, sticky pipelines). Pooled `Client`, `ClusterClient`, `Ring`, and `AutoPipeliner` keep the same method names but return pre-failed `StatusCmd`s with guidance (and full `Args()` for observability) instead of mutating a random pool connection.
> 
> On **pooled** `Pipeline` / `TxPipeline`, those commands are still **queued** but marked `stateRejected`; `Exec` / `Pipelined` fail **before dispatch** via `stateRejectedErr` in standalone, cluster, and ring paths—so ignored return values and mixed batches cannot partially run or silently succeed. **Sticky** pipelines (`Conn`, `Tx` with `sticky: true`) queue and send them normally.
> 
> Tests cover args preservation, pooled vs conn pipelines, cluster/ring fail-before-dispatch, and Tx stickiness. CI **govulncheck** uses Go `stable` instead of `1.26.x`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b6008a4f95e450f52331c761005c3f6ce9986f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->