### PR TITLE
perf(autopipeline): better pool utilization on stranglers - *Client

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
+          go-version: "stable"
           cache: true
 
       - name: Install govulncheck

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -1882,12 +1882,21 @@ func (ap *AutoPipeliner) silenceGap() time.Duration {
 // without blocking: an idle connection is ready, or the pool has not yet dialed
 // to capacity (the pipeline pool runs MinIdleConns=0, so it dials on demand up
 // to Size). When the pool is unknown (nil — e.g. a cluster client) it returns
-// false, so the straggler-hold keeps its conservative long hold. Two cheap
-// reads (a connsMu lock each); called only on a gap fire, not per command.
+// false, so the straggler-hold keeps its conservative long hold. Called only on
+// a gap fire, not per command.
+//
+// Prefer the pool's own HasFreeCapacity probe (all *ConnPool implement it): the
+// plain IdleLen()/Len()<Size() heuristic below ignores MaxActiveConns, so a pool
+// with MaxActiveConns < PoolSize and no idle conn would report free even though
+// the flush's Get would hit ErrPoolExhausted (codex #3962). The heuristic stays
+// as a fallback for any Pooler that does not implement the probe.
 func (ap *AutoPipeliner) pipelineHasFreeConn() bool {
 	p := ap.pipelinePool
 	if p == nil {
 		return false
+	}
+	if hc, ok := p.(interface{ HasFreeCapacity() bool }); ok {
+		return hc.HasFreeCapacity()
 	}
 	return p.IdleLen() > 0 || p.Len() < p.Size()
 }

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -553,12 +553,15 @@ type AutoPipeliner struct {
 	// tell whether flushing a tiny batch now would contend for a scarce pooled
 	// connection — see awaitExpectedArrivals / pipelineHasFreeConn.
 	pipelinePool pool.Pooler
-	// cscEnabled: client-side caching is active on the underlying client
-	// (captured at construction; CSC attaches at client creation). Gates the
-	// cacheable-solo routing: only a CSC client routes through Process (which
-	// honors the cache); otherwise solos stay on the pipeline pool.
-	cscEnabled bool
-	config     *AutoPipelineOptions
+	// cscActiveFn reports whether client-side caching is CURRENTLY active on the
+	// underlying client (nil when the client type exposes none). Consulted per
+	// solo dispatch — not captured as a bool — because CSC can disable itself
+	// mid-life (RESP3 fallback, processor damping), after which cacheable solos
+	// should return to the pipeline pool instead of the main pool. Gates the
+	// cacheable-solo routing: only an active-CSC client routes through Process
+	// (which honors the cache).
+	cscActiveFn func() bool
+	config      *AutoPipelineOptions
 	// blocking selects how the typed command surface (Set, Get, ...) behaves:
 	// when true the command call itself blocks until the command has executed
 	// (drop-in, synchronous shape); when false the call returns immediately and
@@ -812,10 +815,10 @@ func newAutoPipeliner(pipeliner cmdableClient, config *AutoPipelineOptions, bloc
 	if pp, ok := pipeliner.(interface{ getPipelinePool() pool.Pooler }); ok {
 		ap.pipelinePool = pp.getPipelinePool()
 	}
-	// CSC state (in-package assertion; *ClusterClient does not expose it) — see
-	// the cscEnabled field doc.
+	// CSC probe (in-package assertion; *ClusterClient does not expose it) — see
+	// the cscActiveFn field doc.
 	if cc, ok := pipeliner.(interface{ autopipelineCSCActive() bool }); ok {
-		ap.cscEnabled = cc.autopipelineCSCActive()
+		ap.cscActiveFn = cc.autopipelineCSCActive
 	}
 
 	// Route the typed command surface. Blocking: the command call blocks until
@@ -2412,9 +2415,9 @@ func (s *apShard) flushBatchSlice() {
 			err := ap.pipeliner.withProcessHook(context.Background(), solo, func(ctx context.Context, cmd Cmder) error {
 				// A cacheable solo on a CSC client goes through Process so the cache
 				// is honored (processPipeline bypasses processCached). Gated on
-				// cscEnabled: without CSC, Process would just run on the MAIN pool,
-				// ignoring the pipeline pool the straggler gate probed.
-				if ap.cscEnabled && isCacheable(cmd) {
+				// the LIVE CSC state: without active CSC, Process would just run on
+				// the MAIN pool, ignoring the pipeline pool the straggler gate probed.
+				if ap.cscActiveFn != nil && ap.cscActiveFn() && isCacheable(cmd) {
 					return ap.pipeliner.process(ctx, cmd)
 				}
 				// One-command pipeline on the PIPELINE pool (falls back to the main

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -553,12 +553,10 @@ type AutoPipeliner struct {
 	// tell whether flushing a tiny batch now would contend for a scarce pooled
 	// connection — see awaitExpectedArrivals / pipelineHasFreeConn.
 	pipelinePool pool.Pooler
-	// cscEnabled records whether the underlying client has client-side caching
-	// active. Captured once at construction (CSC attaches at client creation,
-	// before the autopipeliner is lazily built). Only a CSC client benefits from
-	// routing a cacheable solo straggler through the single-command Process path
-	// (which honors the cache); a non-CSC client must instead dispatch it on the
-	// pipeline pool the straggler gate probed, not the main pool (#3962).
+	// cscEnabled: client-side caching is active on the underlying client
+	// (captured at construction; CSC attaches at client creation). Gates the
+	// cacheable-solo routing: only a CSC client routes through Process (which
+	// honors the cache); otherwise solos stay on the pipeline pool.
 	cscEnabled bool
 	config     *AutoPipelineOptions
 	// blocking selects how the typed command surface (Set, Get, ...) behaves:
@@ -814,9 +812,8 @@ func newAutoPipeliner(pipeliner cmdableClient, config *AutoPipelineOptions, bloc
 	if pp, ok := pipeliner.(interface{ getPipelinePool() pool.Pooler }); ok {
 		ap.pipelinePool = pp.getPipelinePool()
 	}
-	// Capture whether client-side caching is active (in-package, promoted to
-	// *Client; a *ClusterClient does not expose it). Used to route a cacheable
-	// solo straggler: through Process only when the cache can actually serve it.
+	// CSC state (in-package assertion; *ClusterClient does not expose it) — see
+	// the cscEnabled field doc.
 	if cc, ok := pipeliner.(interface{ autopipelineCSCActive() bool }); ok {
 		ap.cscEnabled = cc.autopipelineCSCActive()
 	}
@@ -2413,21 +2410,15 @@ func (s *apShard) flushBatchSlice() {
 			// deadlock-free via the dispGid guard stamped above.
 			// A successful short-circuit stays successful (see dispatchCmds).
 			err := ap.pipeliner.withProcessHook(context.Background(), solo, func(ctx context.Context, cmd Cmder) error {
-				// A cacheable command goes through the single-command Process path so
-				// client-side caching is honored (processCommand -> processCached) —
-				// processPipeline bypasses that branch and would silently drop CSC
-				// hits/fills for one-command flushes (codex #3962). But ONLY when the
-				// client actually has CSC: on a non-CSC client Process just runs on the
-				// MAIN pool, so a cacheable solo would ignore the dedicated pipeline pool
-				// the straggler gate probed and could contend on a saturated main pool
-				// while pipeline capacity sits free. So gate on cscEnabled.
+				// A cacheable solo on a CSC client goes through Process so the cache
+				// is honored (processPipeline bypasses processCached). Gated on
+				// cscEnabled: without CSC, Process would just run on the MAIN pool,
+				// ignoring the pipeline pool the straggler gate probed.
 				if ap.cscEnabled && isCacheable(cmd) {
 					return ap.pipeliner.process(ctx, cmd)
 				}
-				// Otherwise dispatch as a one-command pipeline on the PIPELINE pool, the
-				// same pool the straggler-hold gate probes (processPipeline falls back to
-				// the main pool when none exists). The solo goroutine dispatch (the 2xRTT
-				// phase-lock fix) is unchanged.
+				// One-command pipeline on the PIPELINE pool (falls back to the main
+				// pool when none exists).
 				return ap.pipeliner.processPipeline(ctx, []Cmder{cmd})
 			})
 			solo.SetErr(err)

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -553,7 +553,14 @@ type AutoPipeliner struct {
 	// tell whether flushing a tiny batch now would contend for a scarce pooled
 	// connection — see awaitExpectedArrivals / pipelineHasFreeConn.
 	pipelinePool pool.Pooler
-	config       *AutoPipelineOptions
+	// cscEnabled records whether the underlying client has client-side caching
+	// active. Captured once at construction (CSC attaches at client creation,
+	// before the autopipeliner is lazily built). Only a CSC client benefits from
+	// routing a cacheable solo straggler through the single-command Process path
+	// (which honors the cache); a non-CSC client must instead dispatch it on the
+	// pipeline pool the straggler gate probed, not the main pool (#3962).
+	cscEnabled bool
+	config     *AutoPipelineOptions
 	// blocking selects how the typed command surface (Set, Get, ...) behaves:
 	// when true the command call itself blocks until the command has executed
 	// (drop-in, synchronous shape); when false the call returns immediately and
@@ -806,6 +813,12 @@ func newAutoPipeliner(pipeliner cmdableClient, config *AutoPipelineOptions, bloc
 	// keeps its conservative long hold rather than guess at pool pressure.
 	if pp, ok := pipeliner.(interface{ getPipelinePool() pool.Pooler }); ok {
 		ap.pipelinePool = pp.getPipelinePool()
+	}
+	// Capture whether client-side caching is active (in-package, promoted to
+	// *Client; a *ClusterClient does not expose it). Used to route a cacheable
+	// solo straggler: through Process only when the cache can actually serve it.
+	if cc, ok := pipeliner.(interface{ autopipelineCSCActive() bool }); ok {
+		ap.cscEnabled = cc.autopipelineCSCActive()
 	}
 
 	// Route the typed command surface. Blocking: the command call blocks until
@@ -2400,19 +2413,21 @@ func (s *apShard) flushBatchSlice() {
 			// deadlock-free via the dispGid guard stamped above.
 			// A successful short-circuit stays successful (see dispatchCmds).
 			err := ap.pipeliner.withProcessHook(context.Background(), solo, func(ctx context.Context, cmd Cmder) error {
-				// A CACHEABLE command goes through the single-command Process path so
-				// client-side caching is honored (processCommand -> processCached);
+				// A cacheable command goes through the single-command Process path so
+				// client-side caching is honored (processCommand -> processCached) —
 				// processPipeline bypasses that branch and would silently drop CSC
-				// hits/fills for one-command flushes (codex #3962). Process is a no-op
-				// vs. the pipeline pool for CSC purposes on non-CSC clients (it just
-				// runs on the main pool — fine for a single command).
-				if isCacheable(cmd) {
+				// hits/fills for one-command flushes (codex #3962). But ONLY when the
+				// client actually has CSC: on a non-CSC client Process just runs on the
+				// MAIN pool, so a cacheable solo would ignore the dedicated pipeline pool
+				// the straggler gate probed and could contend on a saturated main pool
+				// while pipeline capacity sits free. So gate on cscEnabled.
+				if ap.cscEnabled && isCacheable(cmd) {
 					return ap.pipeliner.process(ctx, cmd)
 				}
-				// Non-cacheable solo: dispatch as a one-command pipeline on the
-				// PIPELINE pool, the same pool the straggler-hold gate probes
-				// (processPipeline falls back to the main pool when none exists). The
-				// solo goroutine dispatch (the 2xRTT phase-lock fix) is unchanged.
+				// Otherwise dispatch as a one-command pipeline on the PIPELINE pool, the
+				// same pool the straggler-hold gate probes (processPipeline falls back to
+				// the main pool when none exists). The solo goroutine dispatch (the 2xRTT
+				// phase-lock fix) is unchanged.
 				return ap.pipeliner.processPipeline(ctx, []Cmder{cmd})
 			})
 			solo.SetErr(err)

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -2400,13 +2400,19 @@ func (s *apShard) flushBatchSlice() {
 			// deadlock-free via the dispGid guard stamped above.
 			// A successful short-circuit stays successful (see dispatchCmds).
 			err := ap.pipeliner.withProcessHook(context.Background(), solo, func(ctx context.Context, cmd Cmder) error {
-				// Dispatch on the PIPELINE pool (as a one-command pipeline), not the
-				// main pool, so the flush uses the same pool the straggler-hold gate
-				// probes (codex #3962). processPipeline falls back to the main pool
-				// when no dedicated pipeline pool exists, so this is a no-op for
-				// default clients and only unifies the pools when one is configured.
-				// The solo goroutine dispatch (which is what avoids the 2xRTT
-				// flusher phase-lock) is unchanged.
+				// A CACHEABLE command goes through the single-command Process path so
+				// client-side caching is honored (processCommand -> processCached);
+				// processPipeline bypasses that branch and would silently drop CSC
+				// hits/fills for one-command flushes (codex #3962). Process is a no-op
+				// vs. the pipeline pool for CSC purposes on non-CSC clients (it just
+				// runs on the main pool — fine for a single command).
+				if isCacheable(cmd) {
+					return ap.pipeliner.process(ctx, cmd)
+				}
+				// Non-cacheable solo: dispatch as a one-command pipeline on the
+				// PIPELINE pool, the same pool the straggler-hold gate probes
+				// (processPipeline falls back to the main pool when none exists). The
+				// solo goroutine dispatch (the 2xRTT phase-lock fix) is unchanged.
 				return ap.pipeliner.processPipeline(ctx, []Cmder{cmd})
 			})
 			solo.SetErr(err)

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sys/cpu"
 
 	"github.com/redis/go-redis/v9/internal"
+	"github.com/redis/go-redis/v9/internal/pool"
 )
 
 // AutoPipelineOptions configures the autopipelining behavior.
@@ -545,7 +546,14 @@ type AutoPipeliner struct {
 	cmdable // Embed cmdable to get all Redis command methods
 
 	pipeliner cmdableClient
-	config    *AutoPipelineOptions
+	// pipelinePool is the connection pool that backs autopipelined batch
+	// dispatch (distinct from the client's main pool). Captured once at
+	// construction via an in-package assertion; nil when the underlying client
+	// does not expose one (e.g. *ClusterClient). The straggler-hold reads it to
+	// tell whether flushing a tiny batch now would contend for a scarce pooled
+	// connection — see awaitExpectedArrivals / pipelineHasFreeConn.
+	pipelinePool pool.Pooler
+	config       *AutoPipelineOptions
 	// blocking selects how the typed command surface (Set, Get, ...) behaves:
 	// when true the command call itself blocks until the command has executed
 	// (drop-in, synchronous shape); when false the call returns immediately and
@@ -792,6 +800,12 @@ func newAutoPipeliner(pipeliner cmdableClient, config *AutoPipelineOptions, bloc
 		blocking:  blocking,
 		ctx:       ctx,
 		cancel:    cancel,
+	}
+	// Capture the pipeline pool (in-package, promoted to *Client). nil for a
+	// client that has none (e.g. *ClusterClient) — the straggler-hold then
+	// keeps its conservative long hold rather than guess at pool pressure.
+	if pp, ok := pipeliner.(interface{ getPipelinePool() pool.Pooler }); ok {
+		ap.pipelinePool = pp.getPipelinePool()
 	}
 
 	// Route the typed command surface. Blocking: the command call blocks until
@@ -1820,6 +1834,23 @@ const (
 // near-empty flush; once nothing is in flight, any size flushes immediately.
 const coalesceMinFlush = 8
 
+// stragglerHoldGaps bounds the straggler-hold WHEN the pipeline pool has a free
+// connection (see awaitExpectedArrivals): at most this many silence gaps (each
+// clamp(execEWMA/8, 200µs, 2ms), so the bound tracks the round trip) pass before
+// queued stragglers flush. The old behavior re-armed until
+// autoPipelinePermitBackstop — effectively until the in-flight batch's reply
+// landed, ~1 RTT — so a straggler that enqueued behind an in-flight batch waited
+// a full round trip BEFORE its own, i.e. every such op paid ~2x RTT (measured
+// with a phase trace on a deterministic 50ms link: uncached p95 pinned at 2x RTT
+// / 107ms at low-to-mid concurrency, straggler-hold avg == 1 RTT; the bound
+// collapsed that to ~1 RTT / 62ms). The bound is applied ONLY when a pooled
+// connection is idle or dial-able — when the pool is saturated the long hold is
+// kept, because flushing tiny batches into a full pool thrashes it and cuts
+// throughput (measured ~7x at a squeezed pool). The 30s
+// autoPipelinePermitBackstop remains the absolute safety ceiling on the flush
+// path itself (a wedged connection).
+const stragglerHoldGaps = 3
+
 // observeBatchExec folds one batch execution duration into execEWMA.
 func (ap *AutoPipeliner) observeBatchExec(d time.Duration) {
 	sample := int64(d)
@@ -1845,6 +1876,20 @@ func (ap *AutoPipeliner) silenceGap() time.Duration {
 		return silenceGapCeil
 	}
 	return g
+}
+
+// pipelineHasFreeConn reports whether the pipeline pool can serve another batch
+// without blocking: an idle connection is ready, or the pool has not yet dialed
+// to capacity (the pipeline pool runs MinIdleConns=0, so it dials on demand up
+// to Size). When the pool is unknown (nil — e.g. a cluster client) it returns
+// false, so the straggler-hold keeps its conservative long hold. Two cheap
+// reads (a connsMu lock each); called only on a gap fire, not per command.
+func (ap *AutoPipeliner) pipelineHasFreeConn() bool {
+	p := ap.pipelinePool
+	if p == nil {
+		return false
+	}
+	return p.IdleLen() > 0 || p.Len() < p.Size()
 }
 
 // awaitExpectedArrivals holds the flusher while related work is in motion, so
@@ -1905,15 +1950,33 @@ func (s *apShard) awaitExpectedArrivals(batchSize int) {
 				// flushing a near-empty pipeline burns a connection for a full
 				// round trip (measured at high WAN concurrency: straggler
 				// flushes of 1-3 commands starved the connection pool and
-				// doubled p50). Hold them — the next completed batch's wave
-				// sweeps them along, and the wave path below flushes promptly.
-				// The hold is bounded like the permit wait: with read timeouts
-				// disabled a wedged batch could pin inFlight forever, and the
-				// held stragglers must not hang with it.
+				// doubled p50). How long to hold depends on whether the pipeline
+				// pool has a connection to spare:
+				//
+				//   - a connection is free -> bound the hold at stragglerHoldGaps
+				//     silence gaps (a few ms). Flushing then costs an otherwise-
+				//     idle connection and saves the straggler ~1 RTT. Waiting a
+				//     whole round trip here (the old behavior) is what pinned
+				//     low-concurrency stragglers at 2x RTT.
+				//   - the pool is saturated -> keep the original long hold. Tiny
+				//     flushes into a full pool thrash it: they cannot coalesce
+				//     into the deep pipelines the scarce connections need, and
+				//     throughput collapses (measured at a squeezed pool: an
+				//     unconditional few-ms bound cut throughput ~7x). Holding
+				//     lets the next completed batch's wave sweep the stragglers
+				//     along.
+				//
+				// A wedged in-flight batch cannot hang the held stragglers past
+				// the bound (the free-conn case caps at a few ms; the flush path
+				// keeps its own autoPipelinePermitBackstop safety ceiling).
 				if holdStart.IsZero() {
 					holdStart = time.Now()
 				}
-				if time.Since(holdStart) < autoPipelinePermitBackstop {
+				stragCap := autoPipelinePermitBackstop
+				if ap.pipelineHasFreeConn() {
+					stragCap = stragglerHoldGaps * gap
+				}
+				if time.Since(holdStart) < stragCap {
 					lastSeenExpected = ap.expectedArrivals.Load()
 					fallback.Reset(gap)
 					continue

--- a/autopipeline.go
+++ b/autopipeline.go
@@ -2400,7 +2400,14 @@ func (s *apShard) flushBatchSlice() {
 			// deadlock-free via the dispGid guard stamped above.
 			// A successful short-circuit stays successful (see dispatchCmds).
 			err := ap.pipeliner.withProcessHook(context.Background(), solo, func(ctx context.Context, cmd Cmder) error {
-				return ap.pipeliner.process(ctx, cmd)
+				// Dispatch on the PIPELINE pool (as a one-command pipeline), not the
+				// main pool, so the flush uses the same pool the straggler-hold gate
+				// probes (codex #3962). processPipeline falls back to the main pool
+				// when no dedicated pipeline pool exists, so this is a no-op for
+				// default clients and only unifies the pools when one is configured.
+				// The solo goroutine dispatch (which is what avoids the 2xRTT
+				// flusher phase-lock) is unchanged.
+				return ap.pipeliner.processPipeline(ctx, []Cmder{cmd})
 			})
 			solo.SetErr(err)
 			ap.observeBatchExec(time.Since(execStart))

--- a/autopipeline_internal_test.go
+++ b/autopipeline_internal_test.go
@@ -1468,3 +1468,49 @@ func TestAsyncProcessReportsSubmitRejection(t *testing.T) {
 		t.Fatalf("Process after Close = %v, want ErrClosed", err)
 	}
 }
+
+// TestAutopipelineSoloRoutingGate pins #3962: a cacheable solo straggler is
+// routed through the cache-honoring Process path (main pool) ONLY when the
+// client has client-side caching active. A non-CSC client (the default) must
+// keep cacheable solos on the pipeline pool the straggler gate probed, so
+// ap.cscEnabled — the gate — must be false there and true for a CSC client.
+func TestAutopipelineSoloRoutingGate(t *testing.T) {
+	ctx := context.Background()
+
+	// Non-CSC client: dial-free and deterministic.
+	plain := NewClient(&Options{Addr: "localhost:1", Protocol: 3})
+	defer plain.Close()
+	ap, err := plain.AsyncAutoPipeline()
+	if err != nil {
+		t.Fatalf("AsyncAutoPipeline: %v", err)
+	}
+	defer ap.Close()
+	if ap.cscEnabled {
+		t.Fatal("non-CSC client: ap.cscEnabled = true, want false — a cacheable solo would wrongly use the main pool instead of the pipeline pool")
+	}
+
+	// CSC client: needs a live RESP3 server for CLIENT TRACKING to attach.
+	if err := NewClient(&Options{Addr: internalTestRedisAddr(), Protocol: 3}).Ping(ctx).Err(); err != nil {
+		t.Skipf("no redis for the CSC half: %v", err)
+	}
+	cscC := NewClient(&Options{
+		Addr:                  internalTestRedisAddr(),
+		Protocol:              3,
+		ClientSideCacheConfig: &ClientSideCacheConfig{MaxEntries: 128},
+	})
+	defer cscC.Close()
+	if err := cscC.Ping(ctx).Err(); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
+	if !cscC.autopipelineCSCActive() {
+		t.Skip("client-side caching did not attach (server lacks CLIENT TRACKING?)")
+	}
+	apc, err := cscC.AsyncAutoPipeline()
+	if err != nil {
+		t.Fatalf("AsyncAutoPipeline (csc): %v", err)
+	}
+	defer apc.Close()
+	if !apc.cscEnabled {
+		t.Fatal("CSC client: ap.cscEnabled = false, want true — cacheable solos must honor the cache")
+	}
+}

--- a/autopipeline_internal_test.go
+++ b/autopipeline_internal_test.go
@@ -1473,7 +1473,8 @@ func TestAsyncProcessReportsSubmitRejection(t *testing.T) {
 // routed through the cache-honoring Process path (main pool) ONLY when the
 // client has client-side caching active. A non-CSC client (the default) must
 // keep cacheable solos on the pipeline pool the straggler gate probed, so
-// ap.cscEnabled — the gate — must be false there and true for a CSC client.
+// the live gate (cscActiveFn) must report false there and true for a CSC
+// client — and false again after CSC disables itself mid-life.
 func TestAutopipelineSoloRoutingGate(t *testing.T) {
 	ctx := context.Background()
 
@@ -1485,8 +1486,8 @@ func TestAutopipelineSoloRoutingGate(t *testing.T) {
 		t.Fatalf("AsyncAutoPipeline: %v", err)
 	}
 	defer ap.Close()
-	if ap.cscEnabled {
-		t.Fatal("non-CSC client: ap.cscEnabled = true, want false — a cacheable solo would wrongly use the main pool instead of the pipeline pool")
+	if ap.cscActiveFn != nil && ap.cscActiveFn() {
+		t.Fatal("non-CSC client: gate reports active, want inactive — a cacheable solo would wrongly use the main pool instead of the pipeline pool")
 	}
 
 	// CSC client: needs a live RESP3 server for CLIENT TRACKING to attach.
@@ -1510,7 +1511,13 @@ func TestAutopipelineSoloRoutingGate(t *testing.T) {
 		t.Fatalf("AsyncAutoPipeline (csc): %v", err)
 	}
 	defer apc.Close()
-	if !apc.cscEnabled {
-		t.Fatal("CSC client: ap.cscEnabled = false, want true — cacheable solos must honor the cache")
+	if apc.cscActiveFn == nil || !apc.cscActiveFn() {
+		t.Fatal("CSC client: gate reports inactive, want active — cacheable solos must honor the cache")
+	}
+	// Mid-life disable (RESP3 fallback, processor damping): the LIVE gate must
+	// flip so cacheable solos return to the pipeline pool.
+	cscC.disableCSCServing(ctx, "test: mid-life disable")
+	if apc.cscActiveFn() {
+		t.Fatal("gate still reports active after CSC disabled itself mid-life")
 	}
 }

--- a/internal/pool/has_free_capacity_test.go
+++ b/internal/pool/has_free_capacity_test.go
@@ -81,14 +81,46 @@ func TestHasFreeCapacityWithoutMaxActiveConns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	// Grown to PoolSize (1), none idle: Len() >= Size() so the conservative gate
-	// reports false (matching the old heuristic), even though a second Get would
-	// still succeed non-pooled.
+	// Grown to PoolSize (1), no idle conn and no free turn (the one turn is held):
+	// the gate reports false.
 	if connPool.HasFreeCapacity() {
-		t.Fatal("at PoolSize with no idle conn: HasFreeCapacity() = true, want false (conservative)")
+		t.Fatal("at PoolSize with no idle conn / no free turn: HasFreeCapacity() = true, want false")
 	}
 	connPool.Put(ctx, cn)
 	if !connPool.HasFreeCapacity() {
-		t.Fatal("with an idle conn available: HasFreeCapacity() = false, want true")
+		t.Fatal("with a usable idle conn available: HasFreeCapacity() = false, want true")
+	}
+}
+
+// TestHasFreeCapacityExcludesUnusableIdle pins the refinement that an idle
+// connection which is not usable (mid handoff / re-auth) does NOT count as
+// capacity — the old IdleLen()>0 term would have wrongly reported free.
+func TestHasFreeCapacityExcludesUnusableIdle(t *testing.T) {
+	connPool := pool.NewConnPool(&pool.Options{
+		Dialer:             dummyDialer,
+		PoolSize:           1,
+		MaxConcurrentDials: 1,
+		PoolTimeout:        time.Second,
+		DialTimeout:        time.Second,
+		ConnMaxIdleTime:    -1,
+	})
+	t.Cleanup(func() { _ = connPool.Close() })
+	ctx := context.Background()
+
+	cn, err := connPool.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	connPool.Put(ctx, cn) // one usable idle conn
+	if !connPool.HasFreeCapacity() {
+		t.Fatal("usable idle conn: HasFreeCapacity() = false, want true")
+	}
+
+	// Mark the idle conn unusable (as a handoff / re-auth would). It is still in
+	// idleConns, so IdleLen()>0, but it cannot serve a Get; at PoolSize there is
+	// also nothing to dial, so capacity must read false.
+	cn.SetUsable(false)
+	if connPool.HasFreeCapacity() {
+		t.Fatal("idle conn is UNUSABLE and pool is at PoolSize: HasFreeCapacity() = true, want false")
 	}
 }

--- a/internal/pool/has_free_capacity_test.go
+++ b/internal/pool/has_free_capacity_test.go
@@ -1,0 +1,94 @@
+package pool_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9/internal/pool"
+)
+
+// TestHasFreeCapacityHonorsMaxActiveConns pins the branch the plain
+// IdleLen()>0 || Len()<Size() heuristic missed: with MaxActiveConns < PoolSize
+// and no idle connection, the pool cannot serve another Get (newConn returns
+// ErrPoolExhausted once poolSize >= MaxActiveConns), yet Len() < Size() still
+// holds. HasFreeCapacity must report false there — that is what makes the
+// autopipeline straggler-hold gate stop shortening the hold into a pool the
+// flush's Get would exhaust (#3962).
+func TestHasFreeCapacityHonorsMaxActiveConns(t *testing.T) {
+	connPool := pool.NewConnPool(&pool.Options{
+		Dialer:             dummyDialer,
+		PoolSize:           4, // Len()<Size() alone would report "free"...
+		MaxActiveConns:     1, // ...but only one active connection is allowed.
+		MaxConcurrentDials: 1,
+		PoolTimeout:        time.Second,
+		DialTimeout:        time.Second,
+		ConnMaxIdleTime:    -1,
+	})
+	t.Cleanup(func() { _ = connPool.Close() })
+	ctx := context.Background()
+
+	// Fresh pool: nothing dialed yet, below PoolSize and MaxActiveConns — the
+	// first Get can dial, so there is free capacity.
+	if !connPool.HasFreeCapacity() {
+		t.Fatal("fresh pool: HasFreeCapacity() = false, want true (first Get can dial)")
+	}
+
+	first, err := connPool.Get(ctx)
+	if err != nil {
+		t.Fatalf("first Get: %v", err)
+	}
+
+	// One active connection (== MaxActiveConns) and none idle: the next Get would
+	// return ErrPoolExhausted even though Len()(=1) < Size()(=4). The old heuristic
+	// would wrongly report free; HasFreeCapacity must report false.
+	if connPool.HasFreeCapacity() {
+		t.Fatal("at MaxActiveConns with no idle conn: HasFreeCapacity() = true, want false")
+	}
+
+	// Return it: an idle connection is now ready, so there is capacity again.
+	connPool.Put(ctx, first)
+	if !connPool.HasFreeCapacity() {
+		t.Fatal("with an idle conn available: HasFreeCapacity() = false, want true")
+	}
+}
+
+// TestHasFreeCapacityWithoutMaxActiveConns confirms that with MaxActiveConns
+// unset HasFreeCapacity reduces EXACTLY to the prior `IdleLen()>0 || Len()<Size()`
+// heuristic: a fresh pool is free, a pool grown to PoolSize with no idle conn is
+// reported not-free, and an idle conn makes it free again. This is a conservative
+// gate, not an admission check: a second Get on the PoolSize-full pool would in
+// fact still succeed with a non-pooled connection (PoolSize does not hard-block
+// dials) — HasFreeCapacity deliberately does not track that, it just keeps the
+// straggler-hold conservative.
+func TestHasFreeCapacityWithoutMaxActiveConns(t *testing.T) {
+	connPool := pool.NewConnPool(&pool.Options{
+		Dialer:             dummyDialer,
+		PoolSize:           1,
+		MaxConcurrentDials: 1,
+		PoolTimeout:        time.Second,
+		DialTimeout:        time.Second,
+		ConnMaxIdleTime:    -1,
+	})
+	t.Cleanup(func() { _ = connPool.Close() })
+	ctx := context.Background()
+
+	if !connPool.HasFreeCapacity() {
+		t.Fatal("fresh pool: HasFreeCapacity() = false, want true")
+	}
+
+	cn, err := connPool.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	// Grown to PoolSize (1), none idle: Len() >= Size() so the conservative gate
+	// reports false (matching the old heuristic), even though a second Get would
+	// still succeed non-pooled.
+	if connPool.HasFreeCapacity() {
+		t.Fatal("at PoolSize with no idle conn: HasFreeCapacity() = true, want false (conservative)")
+	}
+	connPool.Put(ctx, cn)
+	if !connPool.HasFreeCapacity() {
+		t.Fatal("with an idle conn available: HasFreeCapacity() = false, want true")
+	}
+}

--- a/internal/pool/has_free_capacity_test.go
+++ b/internal/pool/has_free_capacity_test.go
@@ -124,3 +124,38 @@ func TestHasFreeCapacityExcludesUnusableIdle(t *testing.T) {
 		t.Fatal("idle conn is UNUSABLE and pool is at PoolSize: HasFreeCapacity() = true, want false")
 	}
 }
+
+// TestHasFreeCapacityExcludesHandoffIdle pins the OnGet-reject refinement (#3962):
+// an idle connection marked ShouldHandoff is still StateIdle/usable, but an OnGet
+// hook (maintnotifications) diverts it to handoff instead of serving it, so
+// HasFreeCapacity must not count it as capacity. With the pool at PoolSize (no
+// dial possible), a lone handoff-marked idle conn means no free capacity.
+func TestHasFreeCapacityExcludesHandoffIdle(t *testing.T) {
+	connPool := pool.NewConnPool(&pool.Options{
+		Dialer:             dummyDialer,
+		PoolSize:           1,
+		MaxActiveConns:     1,
+		MaxConcurrentDials: 1,
+		PoolTimeout:        time.Second,
+		DialTimeout:        time.Second,
+		ConnMaxIdleTime:    -1,
+	})
+	t.Cleanup(func() { _ = connPool.Close() })
+	ctx := context.Background()
+
+	cn, err := connPool.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if err := cn.MarkForHandoff("new-endpoint:6379", 1); err != nil {
+		t.Fatalf("MarkForHandoff: %v", err)
+	}
+	if !cn.IsUsable() {
+		t.Fatal("precondition: a handoff-marked conn should still be IsUsable (StateIdle)")
+	}
+	connPool.Put(ctx, cn)
+
+	if connPool.HasFreeCapacity() {
+		t.Fatal("HasFreeCapacity() = true with only a handoff-marked idle conn — an OnGet hook would divert it, so it must not count")
+	}
+}

--- a/internal/pool/has_free_capacity_test.go
+++ b/internal/pool/has_free_capacity_test.go
@@ -8,13 +8,9 @@ import (
 	"github.com/redis/go-redis/v9/internal/pool"
 )
 
-// TestHasFreeCapacityHonorsMaxActiveConns pins the branch the plain
-// IdleLen()>0 || Len()<Size() heuristic missed: with MaxActiveConns < PoolSize
-// and no idle connection, the pool cannot serve another Get (newConn returns
-// ErrPoolExhausted once poolSize >= MaxActiveConns), yet Len() < Size() still
-// holds. HasFreeCapacity must report false there — that is what makes the
-// autopipeline straggler-hold gate stop shortening the hold into a pool the
-// flush's Get would exhaust (#3962).
+// TestHasFreeCapacityHonorsMaxActiveConns: with MaxActiveConns < PoolSize and
+// no idle conn, a Get would fail ErrPoolExhausted even though Len() < Size() —
+// HasFreeCapacity must report false.
 func TestHasFreeCapacityHonorsMaxActiveConns(t *testing.T) {
 	connPool := pool.NewConnPool(&pool.Options{
 		Dialer:             dummyDialer,
@@ -53,14 +49,10 @@ func TestHasFreeCapacityHonorsMaxActiveConns(t *testing.T) {
 	}
 }
 
-// TestHasFreeCapacityWithoutMaxActiveConns confirms that with MaxActiveConns
-// unset HasFreeCapacity reduces EXACTLY to the prior `IdleLen()>0 || Len()<Size()`
-// heuristic: a fresh pool is free, a pool grown to PoolSize with no idle conn is
-// reported not-free, and an idle conn makes it free again. This is a conservative
-// gate, not an admission check: a second Get on the PoolSize-full pool would in
-// fact still succeed with a non-pooled connection (PoolSize does not hard-block
-// dials) — HasFreeCapacity deliberately does not track that, it just keeps the
-// straggler-hold conservative.
+// TestHasFreeCapacityWithoutMaxActiveConns: with MaxActiveConns unset the gate
+// reduces to the prior idle-or-under-size heuristic (fresh pool free, full pool
+// with no idle not-free, idle conn free again). Conservative by design: it does
+// not track non-pooled overflow Gets.
 func TestHasFreeCapacityWithoutMaxActiveConns(t *testing.T) {
 	connPool := pool.NewConnPool(&pool.Options{
 		Dialer:             dummyDialer,
@@ -92,9 +84,8 @@ func TestHasFreeCapacityWithoutMaxActiveConns(t *testing.T) {
 	}
 }
 
-// TestHasFreeCapacityExcludesUnusableIdle pins the refinement that an idle
-// connection which is not usable (mid handoff / re-auth) does NOT count as
-// capacity — the old IdleLen()>0 term would have wrongly reported free.
+// TestHasFreeCapacityExcludesUnusableIdle: a not-usable idle conn (mid handoff
+// or re-auth) must not count as capacity.
 func TestHasFreeCapacityExcludesUnusableIdle(t *testing.T) {
 	connPool := pool.NewConnPool(&pool.Options{
 		Dialer:             dummyDialer,
@@ -125,11 +116,9 @@ func TestHasFreeCapacityExcludesUnusableIdle(t *testing.T) {
 	}
 }
 
-// TestHasFreeCapacityExcludesHandoffIdle pins the OnGet-reject refinement (#3962):
-// an idle connection marked ShouldHandoff is still StateIdle/usable, but an OnGet
-// hook (maintnotifications) diverts it to handoff instead of serving it, so
-// HasFreeCapacity must not count it as capacity. With the pool at PoolSize (no
-// dial possible), a lone handoff-marked idle conn means no free capacity.
+// TestHasFreeCapacityExcludesHandoffIdle: a handoff-marked idle conn is still
+// StateIdle/usable but an OnGet hook diverts it, so it must not count as
+// capacity.
 func TestHasFreeCapacityExcludesHandoffIdle(t *testing.T) {
 	connPool := pool.NewConnPool(&pool.Options{
 		Dialer:             dummyDialer,

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1692,8 +1692,10 @@ func (p *ConnPool) Size() int {
 // in order: a truly servable idle conn (usableIdleLen — plain IdleLen counts
 // not-usable and handoff-marked entries an OnGet hook would divert); a free
 // pool turn (accounts for in-use conns AND in-flight dials); room under
-// PoolSize and MaxActiveConns (newConn's hard dial gate); and a free dial slot
-// (MaxConcurrentDials below PoolSize can saturate slots while a turn is free).
+// PoolSize and MaxActiveConns (newConn's hard dial gate); a free dial slot
+// (MaxConcurrentDials below PoolSize can saturate slots while a turn is free);
+// and the dial circuit breaker not being open (a saturated dialErrorsNum makes
+// the Get fail fast rather than serve).
 func (p *ConnPool) HasFreeCapacity() bool {
 	if p.usableIdleLen() > 0 {
 		return true
@@ -1709,6 +1711,12 @@ func (p *ConnPool) HasFreeCapacity() bool {
 		return false
 	}
 	if c := cap(p.dialsInProgress); c > 0 && len(p.dialsInProgress) >= c {
+		return false
+	}
+	// Dial circuit breaker open (dialConn fails fast until a background probe
+	// succeeds): the Get would need this dial and error immediately, so there is
+	// no capacity to report.
+	if p.dialErrorsNum.Load() >= uint32(p.cfg.PoolSize) {
 		return false
 	}
 	return true

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1686,6 +1686,36 @@ func (p *ConnPool) Size() int {
 	return int(p.cfg.PoolSize)
 }
 
+// HasFreeCapacity reports whether the pool likely has room to serve another
+// batch without contention: an idle connection is ready, or the pool has not
+// grown to PoolSize AND (when set) MaxActiveConns still permits a dial.
+//
+// It is a conservative, best-effort gate for the autopipeline straggler-hold,
+// NOT an admission check. In particular it keeps the pre-existing PoolSize term
+// verbatim (`Len() < Size()`), so it can report false when a non-pooled dial
+// would in fact still succeed — PoolSize does not hard-block dials, only
+// MaxActiveConns does (newConn returns ErrPoolExhausted once poolSize >=
+// MaxActiveConns). Reporting false only makes the straggler-hold stay long,
+// which costs latency, not correctness.
+//
+// The one term it adds over the plain `IdleLen()>0 || Len()<Size()` heuristic is
+// MaxActiveConns, checked against poolSize the way newConn gates dials: without
+// it a pool with MaxActiveConns < PoolSize and no idle connection reported free
+// even though the next Get would exhaust. With MaxActiveConns == 0 the result is
+// identical to the old heuristic.
+func (p *ConnPool) HasFreeCapacity() bool {
+	if p.IdleLen() > 0 {
+		return true
+	}
+	if p.Len() >= p.Size() {
+		return false
+	}
+	if m := p.cfg.MaxActiveConns; m > 0 && p.poolSize.Load() >= m {
+		return false
+	}
+	return true
+}
+
 func (p *ConnPool) Stats() *Stats {
 	return &Stats{
 		Hits:            atomic.LoadUint32(&p.stats.Hits),

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1686,25 +1686,14 @@ func (p *ConnPool) Size() int {
 	return int(p.cfg.PoolSize)
 }
 
-// HasFreeCapacity reports whether the pool can likely serve another batch
-// without blocking. It is a best-effort, non-blocking probe for the autopipeline
-// straggler-hold gate (a false positive only costs a spill / short hold, never
-// correctness), refined per review (#3962) to these checks in order:
-//
-//  1. A conn a Get would actually serve is ready — reported immediately. IdleLen()
-//     alone is not enough: an idle entry can be not-usable (mid state transition)
-//     or marked for handoff (an OnGet hook would divert it), so usableIdleLen
-//     counts only conns that would truly be served.
-//  2. Otherwise a fresh Get must take a pool turn and (usually) dial. If no turn
-//     is free the Get would block, so report no capacity. A free turn already
-//     accounts for both in-use conns and in-flight dials (each holds a token),
-//     which the old Len()<Size() term missed.
-//  3. A turn is free, so a dial is possible only while under PoolSize and (when
-//     set) MaxActiveConns — the latter is what newConn hard-gates dials on
-//     (ErrPoolExhausted once poolSize >= MaxActiveConns).
-//  4. A dial is required (no usable idle conn), so a dial slot must be free too:
-//     MaxConcurrentDials below PoolSize can leave all dial slots busy while a turn
-//     is free, and the Get would then block on the dial slot.
+// HasFreeCapacity reports whether the pool can likely serve another Get without
+// blocking — a best-effort probe for the autopipeline straggler-hold gate (a
+// false positive only costs a spill / short hold, never correctness). Checks,
+// in order: a truly servable idle conn (usableIdleLen — plain IdleLen counts
+// not-usable and handoff-marked entries an OnGet hook would divert); a free
+// pool turn (accounts for in-use conns AND in-flight dials); room under
+// PoolSize and MaxActiveConns (newConn's hard dial gate); and a free dial slot
+// (MaxConcurrentDials below PoolSize can saturate slots while a turn is free).
 func (p *ConnPool) HasFreeCapacity() bool {
 	if p.usableIdleLen() > 0 {
 		return true
@@ -1719,26 +1708,17 @@ func (p *ConnPool) HasFreeCapacity() bool {
 	if m := p.cfg.MaxActiveConns; m > 0 && size >= m {
 		return false
 	}
-	// A dial is required here (no usable idle conn). When MaxConcurrentDials is set
-	// below PoolSize, all dial slots can be occupied while a pool turn is still
-	// free: the Get would take the turn and then block waiting for a dial slot. So
-	// report no capacity when the dial-concurrency limit is already saturated.
 	if c := cap(p.dialsInProgress); c > 0 && len(p.dialsInProgress) >= c {
 		return false
 	}
 	return true
 }
 
-// usableIdleLen counts idle connections that would actually be served by a Get
-// right now, unlike IdleLen() which counts every idle entry. Excludes:
-//   - not-usable conns (mid state transition): IsUsable() is false; and
-//   - conns an OnGet hook would reject — a conn already marked ShouldHandoff
-//     (maintnotifications) is still StateIdle/usable but the pool hook diverts it
-//     to handoff instead of serving it, so counting it over-reports capacity.
-//
-// (A conn whose ID a streaming re-auth just marked for refresh is a rarer residual
-// false positive; the gate is best-effort, so it is acceptable.) The idle slice is
-// bounded by PoolSize, so the scan is cheap.
+// usableIdleLen counts idle connections a Get would actually serve, unlike
+// IdleLen(): it excludes not-usable conns (mid state transition) and
+// handoff-marked conns (still StateIdle/usable, but the OnGet pool hook diverts
+// them to handoff). Best-effort — a re-auth-marked conn is a rare residual
+// false positive. The idle slice is bounded by PoolSize, so the scan is cheap.
 func (p *ConnPool) usableIdleLen() int {
 	p.connsMu.Lock()
 	n := 0

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1689,11 +1689,12 @@ func (p *ConnPool) Size() int {
 // HasFreeCapacity reports whether the pool can likely serve another batch
 // without blocking. It is a best-effort, non-blocking probe for the autopipeline
 // straggler-hold gate (a false positive only costs a spill / short hold, never
-// correctness), refined per review (#3962) to three checks in order:
+// correctness), refined per review (#3962) to these checks in order:
 //
-//  1. A USABLE idle connection is ready — served immediately. IdleLen() alone is
-//     not enough: an idle entry can be mid-handoff/re-auth (StateUnusable) and
-//     would be skipped by popIdle, so count only usable idle conns.
+//  1. A conn a Get would actually serve is ready — reported immediately. IdleLen()
+//     alone is not enough: an idle entry can be not-usable (mid state transition)
+//     or marked for handoff (an OnGet hook would divert it), so usableIdleLen
+//     counts only conns that would truly be served.
 //  2. Otherwise a fresh Get must take a pool turn and (usually) dial. If no turn
 //     is free the Get would block, so report no capacity. A free turn already
 //     accounts for both in-use conns and in-flight dials (each holds a token),
@@ -1701,6 +1702,9 @@ func (p *ConnPool) Size() int {
 //  3. A turn is free, so a dial is possible only while under PoolSize and (when
 //     set) MaxActiveConns — the latter is what newConn hard-gates dials on
 //     (ErrPoolExhausted once poolSize >= MaxActiveConns).
+//  4. A dial is required (no usable idle conn), so a dial slot must be free too:
+//     MaxConcurrentDials below PoolSize can leave all dial slots busy while a turn
+//     is free, and the Get would then block on the dial slot.
 func (p *ConnPool) HasFreeCapacity() bool {
 	if p.usableIdleLen() > 0 {
 		return true
@@ -1715,17 +1719,31 @@ func (p *ConnPool) HasFreeCapacity() bool {
 	if m := p.cfg.MaxActiveConns; m > 0 && size >= m {
 		return false
 	}
+	// A dial is required here (no usable idle conn). When MaxConcurrentDials is set
+	// below PoolSize, all dial slots can be occupied while a pool turn is still
+	// free: the Get would take the turn and then block waiting for a dial slot. So
+	// report no capacity when the dial-concurrency limit is already saturated.
+	if c := cap(p.dialsInProgress); c > 0 && len(p.dialsInProgress) >= c {
+		return false
+	}
 	return true
 }
 
-// usableIdleLen counts idle connections that are actually usable right now
-// (not mid-handoff or re-auth), unlike IdleLen() which counts every idle entry.
-// The idle slice is bounded by PoolSize, so the scan is cheap.
+// usableIdleLen counts idle connections that would actually be served by a Get
+// right now, unlike IdleLen() which counts every idle entry. Excludes:
+//   - not-usable conns (mid state transition): IsUsable() is false; and
+//   - conns an OnGet hook would reject — a conn already marked ShouldHandoff
+//     (maintnotifications) is still StateIdle/usable but the pool hook diverts it
+//     to handoff instead of serving it, so counting it over-reports capacity.
+//
+// (A conn whose ID a streaming re-auth just marked for refresh is a rarer residual
+// false positive; the gate is best-effort, so it is acceptable.) The idle slice is
+// bounded by PoolSize, so the scan is cheap.
 func (p *ConnPool) usableIdleLen() int {
 	p.connsMu.Lock()
 	n := 0
 	for _, cn := range p.idleConns {
-		if cn.IsUsable() {
+		if cn.IsUsable() && !cn.ShouldHandoff() {
 			n++
 		}
 	}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1686,34 +1686,51 @@ func (p *ConnPool) Size() int {
 	return int(p.cfg.PoolSize)
 }
 
-// HasFreeCapacity reports whether the pool likely has room to serve another
-// batch without contention: an idle connection is ready, or the pool has not
-// grown to PoolSize AND (when set) MaxActiveConns still permits a dial.
+// HasFreeCapacity reports whether the pool can likely serve another batch
+// without blocking. It is a best-effort, non-blocking probe for the autopipeline
+// straggler-hold gate (a false positive only costs a spill / short hold, never
+// correctness), refined per review (#3962) to three checks in order:
 //
-// It is a conservative, best-effort gate for the autopipeline straggler-hold,
-// NOT an admission check. In particular it keeps the pre-existing PoolSize term
-// verbatim (`Len() < Size()`), so it can report false when a non-pooled dial
-// would in fact still succeed — PoolSize does not hard-block dials, only
-// MaxActiveConns does (newConn returns ErrPoolExhausted once poolSize >=
-// MaxActiveConns). Reporting false only makes the straggler-hold stay long,
-// which costs latency, not correctness.
-//
-// The one term it adds over the plain `IdleLen()>0 || Len()<Size()` heuristic is
-// MaxActiveConns, checked against poolSize the way newConn gates dials: without
-// it a pool with MaxActiveConns < PoolSize and no idle connection reported free
-// even though the next Get would exhaust. With MaxActiveConns == 0 the result is
-// identical to the old heuristic.
+//  1. A USABLE idle connection is ready — served immediately. IdleLen() alone is
+//     not enough: an idle entry can be mid-handoff/re-auth (StateUnusable) and
+//     would be skipped by popIdle, so count only usable idle conns.
+//  2. Otherwise a fresh Get must take a pool turn and (usually) dial. If no turn
+//     is free the Get would block, so report no capacity. A free turn already
+//     accounts for both in-use conns and in-flight dials (each holds a token),
+//     which the old Len()<Size() term missed.
+//  3. A turn is free, so a dial is possible only while under PoolSize and (when
+//     set) MaxActiveConns — the latter is what newConn hard-gates dials on
+//     (ErrPoolExhausted once poolSize >= MaxActiveConns).
 func (p *ConnPool) HasFreeCapacity() bool {
-	if p.IdleLen() > 0 {
+	if p.usableIdleLen() > 0 {
 		return true
 	}
-	if p.Len() >= p.Size() {
+	if p.semaphore.Available() <= 0 {
 		return false
 	}
-	if m := p.cfg.MaxActiveConns; m > 0 && p.poolSize.Load() >= m {
+	size := p.poolSize.Load()
+	if size >= p.cfg.PoolSize {
+		return false
+	}
+	if m := p.cfg.MaxActiveConns; m > 0 && size >= m {
 		return false
 	}
 	return true
+}
+
+// usableIdleLen counts idle connections that are actually usable right now
+// (not mid-handoff or re-auth), unlike IdleLen() which counts every idle entry.
+// The idle slice is bounded by PoolSize, so the scan is cheap.
+func (p *ConnPool) usableIdleLen() int {
+	p.connsMu.Lock()
+	n := 0
+	for _, cn := range p.idleConns {
+		if cn.IsUsable() {
+			n++
+		}
+	}
+	p.connsMu.Unlock()
+	return n
 }
 
 func (p *ConnPool) Stats() *Stats {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -1697,11 +1697,15 @@ func (p *ConnPool) Size() int {
 // and the dial circuit breaker not being open (a saturated dialErrorsNum makes
 // the Get fail fast rather than serve).
 func (p *ConnPool) HasFreeCapacity() bool {
-	if p.usableIdleLen() > 0 {
-		return true
-	}
+	// Turn check comes FIRST: Get acquires a turn before popIdle, so with the
+	// semaphore exhausted even a usable idle conn is not immediately servable
+	// (putConnWithoutTurn can re-pool a conn while its turn stays held, so
+	// idle > 0 does not imply a free turn).
 	if p.semaphore.Available() <= 0 {
 		return false
+	}
+	if p.usableIdleLen() > 0 {
+		return true
 	}
 	size := p.poolSize.Load()
 	if size >= p.cfg.PoolSize {

--- a/internal/semaphore.go
+++ b/internal/semaphore.go
@@ -61,6 +61,14 @@ func NewFastSemaphore(capacity int32) *FastSemaphore {
 	}
 }
 
+// Available returns the number of tokens currently free (an approximation under
+// concurrency). Zero means every turn is taken — by an in-use connection or an
+// in-flight dial — so the next Acquire would block. Used as a non-blocking
+// capacity probe; not a synchronization primitive.
+func (s *FastSemaphore) Available() int {
+	return len(s.tokens)
+}
+
 // TryAcquire attempts to acquire a token without blocking.
 // Returns true if successful, false if no tokens available.
 func (s *FastSemaphore) TryAcquire() bool {

--- a/pipeline_pool_getter_test.go
+++ b/pipeline_pool_getter_test.go
@@ -1,0 +1,69 @@
+package redis
+
+import "testing"
+
+// TestAutoPipelineCapturesPipelinePool guards the regression that motivated the
+// getter: the straggler-hold pool gate reaches the pipeline pool through an
+// in-package interface assertion (`getPipelinePool() pool.Pooler`) in
+// newAutoPipeliner. Without the getter that assertion fails silently,
+// ap.pipelinePool stays nil, pipelineHasFreeConn() always returns false, and the
+// gate degrades to a no-op — compiling and passing every functional test while
+// doing nothing. This asserts the pool is actually captured and the gate is live.
+func TestAutoPipelineCapturesPipelinePool(t *testing.T) {
+	// Buffer sizes trigger creation of the dedicated pipeline pool.
+	c := NewClient(&Options{
+		Addr:                    ":6379",
+		PipelineReadBufferSize:  64 * 1024,
+		PipelineWriteBufferSize: 64 * 1024,
+		PipelinePoolSize:        4,
+	})
+	defer c.Close()
+
+	if c.getPipelinePool() == nil {
+		t.Fatal("getPipelinePool() returned nil for a client configured with a pipeline pool")
+	}
+	if c.getPipelinePool() != c.pipelinePool {
+		t.Fatal("getPipelinePool() did not return the client's pipeline pool")
+	}
+
+	ap, err := c.AsyncAutoPipeline()
+	if err != nil {
+		t.Fatalf("AsyncAutoPipeline: %v", err)
+	}
+	defer ap.Close()
+
+	if ap.pipelinePool == nil {
+		t.Fatal("AutoPipeliner captured a nil pipeline pool: the getPipelinePool assertion failed, " +
+			"so the straggler-hold gate is inert")
+	}
+	// Fresh, un-dialed pool: no idle conns yet, but room to dial (Len < Size),
+	// so the gate should see spare capacity.
+	if !ap.pipelineHasFreeConn() {
+		t.Fatal("pipelineHasFreeConn() should be true for a fresh dial-able pipeline pool")
+	}
+}
+
+// TestAutoPipelineNilPipelinePoolConservative verifies the safe fallback: a
+// client with no pipeline pool captures nil and the gate stays conservative
+// (pipelineHasFreeConn() == false → the original long hold is kept).
+func TestAutoPipelineNilPipelinePoolConservative(t *testing.T) {
+	c := NewClient(&Options{Addr: ":6379"}) // no pipeline buffers => no pipeline pool
+	defer c.Close()
+
+	if c.getPipelinePool() != nil {
+		t.Fatal("expected a nil pipeline pool when none is configured")
+	}
+
+	ap, err := c.AsyncAutoPipeline()
+	if err != nil {
+		t.Fatalf("AsyncAutoPipeline: %v", err)
+	}
+	defer ap.Close()
+
+	if ap.pipelinePool != nil {
+		t.Fatal("expected AutoPipeliner to capture a nil pipeline pool")
+	}
+	if ap.pipelineHasFreeConn() {
+		t.Fatal("pipelineHasFreeConn() must be false when there is no pipeline pool")
+	}
+}

--- a/redis.go
+++ b/redis.go
@@ -1088,6 +1088,15 @@ func (c *baseClient) withConn(
 	return fnErr
 }
 
+// getPipelinePool returns the dedicated pipeline connection pool as a
+// pool.Pooler, or nil when the client has none. AutoPipeliner reads it (via an
+// in-package interface assertion on its underlying client) so the straggler
+// hold can gate on live pipeline-pool occupancy; without this accessor that
+// assertion fails and the gate silently degrades to the conservative long hold.
+func (c *baseClient) getPipelinePool() pool.Pooler {
+	return c.pipelinePool
+}
+
 // withPipelineConn executes fn with a connection from the pipeline pool when
 // one is configured (PipelineReadBufferSize/PipelineWriteBufferSize set),
 // otherwise it falls back to the regular pool via withConn.

--- a/redis.go
+++ b/redis.go
@@ -1179,9 +1179,8 @@ func (c *baseClient) cscTrackingRequested() bool {
 }
 
 // autopipelineCSCActive reports whether client-side caching can serve this
-// client, so the autopipeliner routes a cacheable solo straggler through the
-// cache-honoring Process path only when it would actually help (#3962). Captured
-// once at autopipeliner construction via an in-package type assertion.
+// client; the autopipeliner captures it at construction to gate cacheable-solo
+// routing through the cache-honoring Process path.
 func (c *baseClient) autopipelineCSCActive() bool {
 	return c.csc != nil && c.cscActive != nil && c.cscActive.Load()
 }

--- a/redis.go
+++ b/redis.go
@@ -1178,6 +1178,14 @@ func (c *baseClient) cscTrackingRequested() bool {
 	return c.opt.DB == 0
 }
 
+// autopipelineCSCActive reports whether client-side caching can serve this
+// client, so the autopipeliner routes a cacheable solo straggler through the
+// cache-honoring Process path only when it would actually help (#3962). Captured
+// once at autopipeliner construction via an in-package type assertion.
+func (c *baseClient) autopipelineCSCActive() bool {
+	return c.csc != nil && c.cscActive != nil && c.cscActive.Load()
+}
+
 func (c *baseClient) process(ctx context.Context, cmd Cmder) error {
 	opDurationCallback := otel.GetOperationDurationCallback()
 	if opDurationCallback == nil {


### PR DESCRIPTION
The async autopipeline held 1-3 queued "straggler" commands until the in-flight batch's reply landed (~1 RTT) whenever any batch was executing, so on a slow link an uncached command that enqueued behind an in-flight batch paid ~2x RTT. A phase trace on a deterministic 50ms link pinned it: service (round trip) was clean at 1 RTT and the concurrency permits were never exhausted, but the straggler-hold re-armed for a full RTT (uncached p95 stuck at 107ms / 2x RTT at low-to-mid concurrency).

Bound that hold to a few silence gaps (stragglerHoldGaps * gap, which tracks the round trip) ONLY when the pipeline pool has a connection to spare (an idle conn, or room to dial — the pipeline pool runs MinIdleConns=0). When the pool is saturated, keep the original long hold: flushing tiny batches into a full pool thrashes it because they cannot coalesce into the deep pipelines the scarce connections need (an unconditional few-ms bound cut throughput ~7x at a squeezed pool). The 30s autoPipelinePermitBackstop remains the flush-path safety ceiling.

The pipeline pool is captured once at construction via an in-package assertion and is nil for clients without one (e.g. *ClusterClient), which then keep the prior long hold.

Measured (50ms proxy, churn, inflight 1): default pool uncached p95/p99 111->65ms; squeezed pool (pipeline-pool 2, uncached-heavy) no throughput regression; real WAN uncached p99 314->177ms (residual is link jitter, present on the untouched cached path too).

### Review refinements

`HasFreeCapacity` was tightened from the review: when a dial would be needed it
also requires a free dial slot, and idle connections that are unusable or marked
for handoff do not count as capacity. The solo-straggler dispatch routes a
cacheable command through the CSC-honoring Process path ONLY when client-side
caching is actually active — otherwise it stays on the pipeline pool the
straggler gate probed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when autopipeline flushes small batches and which pool those solos use. Heuristic pool-capacity and CSC-live gates can mis-fire under load or mid-life CSC disable, affecting latency and throughput rather than correctness.
> 
> **Overview**
> Cuts uncached autopipeline latency for stragglers that used to wait a full in-flight RTT before flushing. Tiny queued batches now flush after a few silence gaps **only when the pipeline pool can serve another Get**; a saturated pool keeps the long hold so tiny flushes do not thrash scarce connections.
> 
> Adds `ConnPool.HasFreeCapacity` (turns, usable idle, MaxActiveConns, dial slots, circuit breaker) and captures the pipeline pool at AutoPipeliner construction. Cluster / no-pipeline-pool clients stay on the conservative hold.
> 
> Solo cacheable commands go through CSC `Process` only while client-side caching is **currently** active; otherwise they stay on the pipeline pool the gate probed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab3e290a3ee11aa636ce1b703473c66b55756d4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->