### PR TITLE
feat(csc): full-duplex reader-miss coalescing + invalidation batching

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
+          go-version: "stable"
           cache: true
 
       - name: Install govulncheck

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -3,7 +3,7 @@ name: govulncheck
 
 on:
   pull_request:
-    branches: [master, v9, v9.7, v9.8, "ndyakov/**", "ofekshenawa/**", "ce/**", "feature/**"]
+    branches: [master, v9, v9.7, v9.8, "ndyakov/**", "ofekshenawa/**","vkotsev/**", "ce/**", "feature/**"]
   push:
     branches: [master, v9, "v9.*"]
   schedule:
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
+          go-version: "stable"
           cache: true
 
       - name: Install govulncheck

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
       - name: Check Spelling
-        uses: rojopolis/spellcheck-github-actions@0.63.0
+        uses: rojopolis/spellcheck-github-actions@0.66.0
         with:
           config_path: .github/spellcheck-settings.yml
           task_name: Markdown

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,14 @@ that you are using supported versions of Docker and go.
 ### Security Vulnerabilities
 
 **NOTE**: If you find a security vulnerability, do NOT open an issue.
-Email [Redis Open Source (<oss@redis.com>)](mailto:oss@redis.com) instead.
+
+If you believe you have found a security vulnerability, to ensure proper
+review and assessment, we kindly ask vulnerability reports be submitted
+through our
+[Redis Vulnerability Disclosure Program](https://redis.io/redis-responsible-vulnerability-disclosure/).
+Alternatively reach out via email to
+[security@redis.com](mailto:security@redis.com). See
+[SECURITY.md](SECURITY.md) for the full policy.
 
 In order to determine whether you are dealing with a security issue, ask
 yourself these two questions:
@@ -83,8 +90,8 @@ yourself these two questions:
 
 If the answer to either of those two questions are *yes*, then you're
 probably dealing with a security issue. Note that even if you answer
-*no*  to both questions, you may still be dealing with a security
-issue, so if you're unsure, just email [us](mailto:oss@redis.com).
+*no* to both questions, you may still be dealing with a security
+issue, so if you're unsure, report it through the channels above.
 
 ### Everything Else
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+go-redis is generally backward compatible with very few exceptions, so we
+recommend users to always use the latest version to experience stability,
+performance and security. Security fixes are released as part of the latest
+release of the v9 line; older major versions are no longer maintained.
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability, to ensure proper
+review and assessment, we kindly ask vulnerability reports be submitted
+through our
+[Redis Vulnerability Disclosure Program](https://redis.io/redis-responsible-vulnerability-disclosure/).
+Alternatively reach out via email to
+[security@redis.com](mailto:security@redis.com).
+
+Please do **not** report security vulnerabilities through public GitHub
+issues.

--- a/command.go
+++ b/command.go
@@ -1875,7 +1875,7 @@ func (cmd *StringCmd) Scan(val interface{}) error {
 	if cmd.err != nil {
 		return cmd.err
 	}
-	return proto.Scan([]byte(cmd.val), val)
+	return proto.Scan(util.StringToBytes(cmd.val), val)
 }
 
 func (cmd *StringCmd) String() string {

--- a/csc_coalesce_options_test.go
+++ b/csc_coalesce_options_test.go
@@ -5,31 +5,6 @@ import (
 	"time"
 )
 
-// TestCSCCoalesceModeRejectsPinnedPublicly pins that the buggy "pinned" PROTOTYPE
-// engine (no idle invalidation drain; can serve stale) is NOT selectable from the
-// public ClientSideCacheCoalesceMode option — it falls back to "workers" — while
-// the internal benchmark hook can still force it.
-func TestCSCCoalesceModeRejectsPinnedPublicly(t *testing.T) {
-	if got := cscCoalesceMode(&Options{ClientSideCacheCoalesceMode: "pinned"}); got != "workers" {
-		t.Fatalf("public \"pinned\" => %q, want \"workers\"", got)
-	}
-	if got := cscCoalesceMode(&Options{ClientSideCacheCoalesceMode: "fullduplex"}); got != "fullduplex" {
-		t.Fatalf("\"fullduplex\" => %q, want \"fullduplex\"", got)
-	}
-	if got := cscCoalesceMode(&Options{ClientSideCacheCoalesceMode: ""}); got != "workers" {
-		t.Fatalf("\"\" => %q, want \"workers\"", got)
-	}
-	if got := cscCoalesceMode(nil); got != "workers" {
-		t.Fatalf("nil opt => %q, want \"workers\"", got)
-	}
-
-	cscForcePinned = true
-	defer func() { cscForcePinned = false }()
-	if got := cscCoalesceMode(&Options{ClientSideCacheCoalesceMode: "pinned"}); got != "pinned" {
-		t.Fatalf("forced \"pinned\" => %q, want \"pinned\" (benchmark hook)", got)
-	}
-}
-
 // TestUniversalOptionsSimpleCopiesCSCCoalesce guards that the new CSC miss-
 // coalescing / invalidation-batching knobs reach a standalone Client through
 // UniversalOptions.Simple() (they were previously Options-only, so UniversalClient
@@ -38,8 +13,6 @@ func TestUniversalOptionsSimpleCopiesCSCCoalesce(t *testing.T) {
 	u := &UniversalOptions{
 		ClientSideCacheRefreshOnInvalidate:     true,
 		ClientSideCacheCoalesceMisses:          true,
-		ClientSideCacheCoalesceMode:            "fullduplex",
-		ClientSideCacheCoalesceWorkers:         5,
 		ClientSideCacheInvalidationBatchWindow: 7 * time.Millisecond,
 	}
 	o := u.Simple()
@@ -48,12 +21,6 @@ func TestUniversalOptionsSimpleCopiesCSCCoalesce(t *testing.T) {
 	}
 	if !o.ClientSideCacheCoalesceMisses {
 		t.Error("Simple() dropped ClientSideCacheCoalesceMisses")
-	}
-	if o.ClientSideCacheCoalesceMode != "fullduplex" {
-		t.Errorf("Simple() ClientSideCacheCoalesceMode = %q, want \"fullduplex\"", o.ClientSideCacheCoalesceMode)
-	}
-	if o.ClientSideCacheCoalesceWorkers != 5 {
-		t.Errorf("Simple() ClientSideCacheCoalesceWorkers = %d, want 5", o.ClientSideCacheCoalesceWorkers)
 	}
 	if o.ClientSideCacheInvalidationBatchWindow != 7*time.Millisecond {
 		t.Errorf("Simple() ClientSideCacheInvalidationBatchWindow = %v, want 7ms", o.ClientSideCacheInvalidationBatchWindow)

--- a/csc_coalesce_options_test.go
+++ b/csc_coalesce_options_test.go
@@ -1,0 +1,61 @@
+package redis
+
+import (
+	"testing"
+	"time"
+)
+
+// TestCSCCoalesceModeRejectsPinnedPublicly pins that the buggy "pinned" PROTOTYPE
+// engine (no idle invalidation drain; can serve stale) is NOT selectable from the
+// public ClientSideCacheCoalesceMode option — it falls back to "workers" — while
+// the internal benchmark hook can still force it.
+func TestCSCCoalesceModeRejectsPinnedPublicly(t *testing.T) {
+	if got := cscCoalesceMode(&Options{ClientSideCacheCoalesceMode: "pinned"}); got != "workers" {
+		t.Fatalf("public \"pinned\" => %q, want \"workers\"", got)
+	}
+	if got := cscCoalesceMode(&Options{ClientSideCacheCoalesceMode: "fullduplex"}); got != "fullduplex" {
+		t.Fatalf("\"fullduplex\" => %q, want \"fullduplex\"", got)
+	}
+	if got := cscCoalesceMode(&Options{ClientSideCacheCoalesceMode: ""}); got != "workers" {
+		t.Fatalf("\"\" => %q, want \"workers\"", got)
+	}
+	if got := cscCoalesceMode(nil); got != "workers" {
+		t.Fatalf("nil opt => %q, want \"workers\"", got)
+	}
+
+	cscForcePinned = true
+	defer func() { cscForcePinned = false }()
+	if got := cscCoalesceMode(&Options{ClientSideCacheCoalesceMode: "pinned"}); got != "pinned" {
+		t.Fatalf("forced \"pinned\" => %q, want \"pinned\" (benchmark hook)", got)
+	}
+}
+
+// TestUniversalOptionsSimpleCopiesCSCCoalesce guards that the new CSC miss-
+// coalescing / invalidation-batching knobs reach a standalone Client through
+// UniversalOptions.Simple() (they were previously Options-only, so UniversalClient
+// users could not enable them).
+func TestUniversalOptionsSimpleCopiesCSCCoalesce(t *testing.T) {
+	u := &UniversalOptions{
+		ClientSideCacheRefreshOnInvalidate:     true,
+		ClientSideCacheCoalesceMisses:          true,
+		ClientSideCacheCoalesceMode:            "fullduplex",
+		ClientSideCacheCoalesceWorkers:         5,
+		ClientSideCacheInvalidationBatchWindow: 7 * time.Millisecond,
+	}
+	o := u.Simple()
+	if !o.ClientSideCacheRefreshOnInvalidate {
+		t.Error("Simple() dropped ClientSideCacheRefreshOnInvalidate")
+	}
+	if !o.ClientSideCacheCoalesceMisses {
+		t.Error("Simple() dropped ClientSideCacheCoalesceMisses")
+	}
+	if o.ClientSideCacheCoalesceMode != "fullduplex" {
+		t.Errorf("Simple() ClientSideCacheCoalesceMode = %q, want \"fullduplex\"", o.ClientSideCacheCoalesceMode)
+	}
+	if o.ClientSideCacheCoalesceWorkers != 5 {
+		t.Errorf("Simple() ClientSideCacheCoalesceWorkers = %d, want 5", o.ClientSideCacheCoalesceWorkers)
+	}
+	if o.ClientSideCacheInvalidationBatchWindow != 7*time.Millisecond {
+		t.Errorf("Simple() ClientSideCacheInvalidationBatchWindow = %v, want 7ms", o.ClientSideCacheInvalidationBatchWindow)
+	}
+}

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -41,6 +41,14 @@ func cscRegisterCleanups(c *Client) {
 	// receive gives each request exactly one consumer).
 	active := c.baseClient.cscActive
 	mc := c.baseClient.cscMissCoalescer.Load()
+	// Capture the refresh handle too (set during attach; nil when refresh is off):
+	// runCSCRefresher parks on its ticker/queue and holds *baseClient, so a client
+	// dropped WITHOUT Close would leak the refresher goroutine and everything it
+	// retains (cache, pools) — the coalescer/drainer stops below would not reach it.
+	// signalStop is idempotent and non-blocking, matching the other stops here. The
+	// handle is channels only (no *Client), so capturing it keeps the wrapper
+	// collectible.
+	rh := c.baseClient.cscRefreshHandle
 	runtime.AddCleanup(c, func(h *cscDrainHandle) {
 		if active != nil {
 			active.Store(false)
@@ -51,6 +59,9 @@ func cscRegisterCleanups(c *Client) {
 			// alive re-runs the read on the (possibly still open) pool instead
 			// of surfacing a spurious ErrClosed.
 			mc.drainQueueErr(errCSCRetryUncached)
+		}
+		if rh != nil {
+			rh.signalStop()
 		}
 		h.signalStop()
 	}, h)

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -1167,11 +1167,19 @@ func (c *baseClient) processCached(ctx context.Context, cmd Cmder, state *proces
 	// off). Load the pointer ONCE: a concurrent Close swaps it to nil, and a
 	// second load after the nil-check would call fetch on a nil receiver.
 	if mc := c.cscMissCoalescer.Load(); shouldFetch && mc != nil {
-		err := mc.fetch(ctx, cmd, key, token)
+		served, err := mc.fetch(ctx, cmd, key, token)
 		if err == errCSCRetryUncached {
 			// CSC was disabled mid-miss; the command is fine and the reservation is
 			// already cancelled — run it uncached instead of surfacing ErrClosed.
 			return c.processWithRetry(ctx, cmd, nil, state)
+		}
+		// Native-recorder attribution: the coalesced fetch contacted Redis on
+		// the session's held connection — report it as one attempt on that conn
+		// so operation-duration metrics carry a real server.address instead of
+		// zero attempts and a nil connection.
+		if state != nil && served != nil {
+			state.attempts++
+			state.lastConn = served
 		}
 		return err
 	}

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -47,7 +47,10 @@ func cscRegisterCleanups(c *Client) {
 		}
 		if mc != nil {
 			mc.stopWorkers()
-			mc.drainQueueErr(pool.ErrClosed)
+			// Retry-uncached, matching every other stop path: a clone still
+			// alive re-runs the read on the (possibly still open) pool instead
+			// of surfacing a spurious ErrClosed.
+			mc.drainQueueErr(errCSCRetryUncached)
 		}
 		h.signalStop()
 	}, h)
@@ -361,6 +364,12 @@ func (h *invalidateHandler) releaseLocked() {
 		// A fresh binding folds in its own window; do not inherit this one's.
 		h.invalBatchWindow = 0
 		h.invalBatchWindowSet = false
+		// Clear the refresh bindings with the binding itself: a client dropped
+		// without Close never runs clearRefreshQueue, and a successor reusing
+		// this handler must not inherit (or later restore) a dead queue whose
+		// consumer is gone — hot entries offered there would vanish silently.
+		h.refresh = nil
+		h.refreshStack = nil
 	}
 }
 

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -168,11 +168,15 @@ func (h *invalidateHandler) ensureBatcher() *cscInvalBatcher {
 	}
 	if h.batcher == nil {
 		h.batcher = &cscInvalBatcher{
-			h:      h,
 			window: w,
-			ch:     make(chan string, 8192),
-			stopCh: make(chan struct{}),
-			dropCh: make(chan struct{}, 1),
+			// Snapshot the binding for the batcher's lifetime (⊂ the binding's:
+			// releaseLocked stops it before clearing these) so the release-time
+			// stop-drain still applies queued deletes after h.cache is nilled.
+			cache:   h.cache,
+			refresh: h.refresh,
+			ch:      make(chan string, 8192),
+			stopCh:  make(chan struct{}),
+			dropCh:  make(chan struct{}, 1),
 		}
 		go h.batcher.run()
 	}

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -82,6 +82,36 @@ type invalidateHandler struct {
 	// refresh, when set, receives evicted-but-hot entries for immediate refetch.
 	// Feeding it must never block the invalidation-delivery path.
 	refresh *cscRefreshQueue
+
+	// batcher offloads invalidation cache-deletes to a windowed background
+	// goroutine (Options.ClientSideCacheInvalidationBatchWindow). Lazily started;
+	// nil when disabled. Not stopped here — it idles harmlessly after the binding
+	// is released (flush no-ops on a nil cache) and exits with the process.
+	batcher     *cscInvalBatcher
+	batcherOnce sync.Once
+
+	// invalBatchWindow is the coalescing window for the batcher above, threaded
+	// from the owning client's Options at attach time. 0 (default) deletes inline.
+	// Read under mu alongside cache/keyPrefix/refresh.
+	invalBatchWindow time.Duration
+}
+
+// setInvalBatchWindow records the invalidation-batch coalescing window from the
+// owning client's Options. Set before any push can arrive (attach time).
+func (h *invalidateHandler) setInvalBatchWindow(w time.Duration) {
+	h.mu.Lock()
+	h.invalBatchWindow = w
+	h.mu.Unlock()
+}
+
+// ensureBatcher lazily starts the windowed invalidation batcher.
+func (h *invalidateHandler) ensureBatcher(w time.Duration) *cscInvalBatcher {
+	h.batcherOnce.Do(func() {
+		b := &cscInvalBatcher{h: h, window: w, ch: make(chan string, 8192)}
+		h.batcher = b
+		go b.run()
+	})
+	return h.batcher
 }
 
 func (h *invalidateHandler) setRefreshQueue(q *cscRefreshQueue) {
@@ -97,6 +127,7 @@ func (h *invalidateHandler) HandlePushNotification(
 ) error {
 	h.mu.RLock()
 	cache, keyPrefix, refresh := h.cache, h.keyPrefix, h.refresh
+	window := h.invalBatchWindow
 	h.mu.RUnlock()
 	if cache == nil || len(notification) < 2 {
 		return nil
@@ -106,6 +137,27 @@ func (h *invalidateHandler) HandlePushNotification(
 	case nil:
 		cache.Flush()
 	case []interface{}:
+		// Offload path: enqueue keys to the windowed background batcher instead of
+		// deleting inline, so invalidation work does not steal time from the
+		// coalescer's miss-reply reader (the low-concurrency churn p99 tail).
+		if window > 0 {
+			if _, ok := cache.(*LocalCache); ok {
+				b := h.ensureBatcher(window)
+				for _, k := range payload {
+					var name string
+					switch v := k.(type) {
+					case string:
+						name = v
+					case []byte:
+						name = string(v)
+					default:
+						continue
+					}
+					b.enqueue(cscNamespacedKey(keyPrefix, name))
+				}
+				return nil
+			}
+		}
 		var hot []cscRefreshTarget
 		lc, canRefresh := cache.(*LocalCache)
 		canRefresh = canRefresh && refresh != nil
@@ -296,6 +348,12 @@ func (c *baseClient) attachSharedTrackingCSC(ctx context.Context, cache Cache) {
 	if err := registerInvalidateHandler(c.pushProcessor, cache, c.cscKeyPrefix); err != nil {
 		internal.Logger.Printf(ctx, "csc: failed to register invalidate handler: %v", err)
 		return
+	}
+	// Thread the invalidation-batch window from Options before any push can
+	// arrive, so the batcher (if enabled) sees the configured window on the very
+	// first invalidation rather than a zero default.
+	if ih := lookupInvalidateHandler(c.pushProcessor); ih != nil {
+		ih.setInvalBatchWindow(c.opt.ClientSideCacheInvalidationBatchWindow)
 	}
 	c.csc = cache
 	c.registerConnEvictHook(cache, reg)
@@ -894,7 +952,8 @@ func (c *baseClient) processCached(ctx context.Context, cmd Cmder, state *proces
 			c.csc.DeleteByCacheKey(key)
 		}
 		// Original fetcher cancelled or its value was invalidated; try to take
-		// over so later waiters still benefit from the cache.
+		// over so later waiters still benefit from the cache. This is the 2x-RTT
+		// path under churn: we waited a round trip and still must fetch ourselves.
 		token, shouldFetch = c.csc.Reserve(key, nsRedisKeys)
 	}
 

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -84,11 +84,12 @@ type invalidateHandler struct {
 	refresh *cscRefreshQueue
 
 	// batcher offloads invalidation cache-deletes to a windowed background
-	// goroutine (Options.ClientSideCacheInvalidationBatchWindow). Lazily started;
-	// nil when disabled. Not stopped here — it idles harmlessly after the binding
-	// is released (flush no-ops on a nil cache) and exits with the process.
-	batcher     *cscInvalBatcher
-	batcherOnce sync.Once
+	// goroutine (Options.ClientSideCacheInvalidationBatchWindow). Lazily started
+	// (ensureBatcher) and nil when disabled; guarded by mu. Stopped and cleared
+	// when the last user releases (releaseLocked), so its goroutine does not live
+	// past the binding re-arming its timer forever; a later re-acquire starts a
+	// fresh one (picking up the successor's window).
+	batcher *cscInvalBatcher
 
 	// invalBatchWindow is the coalescing window for the batcher above, threaded
 	// from the owning client's Options at attach time. 0 (default) deletes inline.
@@ -104,13 +105,35 @@ func (h *invalidateHandler) setInvalBatchWindow(w time.Duration) {
 	h.mu.Unlock()
 }
 
-// ensureBatcher lazily starts the windowed invalidation batcher.
+// ensureBatcher lazily starts the windowed invalidation batcher. The common
+// case (already started) is a shared RLock; only first-start takes the write
+// lock, so the hot invalidation path stays cheap.
 func (h *invalidateHandler) ensureBatcher(w time.Duration) *cscInvalBatcher {
-	h.batcherOnce.Do(func() {
-		b := &cscInvalBatcher{h: h, window: w, ch: make(chan string, 8192)}
-		h.batcher = b
-		go b.run()
-	})
+	h.mu.RLock()
+	b := h.batcher
+	h.mu.RUnlock()
+	if b != nil {
+		return b
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	// Do not start a batcher for a released binding. releaseLocked stops+nils the
+	// batcher under this same lock when users hits 0, so a push racing that last
+	// release must NOT resurrect a goroutine that nothing would ever stop (once
+	// users is 0, release() no longer runs). The caller falls back to the inline
+	// delete path when this returns nil.
+	if h.users == 0 {
+		return nil
+	}
+	if h.batcher == nil {
+		h.batcher = &cscInvalBatcher{
+			h:      h,
+			window: w,
+			ch:     make(chan string, 8192),
+			stopCh: make(chan struct{}),
+		}
+		go h.batcher.run()
+	}
 	return h.batcher
 }
 
@@ -142,20 +165,24 @@ func (h *invalidateHandler) HandlePushNotification(
 		// coalescer's miss-reply reader (the low-concurrency churn p99 tail).
 		if window > 0 {
 			if _, ok := cache.(*LocalCache); ok {
-				b := h.ensureBatcher(window)
-				for _, k := range payload {
-					var name string
-					switch v := k.(type) {
-					case string:
-						name = v
-					case []byte:
-						name = string(v)
-					default:
-						continue
+				// nil when the binding was just released (users==0): fall through
+				// to the inline delete path below rather than enqueue on a nil
+				// batcher (which would panic).
+				if b := h.ensureBatcher(window); b != nil {
+					for _, k := range payload {
+						var name string
+						switch v := k.(type) {
+						case string:
+							name = v
+						case []byte:
+							name = string(v)
+						default:
+							continue
+						}
+						b.enqueue(cscNamespacedKey(keyPrefix, name))
 					}
-					b.enqueue(cscNamespacedKey(keyPrefix, name))
+					return nil
 				}
-				return nil
 			}
 		}
 		var hot []cscRefreshTarget
@@ -198,6 +225,14 @@ func (h *invalidateHandler) releaseLocked() {
 	if h.users == 0 {
 		h.cache = nil
 		h.keyPrefix = ""
+		// Stop the windowed batcher so its goroutine does not outlive the binding
+		// (re-arming its timer forever). stop() only closes a channel — it never
+		// touches h.mu and does not wait — so it is safe under the lock. A later
+		// re-acquire starts a fresh batcher via ensureBatcher.
+		if h.batcher != nil {
+			h.batcher.stop()
+			h.batcher = nil
+		}
 	}
 }
 

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"weak"
 
 	"github.com/redis/go-redis/v9/internal"
 	"github.com/redis/go-redis/v9/internal/pool"
@@ -26,6 +27,9 @@ func cscRegisterCleanups(c *Client) {
 	if h == nil {
 		return
 	}
+	// Weak back-reference for the push-handler adapter's canonical close (see
+	// baseClient.cscClientWeak): must be weak or this cleanup never fires.
+	c.baseClient.cscClientWeak = weak.Make(c)
 	// Capture cscActive (a standalone *atomic.Bool, not *Client) so the cleanup
 	// also stops clones from serving once the drainer is gone. Capture the miss
 	// coalescer too (set during attach; nil when off): its sessions wait on
@@ -92,8 +96,16 @@ type invalidateHandler struct {
 	users     int
 
 	// refresh, when set, receives evicted-but-hot entries for immediate refetch.
-	// Feeding it must never block the invalidation-delivery path.
+	// Feeding it must never block the invalidation-delivery path. It is the TOP
+	// of refreshStack: clients sharing this handler each attach their own queue
+	// and the newest attachment is active; when it clears, the next-newest live
+	// binding is RESTORED (closing the newest owner must not sever an older
+	// sibling's still-running refresher).
 	refresh *cscRefreshQueue
+
+	// refreshStack holds every live refresh binding in attach order (older
+	// first). Guarded by mu. Small: one entry per client sharing the handler.
+	refreshStack []*cscRefreshQueue
 
 	// batcher offloads invalidation cache-deletes to a windowed background
 	// goroutine (Options.ClientSideCacheInvalidationBatchWindow). Lazily started
@@ -192,12 +204,26 @@ func (h *invalidateHandler) ensureBatcher() *cscInvalBatcher {
 // would keep deleting entries but silently stop feeding the survivor's
 // refresher.
 func (h *invalidateHandler) clearRefreshQueue(q *cscRefreshQueue) {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	if q == nil || h.refresh != q {
+	if q == nil {
 		return
 	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i, b := range h.refreshStack {
+		if b == q {
+			h.refreshStack = append(h.refreshStack[:i], h.refreshStack[i+1:]...)
+			break
+		}
+	}
+	if h.refresh != q {
+		return // a newer sibling owns the active binding; nothing else changes
+	}
+	// Restore the next-newest live binding (nil when none): the surviving
+	// sibling's refresher keeps getting fed after the newest owner closes.
 	h.refresh = nil
+	if n := len(h.refreshStack); n > 0 {
+		h.refresh = h.refreshStack[n-1]
+	}
 	if h.batcher != nil {
 		h.batcher.stop()
 		h.batcher = nil
@@ -207,6 +233,18 @@ func (h *invalidateHandler) clearRefreshQueue(q *cscRefreshQueue) {
 func (h *invalidateHandler) setRefreshQueue(q *cscRefreshQueue) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	if q != nil {
+		found := false
+		for _, b := range h.refreshStack {
+			if b == q {
+				found = true
+				break
+			}
+		}
+		if !found {
+			h.refreshStack = append(h.refreshStack, q)
+		}
+	}
 	if h.refresh == q {
 		return
 	}
@@ -813,10 +851,22 @@ type cscHandlerClient struct {
 	*baseClient
 }
 
+// closeCanonical closes through the canonical *Client wrapper while it is
+// still alive — Client.Close also stops the cached autopipeliners, which
+// baseClient.Close does not, so closing only the baseClient would leave flush
+// goroutines running against closed pools. Falls back to baseClient.Close if
+// the wrapper was already collected (weak ref: see baseClient.cscClientWeak).
+func (c cscHandlerClient) closeCanonical() error {
+	if cl := c.cscClientWeak.Value(); cl != nil {
+		return cl.Close()
+	}
+	return c.baseClient.Close()
+}
+
 func (c cscHandlerClient) Close() error {
 	h := c.cscDrainHandle
 	if h == nil {
-		return c.baseClient.Close()
+		return c.closeCanonical()
 	}
 	h.handlerCloseOnce.Do(func() {
 		// Close has logically started: stop cache hits immediately and let the
@@ -826,7 +876,7 @@ func (c cscHandlerClient) Close() error {
 		}
 		h.signalStop()
 		go func() {
-			if err := c.baseClient.Close(); err != nil {
+			if err := c.closeCanonical(); err != nil {
 				internal.Logger.Printf(context.Background(), "csc: deferred client close failed: %v", err)
 			}
 		}()

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -27,11 +27,21 @@ func cscRegisterCleanups(c *Client) {
 		return
 	}
 	// Capture cscActive (a standalone *atomic.Bool, not *Client) so the cleanup
-	// also stops clones from serving once the drainer is gone.
+	// also stops clones from serving once the drainer is gone. Capture the miss
+	// coalescer too (started during attach, so already set here — nil when the
+	// option is off): its workers wait on their own stop channel, so without
+	// this a client dropped WITHOUT Close would leak them — and everything they
+	// retain (cache, pools) — per forgotten client. stopWorkers is idempotent
+	// (sync.Once), so an explicit Close racing this cleanup is safe; it only
+	// signals, never blocks, keeping the cleanup non-blocking.
 	active := c.baseClient.cscActive
+	mc := c.baseClient.cscMissCoalescer.Load()
 	runtime.AddCleanup(c, func(h *cscDrainHandle) {
 		if active != nil {
 			active.Store(false)
+		}
+		if mc != nil {
+			mc.stopWorkers()
 		}
 		h.signalStop()
 	}, h)
@@ -1063,9 +1073,11 @@ func (c *baseClient) processCached(ctx context.Context, cmd Cmder, state *proces
 		token, shouldFetch = c.csc.Reserve(key, nsRedisKeys)
 	}
 
-	// Reader-miss coalescing: hand the reserved miss to the batcher (no-op when off).
-	if shouldFetch && c.cscMissCoalescer != nil {
-		err := c.cscMissCoalescer.fetch(ctx, cmd, key, token)
+	// Reader-miss coalescing: hand the reserved miss to the batcher (no-op when
+	// off). Load the pointer ONCE: a concurrent Close swaps it to nil, and a
+	// second load after the nil-check would call fetch on a nil receiver.
+	if mc := c.cscMissCoalescer.Load(); shouldFetch && mc != nil {
+		err := mc.fetch(ctx, cmd, key, token)
 		if err == errCSCRetryUncached {
 			// The coalescer bowed out because CSC serving was disabled mid-miss; the
 			// command itself is fine and the reservation was already cancelled. Run it

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -42,6 +42,14 @@ func cscRegisterCleanups(c *Client) {
 		}
 		if mc != nil {
 			mc.stopWorkers()
+			// Drain-cancel anything still queued (non-blocking): a request whose
+			// caller already gave up (ctx cancel) can sit in mc.ch holding an
+			// IN_PROGRESS reservation, and with the workers stopped nothing would
+			// ever settle its token — another client sharing the same injected
+			// cache would then block on that key until StaleTimeout. Channel
+			// receive is safe against a worker doing a final grab; each request is
+			// consumed by exactly one side.
+			mc.drainQueueErr(pool.ErrClosed)
 		}
 		h.signalStop()
 	}, h)

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -28,12 +28,13 @@ func cscRegisterCleanups(c *Client) {
 	}
 	// Capture cscActive (a standalone *atomic.Bool, not *Client) so the cleanup
 	// also stops clones from serving once the drainer is gone. Capture the miss
-	// coalescer too (started during attach, so already set here — nil when the
-	// option is off): its workers wait on their own stop channel, so without
-	// this a client dropped WITHOUT Close would leak them — and everything they
-	// retain (cache, pools) — per forgotten client. stopWorkers is idempotent
-	// (sync.Once), so an explicit Close racing this cleanup is safe; it only
-	// signals, never blocks, keeping the cleanup non-blocking.
+	// coalescer too (set during attach; nil when off): its sessions wait on
+	// their own stop channel, so a client dropped WITHOUT Close would leak them
+	// and everything they retain (cache, pools). stopWorkers is idempotent and
+	// signal-only, keeping the cleanup non-blocking; the drain-cancel then
+	// settles any queued request whose reservation would otherwise stay
+	// IN_PROGRESS and block a cache-sharing client until StaleTimeout (channel
+	// receive gives each request exactly one consumer).
 	active := c.baseClient.cscActive
 	mc := c.baseClient.cscMissCoalescer.Load()
 	runtime.AddCleanup(c, func(h *cscDrainHandle) {
@@ -42,13 +43,6 @@ func cscRegisterCleanups(c *Client) {
 		}
 		if mc != nil {
 			mc.stopWorkers()
-			// Drain-cancel anything still queued (non-blocking): a request whose
-			// caller already gave up (ctx cancel) can sit in mc.ch holding an
-			// IN_PROGRESS reservation, and with the workers stopped nothing would
-			// ever settle its token — another client sharing the same injected
-			// cache would then block on that key until StaleTimeout. Channel
-			// receive is safe against a worker doing a final grab; each request is
-			// consumed by exactly one side.
 			mc.drainQueueErr(pool.ErrClosed)
 		}
 		h.signalStop()
@@ -119,23 +113,16 @@ type invalidateHandler struct {
 	invalBatchWindowSet bool
 }
 
-// setInvalBatchWindow folds one client's invalidation-batch window into the
-// shared handler's effective window. Called at attach time, before that
-// client's pushes can arrive. Multiple clients can share one handler
-// (same processor + cache), each with its own configured window, and the
-// handler runs ONE batcher — so the effective window is the STRICTEST across
-// attached clients: the smallest nonzero window, with zero (batching off,
-// inline deletes) strictest of all. Tightening can never violate any client's
-// staleness bound; taking the latest window as-is could (a later 1s attach
-// would silently loosen an earlier 10ms client's bound). The window is not
-// re-loosened when the strict client closes — bindings carry no identity to
-// track that, and staying stricter costs only batching efficiency, never
-// correctness.
-//
-// On a tighten, an already-running batcher was created with the looser window
-// (its window is fixed at creation), so stop and drop it; the next invalidation
-// lazily starts a fresh one with the new window via ensureBatcher. stop()
-// flushes what it holds, so no queued delete is lost.
+// setInvalBatchWindow folds one client's window into the shared handler's
+// effective window at attach time. Clients sharing a handler may configure
+// different windows but the handler runs ONE batcher, so the effective window
+// is the STRICTEST attached: smallest nonzero, with explicit zero (inline
+// deletes) strictest of all — tightening can never violate a client's staleness
+// bound, while taking the latest as-is could loosen an earlier stricter one.
+// Not re-loosened on close (bindings carry no identity; staying stricter costs
+// only efficiency). On a tighten the running batcher (window fixed at creation)
+// is stopped — stop() flushes, so no queued delete is lost — and the next
+// invalidation rebuilds via ensureBatcher.
 func (h *invalidateHandler) setInvalBatchWindow(w time.Duration) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -175,11 +162,9 @@ func (h *invalidateHandler) ensureBatcher() *cscInvalBatcher {
 	if h.users == 0 {
 		return nil
 	}
-	// Read the window HERE, under the same lock setInvalBatchWindow writes it —
-	// not from the caller's pre-lock snapshot, which a concurrent tighten (or an
-	// explicit 0 turning batching off) could have superseded; building from the
-	// snapshot would resurrect the old, looser cadence. 0 means batching is off:
-	// return nil so the caller deletes inline.
+	// Read the window under this lock (not a caller snapshot a concurrent
+	// tighten could supersede). 0 = batching off: return nil, caller deletes
+	// inline.
 	w := h.invalBatchWindow
 	if w <= 0 {
 		return nil
@@ -208,11 +193,9 @@ func (h *invalidateHandler) setRefreshQueue(q *cscRefreshQueue) {
 		return
 	}
 	h.refresh = q
-	// A running batcher snapshotted the previous refresh binding at creation
-	// (see ensureBatcher); a client attaching refresh-on-invalidate later would
-	// otherwise leave batched deletes permanently feeding a nil refresher. Drop
-	// it so the next invalidation rebuilds with the new snapshot; stop() flushes
-	// what it holds, so no queued delete is lost.
+	// A running batcher snapshotted the previous refresh binding at creation;
+	// drop it so the next invalidation rebuilds with the new one (stop()
+	// flushes, so no queued delete is lost).
 	if h.batcher != nil {
 		h.batcher.stop()
 		h.batcher = nil
@@ -236,10 +219,8 @@ func (h *invalidateHandler) HandlePushNotification(
 	switch payload := notification[1].(type) {
 	case nil:
 		cache.Flush()
-		// A full flush (FLUSHDB/FLUSHALL) removed every entry, so any per-key
-		// deletes the batcher still has queued are redundant — applying them after
-		// the flush would evict entries a reader repopulated post-flush, an extra
-		// miss for up to the window. Drop the batcher's pending queue.
+		// A full flush removed every entry: queued per-key deletes are redundant
+		// and would evict entries repopulated post-flush. Drop them.
 		if batcher != nil {
 			batcher.drop()
 		}
@@ -318,8 +299,7 @@ func (h *invalidateHandler) releaseLocked() {
 			h.batcher.stop()
 			h.batcher = nil
 		}
-		// A later re-acquire is a fresh binding: it must fold in its own window,
-		// not inherit the strictest window of the released one.
+		// A fresh binding folds in its own window; do not inherit this one's.
 		h.invalBatchWindow = 0
 		h.invalBatchWindowSet = false
 	}
@@ -1099,9 +1079,8 @@ func (c *baseClient) processCached(ctx context.Context, cmd Cmder, state *proces
 	if mc := c.cscMissCoalescer.Load(); shouldFetch && mc != nil {
 		err := mc.fetch(ctx, cmd, key, token)
 		if err == errCSCRetryUncached {
-			// The coalescer bowed out because CSC serving was disabled mid-miss; the
-			// command itself is fine and the reservation was already cancelled. Run it
-			// uncached on the normal path rather than surfacing a spurious ErrClosed.
+			// CSC was disabled mid-miss; the command is fine and the reservation is
+			// already cancelled — run it uncached instead of surfacing ErrClosed.
 			return c.processWithRetry(ctx, cmd, nil, state)
 		}
 		return err

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -49,6 +49,17 @@ func cscRegisterCleanups(c *Client) {
 	// handle is channels only (no *Client), so capturing it keeps the wrapper
 	// collectible.
 	rh := c.baseClient.cscRefreshHandle
+	// Capture this client's refresh queue too: signalStop stops the refresher
+	// goroutine, but with a SHARED cache+processor the invalidate handler still
+	// holds this queue as (possibly) the active refresh binding. If a sibling
+	// client survives, invalidations would keep feeding a stopped queue and the
+	// shared cache's refresh-on-invalidate would silently degrade to plain
+	// eviction. clearRefreshQueue unbinds it and restores the sibling's binding,
+	// mirroring stopCSCRefresher on the clean Close path. A queue is only ever
+	// created inside attachSharedTrackingCSC, which also builds the drain handle
+	// (startBackgroundDrainer), so h.invalidateHandler is set whenever q is
+	// non-nil; a Conn() clone bails before startCSCRefresher and never has one.
+	q := c.baseClient.cscRefreshQueue
 	runtime.AddCleanup(c, func(h *cscDrainHandle) {
 		if active != nil {
 			active.Store(false)
@@ -62,6 +73,9 @@ func cscRegisterCleanups(c *Client) {
 		}
 		if rh != nil {
 			rh.signalStop()
+		}
+		if q != nil && h.invalidateHandler != nil {
+			h.invalidateHandler.clearRefreshQueue(q)
 		}
 		h.signalStop()
 	}, h)

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -98,11 +98,24 @@ type invalidateHandler struct {
 }
 
 // setInvalBatchWindow records the invalidation-batch coalescing window from the
-// owning client's Options. Set before any push can arrive (attach time).
+// owning client's Options. Normally set before any push can arrive (attach
+// time). When a second client binds to the same shared handler with a different
+// window, an already-running batcher was created with the previous window (its
+// window is fixed at creation), so it would keep honoring the old cadence and the
+// new client's staleness bound would not hold. Stop and drop that batcher so the
+// next invalidation lazily starts a fresh one with the new window via
+// ensureBatcher; stop() flushes what it holds, so no queued delete is lost.
 func (h *invalidateHandler) setInvalBatchWindow(w time.Duration) {
 	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.invalBatchWindow == w {
+		return
+	}
 	h.invalBatchWindow = w
-	h.mu.Unlock()
+	if h.batcher != nil {
+		h.batcher.stop()
+		h.batcher = nil
+	}
 }
 
 // ensureBatcher lazily starts the windowed invalidation batcher. The common
@@ -131,6 +144,7 @@ func (h *invalidateHandler) ensureBatcher(w time.Duration) *cscInvalBatcher {
 			window: w,
 			ch:     make(chan string, 8192),
 			stopCh: make(chan struct{}),
+			dropCh: make(chan struct{}, 1),
 		}
 		go h.batcher.run()
 	}
@@ -151,6 +165,7 @@ func (h *invalidateHandler) HandlePushNotification(
 	h.mu.RLock()
 	cache, keyPrefix, refresh := h.cache, h.keyPrefix, h.refresh
 	window := h.invalBatchWindow
+	batcher := h.batcher
 	h.mu.RUnlock()
 	if cache == nil || len(notification) < 2 {
 		return nil
@@ -159,6 +174,13 @@ func (h *invalidateHandler) HandlePushNotification(
 	switch payload := notification[1].(type) {
 	case nil:
 		cache.Flush()
+		// A full flush (FLUSHDB/FLUSHALL) removed every entry, so any per-key
+		// deletes the batcher still has queued are redundant — applying them after
+		// the flush would evict entries a reader repopulated post-flush, an extra
+		// miss for up to the window. Drop the batcher's pending queue.
+		if batcher != nil {
+			batcher.drop()
+		}
 	case []interface{}:
 		// Offload path: enqueue keys to the windowed background batcher instead of
 		// deleting inline, so invalidation work does not steal time from the

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -177,13 +177,31 @@ func (h *invalidateHandler) ensureBatcher() *cscInvalBatcher {
 			// stop-drain still applies queued deletes after h.cache is nilled.
 			cache:   h.cache,
 			refresh: h.refresh,
-			ch:      make(chan string, 8192),
+			ch:      make(chan cscInvalItem, 8192),
 			stopCh:  make(chan struct{}),
-			dropCh:  make(chan struct{}, 1),
 		}
 		go h.batcher.run()
 	}
 	return h.batcher
+}
+
+// clearRefreshQueue clears the handler's refresh binding ONLY while it still
+// points at q: two clients sharing one cache and push processor each attach
+// their own queue (last attach wins), and a closing client must not clobber
+// the binding of a live sibling that re-attached after it — invalidations
+// would keep deleting entries but silently stop feeding the survivor's
+// refresher.
+func (h *invalidateHandler) clearRefreshQueue(q *cscRefreshQueue) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if q == nil || h.refresh != q {
+		return
+	}
+	h.refresh = nil
+	if h.batcher != nil {
+		h.batcher.stop()
+		h.batcher = nil
+	}
 }
 
 func (h *invalidateHandler) setRefreshQueue(q *cscRefreshQueue) {
@@ -218,12 +236,15 @@ func (h *invalidateHandler) HandlePushNotification(
 
 	switch payload := notification[1].(type) {
 	case nil:
-		cache.Flush()
-		// A full flush removed every entry: queued per-key deletes are redundant
-		// and would evict entries repopulated post-flush. Drop them.
+		// Supersede queued per-key deletes BEFORE flushing: drop() bumps the
+		// batcher epoch, so anything already enqueued (pre-flush, redundant by
+		// the flush) is skipped at apply, while an invalidation racing in from
+		// another tracked connection AFTER this point carries the new epoch and
+		// still applies — its post-flush delete must not be lost.
 		if batcher != nil {
 			batcher.drop()
 		}
+		cache.Flush()
 	case []interface{}:
 		// Offload path: enqueue keys to the windowed background batcher instead of
 		// deleting inline, so invalidation work does not steal time from the
@@ -707,32 +728,38 @@ func (c *baseClient) cscForgetConn(connID uint64) {
 // args, and pipelines — are also caught: the guard matches on the command's
 // leading args, not the typed method.
 var errClientTrackingWithCSC = errors.New(
-	"redis: CLIENT TRACKING is not allowed when client-side caching is enabled")
+	"redis: CLIENT TRACKING is not allowed when client-side caching is enabled",
+)
 
 // errSelectWithCSC rejects runtime SELECT on clients with built-in CSC. Cache
 // keys use Options.DB, while SELECT mutates only the chosen pool connection.
 var errSelectWithCSC = errors.New(
-	"redis: SELECT is not allowed when client-side caching is enabled")
+	"redis: SELECT is not allowed when client-side caching is enabled",
+)
 
 // errAuthWithCSC rejects runtime authentication because it can change one
 // connection's ACL identity without changing the client's fixed cache namespace.
 var errAuthWithCSC = errors.New(
-	"redis: AUTH is not allowed when client-side caching is enabled")
+	"redis: AUTH is not allowed when client-side caching is enabled",
+)
 
 // errHelloWithCSC rejects HELLO with arguments because it can switch a tracked
 // connection out of RESP3 (and can also change authentication).
 var errHelloWithCSC = errors.New(
-	"redis: HELLO with arguments is not allowed when client-side caching is enabled")
+	"redis: HELLO with arguments is not allowed when client-side caching is enabled",
+)
 
 // errResetWithCSC rejects RESET because it disables tracking and switches the
 // connection to RESP2.
 var errResetWithCSC = errors.New(
-	"redis: RESET is not allowed when client-side caching is enabled")
+	"redis: RESET is not allowed when client-side caching is enabled",
+)
 
 // errSubscribeWithCSC rejects raw subscriptions on the ordinary pool. The
 // typed Subscribe methods use dedicated PubSub connections and remain allowed.
 var errSubscribeWithCSC = errors.New(
-	"redis: SUBSCRIBE is not allowed on pooled connections when client-side caching is enabled")
+	"redis: SUBSCRIBE is not allowed on pooled connections when client-side caching is enabled",
+)
 
 // cscCommandError rejects commands that can make a pooled connection's state
 // diverge from the assumptions used by CSC.
@@ -943,12 +970,16 @@ func (c *baseClient) stopBackgroundDrainer() {
 		return
 	}
 	h.teardownOnce.Do(func() {
-		c.stopCSCRefresher()
-		c.stopCSCMissCoalescer()
-		// Stop serving cache hits on any clone before the drainer is gone.
+		// Deactivate serving FIRST: with the flag still true a clone's miss
+		// could route to the just-stopped coalescer and fail with ErrClosed
+		// while the pool is still open. Once false, racing reads take the
+		// plain uncached path (fetch's stop returns errCSCRetryUncached as the
+		// backstop for requests already in flight).
 		if c.cscActive != nil {
 			c.cscActive.Store(false)
 		}
+		c.stopCSCRefresher()
+		c.stopCSCMissCoalescer()
 		h.signalStop()
 		<-h.done
 		// The drainer's exit defer revoked and evicted this pool's coverage

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -218,6 +218,7 @@ func (h *invalidateHandler) ensureBatcher() *cscInvalBatcher {
 			cache:   h.cache,
 			refresh: h.refresh,
 			ch:      make(chan cscInvalItem, 8192),
+			wake:    make(chan struct{}, 1),
 			stopCh:  make(chan struct{}),
 		}
 		go h.batcher.run()

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -91,26 +91,45 @@ type invalidateHandler struct {
 	// fresh one (picking up the successor's window).
 	batcher *cscInvalBatcher
 
-	// invalBatchWindow is the coalescing window for the batcher above, threaded
-	// from the owning client's Options at attach time. 0 (default) deletes inline.
-	// Read under mu alongside cache/keyPrefix/refresh.
-	invalBatchWindow time.Duration
+	// invalBatchWindow is the EFFECTIVE coalescing window for the batcher above:
+	// the strictest window folded in across attached clients (see
+	// setInvalBatchWindow — 0/inline strictest, then smaller nonzero). 0
+	// (default) deletes inline. invalBatchWindowSet distinguishes "no client has
+	// attached a window yet" from an explicit 0 (inline) that must win over any
+	// later nonzero window. Read under mu alongside cache/keyPrefix/refresh.
+	invalBatchWindow    time.Duration
+	invalBatchWindowSet bool
 }
 
-// setInvalBatchWindow records the invalidation-batch coalescing window from the
-// owning client's Options. Normally set before any push can arrive (attach
-// time). When a second client binds to the same shared handler with a different
-// window, an already-running batcher was created with the previous window (its
-// window is fixed at creation), so it would keep honoring the old cadence and the
-// new client's staleness bound would not hold. Stop and drop that batcher so the
-// next invalidation lazily starts a fresh one with the new window via
-// ensureBatcher; stop() flushes what it holds, so no queued delete is lost.
+// setInvalBatchWindow folds one client's invalidation-batch window into the
+// shared handler's effective window. Called at attach time, before that
+// client's pushes can arrive. Multiple clients can share one handler
+// (same processor + cache), each with its own configured window, and the
+// handler runs ONE batcher — so the effective window is the STRICTEST across
+// attached clients: the smallest nonzero window, with zero (batching off,
+// inline deletes) strictest of all. Tightening can never violate any client's
+// staleness bound; taking the latest window as-is could (a later 1s attach
+// would silently loosen an earlier 10ms client's bound). The window is not
+// re-loosened when the strict client closes — bindings carry no identity to
+// track that, and staying stricter costs only batching efficiency, never
+// correctness.
+//
+// On a tighten, an already-running batcher was created with the looser window
+// (its window is fixed at creation), so stop and drop it; the next invalidation
+// lazily starts a fresh one with the new window via ensureBatcher. stop()
+// flushes what it holds, so no queued delete is lost.
 func (h *invalidateHandler) setInvalBatchWindow(w time.Duration) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if h.invalBatchWindow == w {
-		return
+	if h.invalBatchWindowSet {
+		cur := h.invalBatchWindow
+		// Strictness: 0 (inline) is strictest; among nonzero, smaller is stricter.
+		stricter := (w == 0 && cur != 0) || (w != 0 && cur != 0 && w < cur)
+		if !stricter {
+			return
+		}
 	}
+	h.invalBatchWindowSet = true
 	h.invalBatchWindow = w
 	if h.batcher != nil {
 		h.batcher.stop()
@@ -121,7 +140,7 @@ func (h *invalidateHandler) setInvalBatchWindow(w time.Duration) {
 // ensureBatcher lazily starts the windowed invalidation batcher. The common
 // case (already started) is a shared RLock; only first-start takes the write
 // lock, so the hot invalidation path stays cheap.
-func (h *invalidateHandler) ensureBatcher(w time.Duration) *cscInvalBatcher {
+func (h *invalidateHandler) ensureBatcher() *cscInvalBatcher {
 	h.mu.RLock()
 	b := h.batcher
 	h.mu.RUnlock()
@@ -136,6 +155,15 @@ func (h *invalidateHandler) ensureBatcher(w time.Duration) *cscInvalBatcher {
 	// users is 0, release() no longer runs). The caller falls back to the inline
 	// delete path when this returns nil.
 	if h.users == 0 {
+		return nil
+	}
+	// Read the window HERE, under the same lock setInvalBatchWindow writes it —
+	// not from the caller's pre-lock snapshot, which a concurrent tighten (or an
+	// explicit 0 turning batching off) could have superseded; building from the
+	// snapshot would resurrect the old, looser cadence. 0 means batching is off:
+	// return nil so the caller deletes inline.
+	w := h.invalBatchWindow
+	if w <= 0 {
 		return nil
 	}
 	if h.batcher == nil {
@@ -187,10 +215,11 @@ func (h *invalidateHandler) HandlePushNotification(
 		// coalescer's miss-reply reader (the low-concurrency churn p99 tail).
 		if window > 0 {
 			if _, ok := cache.(*LocalCache); ok {
-				// nil when the binding was just released (users==0): fall through
-				// to the inline delete path below rather than enqueue on a nil
+				// nil when the binding was just released (users==0) or when a
+				// concurrent window change turned batching off: fall through to
+				// the inline delete path below rather than enqueue on a nil
 				// batcher (which would panic).
-				if b := h.ensureBatcher(window); b != nil {
+				if b := h.ensureBatcher(); b != nil {
 					for _, k := range payload {
 						var name string
 						switch v := k.(type) {
@@ -255,6 +284,10 @@ func (h *invalidateHandler) releaseLocked() {
 			h.batcher.stop()
 			h.batcher = nil
 		}
+		// A later re-acquire is a fresh binding: it must fold in its own window,
+		// not inherit the strictest window of the released one.
+		h.invalBatchWindow = 0
+		h.invalBatchWindowSet = false
 	}
 }
 

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -896,6 +896,18 @@ func applyCachedReply(cmd Cmder, raw []byte) error {
 	return cmd.readReply(proto.NewReaderSize(bytes.NewReader(raw), len(raw)+1))
 }
 
+// classifyCachedReply reports the same error applyCachedReply would, without a
+// caller command to populate. The miss coalescer uses it on the abandoned path
+// (the caller returned and owns its Cmder again) to decide cache-vs-cancel: a
+// value or Nil is cacheable, a top-level RESP error is not. It reads the frame
+// generically, so it can only diverge from a concrete cmd's readReply on a
+// well-formed reply of an unexpected shape — which the next reader re-parses and
+// drops (see processCached), so a rare mis-cache self-heals.
+func classifyCachedReply(raw []byte) error {
+	_, err := proto.NewReaderSize(bytes.NewReader(raw), len(raw)+1).ReadReply()
+	return err
+}
+
 // isCacheableReplyResult reports whether a fully read Redis reply can be
 // cached. redis.Nil is a normal negative lookup, not a transport/protocol
 // failure; tracking will invalidate it if the key is later created.
@@ -994,7 +1006,14 @@ func (c *baseClient) processCached(ctx context.Context, cmd Cmder, state *proces
 
 	// Reader-miss coalescing: hand the reserved miss to the batcher (no-op when off).
 	if shouldFetch && c.cscMissCoalescer != nil {
-		return c.cscMissCoalescer.fetch(ctx, cmd, key, token)
+		err := c.cscMissCoalescer.fetch(ctx, cmd, key, token)
+		if err == errCSCRetryUncached {
+			// The coalescer bowed out because CSC serving was disabled mid-miss; the
+			// command itself is fine and the reservation was already cancelled. Run it
+			// uncached on the normal path rather than surfacing a spurious ErrClosed.
+			return c.processWithRetry(ctx, cmd, nil, state)
+		}
+		return err
 	}
 
 	var fc cscFetchCapture

--- a/csc_integration.go
+++ b/csc_integration.go
@@ -195,8 +195,20 @@ func (h *invalidateHandler) ensureBatcher() *cscInvalBatcher {
 
 func (h *invalidateHandler) setRefreshQueue(q *cscRefreshQueue) {
 	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.refresh == q {
+		return
+	}
 	h.refresh = q
-	h.mu.Unlock()
+	// A running batcher snapshotted the previous refresh binding at creation
+	// (see ensureBatcher); a client attaching refresh-on-invalidate later would
+	// otherwise leave batched deletes permanently feeding a nil refresher. Drop
+	// it so the next invalidation rebuilds with the new snapshot; stop() flushes
+	// what it holds, so no queued delete is lost.
+	if h.batcher != nil {
+		h.batcher.stop()
+		h.batcher = nil
+	}
 }
 
 // HandlePushNotification decodes ["invalidate", <keys>] notifications. A nil

--- a/csc_inval_batch.go
+++ b/csc_inval_batch.go
@@ -24,13 +24,10 @@ const cscInvalBatchMax = 4096 // size-cap flush regardless of the timer
 
 type cscInvalBatcher struct {
 	window time.Duration
-	// cache/refresh are snapshotted at creation rather than re-read from the
-	// binding on every apply: the batcher's lifetime is strictly inside one
-	// binding (releaseLocked stops it before users hits 0 clears the binding),
-	// and the snapshot is what lets the release-time stop-drain still apply
-	// queued deletes AFTER releaseLocked has nilled h.cache — dropping them
-	// there would let a successor reusing the same shared cache serve
-	// pre-invalidation values until TTL/MaxStaleness.
+	// cache/refresh are snapshotted at creation (batcher lifetime is inside the
+	// binding lifetime): the release-time stop-drain must still apply queued
+	// deletes AFTER releaseLocked nils h.cache, or a successor reusing the
+	// shared cache serves stale until TTL/MaxStaleness.
 	cache   Cache
 	refresh *cscRefreshQueue
 
@@ -38,23 +35,18 @@ type cscInvalBatcher struct {
 	stopCh   chan struct{}
 	dropCh   chan struct{} // cap-1: signal run() to discard its in-progress batch
 	stopOnce sync.Once
-	// stopMu/stopped interlock enqueue against stop: a handler goroutine can hold
-	// a batcher pointer across a concurrent stop (a window-change rebuild while
-	// HandlePushNotification is mid-enqueue-loop, or ensureBatcher's RLock fast
-	// path returning a just-stopped instance). enqueue sends while holding the
-	// read side, so every key sent lands BEFORE stop's write side closes stopCh —
-	// guaranteeing run()'s stop-drain sees it; once stopped, enqueue applies
-	// inline instead, so no delete is ever parked in a channel nothing drains
-	// (which would serve pre-invalidation values until TTL/MaxStaleness).
+	// stopMu/stopped interlock enqueue against stop: a handler can hold a stale
+	// batcher pointer across a rebuild. enqueue sends under the read side, so a
+	// sent key lands BEFORE stop closes stopCh (the stop-drain sees it); once
+	// stopped, enqueue applies inline — no delete is ever parked in a channel
+	// nothing drains.
 	stopMu  sync.RWMutex
 	stopped bool
 }
 
-// stop signals run() to flush and exit; idempotent. It closes a channel and
-// flips the stopped flag — it never touches h.mu and does not wait for the
-// goroutine — so it is safe to call while holding the handler lock (see
-// releaseLocked). Lock order is h.mu → stopMu, never the reverse: enqueue's
-// stopMu critical section contains only the flag check and a channel send.
+// stop signals run() to flush and exit; idempotent, never touches h.mu, does
+// not wait — safe under the handler lock. Lock order h.mu -> stopMu, never
+// reversed (enqueue's stopMu section is only the flag check and the send).
 func (b *cscInvalBatcher) stop() {
 	b.stopOnce.Do(func() {
 		b.stopMu.Lock()
@@ -64,12 +56,10 @@ func (b *cscInvalBatcher) stop() {
 	})
 }
 
-// drop discards everything the batcher currently has queued — the channel plus
-// the run loop's in-progress batch — WITHOUT applying it. Called after a full
-// cache Flush (FLUSHDB/FLUSHALL) has already removed every entry, so the queued
-// per-key deletes are redundant; applying them would evict entries a reader
-// repopulated after the flush (an extra miss within the window). Best-effort: a
-// key racing in right after is treated as a normal post-flush invalidation.
+// drop discards everything queued (channel + the run loop's in-progress batch)
+// WITHOUT applying: after a full cache Flush the per-key deletes are redundant
+// and would evict post-flush repopulations. Best-effort against racing
+// enqueues.
 func (b *cscInvalBatcher) drop() {
 	// Drain queued keys (best-effort, non-blocking).
 	for draining := true; draining; {
@@ -106,11 +96,8 @@ func (b *cscInvalBatcher) enqueue(nsKey string) {
 	}
 }
 
-// apply deletes the given namespaced keys and feeds any evicted-hot entries to
-// the refresher. Uses the creation-time snapshot (see the struct fields), NOT a
-// re-read of the live binding: releaseLocked nils the binding before this
-// goroutine's final stop-drain flush runs, and these deletes must still land on
-// the (possibly shared, successor-reused) cache.
+// apply deletes the namespaced keys and feeds evicted-hot entries to the
+// refresher, using the creation-time snapshot (see the struct fields).
 func (b *cscInvalBatcher) apply(keys []string) {
 	cache, refresh := b.cache, b.refresh
 	if cache == nil {
@@ -149,12 +136,9 @@ func (b *cscInvalBatcher) run() {
 	for {
 		select {
 		case <-b.stopCh:
-			// Stopped: by the last user releasing the binding (deletes are then a
-			// no-op on the nil cache) or by a window change rebuilding the batcher
-			// (setInvalBatchWindow), where the queued deletes are still live and
-			// must not be lost — the cache would serve pre-invalidation values
-			// until TTL/MaxStaleness. Drain what is still buffered in ch into the
-			// batch, then flush once and exit.
+			// Stopped (last release, or a window-change rebuild where queued deletes
+			// are still live and must not be lost): drain ch into the batch, flush
+			// once, exit.
 			for draining := true; draining; {
 				select {
 				case k := <-b.ch:

--- a/csc_inval_batch.go
+++ b/csc_inval_batch.go
@@ -27,6 +27,7 @@ type cscInvalBatcher struct {
 	window   time.Duration
 	ch       chan string
 	stopCh   chan struct{}
+	dropCh   chan struct{} // cap-1: signal run() to discard its in-progress batch
 	stopOnce sync.Once
 }
 
@@ -35,6 +36,29 @@ type cscInvalBatcher struct {
 // call while holding the handler lock (see releaseLocked).
 func (b *cscInvalBatcher) stop() {
 	b.stopOnce.Do(func() { close(b.stopCh) })
+}
+
+// drop discards everything the batcher currently has queued — the channel plus
+// the run loop's in-progress batch — WITHOUT applying it. Called after a full
+// cache Flush (FLUSHDB/FLUSHALL) has already removed every entry, so the queued
+// per-key deletes are redundant; applying them would evict entries a reader
+// repopulated after the flush (an extra miss within the window). Best-effort: a
+// key racing in right after is treated as a normal post-flush invalidation.
+func (b *cscInvalBatcher) drop() {
+	// Drain queued keys (best-effort, non-blocking).
+	for draining := true; draining; {
+		select {
+		case <-b.ch:
+		default:
+			draining = false
+		}
+	}
+	// Signal run() to clear its in-progress batch; the cap-1 buffer means a signal
+	// is never lost even if run() is not currently selecting.
+	select {
+	case b.dropCh <- struct{}{}:
+	default:
+	}
 }
 
 // enqueue hands a namespaced key to the batcher without blocking the caller. On
@@ -95,6 +119,11 @@ func (b *cscInvalBatcher) run() {
 			// re-arming the timer forever.
 			flush()
 			return
+		case <-b.dropCh:
+			// A full cache Flush superseded the queued deletes: discard the
+			// in-progress batch without applying it (see drop()).
+			pending = pending[:0]
+			clear(seen)
 		case k := <-b.ch:
 			if _, dup := seen[k]; !dup {
 				seen[k] = struct{}{}

--- a/csc_inval_batch.go
+++ b/csc_inval_batch.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -22,6 +23,13 @@ import (
 
 const cscInvalBatchMax = 4096 // size-cap flush regardless of the timer
 
+// cscInvalItem is one queued invalidation, tagged with the batcher epoch it
+// was enqueued under so a full-cache flush can supersede it (see drop()).
+type cscInvalItem struct {
+	key   string
+	epoch uint64
+}
+
 type cscInvalBatcher struct {
 	window time.Duration
 	// cache/refresh are snapshotted at creation (batcher lifetime is inside the
@@ -31,10 +39,12 @@ type cscInvalBatcher struct {
 	cache   Cache
 	refresh *cscRefreshQueue
 
-	ch       chan string
+	ch       chan cscInvalItem
 	stopCh   chan struct{}
-	dropCh   chan struct{} // cap-1: signal run() to discard its in-progress batch
 	stopOnce sync.Once
+	// epoch versions enqueued invalidations against full-cache flushes: drop()
+	// bumps it, and apply skips items from an older epoch. See drop().
+	epoch atomic.Uint64
 	// stopMu/stopped interlock enqueue against stop: a handler can hold a stale
 	// batcher pointer across a rebuild. enqueue sends under the read side, so a
 	// sent key lands BEFORE stop closes stopCh (the stop-drain sees it); once
@@ -56,57 +66,56 @@ func (b *cscInvalBatcher) stop() {
 	})
 }
 
-// drop discards everything queued (channel + the run loop's in-progress batch)
-// WITHOUT applying: after a full cache Flush the per-key deletes are redundant
-// and would evict post-flush repopulations. Best-effort against racing
-// enqueues.
+// drop marks everything enqueued so far as superseded by a full cache Flush:
+// bumping the epoch makes apply skip stale-epoch items — both queued and in an
+// in-progress batch — without draining anything. The old drain-based drop
+// could discard a NEWER per-key invalidation racing in from another tracked
+// connection after the flush, losing its delete and leaving a repopulated
+// entry stale; with epochs that item carries the new epoch and survives.
+// Callers bump BEFORE flushing the cache, so a stale epoch always means
+// "enqueued before the flush", where the delete is redundant by the flush.
 func (b *cscInvalBatcher) drop() {
-	// Drain queued keys (best-effort, non-blocking).
-	for draining := true; draining; {
-		select {
-		case <-b.ch:
-		default:
-			draining = false
-		}
-	}
-	// Signal run() to clear its in-progress batch; the cap-1 buffer means a signal
-	// is never lost even if run() is not currently selecting.
-	select {
-	case b.dropCh <- struct{}{}:
-	default:
-	}
+	b.epoch.Add(1)
 }
 
 // enqueue hands a namespaced key to the batcher without blocking the caller. On
 // a full queue — or once the batcher is stopped (see stopMu) — it applies the
 // delete inline so an invalidation is never dropped.
 func (b *cscInvalBatcher) enqueue(nsKey string) {
+	it := cscInvalItem{key: nsKey, epoch: b.epoch.Load()}
 	b.stopMu.RLock()
 	if b.stopped {
 		b.stopMu.RUnlock()
-		b.apply([]string{nsKey})
+		b.apply([]cscInvalItem{it})
 		return
 	}
 	select {
-	case b.ch <- nsKey:
+	case b.ch <- it:
 		b.stopMu.RUnlock()
 	default:
 		b.stopMu.RUnlock()
-		b.apply([]string{nsKey})
+		b.apply([]cscInvalItem{it})
 	}
 }
 
 // apply deletes the namespaced keys and feeds evicted-hot entries to the
 // refresher, using the creation-time snapshot (see the struct fields).
-func (b *cscInvalBatcher) apply(keys []string) {
+func (b *cscInvalBatcher) apply(items []cscInvalItem) {
 	cache, refresh := b.cache, b.refresh
 	if cache == nil {
 		return
 	}
+	cur := b.epoch.Load()
 	lc, canRefresh := cache.(*LocalCache)
 	canRefresh = canRefresh && refresh != nil
 	var hot []cscRefreshTarget
-	for _, k := range keys {
+	for _, it := range items {
+		// Stale epoch: enqueued before a full cache Flush that superseded it
+		// (see drop()); applying it would only evict a post-flush repopulation.
+		if it.epoch != cur {
+			continue
+		}
+		k := it.key
 		if !canRefresh {
 			cache.DeleteByRedisKey(k)
 			continue
@@ -121,8 +130,11 @@ func (b *cscInvalBatcher) apply(keys []string) {
 func (b *cscInvalBatcher) run() {
 	t := time.NewTimer(b.window)
 	defer t.Stop()
-	pending := make([]string, 0, 256)
-	seen := make(map[string]struct{}, 256)
+	pending := make([]cscInvalItem, 0, 256)
+	// seen dedups by key WITHIN an epoch: the same key arriving again after a
+	// flush bumped the epoch must be re-appended (the old occurrence will be
+	// skipped by apply), or its post-flush delete would be lost to dedup.
+	seen := make(map[string]uint64, 256)
 	flush := func() {
 		if len(pending) == 0 {
 			return
@@ -141,10 +153,10 @@ func (b *cscInvalBatcher) run() {
 			// once, exit.
 			for draining := true; draining; {
 				select {
-				case k := <-b.ch:
-					if _, dup := seen[k]; !dup {
-						seen[k] = struct{}{}
-						pending = append(pending, k)
+				case it := <-b.ch:
+					if e, dup := seen[it.key]; !dup || e != it.epoch {
+						seen[it.key] = it.epoch
+						pending = append(pending, it)
 					}
 				default:
 					draining = false
@@ -152,15 +164,10 @@ func (b *cscInvalBatcher) run() {
 			}
 			flush()
 			return
-		case <-b.dropCh:
-			// A full cache Flush superseded the queued deletes: discard the
-			// in-progress batch without applying it (see drop()).
-			pending = pending[:0]
-			clear(seen)
-		case k := <-b.ch:
-			if _, dup := seen[k]; !dup {
-				seen[k] = struct{}{}
-				pending = append(pending, k)
+		case it := <-b.ch:
+			if e, dup := seen[it.key]; !dup || e != it.epoch {
+				seen[it.key] = it.epoch
+				pending = append(pending, it)
 			}
 			if len(pending) >= cscInvalBatchMax {
 				flush()

--- a/csc_inval_batch.go
+++ b/csc_inval_batch.go
@@ -1,6 +1,9 @@
 package redis
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // Windowed background invalidation batcher.
 //
@@ -20,9 +23,18 @@ import "time"
 const cscInvalBatchMax = 4096 // size-cap flush regardless of the timer
 
 type cscInvalBatcher struct {
-	h      *invalidateHandler
-	window time.Duration
-	ch     chan string
+	h        *invalidateHandler
+	window   time.Duration
+	ch       chan string
+	stopCh   chan struct{}
+	stopOnce sync.Once
+}
+
+// stop signals run() to flush and exit; idempotent. It only closes a channel —
+// it never touches h.mu and does not wait for the goroutine — so it is safe to
+// call while holding the handler lock (see releaseLocked).
+func (b *cscInvalBatcher) stop() {
+	b.stopOnce.Do(func() { close(b.stopCh) })
 }
 
 // enqueue hands a namespaced key to the batcher without blocking the caller. On
@@ -77,6 +89,12 @@ func (b *cscInvalBatcher) run() {
 	}
 	for {
 		select {
+		case <-b.stopCh:
+			// Last user released the binding: flush what is pending (a no-op once
+			// the cache is nil) and exit so the goroutine does not live on
+			// re-arming the timer forever.
+			flush()
+			return
 		case k := <-b.ch:
 			if _, dup := seen[k]; !dup {
 				seen[k] = struct{}{}

--- a/csc_inval_batch.go
+++ b/csc_inval_batch.go
@@ -1,9 +1,12 @@
 package redis
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/redis/go-redis/v9/internal"
 )
 
 // Windowed background invalidation batcher.
@@ -42,6 +45,21 @@ type cscInvalBatcher struct {
 	ch       chan cscInvalItem
 	stopCh   chan struct{}
 	stopOnce sync.Once
+	// spill absorbs invalidations that arrive while ch is full, so an overflow
+	// never applies a delete inline on the producer — critically the coalescer's
+	// reply reader, where inline apply (lock-held cache work) stalls miss replies
+	// (head-of-line). The worker drains spill through the SAME seen/pending dedup
+	// pipeline as ch, so a burst of duplicate keys collapses to one delete per
+	// key; distinct keys are bounded by the tracked keyset (⊂ cache capacity), so
+	// spill needs no hard cap — the worker catches up. wake nudges the worker to
+	// drain promptly (cap 1, coalescing: one wake drains the whole slice).
+	spillMu sync.Mutex
+	spill   []cscInvalItem
+	wake    chan struct{}
+	// spilled counts overflow events (ch full at send time). Internal; read by
+	// tests and available for a future stat, so the feature's degradation under
+	// invalidation bursts is observable instead of silent.
+	spilled atomic.Uint64
 	// epoch versions enqueued invalidations against full-cache flushes: drop()
 	// bumps it, and apply skips items from an older epoch. applyMu serializes
 	// the two: without it, apply could snapshot the epoch, a concurrent
@@ -89,9 +107,11 @@ func (b *cscInvalBatcher) drop() {
 	b.applyMu.Unlock()
 }
 
-// enqueue hands a namespaced key to the batcher without blocking the caller. On
-// a full queue — or once the batcher is stopped (see stopMu) — it applies the
-// delete inline so an invalidation is never dropped.
+// enqueue hands a namespaced key to the batcher without blocking the caller and
+// without ever applying a delete inline on the producer (see the spill field):
+// on a full ch it appends to spill and nudges the worker; only once the batcher
+// is stopped (no worker left to drain, see stopMu) does it apply inline so an
+// invalidation is never dropped.
 func (b *cscInvalBatcher) enqueue(nsKey string) {
 	it := cscInvalItem{key: nsKey, epoch: b.epoch.Load()}
 	b.stopMu.RLock()
@@ -104,9 +124,31 @@ func (b *cscInvalBatcher) enqueue(nsKey string) {
 	case b.ch <- it:
 		b.stopMu.RUnlock()
 	default:
+		// ch full: park on spill (off the producer's read path) for the worker
+		// to drain, instead of applying inline here. Correctness is unchanged —
+		// the item carries its enqueue-time epoch and the worker applies it under
+		// applyMu with the same epoch check as the ch path.
+		b.spillMu.Lock()
+		b.spill = append(b.spill, it)
+		b.spillMu.Unlock()
 		b.stopMu.RUnlock()
-		b.apply([]cscInvalItem{it})
+		b.spilled.Add(1)
+		select {
+		case b.wake <- struct{}{}:
+		default:
+		}
 	}
+}
+
+// takeSpill swaps out the accumulated spill for the worker to drain. Returns nil
+// when empty. The swapped slice is owned by the caller; b.spill starts fresh so
+// concurrent enqueues never race the drain.
+func (b *cscInvalBatcher) takeSpill() []cscInvalItem {
+	b.spillMu.Lock()
+	s := b.spill
+	b.spill = nil
+	b.spillMu.Unlock()
+	return s
 }
 
 // apply deletes the namespaced keys and feeds evicted-hot entries to the
@@ -154,41 +196,68 @@ func (b *cscInvalBatcher) run() {
 		if len(pending) == 0 {
 			return
 		}
-		b.apply(pending)
+		// Recover so a panic in a cache/refresh call can never kill the worker:
+		// overflow is parked on the unbounded spill buffer, so a dead worker would
+		// let spill grow without bound. Log and keep looping instead.
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					internal.Logger.Printf(context.Background(),
+						"redis: csc invalidation batch apply panic: %v", r)
+				}
+			}()
+			b.apply(pending)
+		}()
 		pending = pending[:0]
 		for k := range seen {
 			delete(seen, k)
+		}
+	}
+	// add runs one item through the epoch-scoped dedup and size-flushes at the
+	// cap. Shared by the ch, spill, and stop-drain paths so spilled items get the
+	// SAME dedup as fast-path items — a burst of duplicate keys collapses to one
+	// delete per key.
+	add := func(it cscInvalItem) {
+		if e, dup := seen[it.key]; !dup || e != it.epoch {
+			seen[it.key] = it.epoch
+			pending = append(pending, it)
+		}
+		if len(pending) >= cscInvalBatchMax {
+			flush()
+			t.Reset(b.window)
+		}
+	}
+	drainSpill := func() {
+		for _, it := range b.takeSpill() {
+			add(it)
 		}
 	}
 	for {
 		select {
 		case <-b.stopCh:
 			// Stopped (last release, or a window-change rebuild where queued deletes
-			// are still live and must not be lost): drain ch into the batch, flush
-			// once, exit.
+			// are still live and must not be lost): drain spill AND ch into the
+			// batch, flush once, exit. enqueue appends spill under stopMu.RLock, so
+			// anything spilled before stop set stopped=true is visible here.
+			drainSpill()
 			for draining := true; draining; {
 				select {
 				case it := <-b.ch:
-					if e, dup := seen[it.key]; !dup || e != it.epoch {
-						seen[it.key] = it.epoch
-						pending = append(pending, it)
-					}
+					add(it)
 				default:
 					draining = false
 				}
 			}
+			drainSpill() // catch keys spilled during the ch drain
 			flush()
 			return
 		case it := <-b.ch:
-			if e, dup := seen[it.key]; !dup || e != it.epoch {
-				seen[it.key] = it.epoch
-				pending = append(pending, it)
-			}
-			if len(pending) >= cscInvalBatchMax {
-				flush()
-				t.Reset(b.window)
-			}
+			add(it)
+		case <-b.wake:
+			// An overflow parked keys on spill; drain them off the producer.
+			drainSpill()
 		case <-t.C:
+			drainSpill()
 			flush()
 			t.Reset(b.window)
 		}

--- a/csc_inval_batch.go
+++ b/csc_inval_batch.go
@@ -114,9 +114,23 @@ func (b *cscInvalBatcher) run() {
 	for {
 		select {
 		case <-b.stopCh:
-			// Last user released the binding: flush what is pending (a no-op once
-			// the cache is nil) and exit so the goroutine does not live on
-			// re-arming the timer forever.
+			// Stopped: by the last user releasing the binding (deletes are then a
+			// no-op on the nil cache) or by a window change rebuilding the batcher
+			// (setInvalBatchWindow), where the queued deletes are still live and
+			// must not be lost — the cache would serve pre-invalidation values
+			// until TTL/MaxStaleness. Drain what is still buffered in ch into the
+			// batch, then flush once and exit.
+			for draining := true; draining; {
+				select {
+				case k := <-b.ch:
+					if _, dup := seen[k]; !dup {
+						seen[k] = struct{}{}
+						pending = append(pending, k)
+					}
+				default:
+					draining = false
+				}
+			}
 			flush()
 			return
 		case <-b.dropCh:

--- a/csc_inval_batch.go
+++ b/csc_inval_batch.go
@@ -23,19 +23,45 @@ import (
 const cscInvalBatchMax = 4096 // size-cap flush regardless of the timer
 
 type cscInvalBatcher struct {
-	h        *invalidateHandler
-	window   time.Duration
+	window time.Duration
+	// cache/refresh are snapshotted at creation rather than re-read from the
+	// binding on every apply: the batcher's lifetime is strictly inside one
+	// binding (releaseLocked stops it before users hits 0 clears the binding),
+	// and the snapshot is what lets the release-time stop-drain still apply
+	// queued deletes AFTER releaseLocked has nilled h.cache — dropping them
+	// there would let a successor reusing the same shared cache serve
+	// pre-invalidation values until TTL/MaxStaleness.
+	cache   Cache
+	refresh *cscRefreshQueue
+
 	ch       chan string
 	stopCh   chan struct{}
 	dropCh   chan struct{} // cap-1: signal run() to discard its in-progress batch
 	stopOnce sync.Once
+	// stopMu/stopped interlock enqueue against stop: a handler goroutine can hold
+	// a batcher pointer across a concurrent stop (a window-change rebuild while
+	// HandlePushNotification is mid-enqueue-loop, or ensureBatcher's RLock fast
+	// path returning a just-stopped instance). enqueue sends while holding the
+	// read side, so every key sent lands BEFORE stop's write side closes stopCh —
+	// guaranteeing run()'s stop-drain sees it; once stopped, enqueue applies
+	// inline instead, so no delete is ever parked in a channel nothing drains
+	// (which would serve pre-invalidation values until TTL/MaxStaleness).
+	stopMu  sync.RWMutex
+	stopped bool
 }
 
-// stop signals run() to flush and exit; idempotent. It only closes a channel —
-// it never touches h.mu and does not wait for the goroutine — so it is safe to
-// call while holding the handler lock (see releaseLocked).
+// stop signals run() to flush and exit; idempotent. It closes a channel and
+// flips the stopped flag — it never touches h.mu and does not wait for the
+// goroutine — so it is safe to call while holding the handler lock (see
+// releaseLocked). Lock order is h.mu → stopMu, never the reverse: enqueue's
+// stopMu critical section contains only the flag check and a channel send.
 func (b *cscInvalBatcher) stop() {
-	b.stopOnce.Do(func() { close(b.stopCh) })
+	b.stopOnce.Do(func() {
+		b.stopMu.Lock()
+		b.stopped = true
+		b.stopMu.Unlock()
+		close(b.stopCh)
+	})
 }
 
 // drop discards everything the batcher currently has queued — the channel plus
@@ -62,22 +88,31 @@ func (b *cscInvalBatcher) drop() {
 }
 
 // enqueue hands a namespaced key to the batcher without blocking the caller. On
-// a full queue it applies the delete inline so an invalidation is never dropped.
+// a full queue — or once the batcher is stopped (see stopMu) — it applies the
+// delete inline so an invalidation is never dropped.
 func (b *cscInvalBatcher) enqueue(nsKey string) {
+	b.stopMu.RLock()
+	if b.stopped {
+		b.stopMu.RUnlock()
+		b.apply([]string{nsKey})
+		return
+	}
 	select {
 	case b.ch <- nsKey:
+		b.stopMu.RUnlock()
 	default:
+		b.stopMu.RUnlock()
 		b.apply([]string{nsKey})
 	}
 }
 
 // apply deletes the given namespaced keys and feeds any evicted-hot entries to
-// the refresher. Reads the handler binding under its lock, same as the inline path.
+// the refresher. Uses the creation-time snapshot (see the struct fields), NOT a
+// re-read of the live binding: releaseLocked nils the binding before this
+// goroutine's final stop-drain flush runs, and these deletes must still land on
+// the (possibly shared, successor-reused) cache.
 func (b *cscInvalBatcher) apply(keys []string) {
-	h := b.h
-	h.mu.RLock()
-	cache, refresh := h.cache, h.refresh
-	h.mu.RUnlock()
+	cache, refresh := b.cache, b.refresh
 	if cache == nil {
 		return
 	}

--- a/csc_inval_batch.go
+++ b/csc_inval_batch.go
@@ -1,0 +1,94 @@
+package redis
+
+import "time"
+
+// Windowed background invalidation batcher.
+//
+// Normally the invalidate handler deletes cache entries INLINE, on whatever
+// goroutine read the RESP3 "invalidate" push — which, for the coalescer's
+// reply reader, means invalidation work steals time from reading miss replies
+// and inflates the low-concurrency churn p99 tail.
+//
+// When Options.ClientSideCacheInvalidationBatchWindow>0 the handler instead
+// ENQUEUES invalidated keys (cheap, off the read path) and a single background
+// goroutine applies the deletes in batches once per window. Deferring an
+// invalidation's application by <= window means a reader may see the
+// pre-invalidation value for <= window, which is exactly what MaxStaleness=window
+// already licenses; set the window <= MaxStaleness to stay within contract (a
+// nonzero window with MaxStaleness=0 is an explicit strictness relaxation).
+
+const cscInvalBatchMax = 4096 // size-cap flush regardless of the timer
+
+type cscInvalBatcher struct {
+	h      *invalidateHandler
+	window time.Duration
+	ch     chan string
+}
+
+// enqueue hands a namespaced key to the batcher without blocking the caller. On
+// a full queue it applies the delete inline so an invalidation is never dropped.
+func (b *cscInvalBatcher) enqueue(nsKey string) {
+	select {
+	case b.ch <- nsKey:
+	default:
+		b.apply([]string{nsKey})
+	}
+}
+
+// apply deletes the given namespaced keys and feeds any evicted-hot entries to
+// the refresher. Reads the handler binding under its lock, same as the inline path.
+func (b *cscInvalBatcher) apply(keys []string) {
+	h := b.h
+	h.mu.RLock()
+	cache, refresh := h.cache, h.refresh
+	h.mu.RUnlock()
+	if cache == nil {
+		return
+	}
+	lc, canRefresh := cache.(*LocalCache)
+	canRefresh = canRefresh && refresh != nil
+	var hot []cscRefreshTarget
+	for _, k := range keys {
+		if !canRefresh {
+			cache.DeleteByRedisKey(k)
+			continue
+		}
+		hot = lc.deleteByRedisKeyCollectingHot(k, refresh.sinceToken.Load(), hot[:0])
+		for i := range hot {
+			refresh.offer(hot[i])
+		}
+	}
+}
+
+func (b *cscInvalBatcher) run() {
+	t := time.NewTimer(b.window)
+	defer t.Stop()
+	pending := make([]string, 0, 256)
+	seen := make(map[string]struct{}, 256)
+	flush := func() {
+		if len(pending) == 0 {
+			return
+		}
+		b.apply(pending)
+		pending = pending[:0]
+		for k := range seen {
+			delete(seen, k)
+		}
+	}
+	for {
+		select {
+		case k := <-b.ch:
+			if _, dup := seen[k]; !dup {
+				seen[k] = struct{}{}
+				pending = append(pending, k)
+			}
+			if len(pending) >= cscInvalBatchMax {
+				flush()
+				t.Reset(b.window)
+			}
+		case <-t.C:
+			flush()
+			t.Reset(b.window)
+		}
+	}
+}

--- a/csc_inval_batch.go
+++ b/csc_inval_batch.go
@@ -43,8 +43,15 @@ type cscInvalBatcher struct {
 	stopCh   chan struct{}
 	stopOnce sync.Once
 	// epoch versions enqueued invalidations against full-cache flushes: drop()
-	// bumps it, and apply skips items from an older epoch. See drop().
-	epoch atomic.Uint64
+	// bumps it, and apply skips items from an older epoch. applyMu serializes
+	// the two: without it, apply could snapshot the epoch, a concurrent
+	// drop()+Flush() land mid-loop, and the remaining stale items would still
+	// be applied AFTER the flush — evicting post-flush repopulations, the exact
+	// case the epoch exists to prevent. drop() holding applyMu means any
+	// in-flight batch finishes BEFORE the flush (harmless: the flush wipes
+	// everything anyway), and every later apply sees the new epoch.
+	epoch   atomic.Uint64
+	applyMu sync.Mutex
 	// stopMu/stopped interlock enqueue against stop: a handler can hold a stale
 	// batcher pointer across a rebuild. enqueue sends under the read side, so a
 	// sent key lands BEFORE stop closes stopCh (the stop-drain sees it); once
@@ -75,7 +82,11 @@ func (b *cscInvalBatcher) stop() {
 // Callers bump BEFORE flushing the cache, so a stale epoch always means
 // "enqueued before the flush", where the delete is redundant by the flush.
 func (b *cscInvalBatcher) drop() {
+	// Serialize with apply (see applyMu): after drop returns, no stale-epoch
+	// delete can run — the caller may flush the cache immediately.
+	b.applyMu.Lock()
 	b.epoch.Add(1)
+	b.applyMu.Unlock()
 }
 
 // enqueue hands a namespaced key to the batcher without blocking the caller. On
@@ -105,6 +116,10 @@ func (b *cscInvalBatcher) apply(items []cscInvalItem) {
 	if cache == nil {
 		return
 	}
+	// Held for the whole batch so a concurrent drop()+Flush() cannot land
+	// mid-loop and leave stale-epoch deletes running post-flush (see applyMu).
+	b.applyMu.Lock()
+	defer b.applyMu.Unlock()
 	cur := b.epoch.Load()
 	lc, canRefresh := cache.(*LocalCache)
 	canRefresh = canRefresh && refresh != nil

--- a/csc_inval_batch_test.go
+++ b/csc_inval_batch_test.go
@@ -1,0 +1,95 @@
+package redis
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingCache implements just enough of Cache for the batcher's apply path
+// (refresh==nil + a non-*LocalCache cache => apply calls DeleteByRedisKey once
+// per unique key). Other Cache methods are never reached; the embedded nil Cache
+// would panic if one were, which is the intended tripwire.
+type countingCache struct {
+	Cache
+	deletes atomic.Int64
+	mu      sync.Mutex
+	keys    []string
+}
+
+func (c *countingCache) DeleteByRedisKey(k string) int {
+	c.deletes.Add(1)
+	c.mu.Lock()
+	c.keys = append(c.keys, k)
+	c.mu.Unlock()
+	return 1
+}
+
+func newTestBatcher(cache Cache, chCap int, window time.Duration) *cscInvalBatcher {
+	return &cscInvalBatcher{
+		window: window,
+		cache:  cache,
+		ch:     make(chan cscInvalItem, chCap),
+		wake:   make(chan struct{}, 1),
+		stopCh: make(chan struct{}),
+	}
+}
+
+// A full ch must send overflow to spill, never apply a delete inline on the
+// caller (which, on the coalescer's reply reader, would stall miss replies).
+func TestInvalBatcherOverflowSpillsNotInline(t *testing.T) {
+	cache := &countingCache{}
+	// Worker NOT started: ch never drains, so enqueues past its cap must overflow.
+	b := newTestBatcher(cache, 2, time.Hour)
+
+	b.enqueue("k1") // -> ch
+	b.enqueue("k2") // -> ch (now full)
+	b.enqueue("k3") // ch full -> spill
+	b.enqueue("k4") // ch full -> spill
+
+	if got := cache.deletes.Load(); got != 0 {
+		t.Fatalf("overflow applied %d deletes inline on the caller; want 0 (must spill)", got)
+	}
+	if got := b.spilled.Load(); got != 2 {
+		t.Fatalf("spilled counter = %d, want 2", got)
+	}
+	b.spillMu.Lock()
+	n := len(b.spill)
+	b.spillMu.Unlock()
+	if n != 2 {
+		t.Fatalf("spill holds %d items, want 2", n)
+	}
+}
+
+// The worker drains BOTH ch and spill through the shared seen/pending dedup, so a
+// burst of duplicate keys collapses to one delete per unique key.
+func TestInvalBatcherWorkerDrainsSpillDedup(t *testing.T) {
+	cache := &countingCache{}
+	// Large window so only the stop-drain flushes (deterministic single apply).
+	b := newTestBatcher(cache, 2, time.Hour)
+
+	const dups = 200
+	for i := 0; i < dups; i++ {
+		b.enqueue("hot") // fills ch (cap 2) then overflows to spill
+	}
+	b.enqueue("cold")
+
+	if b.spilled.Load() == 0 {
+		t.Fatal("setup: expected overflow to spill")
+	}
+	if got := cache.deletes.Load(); got != 0 {
+		t.Fatalf("setup: %d inline deletes before worker start; want 0", got)
+	}
+
+	go b.run()
+	b.stop() // stop-drain: drains spill + ch, flushes once, exits
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && cache.deletes.Load() < 2 {
+		time.Sleep(time.Millisecond)
+	}
+	if got := cache.deletes.Load(); got != 2 {
+		t.Fatalf("applied %d deletes; want 2 (dedup must collapse %d 'hot' + 1 'cold')", got, dups)
+	}
+}

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -366,28 +366,8 @@ func (mc *cscMissCoalescer) grabInto(dst []*cscMissReq, first *cscMissReq) []*cs
 	return dst
 }
 
-// CSCMissCoalesceStats reports coalescer activity.
-//
-// Experimental: this API may change in a minor release.
-type CSCMissCoalesceStats struct {
-	Active       bool   // a coalescer is running (ClientSideCacheCoalesceMisses on a LocalCache client)
-	Batched      uint64 // misses served through a batch
-	Batches      uint64 // batches flushed
-	Failed       uint64 // misses settled as errors (connection failure)
-	MaxBatchSize uint64
-}
-
-// CSCMissCoalesceStats returns the client's miss-coalescer counters.
-func (c *Client) CSCMissCoalesceStats() CSCMissCoalesceStats {
-	mc := c.baseClient.cscMissCoalescer.Load()
-	if mc == nil {
-		return CSCMissCoalesceStats{}
-	}
-	return CSCMissCoalesceStats{
-		Active:       true,
-		Batched:      mc.batched.Load(),
-		Batches:      mc.batches.Load(),
-		Failed:       mc.failed.Load(),
-		MaxBatchSize: mc.maxBatchSz.Load(),
-	}
-}
+// Coalescer observability is the client's normal telemetry (the otel operation
+// and error callbacks fire for coalesced misses like any other command path).
+// The engine's internal counters (batched/batches/failed/maxBatchSz on
+// cscMissCoalescer) exist for in-package tests, which read them directly off
+// c.cscMissCoalescer — deliberately NOT exported as a stats API.

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"context"
 	"errors"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -70,6 +71,7 @@ const (
 	cscReqPending   uint32 = iota // no one has claimed cmd yet
 	cscReqAbandoned               // caller's ctx (or Close) fired first: cmd is the caller's again
 	cscReqApplying                // reader claimed cmd first: it will write and settle
+	cscReqWriting                 // session writer is serializing cmd's args; spans one batch encode
 )
 
 // cscMissReq is one caller waiting for its missed key. done carries the fetch
@@ -100,6 +102,39 @@ func (r *cscMissReq) claimAbandon() bool {
 // abandoned, in which case it is safe to write the caller's cmd.
 func (r *cscMissReq) claimApply() bool {
 	return r.apply.CompareAndSwap(cscReqPending, cscReqApplying)
+}
+
+// claimWrite is the session writer's side: it claims cmd for the duration of
+// ONE batch encode, so an abandoning caller cannot take cmd back (and start
+// reusing mutable args, e.g. a []byte key) while its args are being read into
+// the wire buffer. releaseWrite returns the request to PENDING as soon as the
+// args are copied — before the socket flush — so the claim never spans I/O.
+func (r *cscMissReq) claimWrite() bool {
+	return r.apply.CompareAndSwap(cscReqPending, cscReqWriting)
+}
+
+func (r *cscMissReq) releaseWrite() {
+	r.apply.CompareAndSwap(cscReqWriting, cscReqPending)
+}
+
+// abandonOrWait resolves the caller-side interlock when the caller stops
+// waiting: true once the request is ABANDONED (the engine will never touch cmd
+// again — including the session writer, which claims WRITING around arg
+// serialization and skips abandoned requests); false if the reader claimed the
+// reply first, in which case the caller must receive done before reusing cmd.
+// A request found mid-serialization is waited out with a yield loop — WRITING
+// spans one in-memory batch encode, never a network round trip.
+func (r *cscMissReq) abandonOrWait() bool {
+	for {
+		if r.claimAbandon() {
+			return true
+		}
+		if r.apply.Load() == cscReqWriting {
+			runtime.Gosched()
+			continue
+		}
+		return false
+	}
 }
 
 type cscMissCoalescer struct {
@@ -213,7 +248,7 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 		// means no reply is being applied — cancel the reservation and return instead
 		// of hanging (a duplicate Cancel, if the drain also got this req, is a no-op
 		// on a settled token).
-		if req.claimAbandon() {
+		if req.abandonOrWait() {
 			mc.c.csc.Cancel(cacheKey, token)
 			return pool.ErrClosed
 		}
@@ -228,7 +263,7 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 		// claimed cmd, wait rather than race by reusing cmd. Either way return the
 		// context error, matching the non-coalesced path (processWithRetry), so a
 		// cancelled Get never returns a value depending on who won the CAS.
-		if !req.claimAbandon() {
+		if !req.abandonOrWait() {
 			<-req.done
 		}
 		return ctx.Err()

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"context"
-	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -37,21 +36,50 @@ import (
 // StaleTimeout.
 //
 // Tradeoff, same as the autopipeline path: a coalesced miss loses per-command
-// MaxRetries/backoff/LOADING handling. Prototype-only; behind GOREDIS_CSC_COALESCE_MISSES.
-
-var cscCoalesceMisses = os.Getenv("GOREDIS_CSC_COALESCE_MISSES") != ""
+// MaxRetries/backoff/LOADING handling. Behind Options.ClientSideCacheCoalesceMisses.
 
 const (
 	cscMissBatchMax   = 128
 	cscMissQueueDepth = 4096
-	// cscMissWorkers batchers run concurrently, each holding one main-pool
-	// (tracked) connection while it writes+reads its batch. Size it to the
-	// caching client's pool (env override): more workers than pool connections
-	// just makes workers block in the pool Get.
+	// cscMissWorkersDefault batchers run concurrently in the default "workers"
+	// mode, each holding one main-pool (tracked) connection while it writes+reads
+	// its batch. Size it to the caching client's pool (env override): more workers
+	// than pool connections just makes workers block in the pool Get.
 	cscMissWorkersDefault = 8
+	// cscFullDuplexDepth caps in-flight commands on the single-connection
+	// full-duplex engine (flow control for the writer).
+	cscFullDuplexDepth = 4096
 )
 
-var cscMissWorkers = envIntDefault("GOREDIS_CSC_COALESCE_WORKERS", cscMissWorkersDefault)
+// Engine selection + tuning come from the client's Options (ClientSideCacheCoalesce*)
+// and are read once, at coalescer construction (per client).
+func cscCoalesceMissesEnabled(opt *Options) bool {
+	return opt != nil && opt.ClientSideCacheCoalesceMisses
+}
+
+func cscMissWorkersCount(opt *Options) int {
+	if opt != nil && opt.ClientSideCacheCoalesceWorkers > 0 {
+		return opt.ClientSideCacheCoalesceWorkers
+	}
+	return cscMissWorkersDefault
+}
+
+// cscCoalesceMode selects the flush engine: "workers" (default, N pool conns,
+// half-duplex batches), "pinned" (1 held conn, serial half-duplex batches), or
+// "fullduplex" (1 held conn, concurrent writer+reader, deep pipeline).
+func cscCoalesceMode(opt *Options) string {
+	if opt == nil {
+		return "workers"
+	}
+	switch opt.ClientSideCacheCoalesceMode {
+	case "pinned":
+		return "pinned"
+	case "fullduplex":
+		return "fullduplex"
+	default:
+		return "workers"
+	}
+}
 
 // cscMissReq is one caller waiting for its missed key. done carries the fetch
 // result back (the reply is already applied to cmd by the time done fires).
@@ -67,6 +95,7 @@ type cscMissCoalescer struct {
 	ch   chan *cscMissReq
 	stop chan struct{}
 	wg   sync.WaitGroup
+	mode string // "workers" | "pinned" | "fullduplex"
 
 	batched    atomic.Uint64 // reqs that went through a batch
 	batches    atomic.Uint64 // batches flushed
@@ -74,10 +103,10 @@ type cscMissCoalescer struct {
 	maxBatchSz atomic.Uint64
 }
 
-// startCSCMissCoalescer launches the batcher goroutines. No-op unless the env
-// flag is set and CSC is active.
+// startCSCMissCoalescer launches the batcher goroutines. No-op unless
+// Options.ClientSideCacheCoalesceMisses is set and CSC is active.
 func (c *baseClient) startCSCMissCoalescer() {
-	if !cscCoalesceMisses || c.cscMissCoalescer != nil {
+	if !cscCoalesceMissesEnabled(c.opt) || c.cscMissCoalescer != nil {
 		return
 	}
 	if _, ok := c.csc.(*LocalCache); !ok {
@@ -87,15 +116,33 @@ func (c *baseClient) startCSCMissCoalescer() {
 		c:    c,
 		ch:   make(chan *cscMissReq, cscMissQueueDepth),
 		stop: make(chan struct{}),
+		mode: cscCoalesceMode(c.opt),
 	}
 	c.cscMissCoalescer = mc
-	n := cscMissWorkers
-	if n < 1 {
-		n = 1
-	}
-	for i := 0; i < n; i++ {
+	switch mc.mode {
+	case "pinned":
 		mc.wg.Add(1)
-		go mc.worker()
+		go mc.pinnedWorker()
+	case "fullduplex":
+		// N independent full-duplex sessions, each holding its own connection and
+		// pulling independent misses from the shared queue. Order-free: coalesced
+		// misses are standalone per-key fetches with no cross-request contract, and
+		// each session's per-conn reader still matches replies to requests. Sharding
+		// spreads the miss + invalidation-drain load off a single connection, which
+		// is what cuts the low-concurrency p99 tail.
+		for i := 0; i < cscFullDuplexConnsDefault; i++ {
+			mc.wg.Add(1)
+			go mc.fullDuplexLoop()
+		}
+	default:
+		n := cscMissWorkersCount(c.opt)
+		if n < 1 {
+			n = 1
+		}
+		for i := 0; i < n; i++ {
+			mc.wg.Add(1)
+			go mc.worker()
+		}
 	}
 }
 
@@ -173,105 +220,161 @@ func (mc *cscMissCoalescer) worker() {
 	}
 }
 
-// flush pipelines a batch of missed commands onto one tracked main-pool connection,
-// applies each reply to its caller's command, and publishes each to the cache.
-// Every req.done is sent exactly once and every token is settled.
+// flush (workers mode) acquires a fresh main-pool connection, pipelines the
+// batch onto it half-duplex (write all, then read all), and releases it. Every
+// req.done is sent exactly once and every token is settled.
+//
+// A published entry is only invalidatable if the connection that read it is
+// running CLIENT TRACKING, so this path must land on a tracked connection.
+// initConn issues CLIENT TRACKING ON for every pooled connection while CSC is
+// active (it is pool-agnostic), so the main pool is tracked and correct. The
+// main pool is used rather than the pipeline pool so the choice stays correct
+// even if a later change makes a dedicated pipeline pool deliberately untracked
+// (publishing a cache entry on an untracked connection would serve stale until
+// TTL). No contention cost: with the coalescer in front, reader misses are
+// handed to it, so the caching client's main pool has no other user.
 func (mc *cscMissCoalescer) flush(batch []*cscMissReq) {
 	c := mc.c
+	mc.countBatch(batch)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cn, err := c.getConn(ctx)
+	if err != nil {
+		mc.settleAllErr(batch, 0, err)
+		return
+	}
+	settled, ferr := mc.flushBatch(ctx, cn, batch)
+	c.releaseConn(ctx, cn, ferr)
+	if ferr != nil {
+		// Write/read failure: settle every request not yet handled as an error so
+		// no caller hangs and no token is left IN_PROGRESS.
+		mc.settleAllErr(batch, settled, ferr)
+	}
+}
+
+// flushBatch writes batch on cn, then reads and settles replies in order.
+// Returns the number settled and any connection error; on error the caller
+// settles the remaining requests. Used by both the workers and pinned engines.
+func (mc *cscMissCoalescer) flushBatch(ctx context.Context, cn *pool.Conn, batch []*cscMissReq) (settled int, err error) {
+	c := mc.c
+	connID := cn.GetID()
+	// Coverage generation captured BEFORE the reads, same discipline as
+	// refreshInvalidatedBatch/fulfillCached: if this conn loses tracking
+	// mid-batch every reply is rejected by fulfillCached rather than published
+	// under lost coverage.
+	capturedGen := c.cscConnInitGen(connID)
+
+	if werr := cn.WithWriter(c.context(ctx), c.opt.WriteTimeout, func(wr *proto.Writer) error {
+		for _, req := range batch {
+			if e := writeCmd(wr, req.cmd); e != nil {
+				return e
+			}
+		}
+		return nil
+	}); werr != nil {
+		return 0, werr
+	}
+
+	rerr := cn.WithReader(c.context(ctx), c.opt.ReadTimeout, func(rd *proto.Reader) error {
+		for settled < len(batch) {
+			// Invalidation pushes share this connection with replies; drain them
+			// first so a push frame is not read as a value.
+			if e := c.processPendingPushNotificationWithReader(ctx, cn, rd); e != nil {
+				internal.Logger.Printf(ctx, "csc: miss-coalesce push drain: %v", e)
+			}
+			raw, e := rd.ReadRawReply()
+			if e != nil {
+				return e
+			}
+			mc.applyAndSettle(batch[settled], raw, connID, capturedGen)
+			settled++
+		}
+		return nil
+	})
+	return settled, rerr
+}
+
+// applyAndSettle applies raw to the caller's command, publishes to the cache
+// when cacheable (under the reading connection's tracking generation), and wakes
+// the caller. Sends req.done exactly once.
+func (mc *cscMissCoalescer) applyAndSettle(req *cscMissReq, raw []byte, connID, capturedGen uint64) {
+	c := mc.c
+	applyErr := applyCachedReply(req.cmd, raw)
+	if isCacheableReplyResult(applyErr) {
+		fc := &cscFetchCapture{
+			raw:     raw,
+			connID:  connID,
+			initGen: capturedGen,
+			key:     req.cacheKey,
+			token:   req.token,
+		}
+		c.fulfillCached(req.cacheKey, req.token, fc)
+	} else {
+		// WRONGTYPE / NOPERM / ...: returned to the caller, not cached.
+		c.csc.Cancel(req.cacheKey, req.token)
+	}
+	req.done <- applyErr
+}
+
+// countBatch records batch-size accounting.
+func (mc *cscMissCoalescer) countBatch(batch []*cscMissReq) {
 	mc.batches.Add(1)
 	mc.batched.Add(uint64(len(batch)))
 	if n := uint64(len(batch)); n > mc.maxBatchSz.Load() {
 		mc.maxBatchSz.Store(n)
 	}
+}
 
-	settled := 0
-	settleRemainingErr := func(err error) {
-		for ; settled < len(batch); settled++ {
-			c.csc.Cancel(batch[settled].cacheKey, batch[settled].token)
-			batch[settled].done <- err
-			mc.failed.Add(1)
+// settleErr cancels the reservation and fails one waiting caller.
+func (mc *cscMissCoalescer) settleErr(req *cscMissReq, err error) {
+	mc.c.csc.Cancel(req.cacheKey, req.token)
+	req.done <- err
+	mc.failed.Add(1)
+}
+
+// settleAllErr fails every request in batch from index `from` onward.
+func (mc *cscMissCoalescer) settleAllErr(batch []*cscMissReq, from int, err error) {
+	for i := from; i < len(batch); i++ {
+		mc.settleErr(batch[i], err)
+	}
+}
+
+// drainQueueErr fails every request currently queued (non-blocking). Used when a
+// connection cannot be acquired, so a caller on a context without a deadline is
+// not blocked forever and no reservation is left IN_PROGRESS.
+func (mc *cscMissCoalescer) drainQueueErr(err error) {
+	for {
+		select {
+		case req := <-mc.ch:
+			mc.settleErr(req, err)
+		default:
+			return
 		}
 	}
+}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	// Fetch on the MAIN pool. A published entry is only invalidatable if the
-	// connection that read it is running CLIENT TRACKING, so this path must land
-	// on a tracked connection. initConn issues CLIENT TRACKING ON for every
-	// pooled connection while CSC is active (it is pool-agnostic), so the main
-	// pool is tracked and correct. withConn is used rather than withPipelineConn
-	// so the choice stays correct even if a later change makes the dedicated
-	// pipeline pool deliberately untracked (pipelines never populate the cache):
-	// publishing a cache entry on an untracked connection would serve stale until
-	// TTL. No contention cost: with the coalescer in front, reader misses are
-	// handed to it, so the caching client's main pool has no other user (hits
-	// need no connection; writes and uncacheable reads go to the separate
-	// autopipelined client).
-	err := c.withConn(ctx, func(ctx context.Context, cn *pool.Conn) error {
-		connID := cn.GetID()
-		// Coverage generation captured BEFORE the reads, same discipline as
-		// refreshInvalidatedBatch/fulfillCached: if this conn loses tracking
-		// mid-batch every reply is rejected by fulfillCached rather than
-		// published under lost coverage.
-		capturedGen := c.cscConnInitGen(connID)
-
-		if err := cn.WithWriter(c.context(ctx), c.opt.WriteTimeout, func(wr *proto.Writer) error {
-			for _, req := range batch {
-				if err := writeCmd(wr, req.cmd); err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
-			return err
+// grabInto appends first plus whatever else is already queued (non-blocking, up
+// to cscMissBatchMax) into dst, reusing dst's backing array.
+func (mc *cscMissCoalescer) grabInto(dst []*cscMissReq, first *cscMissReq) []*cscMissReq {
+	dst = append(dst, first)
+	for len(dst) < cscMissBatchMax {
+		select {
+		case more := <-mc.ch:
+			dst = append(dst, more)
+		default:
+			return dst
 		}
-
-		return cn.WithReader(c.context(ctx), c.opt.ReadTimeout, func(rd *proto.Reader) error {
-			for settled < len(batch) {
-				req := batch[settled]
-				// Invalidation pushes share this connection with replies; drain
-				// them first so a push frame is not read as a value.
-				if err := c.processPendingPushNotificationWithReader(ctx, cn, rd); err != nil {
-					internal.Logger.Printf(ctx, "csc: miss-coalesce push drain: %v", err)
-				}
-				raw, err := rd.ReadRawReply()
-				if err != nil {
-					return err
-				}
-				// Apply the reply to the caller's command first (so its Get()
-				// returns a value), then publish to the cache when cacheable.
-				applyErr := applyCachedReply(req.cmd, raw)
-				if isCacheableReplyResult(applyErr) {
-					fc := &cscFetchCapture{
-						raw:     raw,
-						connID:  connID,
-						initGen: capturedGen,
-						key:     req.cacheKey,
-						token:   req.token,
-					}
-					c.fulfillCached(req.cacheKey, req.token, fc)
-				} else {
-					// WRONGTYPE / NOPERM / ...: returned to the caller, not cached.
-					c.csc.Cancel(req.cacheKey, req.token)
-				}
-				req.done <- applyErr
-				settled++
-			}
-			return nil
-		})
-	})
-	if err != nil {
-		// Acquire/write/read failure: settle every request not yet handled as an
-		// error so no caller hangs and no token is left IN_PROGRESS.
-		settleRemainingErr(err)
 	}
+	return dst
 }
 
 // CSCMissCoalesceStats reports coalescer activity.
 //
 // Experimental: this API may change in a minor release.
 type CSCMissCoalesceStats struct {
+	Mode         string // "workers" | "pinned" | "fullduplex"
 	Batched      uint64 // misses served through a batch
 	Batches      uint64 // batches flushed
 	Failed       uint64 // misses settled as errors (connection failure)
@@ -285,6 +388,7 @@ func (c *Client) CSCMissCoalesceStats() CSCMissCoalesceStats {
 		return CSCMissCoalesceStats{}
 	}
 	return CSCMissCoalesceStats{
+		Mode:         mc.mode,
 		Batched:      mc.batched.Load(),
 		Batches:      mc.batches.Load(),
 		Failed:       mc.failed.Load(),

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -426,20 +426,27 @@ func (mc *cscMissCoalescer) applyAndSettle(req *cscMissReq, raw []byte, connID, 
 }
 
 // batchBudget bounds one whole coalesced flush (pool Get + write + read). It
-// honors the client's configured timeouts instead of a fixed cap: a client that
-// deliberately sets ReadTimeout/WriteTimeout high for slow cacheable reads must
-// not see only its coalesced misses cut off early (WithReader clamps the read to
-// min(ctx deadline, ReadTimeout), so a ctx shorter than ReadTimeout would win).
-// 5s remains the floor for the pool-Get/scheduling overhead; a non-positive
-// configured timeout (disabled) falls back to that floor alone.
+// honors the client's configured limits instead of a fixed cap: the pool Get may
+// legitimately wait up to PoolTimeout under temporary saturation (the normal
+// processWithRetry path does), and a client that deliberately sets
+// ReadTimeout/WriteTimeout high for slow cacheable reads must not see only its
+// coalesced misses cut off early (WithReader clamps the read to min(ctx
+// deadline, ReadTimeout), so a shorter ctx would win). A 5s floor covers
+// scheduling overhead when the configured limits are tiny or disabled.
 func (mc *cscMissCoalescer) batchBudget() time.Duration {
-	budget := 5 * time.Second
 	opt := mc.c.opt
+	var budget time.Duration
+	if opt.PoolTimeout > 0 {
+		budget += opt.PoolTimeout
+	}
 	if opt.WriteTimeout > 0 {
 		budget += opt.WriteTimeout
 	}
 	if opt.ReadTimeout > 0 {
 		budget += opt.ReadTimeout
+	}
+	if budget < 5*time.Second {
+		budget = 5 * time.Second
 	}
 	return budget
 }

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -213,15 +213,19 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 	// never hangs on a post-drain req.
 	select {
 	case <-mc.stop:
+		// Retry-uncached, not ErrClosed: the coalescer stopping does not mean
+		// the CLIENT is closed (teardown deactivates serving before stopping
+		// the coalescer, and a clone can race that window) — the uncached
+		// re-run either succeeds on the open pool or surfaces the real error.
 		mc.c.csc.Cancel(cacheKey, token)
-		return pool.ErrClosed
+		return errCSCRetryUncached
 	default:
 	}
 	select {
 	case mc.ch <- req:
 	case <-mc.stop:
 		mc.c.csc.Cancel(cacheKey, token)
-		return pool.ErrClosed
+		return errCSCRetryUncached
 	case <-ctx.Done():
 		mc.c.csc.Cancel(cacheKey, token)
 		return ctx.Err()
@@ -242,14 +246,15 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 			// would then retain it (and its Cmder) indefinitely. Re-run the
 			// non-blocking drain to empty the queue; settling our own abandoned
 			// req is harmless (done is buffered, the duplicate Cancel is a no-op).
-			mc.drainQueueErr(pool.ErrClosed)
-			return pool.ErrClosed
+			mc.drainQueueErr(errCSCRetryUncached)
+			return errCSCRetryUncached
 		}
-		// The reader claimed cmd and is mid-write: wait so we do not read/reuse cmd
-		// concurrently (the receive is a happens-before edge, so a later cmd.SetErr
-		// is race-free), then return the shutdown error.
-		<-req.done
-		return pool.ErrClosed
+		// The reader claimed cmd and is mid-apply: wait so we do not read/reuse
+		// cmd concurrently (the receive is a happens-before edge), then return
+		// the settle result itself — the reply may have been applied
+		// successfully, and discarding it for a blanket ErrClosed would fail a
+		// read that has its value.
+		return <-req.done
 	case <-ctx.Done():
 		// Caller stopped waiting. If we win the interlock the reader skips the cmd
 		// write but still settles the token and publishes to the cache; if it already

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -10,6 +11,16 @@ import (
 	"github.com/redis/go-redis/v9/internal/pool"
 	"github.com/redis/go-redis/v9/internal/proto"
 )
+
+// errCSCRetryUncached is settled to a coalesced miss when the coalescer bows out
+// for a reason unrelated to the command itself: CSC serving was disabled after
+// the miss was queued (e.g. a RESP3 downgrade, or CLIENT TRACKING rejected during
+// a connection re-init), so this held-connection session would fetch on an
+// untracked conn or none at all. It never reaches the caller — processCached
+// catches it and re-runs the command uncached on the normal path, so a valid
+// cacheable read is not failed with a spurious pool.ErrClosed. The reservation is
+// always cancelled before this is settled, so no waiter is left IN_PROGRESS.
+var errCSCRetryUncached = errors.New("redis: csc miss-coalescer disabled mid-fetch; retry uncached")
 
 // Reader-miss coalescing (PROTOTYPE, env-gated).
 //
@@ -93,6 +104,16 @@ func cscCoalesceMode(opt *Options) string {
 	}
 }
 
+// cscReq* are the states of cscMissReq.apply, the single-word interlock that
+// decides who owns req.cmd: the fetching caller or the worker/reader applying
+// the reply. Exactly one side wins the pending->X CAS, so the worker never
+// writes cmd after the caller has returned and may be reusing it.
+const (
+	cscReqPending   uint32 = iota // no one has claimed cmd yet
+	cscReqAbandoned               // caller's ctx (or Close) fired first: cmd is the caller's again
+	cscReqApplying                // worker/reader claimed cmd first: it will write and settle
+)
+
 // cscMissReq is one caller waiting for its missed key. done carries the fetch
 // result back (the reply is already applied to cmd by the time done fires).
 type cscMissReq struct {
@@ -100,6 +121,28 @@ type cscMissReq struct {
 	cacheKey string
 	token    uint64
 	done     chan error
+	// apply interlocks ownership of cmd between the fetching caller and the
+	// worker/reader. The caller abandons (CAS pending->abandoned) if its context
+	// is cancelled — or Close races its enqueue — before a worker starts applying;
+	// the worker claims (CAS pending->applying) before it writes the reply into
+	// cmd. A plain flag would still race: a worker could read "not abandoned",
+	// begin writing cmd, and the caller cancel mid-write. The CAS makes the two
+	// decisions mutually exclusive. Either way the worker still settles the token
+	// and publishes to the shared cache (the fetch is never wasted) — only the cmd
+	// write is gated.
+	apply atomic.Uint32
+}
+
+// claimAbandon is the caller's side of the cmd interlock: it succeeds only if no
+// worker has started applying, in which case the worker will skip the cmd write.
+func (r *cscMissReq) claimAbandon() bool {
+	return r.apply.CompareAndSwap(cscReqPending, cscReqAbandoned)
+}
+
+// claimApply is the worker's side: it succeeds only if the caller has not
+// abandoned, in which case it is safe to write the caller's cmd.
+func (r *cscMissReq) claimApply() bool {
+	return r.apply.CompareAndSwap(cscReqPending, cscReqApplying)
 }
 
 type cscMissCoalescer struct {
@@ -113,6 +156,10 @@ type cscMissCoalescer struct {
 	batches    atomic.Uint64 // batches flushed
 	failed     atomic.Uint64 // reqs settled as errors (conn failure)
 	maxBatchSz atomic.Uint64
+	// abandonedApplies counts replies whose caller had already abandoned the req
+	// (lost the cmd interlock), so the cmd write was skipped. Used only to assert
+	// the -race abandoned-path test actually hit the window it guards.
+	abandonedApplies atomic.Uint64
 }
 
 // startCSCMissCoalescer launches the batcher goroutines. No-op unless
@@ -186,6 +233,17 @@ func (c *baseClient) stopCSCMissCoalescer() {
 // caller just returns early.
 func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey string, token uint64) error {
 	req := &cscMissReq{cmd: cmd, cacheKey: cacheKey, token: token, done: make(chan error, 1)}
+	// Reject early if the coalescer is already shutting down, so a send does not
+	// win the select race against a closed mc.stop and land in mc.ch after the
+	// shutdown drain (where no worker would ever pick it up). This narrows — but
+	// cannot fully close — that race; the mc.stop case in the wait select below is
+	// what guarantees the caller never hangs on a post-drain req.
+	select {
+	case <-mc.stop:
+		mc.c.csc.Cancel(cacheKey, token)
+		return pool.ErrClosed
+	default:
+	}
 	select {
 	case mc.ch <- req:
 	case <-mc.stop:
@@ -198,9 +256,32 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 	select {
 	case err := <-req.done:
 		return err
+	case <-mc.stop:
+		// Close raced our enqueue: the req may have landed in mc.ch after the
+		// shutdown drain, so no worker will ever settle req.done. If we win the
+		// interlock (no worker is applying), cancel the reservation and return
+		// instead of hanging — a duplicate Cancel, if the drain also got this req,
+		// is a no-op on a settled token. If a worker already claimed cmd, it owns
+		// the write and will settle; wait for it so we do not touch cmd concurrently.
+		if req.claimAbandon() {
+			mc.c.csc.Cancel(cacheKey, token)
+			return pool.ErrClosed
+		}
+		// A worker already claimed cmd and is mid-write: wait for it to finish so we
+		// do not read/reuse cmd concurrently, then return the shutdown error (the
+		// receive is a happens-before edge, so the later cmd.SetErr is race-free).
+		<-req.done
+		return pool.ErrClosed
 	case <-ctx.Done():
-		// The batch will still settle req.done (buffered, cap 1) and the token;
-		// we just stop waiting.
+		// Caller stopped waiting. If we win the interlock the worker skips the cmd
+		// write but still settles the token and publishes to the cache (the fetch is
+		// not wasted); we just return early. If a worker already claimed cmd, it is
+		// mid-write — wait for it rather than race by reusing cmd. Either way return
+		// the context error, matching the non-coalesced path (processWithRetry), so a
+		// cancelled Get never returns a value depending on who won the CAS.
+		if !req.claimAbandon() {
+			<-req.done
+		}
 		return ctx.Err()
 	}
 }
@@ -311,9 +392,23 @@ func (mc *cscMissCoalescer) flushBatch(ctx context.Context, cn *pool.Conn, batch
 // applyAndSettle applies raw to the caller's command, publishes to the cache
 // when cacheable (under the reading connection's tracking generation), and wakes
 // the caller. Sends req.done exactly once.
+//
+// It first claims the cmd interlock: if the caller has abandoned the req (its
+// context was cancelled, or Close raced its enqueue) it has its Cmder back and
+// may be reading or reusing it, so the reply must NOT be written there. The
+// fetch is still not wasted — the reply is classified from a throwaway parse and,
+// when cacheable, published to the shared cache for the next reader; only the
+// caller's cmd write is skipped.
 func (mc *cscMissCoalescer) applyAndSettle(req *cscMissReq, raw []byte, connID, capturedGen uint64) {
 	c := mc.c
-	applyErr := applyCachedReply(req.cmd, raw)
+	var applyErr error
+	if req.claimApply() {
+		applyErr = applyCachedReply(req.cmd, raw)
+	} else {
+		// Abandoned: classify without touching the caller's cmd.
+		applyErr = classifyCachedReply(raw)
+		mc.abandonedApplies.Add(1)
+	}
 	if isCacheableReplyResult(applyErr) {
 		fc := &cscFetchCapture{
 			raw:     raw,

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -277,6 +277,24 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 		// claimed cmd, wait rather than race by reusing cmd. Either way return the
 		// context error, matching the non-coalesced path (processWithRetry), so a
 		// cancelled Get never returns a value depending on who won the CAS.
+		//
+		// Report the cancellation metric here, like processWithRetry: the reader may
+		// still complete the background fetch (a success via applyAndSettle, or its
+		// own error via settleErr), so neither of those records THIS caller's
+		// context cancellation — without this the cancellation rate is undercounted
+		// whenever miss coalescing is enabled. Attribute against the caller's ctx.
+		//
+		// Pass a nil conn deliberately: req.servedBy is written by the session and
+		// only safe to read AFTER the req.done receive (that receive is the
+		// happens-before edge, see the field doc), which has NOT happened on this
+		// branch — reading it here would race the engine's write and, on a
+		// cancellation that beats the serve, be nil anyway. The metric recorder
+		// treats a nil conn as "no peer attributes", matching processWithRetry when
+		// it cancels before a connection is obtained.
+		if errorCallback := pool.GetMetricErrorCallback(); errorCallback != nil {
+			errorType, statusCode, isInternal := classifyCommandError(ctx.Err())
+			errorCallback(ctx, errorType, nil, statusCode, isInternal, 0)
+		}
 		if !req.claimAbandon() {
 			<-req.done
 			return req.servedBy, ctx.Err()

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -1,14 +1,15 @@
 package redis
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/redis/go-redis/v9/internal/pool"
+	"github.com/redis/go-redis/v9/internal/proto"
 )
 
 // errCSCRetryUncached settles a coalesced miss when the coalescer bows out for a
@@ -71,7 +72,6 @@ const (
 	cscReqPending   uint32 = iota // no one has claimed cmd yet
 	cscReqAbandoned               // caller's ctx (or Close) fired first: cmd is the caller's again
 	cscReqApplying                // reader claimed cmd first: it will write and settle
-	cscReqWriting                 // session writer is serializing cmd's args; spans one batch encode
 )
 
 // cscMissReq is one caller waiting for its missed key. done carries the fetch
@@ -81,6 +81,13 @@ type cscMissReq struct {
 	cacheKey string
 	token    uint64
 	done     chan error
+	// wire is cmd's RESP encoding, snapshotted at enqueue while the caller
+	// still owned cmd. The session writer writes ONLY these engine-owned bytes
+	// — it never reads cmd — so an abandoning caller may reuse mutable args
+	// (e.g. a []byte key) the moment fetch returns, and a post-abandon
+	// mutation can neither reach the wire nor publish under the original
+	// cache key. Only the reply side touches cmd, gated by the apply interlock.
+	wire []byte
 	// apply interlocks ownership of cmd between the fetching caller and the
 	// reader. The caller abandons (CAS pending->abandoned) if its context is
 	// cancelled — or Close races its enqueue — before a reply is applied; the
@@ -102,39 +109,6 @@ func (r *cscMissReq) claimAbandon() bool {
 // abandoned, in which case it is safe to write the caller's cmd.
 func (r *cscMissReq) claimApply() bool {
 	return r.apply.CompareAndSwap(cscReqPending, cscReqApplying)
-}
-
-// claimWrite is the session writer's side: it claims cmd for the duration of
-// ONE batch encode, so an abandoning caller cannot take cmd back (and start
-// reusing mutable args, e.g. a []byte key) while its args are being read into
-// the wire buffer. releaseWrite returns the request to PENDING as soon as the
-// args are copied — before the socket flush — so the claim never spans I/O.
-func (r *cscMissReq) claimWrite() bool {
-	return r.apply.CompareAndSwap(cscReqPending, cscReqWriting)
-}
-
-func (r *cscMissReq) releaseWrite() {
-	r.apply.CompareAndSwap(cscReqWriting, cscReqPending)
-}
-
-// abandonOrWait resolves the caller-side interlock when the caller stops
-// waiting: true once the request is ABANDONED (the engine will never touch cmd
-// again — including the session writer, which claims WRITING around arg
-// serialization and skips abandoned requests); false if the reader claimed the
-// reply first, in which case the caller must receive done before reusing cmd.
-// A request found mid-serialization is waited out with a yield loop — WRITING
-// spans one in-memory batch encode, never a network round trip.
-func (r *cscMissReq) abandonOrWait() bool {
-	for {
-		if r.claimAbandon() {
-			return true
-		}
-		if r.apply.Load() == cscReqWriting {
-			runtime.Gosched()
-			continue
-		}
-		return false
-	}
 }
 
 type cscMissCoalescer struct {
@@ -219,6 +193,19 @@ func (mc *cscMissCoalescer) stopWorkers() {
 // wasted), the caller just returns early.
 func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey string, token uint64) error {
 	req := &cscMissReq{cmd: cmd, cacheKey: cacheKey, token: token, done: make(chan error, 1)}
+	// Snapshot the wire form NOW, while the caller still owns cmd: the session
+	// writer writes these engine-owned bytes and never reads cmd again, so an
+	// abandoning caller can immediately reuse mutable args (e.g. a []byte key)
+	// without racing arg serialization, a mutated key can never be sent or
+	// published under the original cache key, and the fetch always completes —
+	// the reservation always settles. The reply side still claims cmd (apply
+	// interlock) before writing the result into it.
+	var wireBuf bytes.Buffer
+	if err := writeCmd(proto.NewWriter(&wireBuf), cmd); err != nil {
+		mc.c.csc.Cancel(cacheKey, token)
+		return err
+	}
+	req.wire = wireBuf.Bytes()
 	// Reject early if the coalescer is already stopping, so a send does not win the
 	// select race against a closed mc.stop and land in mc.ch after the shutdown
 	// drain, where nothing would pick it up. This narrows but cannot close that
@@ -248,8 +235,14 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 		// means no reply is being applied — cancel the reservation and return instead
 		// of hanging (a duplicate Cancel, if the drain also got this req, is a no-op
 		// on a settled token).
-		if req.abandonOrWait() {
+		if req.claimAbandon() {
 			mc.c.csc.Cancel(cacheKey, token)
+			// The req may be sitting in mc.ch AFTER the shutdown drain ran, where
+			// no worker will ever dequeue it — a live WithTimeout clone's pointer
+			// would then retain it (and its Cmder) indefinitely. Re-run the
+			// non-blocking drain to empty the queue; settling our own abandoned
+			// req is harmless (done is buffered, the duplicate Cancel is a no-op).
+			mc.drainQueueErr(pool.ErrClosed)
 			return pool.ErrClosed
 		}
 		// The reader claimed cmd and is mid-write: wait so we do not read/reuse cmd
@@ -263,7 +256,7 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 		// claimed cmd, wait rather than race by reusing cmd. Either way return the
 		// context error, matching the non-coalesced path (processWithRetry), so a
 		// cancelled Get never returns a value depending on who won the CAS.
-		if !req.abandonOrWait() {
+		if !req.claimAbandon() {
 			<-req.done
 		}
 		return ctx.Err()

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -378,7 +378,12 @@ func (mc *cscMissCoalescer) flushBatch(ctx context.Context, cn *pool.Conn, batch
 	// under lost coverage.
 	capturedGen := c.cscConnInitGen(connID)
 
-	if werr := cn.WithWriter(c.context(ctx), c.opt.WriteTimeout, func(wr *proto.Writer) error {
+	// ctx is the ENGINE's own bounded batch budget, not a caller context, so it
+	// must NOT go through c.context() — with ContextTimeoutEnabled=false (the
+	// default) that strips the deadline to context.Background(), and with
+	// ReadTimeout disabled a server that never replies would then block this
+	// worker forever, wedging Close in stopCSCMissCoalescer's wg.Wait.
+	if werr := cn.WithWriter(ctx, c.opt.WriteTimeout, func(wr *proto.Writer) error {
 		for _, req := range batch {
 			if e := writeCmd(wr, req.cmd); e != nil {
 				return e
@@ -389,7 +394,7 @@ func (mc *cscMissCoalescer) flushBatch(ctx context.Context, cn *pool.Conn, batch
 		return 0, werr
 	}
 
-	rerr := cn.WithReader(c.context(ctx), c.opt.ReadTimeout, func(rd *proto.Reader) error {
+	rerr := cn.WithReader(ctx, c.opt.ReadTimeout, func(rd *proto.Reader) error {
 		for settled < len(batch) {
 			// Invalidation pushes share this connection with replies; drain them
 			// first so a push frame is not read as a value.

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -330,7 +330,7 @@ func (mc *cscMissCoalescer) flush(batch []*cscMissReq) {
 	c := mc.c
 	mc.countBatch(batch)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), mc.batchBudget())
 	defer cancel()
 
 	cn, err := c.getConn(ctx)
@@ -423,6 +423,25 @@ func (mc *cscMissCoalescer) applyAndSettle(req *cscMissReq, raw []byte, connID, 
 		c.csc.Cancel(req.cacheKey, req.token)
 	}
 	req.done <- applyErr
+}
+
+// batchBudget bounds one whole coalesced flush (pool Get + write + read). It
+// honors the client's configured timeouts instead of a fixed cap: a client that
+// deliberately sets ReadTimeout/WriteTimeout high for slow cacheable reads must
+// not see only its coalesced misses cut off early (WithReader clamps the read to
+// min(ctx deadline, ReadTimeout), so a ctx shorter than ReadTimeout would win).
+// 5s remains the floor for the pool-Get/scheduling overhead; a non-positive
+// configured timeout (disabled) falls back to that floor alone.
+func (mc *cscMissCoalescer) batchBudget() time.Duration {
+	budget := 5 * time.Second
+	opt := mc.c.opt
+	if opt.WriteTimeout > 0 {
+		budget += opt.WriteTimeout
+	}
+	if opt.ReadTimeout > 0 {
+		budget += opt.ReadTimeout
+	}
+	return budget
 }
 
 // countBatch records batch-size accounting.

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -57,6 +57,13 @@ const (
 	// cscFullDuplexDepth caps in-flight commands on the single-connection
 	// full-duplex engine (flow control for the writer).
 	cscFullDuplexDepth = 4096
+	// cscMissBatchBytes soft-caps the serialized size of one coalesced write
+	// batch so a burst of large commands cannot buffer an unbounded write on the
+	// held connection. The first miss always goes (latency-first — a lone large
+	// command must not stall), so this bounds only the OPPORTUNISTIC coalescing
+	// of already-queued misses; anything not packed stays queued for the next
+	// batch. It does not bound reply sizes, which are inherent to the workload.
+	cscMissBatchBytes = 1 << 20 // 1 MiB
 )
 
 // cscCoalesceMissesEnabled is read once, at coalescer construction (per client).
@@ -421,13 +428,18 @@ func (mc *cscMissCoalescer) drainQueueErr(err error) {
 }
 
 // grabInto appends first plus whatever else is already queued (non-blocking, up
-// to cscMissBatchMax) into dst, reusing dst's backing array.
+// to cscMissBatchMax commands OR cscMissBatchBytes of serialized payload) into
+// dst, reusing dst's backing array. first is always included regardless of size
+// (latency-first: a lone large command must not stall); the byte cap only bounds
+// how many additional already-queued misses are packed onto the same write.
 func (mc *cscMissCoalescer) grabInto(dst []*cscMissReq, first *cscMissReq) []*cscMissReq {
 	dst = append(dst, first)
-	for len(dst) < cscMissBatchMax {
+	nbytes := len(first.wire)
+	for len(dst) < cscMissBatchMax && nbytes < cscMissBatchBytes {
 		select {
 		case more := <-mc.ch:
 			dst = append(dst, more)
+			nbytes += len(more.wire)
 		default:
 			return dst
 		}

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/redis/go-redis/v9/internal/pool"
 	"github.com/redis/go-redis/v9/internal/proto"
 )
 
@@ -165,13 +164,17 @@ func (c *baseClient) stopCSCMissCoalescer() {
 	}
 	mc.stopWorkers()
 	mc.wg.Wait()
-	// Any request still queued after stop is drained and failed so no caller
-	// hangs on its done channel.
+	// Any request still queued after stop is drained and settled so no caller
+	// hangs on its done channel. Retry-uncached, matching fetch's stop paths:
+	// teardown deactivates serving before stopping the coalescer, so a caller
+	// woken here re-runs its read on the (possibly still open) pool instead of
+	// surfacing a spurious ErrClosed mid-window; on a truly closed client the
+	// uncached re-run fails with the real error.
 	for {
 		select {
 		case req := <-mc.ch:
 			mc.c.csc.Cancel(req.cacheKey, req.token)
-			req.done <- pool.ErrClosed
+			req.done <- errCSCRetryUncached
 		default:
 			return
 		}

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -64,18 +64,30 @@ func cscMissWorkersCount(opt *Options) int {
 	return cscMissWorkersDefault
 }
 
+// cscForcePinned lets a benchmark opt into the "pinned" PROTOTYPE engine, which
+// is otherwise NOT reachable from the public ClientSideCacheCoalesceMode option.
+// Pinned holds one connection with no idle invalidation drain, so it can serve
+// stale values after an invalidation (see #3965) and is unsafe for general use;
+// it is kept only for engine benchmark comparison.
+var cscForcePinned bool
+
 // cscCoalesceMode selects the flush engine: "workers" (default, N pool conns,
-// half-duplex batches), "pinned" (1 held conn, serial half-duplex batches), or
-// "fullduplex" (1 held conn, concurrent writer+reader, deep pipeline).
+// half-duplex batches) or "fullduplex" (1 held conn, concurrent writer+reader,
+// deep pipeline). The "pinned" engine is a benchmark-only PROTOTYPE and is NOT
+// selectable via the public option (it falls back to "workers"); it can only be
+// forced internally via cscForcePinned.
 func cscCoalesceMode(opt *Options) string {
 	if opt == nil {
 		return "workers"
 	}
 	switch opt.ClientSideCacheCoalesceMode {
-	case "pinned":
-		return "pinned"
 	case "fullduplex":
 		return "fullduplex"
+	case "pinned":
+		if cscForcePinned {
+			return "pinned"
+		}
+		return "workers"
 	default:
 		return "workers"
 	}

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -146,11 +146,12 @@ func (r *cscMissReq) claimApply() bool {
 }
 
 type cscMissCoalescer struct {
-	c    *baseClient
-	ch   chan *cscMissReq
-	stop chan struct{}
-	wg   sync.WaitGroup
-	mode string // "workers" | "pinned" | "fullduplex"
+	c        *baseClient
+	ch       chan *cscMissReq
+	stop     chan struct{}
+	stopOnce sync.Once // guards close(stop): Close and the GC cleanup can both stop
+	wg       sync.WaitGroup
+	mode     string // "workers" | "pinned" | "fullduplex"
 
 	batched    atomic.Uint64 // reqs that went through a batch
 	batches    atomic.Uint64 // batches flushed
@@ -163,9 +164,13 @@ type cscMissCoalescer struct {
 }
 
 // startCSCMissCoalescer launches the batcher goroutines. No-op unless
-// Options.ClientSideCacheCoalesceMisses is set and CSC is active.
+// Options.ClientSideCacheCoalesceMisses is set and CSC is active, and — see the
+// option's GoDoc — unless the cache is the built-in *LocalCache: the coalescer's
+// publish path (fulfillCached capture, refresh integration, hot-entry
+// collection) is LocalCache-specific, so a custom Cache implementation falls
+// back to per-caller fetches.
 func (c *baseClient) startCSCMissCoalescer() {
-	if !cscCoalesceMissesEnabled(c.opt) || c.cscMissCoalescer != nil {
+	if !cscCoalesceMissesEnabled(c.opt) || c.cscMissCoalescer.Load() != nil {
 		return
 	}
 	if _, ok := c.csc.(*LocalCache); !ok {
@@ -177,7 +182,7 @@ func (c *baseClient) startCSCMissCoalescer() {
 		stop: make(chan struct{}),
 		mode: cscCoalesceMode(c.opt),
 	}
-	c.cscMissCoalescer = mc
+	c.cscMissCoalescer.Store(mc)
 	switch mc.mode {
 	case "pinned":
 		mc.wg.Add(1)
@@ -206,12 +211,13 @@ func (c *baseClient) startCSCMissCoalescer() {
 }
 
 func (c *baseClient) stopCSCMissCoalescer() {
-	mc := c.cscMissCoalescer
+	// Swap, not load-then-nil: exactly one caller wins even if Close races the
+	// GC cleanup path, so mc.stop is closed once.
+	mc := c.cscMissCoalescer.Swap(nil)
 	if mc == nil {
 		return
 	}
-	c.cscMissCoalescer = nil
-	close(mc.stop)
+	mc.stopWorkers()
 	mc.wg.Wait()
 	// Any request still queued after stop is drained and failed so no caller
 	// hangs on its done channel.
@@ -224,6 +230,14 @@ func (c *baseClient) stopCSCMissCoalescer() {
 			return
 		}
 	}
+}
+
+// stopWorkers signals every coalescer goroutine to exit; idempotent, does not
+// wait. Called by stopCSCMissCoalescer (Close) and by the GC cleanup for a
+// client dropped without Close — the workers retain the base client (cache,
+// pools), so leaving them running would leak all of it per forgotten client.
+func (mc *cscMissCoalescer) stopWorkers() {
+	mc.stopOnce.Do(func() { close(mc.stop) })
 }
 
 // fetch hands a reserved miss to the coalescer and waits for the result. The
@@ -330,14 +344,19 @@ func (mc *cscMissCoalescer) flush(batch []*cscMissReq) {
 	c := mc.c
 	mc.countBatch(batch)
 
-	ctx, cancel := context.WithTimeout(context.Background(), mc.batchBudget())
-	defer cancel()
-
-	cn, err := c.getConn(ctx)
+	// Acquire under acquireCtx (PoolTimeout-bounded AND cancelled by stop, so
+	// Close is not stalled behind a Get blocked on a saturated pool), then run
+	// the batch under the full write+read budget.
+	getCtx, getCancel := mc.acquireCtx()
+	cn, err := c.getConn(getCtx)
+	getCancel()
 	if err != nil {
 		mc.settleAllErr(batch, 0, err)
 		return
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), mc.batchBudget())
+	defer cancel()
 	settled, ferr := mc.flushBatch(ctx, cn, batch)
 	c.releaseConn(ctx, cn, ferr)
 	if ferr != nil {
@@ -425,20 +444,17 @@ func (mc *cscMissCoalescer) applyAndSettle(req *cscMissReq, raw []byte, connID, 
 	req.done <- applyErr
 }
 
-// batchBudget bounds one whole coalesced flush (pool Get + write + read). It
-// honors the client's configured limits instead of a fixed cap: the pool Get may
-// legitimately wait up to PoolTimeout under temporary saturation (the normal
-// processWithRetry path does), and a client that deliberately sets
-// ReadTimeout/WriteTimeout high for slow cacheable reads must not see only its
-// coalesced misses cut off early (WithReader clamps the read to min(ctx
-// deadline, ReadTimeout), so a shorter ctx would win). A 5s floor covers
-// scheduling overhead when the configured limits are tiny or disabled.
+// batchBudget bounds one coalesced batch's write + reads (connection
+// acquisition is bounded separately by acquireCtx, which honors PoolTimeout and
+// is cancelled on stop). It honors the client's configured timeouts instead of
+// a fixed cap: a client that deliberately sets ReadTimeout/WriteTimeout high
+// for slow cacheable reads must not see only its coalesced misses cut off early
+// (WithReader clamps the read to min(ctx deadline, ReadTimeout), so a shorter
+// ctx would win). A 5s floor covers scheduling overhead when the configured
+// timeouts are tiny or disabled.
 func (mc *cscMissCoalescer) batchBudget() time.Duration {
 	opt := mc.c.opt
 	var budget time.Duration
-	if opt.PoolTimeout > 0 {
-		budget += opt.PoolTimeout
-	}
 	if opt.WriteTimeout > 0 {
 		budget += opt.WriteTimeout
 	}
@@ -516,7 +532,7 @@ type CSCMissCoalesceStats struct {
 
 // CSCMissCoalesceStats returns the client's miss-coalescer counters.
 func (c *Client) CSCMissCoalesceStats() CSCMissCoalesceStats {
-	mc := c.baseClient.cscMissCoalescer
+	mc := c.baseClient.cscMissCoalescer.Load()
 	if mc == nil {
 		return CSCMissCoalesceStats{}
 	}

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/redis/go-redis/v9/internal/pool"
 	"github.com/redis/go-redis/v9/internal/proto"
 )
 
@@ -80,6 +81,13 @@ type cscMissReq struct {
 	cacheKey string
 	token    uint64
 	done     chan error
+	// servedBy is the session connection that served (or failed) this request,
+	// set by the engine BEFORE settling done (the channel receive is the
+	// happens-before edge for the caller's read). Feeds the native OTel
+	// recorder: processCached stamps it into processState so a coalesced miss
+	// reports its serving connection and an attempt, like any other command.
+	// Nil when the request never reached a session (enqueue reject, abandon).
+	servedBy *pool.Conn
 	// wire is cmd's RESP encoding, snapshotted at enqueue while the caller
 	// still owned cmd. The session writer writes ONLY these engine-owned bytes
 	// — it never reads cmd — so an abandoning caller may reuse mutable args
@@ -194,7 +202,11 @@ func (mc *cscMissCoalescer) stopWorkers() {
 // from here. Honors the caller's context: if it cancels while waiting, the
 // session still settles the token and populates the cache (the fetch is not
 // wasted), the caller just returns early.
-func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey string, token uint64) error {
+//
+// served is the session connection that produced the settle (nil when the
+// request never reached one); processCached stamps it into processState so the
+// native OTel recorder attributes the miss like any other command.
+func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey string, token uint64) (served *pool.Conn, err error) {
 	req := &cscMissReq{cmd: cmd, cacheKey: cacheKey, token: token, done: make(chan error, 1)}
 	// Snapshot the wire form NOW, while the caller still owns cmd: the session
 	// writer writes these engine-owned bytes and never reads cmd again, so an
@@ -206,7 +218,7 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 	var wireBuf bytes.Buffer
 	if err := writeCmd(proto.NewWriter(&wireBuf), cmd); err != nil {
 		mc.c.csc.Cancel(cacheKey, token)
-		return err
+		return nil, err
 	}
 	req.wire = wireBuf.Bytes()
 	// Reject early if the coalescer is already stopping, so a send does not win the
@@ -221,21 +233,21 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 		// the coalescer, and a clone can race that window) — the uncached
 		// re-run either succeeds on the open pool or surfaces the real error.
 		mc.c.csc.Cancel(cacheKey, token)
-		return errCSCRetryUncached
+		return nil, errCSCRetryUncached
 	default:
 	}
 	select {
 	case mc.ch <- req:
 	case <-mc.stop:
 		mc.c.csc.Cancel(cacheKey, token)
-		return errCSCRetryUncached
+		return nil, errCSCRetryUncached
 	case <-ctx.Done():
 		mc.c.csc.Cancel(cacheKey, token)
-		return ctx.Err()
+		return nil, ctx.Err()
 	}
 	select {
 	case err := <-req.done:
-		return err
+		return req.servedBy, err
 	case <-mc.stop:
 		// Close raced our enqueue: the req may have landed in mc.ch after the
 		// shutdown drain, so nothing will settle req.done. Winning the interlock
@@ -250,14 +262,15 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 			// non-blocking drain to empty the queue; settling our own abandoned
 			// req is harmless (done is buffered, the duplicate Cancel is a no-op).
 			mc.drainQueueErr(errCSCRetryUncached)
-			return errCSCRetryUncached
+			return nil, errCSCRetryUncached
 		}
 		// The reader claimed cmd and is mid-apply: wait so we do not read/reuse
 		// cmd concurrently (the receive is a happens-before edge), then return
 		// the settle result itself — the reply may have been applied
 		// successfully, and discarding it for a blanket ErrClosed would fail a
 		// read that has its value.
-		return <-req.done
+		e := <-req.done
+		return req.servedBy, e
 	case <-ctx.Done():
 		// Caller stopped waiting. If we win the interlock the reader skips the cmd
 		// write but still settles the token and publishes to the cache; if it already
@@ -266,8 +279,9 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 		// cancelled Get never returns a value depending on who won the CAS.
 		if !req.claimAbandon() {
 			<-req.done
+			return req.servedBy, ctx.Err()
 		}
-		return ctx.Err()
+		return nil, ctx.Err()
 	}
 }
 
@@ -302,6 +316,14 @@ func (mc *cscMissCoalescer) applyAndSettle(req *cscMissReq, raw []byte, connID, 
 	} else {
 		// WRONGTYPE / NOPERM / ...: returned to the caller, not cached.
 		c.csc.Cancel(req.cacheKey, req.token)
+	}
+	// Native error-metric parity with processWithRetry, which emits for every
+	// non-nil command error (redis.Nil included) on the uncoalesced path.
+	if applyErr != nil {
+		if errorCallback := pool.GetMetricErrorCallback(); errorCallback != nil {
+			errorType, statusCode, isInternal := classifyCommandError(applyErr)
+			errorCallback(context.Background(), errorType, req.servedBy, statusCode, isInternal, 0)
+		}
 	}
 	req.done <- applyErr
 }
@@ -343,9 +365,18 @@ func (mc *cscMissCoalescer) countBatch(batch []*cscMissReq) {
 	}
 }
 
-// settleErr cancels the reservation and fails one waiting caller.
+// settleErr cancels the reservation and fails one waiting caller. It emits the
+// native error metric (parity with processWithRetry and the FD autopipeline
+// engine's failReqs) — except for the retry-uncached sentinel, whose command
+// re-runs on the fully instrumented uncoalesced path and would double-count.
 func (mc *cscMissCoalescer) settleErr(req *cscMissReq, err error) {
 	mc.c.csc.Cancel(req.cacheKey, req.token)
+	if err != errCSCRetryUncached {
+		if errorCallback := pool.GetMetricErrorCallback(); errorCallback != nil {
+			errorType, statusCode, isInternal := classifyCommandError(err)
+			errorCallback(context.Background(), errorType, req.servedBy, statusCode, isInternal, 0)
+		}
+	}
 	req.done <- err
 	mc.failed.Add(1)
 }

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -7,9 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/redis/go-redis/v9/internal"
 	"github.com/redis/go-redis/v9/internal/pool"
-	"github.com/redis/go-redis/v9/internal/proto"
 )
 
 // errCSCRetryUncached is settled to a coalesced miss when the coalescer bows out
@@ -32,11 +30,16 @@ var errCSCRetryUncached = errors.New("redis: csc miss-coalescer disabled mid-fet
 // refresh policy helps because the readers are the bottleneck).
 //
 // This coalesces concurrent misses the way refreshInvalidatedBatch coalesces
-// invalidated keys: each miss's ORIGINAL command is pipelined onto ONE
-// tracked (main-pool) connection, replies are read back in order, each is
-// applied to its caller's command AND published to the shared cache. Individual
-// pipelined commands (not MGET) so it is cluster-safe and works for any read
-// shape, not just string GET.
+// invalidated keys: each miss's ORIGINAL command is streamed onto a held
+// tracked (main-pool) full-duplex connection (see csc_miss_coalesce_modes.go),
+// replies are read back in order, each is applied to its caller's command AND
+// published to the shared cache. Individual pipelined commands (not MGET) so it
+// is cluster-safe and works for any read shape, not just string GET. Misses are
+// CALLER-BLOCKING — a real request waits on each fetch — so the engine is
+// latency-first: a lone miss is written immediately (batching is opportunistic,
+// packing only what is already queued, never waited-for), and new misses stream
+// out while earlier replies are still in flight (~1 RTT per miss, no batch
+// phase-lock, no pool Get on the hot path).
 //
 // It is cache-aware, which is the whole point and the reason it cannot just ride
 // the ordinary autopipeliner: it must Reserve/fulfilCached each key so the entry
@@ -48,60 +51,23 @@ var errCSCRetryUncached = errors.New("redis: csc miss-coalescer disabled mid-fet
 //
 // Tradeoff, same as the autopipeline path: a coalesced miss loses per-command
 // MaxRetries/backoff/LOADING handling. Behind Options.ClientSideCacheCoalesceMisses.
+//
+// (Two earlier engines were removed once full-duplex was feature-complete: a
+// "workers" engine — N pooled connections, half-duplex batches, which added a
+// full batch RTT of tail latency to misses arriving mid-flight — and a "pinned"
+// benchmark prototype with no idle invalidation drain.)
 
 const (
 	cscMissBatchMax   = 128
 	cscMissQueueDepth = 4096
-	// cscMissWorkersDefault batchers run concurrently in the default "workers"
-	// mode, each holding one main-pool (tracked) connection while it writes+reads
-	// its batch. Size it to the caching client's pool (env override): more workers
-	// than pool connections just makes workers block in the pool Get.
-	cscMissWorkersDefault = 8
 	// cscFullDuplexDepth caps in-flight commands on the single-connection
 	// full-duplex engine (flow control for the writer).
 	cscFullDuplexDepth = 4096
 )
 
-// Engine selection + tuning come from the client's Options (ClientSideCacheCoalesce*)
-// and are read once, at coalescer construction (per client).
+// cscCoalesceMissesEnabled is read once, at coalescer construction (per client).
 func cscCoalesceMissesEnabled(opt *Options) bool {
 	return opt != nil && opt.ClientSideCacheCoalesceMisses
-}
-
-func cscMissWorkersCount(opt *Options) int {
-	if opt != nil && opt.ClientSideCacheCoalesceWorkers > 0 {
-		return opt.ClientSideCacheCoalesceWorkers
-	}
-	return cscMissWorkersDefault
-}
-
-// cscForcePinned lets a benchmark opt into the "pinned" PROTOTYPE engine, which
-// is otherwise NOT reachable from the public ClientSideCacheCoalesceMode option.
-// Pinned holds one connection with no idle invalidation drain, so it can serve
-// stale values after an invalidation (see #3965) and is unsafe for general use;
-// it is kept only for engine benchmark comparison.
-var cscForcePinned bool
-
-// cscCoalesceMode selects the flush engine: "workers" (default, N pool conns,
-// half-duplex batches) or "fullduplex" (1 held conn, concurrent writer+reader,
-// deep pipeline). The "pinned" engine is a benchmark-only PROTOTYPE and is NOT
-// selectable via the public option (it falls back to "workers"); it can only be
-// forced internally via cscForcePinned.
-func cscCoalesceMode(opt *Options) string {
-	if opt == nil {
-		return "workers"
-	}
-	switch opt.ClientSideCacheCoalesceMode {
-	case "fullduplex":
-		return "fullduplex"
-	case "pinned":
-		if cscForcePinned {
-			return "pinned"
-		}
-		return "workers"
-	default:
-		return "workers"
-	}
 }
 
 // cscReq* are the states of cscMissReq.apply, the single-word interlock that
@@ -151,7 +117,6 @@ type cscMissCoalescer struct {
 	stop     chan struct{}
 	stopOnce sync.Once // guards close(stop): Close and the GC cleanup can both stop
 	wg       sync.WaitGroup
-	mode     string // "workers" | "pinned" | "fullduplex"
 
 	batched    atomic.Uint64 // reqs that went through a batch
 	batches    atomic.Uint64 // batches flushed
@@ -180,33 +145,17 @@ func (c *baseClient) startCSCMissCoalescer() {
 		c:    c,
 		ch:   make(chan *cscMissReq, cscMissQueueDepth),
 		stop: make(chan struct{}),
-		mode: cscCoalesceMode(c.opt),
 	}
 	c.cscMissCoalescer.Store(mc)
-	switch mc.mode {
-	case "pinned":
+	// N independent full-duplex sessions, each holding its own connection and
+	// pulling independent misses from the shared queue. Order-free: coalesced
+	// misses are standalone per-key fetches with no cross-request contract, and
+	// each session's per-conn reader still matches replies to requests. Sharding
+	// spreads the miss + invalidation-drain load off a single connection, which
+	// is what cuts the low-concurrency p99 tail.
+	for i := 0; i < cscFullDuplexConnsDefault; i++ {
 		mc.wg.Add(1)
-		go mc.pinnedWorker()
-	case "fullduplex":
-		// N independent full-duplex sessions, each holding its own connection and
-		// pulling independent misses from the shared queue. Order-free: coalesced
-		// misses are standalone per-key fetches with no cross-request contract, and
-		// each session's per-conn reader still matches replies to requests. Sharding
-		// spreads the miss + invalidation-drain load off a single connection, which
-		// is what cuts the low-concurrency p99 tail.
-		for i := 0; i < cscFullDuplexConnsDefault; i++ {
-			mc.wg.Add(1)
-			go mc.fullDuplexLoop()
-		}
-	default:
-		n := cscMissWorkersCount(c.opt)
-		if n < 1 {
-			n = 1
-		}
-		for i := 0; i < n; i++ {
-			mc.wg.Add(1)
-			go mc.worker()
-		}
+		go mc.fullDuplexLoop()
 	}
 }
 
@@ -298,119 +247,6 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 		}
 		return ctx.Err()
 	}
-}
-
-func (mc *cscMissCoalescer) worker() {
-	defer mc.wg.Done()
-	batch := make([]*cscMissReq, 0, cscMissBatchMax)
-	for {
-		select {
-		case <-mc.stop:
-			return
-		case req := <-mc.ch:
-			batch = append(batch[:0], req)
-			// Take whatever else is already waiting so one connection serves many
-			// misses. A lone miss (nothing queued) flushes immediately — at
-			// inflight 1 every caller is blocked on its own Get, so any
-			// accumulation delay would be pure added latency.
-		drain:
-			for len(batch) < cscMissBatchMax {
-				select {
-				case more := <-mc.ch:
-					batch = append(batch, more)
-				default:
-					break drain
-				}
-			}
-			mc.flush(batch)
-		}
-	}
-}
-
-// flush (workers mode) acquires a fresh main-pool connection, pipelines the
-// batch onto it half-duplex (write all, then read all), and releases it. Every
-// req.done is sent exactly once and every token is settled.
-//
-// A published entry is only invalidatable if the connection that read it is
-// running CLIENT TRACKING, so this path must land on a tracked connection.
-// initConn issues CLIENT TRACKING ON for every pooled connection while CSC is
-// active (it is pool-agnostic), so the main pool is tracked and correct. The
-// main pool is used rather than the pipeline pool so the choice stays correct
-// even if a later change makes a dedicated pipeline pool deliberately untracked
-// (publishing a cache entry on an untracked connection would serve stale until
-// TTL). No contention cost: with the coalescer in front, reader misses are
-// handed to it, so the caching client's main pool has no other user.
-func (mc *cscMissCoalescer) flush(batch []*cscMissReq) {
-	c := mc.c
-	mc.countBatch(batch)
-
-	// Acquire under acquireCtx (PoolTimeout-bounded AND cancelled by stop, so
-	// Close is not stalled behind a Get blocked on a saturated pool), then run
-	// the batch under the full write+read budget.
-	getCtx, getCancel := mc.acquireCtx()
-	cn, err := c.getConn(getCtx)
-	getCancel()
-	if err != nil {
-		mc.settleAllErr(batch, 0, err)
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), mc.batchBudget())
-	defer cancel()
-	settled, ferr := mc.flushBatch(ctx, cn, batch)
-	c.releaseConn(ctx, cn, ferr)
-	if ferr != nil {
-		// Write/read failure: settle every request not yet handled as an error so
-		// no caller hangs and no token is left IN_PROGRESS.
-		mc.settleAllErr(batch, settled, ferr)
-	}
-}
-
-// flushBatch writes batch on cn, then reads and settles replies in order.
-// Returns the number settled and any connection error; on error the caller
-// settles the remaining requests. Used by both the workers and pinned engines.
-func (mc *cscMissCoalescer) flushBatch(ctx context.Context, cn *pool.Conn, batch []*cscMissReq) (settled int, err error) {
-	c := mc.c
-	connID := cn.GetID()
-	// Coverage generation captured BEFORE the reads, same discipline as
-	// refreshInvalidatedBatch/fulfillCached: if this conn loses tracking
-	// mid-batch every reply is rejected by fulfillCached rather than published
-	// under lost coverage.
-	capturedGen := c.cscConnInitGen(connID)
-
-	// ctx is the ENGINE's own bounded batch budget, not a caller context, so it
-	// must NOT go through c.context() — with ContextTimeoutEnabled=false (the
-	// default) that strips the deadline to context.Background(), and with
-	// ReadTimeout disabled a server that never replies would then block this
-	// worker forever, wedging Close in stopCSCMissCoalescer's wg.Wait.
-	if werr := cn.WithWriter(ctx, c.opt.WriteTimeout, func(wr *proto.Writer) error {
-		for _, req := range batch {
-			if e := writeCmd(wr, req.cmd); e != nil {
-				return e
-			}
-		}
-		return nil
-	}); werr != nil {
-		return 0, werr
-	}
-
-	rerr := cn.WithReader(ctx, c.opt.ReadTimeout, func(rd *proto.Reader) error {
-		for settled < len(batch) {
-			// Invalidation pushes share this connection with replies; drain them
-			// first so a push frame is not read as a value.
-			if e := c.processPendingPushNotificationWithReader(ctx, cn, rd); e != nil {
-				internal.Logger.Printf(ctx, "csc: miss-coalesce push drain: %v", e)
-			}
-			raw, e := rd.ReadRawReply()
-			if e != nil {
-				return e
-			}
-			mc.applyAndSettle(batch[settled], raw, connID, capturedGen)
-			settled++
-		}
-		return nil
-	})
-	return settled, rerr
 }
 
 // applyAndSettle applies raw to the caller's command, publishes to the cache
@@ -534,7 +370,7 @@ func (mc *cscMissCoalescer) grabInto(dst []*cscMissReq, first *cscMissReq) []*cs
 //
 // Experimental: this API may change in a minor release.
 type CSCMissCoalesceStats struct {
-	Mode         string // "workers" | "pinned" | "fullduplex"
+	Active       bool   // a coalescer is running (ClientSideCacheCoalesceMisses on a LocalCache client)
 	Batched      uint64 // misses served through a batch
 	Batches      uint64 // batches flushed
 	Failed       uint64 // misses settled as errors (connection failure)
@@ -548,7 +384,7 @@ func (c *Client) CSCMissCoalesceStats() CSCMissCoalesceStats {
 		return CSCMissCoalesceStats{}
 	}
 	return CSCMissCoalesceStats{
-		Mode:         mc.mode,
+		Active:       true,
 		Batched:      mc.batched.Load(),
 		Batches:      mc.batches.Load(),
 		Failed:       mc.failed.Load(),

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -10,52 +10,44 @@ import (
 	"github.com/redis/go-redis/v9/internal/pool"
 )
 
-// errCSCRetryUncached is settled to a coalesced miss when the coalescer bows out
-// for a reason unrelated to the command itself: CSC serving was disabled after
-// the miss was queued (e.g. a RESP3 downgrade, or CLIENT TRACKING rejected during
-// a connection re-init), so this held-connection session would fetch on an
-// untracked conn or none at all. It never reaches the caller — processCached
-// catches it and re-runs the command uncached on the normal path, so a valid
-// cacheable read is not failed with a spurious pool.ErrClosed. The reservation is
-// always cancelled before this is settled, so no waiter is left IN_PROGRESS.
+// errCSCRetryUncached settles a coalesced miss when the coalescer bows out for a
+// reason unrelated to the command itself: CSC serving was disabled after the
+// miss was queued (a RESP3 downgrade, or CLIENT TRACKING rejected during a
+// connection re-init), so this session would fetch on an untracked conn or none
+// at all. It never reaches the caller — processCached catches it and re-runs the
+// command uncached, so a valid cacheable read is not failed with a spurious
+// pool.ErrClosed. The reservation is always cancelled before this is settled, so
+// no waiter is left IN_PROGRESS.
 var errCSCRetryUncached = errors.New("redis: csc miss-coalescer disabled mid-fetch; retry uncached")
 
-// Reader-miss coalescing (PROTOTYPE, env-gated).
+// Reader-miss coalescing, behind Options.ClientSideCacheCoalesceMisses.
 //
 // The two-client CSC shape serves cache HITS locally (no connection) but every
-// cache MISS fetches on the caching client's MAIN pool, one command per
-// connection. Under churn at a small pool that is the wall: N concurrent misses
-// contend for pool connections one GET at a time (measured: at CSC pool 8 the
-// reader misses alone saturate the pool, p99 ~420ms at 64 workers, and no
-// refresh policy helps because the readers are the bottleneck).
+// MISS fetches on the caching client's MAIN pool, one command per connection.
+// At a small pool that is the wall: N concurrent misses contend one GET at a
+// time (measured: at CSC pool 8 the reader misses alone saturate the pool, p99
+// ~420ms at 64 workers, and no refresh policy helps — the readers are the
+// bottleneck).
 //
-// This coalesces concurrent misses the way refreshInvalidatedBatch coalesces
-// invalidated keys: each miss's ORIGINAL command is streamed onto a held
-// tracked (main-pool) full-duplex connection (see csc_miss_coalesce_modes.go),
-// replies are read back in order, each is applied to its caller's command AND
-// published to the shared cache. Individual pipelined commands (not MGET) so it
-// is cluster-safe and works for any read shape, not just string GET. Misses are
-// CALLER-BLOCKING — a real request waits on each fetch — so the engine is
-// latency-first: a lone miss is written immediately (batching is opportunistic,
-// packing only what is already queued, never waited-for), and new misses stream
-// out while earlier replies are still in flight (~1 RTT per miss, no batch
+// This streams each miss's ORIGINAL command onto a held tracked (main-pool)
+// full-duplex connection (see csc_miss_coalesce_modes.go), reads the replies
+// back in order, and applies each to its caller's command AND to the shared
+// cache. Individual pipelined commands (not MGET), so it is cluster-safe and
+// works for any read shape, not just string GET. Misses are CALLER-BLOCKING, so
+// the engine is latency-first: a lone miss is written immediately (batching only
+// packs what is already queued, never waits for more), and new misses stream out
+// while earlier replies are still in flight (~1 RTT per miss, no batch
 // phase-lock, no pool Get on the hot path).
 //
-// It is cache-aware, which is the whole point and the reason it cannot just ride
-// the ordinary autopipeliner: it must Reserve/fulfilCached each key so the entry
-// is tracked and single-flighted. Reserve is done by the caller in processCached
-// (only shouldFetch==true misses reach here); this owns the token from that
-// point and settles it — fulfilled or cancelled — before waking the caller, or a
-// dangling IN_PROGRESS entry would block every reader of that key for
-// StaleTimeout.
+// Being cache-aware is why it cannot just ride the ordinary autopipeliner: it
+// must Reserve/fulfilCached each key so the entry is tracked and
+// single-flighted. The caller Reserves in processCached (only shouldFetch==true
+// misses reach here); the engine owns the token from that point and settles it —
+// fulfilled or cancelled — before waking the caller, or a dangling IN_PROGRESS
+// entry blocks every reader of that key for StaleTimeout.
 //
 // Tradeoff, same as the autopipeline path: a coalesced miss loses per-command
-// MaxRetries/backoff/LOADING handling. Behind Options.ClientSideCacheCoalesceMisses.
-//
-// (Two earlier engines were removed once full-duplex was feature-complete: a
-// "workers" engine — N pooled connections, half-duplex batches, which added a
-// full batch RTT of tail latency to misses arriving mid-flight — and a "pinned"
-// benchmark prototype with no idle invalidation drain.)
+// MaxRetries/backoff/LOADING handling.
 
 const (
 	cscMissBatchMax   = 128
@@ -70,14 +62,14 @@ func cscCoalesceMissesEnabled(opt *Options) bool {
 	return opt != nil && opt.ClientSideCacheCoalesceMisses
 }
 
-// cscReq* are the states of cscMissReq.apply, the single-word interlock that
-// decides who owns req.cmd: the fetching caller or the worker/reader applying
-// the reply. Exactly one side wins the pending->X CAS, so the worker never
-// writes cmd after the caller has returned and may be reusing it.
+// cscReq* are the states of cscMissReq.apply, the single-word interlock over who
+// owns req.cmd: the fetching caller or the reader applying the reply. Exactly
+// one side wins the pending->X CAS, so the reader never writes cmd after the
+// caller has returned and may be reusing it.
 const (
 	cscReqPending   uint32 = iota // no one has claimed cmd yet
 	cscReqAbandoned               // caller's ctx (or Close) fired first: cmd is the caller's again
-	cscReqApplying                // worker/reader claimed cmd first: it will write and settle
+	cscReqApplying                // reader claimed cmd first: it will write and settle
 )
 
 // cscMissReq is one caller waiting for its missed key. done carries the fetch
@@ -88,24 +80,23 @@ type cscMissReq struct {
 	token    uint64
 	done     chan error
 	// apply interlocks ownership of cmd between the fetching caller and the
-	// worker/reader. The caller abandons (CAS pending->abandoned) if its context
-	// is cancelled — or Close races its enqueue — before a worker starts applying;
-	// the worker claims (CAS pending->applying) before it writes the reply into
-	// cmd. A plain flag would still race: a worker could read "not abandoned",
-	// begin writing cmd, and the caller cancel mid-write. The CAS makes the two
-	// decisions mutually exclusive. Either way the worker still settles the token
-	// and publishes to the shared cache (the fetch is never wasted) — only the cmd
-	// write is gated.
+	// reader. The caller abandons (CAS pending->abandoned) if its context is
+	// cancelled — or Close races its enqueue — before a reply is applied; the
+	// reader claims (CAS pending->applying) before it writes the reply into cmd. A
+	// plain flag would still race: the reader could read "not abandoned", begin
+	// writing cmd, and the caller cancel mid-write. Either way the reader still
+	// settles the token and publishes to the shared cache (the fetch is never
+	// wasted) — only the cmd write is gated.
 	apply atomic.Uint32
 }
 
 // claimAbandon is the caller's side of the cmd interlock: it succeeds only if no
-// worker has started applying, in which case the worker will skip the cmd write.
+// reply is being applied, in which case the reader skips the cmd write.
 func (r *cscMissReq) claimAbandon() bool {
 	return r.apply.CompareAndSwap(cscReqPending, cscReqAbandoned)
 }
 
-// claimApply is the worker's side: it succeeds only if the caller has not
+// claimApply is the reader's side: it succeeds only if the caller has not
 // abandoned, in which case it is safe to write the caller's cmd.
 func (r *cscMissReq) claimApply() bool {
 	return r.apply.CompareAndSwap(cscReqPending, cscReqApplying)
@@ -122,18 +113,17 @@ type cscMissCoalescer struct {
 	batches    atomic.Uint64 // batches flushed
 	failed     atomic.Uint64 // reqs settled as errors (conn failure)
 	maxBatchSz atomic.Uint64
-	// abandonedApplies counts replies whose caller had already abandoned the req
-	// (lost the cmd interlock), so the cmd write was skipped. Used only to assert
-	// the -race abandoned-path test actually hit the window it guards.
+	// abandonedApplies counts replies whose caller had already abandoned the req,
+	// so the cmd write was skipped. Read only by the -race abandoned-path test, to
+	// assert it hit the window it guards.
 	abandonedApplies atomic.Uint64
 }
 
-// startCSCMissCoalescer launches the batcher goroutines. No-op unless
+// startCSCMissCoalescer launches the coalescer sessions. No-op unless
 // Options.ClientSideCacheCoalesceMisses is set and CSC is active, and — see the
-// option's GoDoc — unless the cache is the built-in *LocalCache: the coalescer's
-// publish path (fulfillCached capture, refresh integration, hot-entry
-// collection) is LocalCache-specific, so a custom Cache implementation falls
-// back to per-caller fetches.
+// option's GoDoc — unless the cache is the built-in *LocalCache: the publish path
+// (fulfillCached capture, refresh integration, hot-entry collection) is
+// LocalCache-specific, so a custom Cache falls back to per-caller fetches.
 func (c *baseClient) startCSCMissCoalescer() {
 	if !cscCoalesceMissesEnabled(c.opt) || c.cscMissCoalescer.Load() != nil {
 		return
@@ -148,11 +138,9 @@ func (c *baseClient) startCSCMissCoalescer() {
 	}
 	c.cscMissCoalescer.Store(mc)
 	// N independent full-duplex sessions, each holding its own connection and
-	// pulling independent misses from the shared queue. Order-free: coalesced
-	// misses are standalone per-key fetches with no cross-request contract, and
-	// each session's per-conn reader still matches replies to requests. Sharding
-	// spreads the miss + invalidation-drain load off a single connection, which
-	// is what cuts the low-concurrency p99 tail.
+	// pulling misses from the shared queue. Order-free: coalesced misses are
+	// standalone per-key fetches with no cross-request contract, and each
+	// session's per-conn reader still matches replies to its own requests.
 	for i := 0; i < cscFullDuplexConnsDefault; i++ {
 		mc.wg.Add(1)
 		go mc.fullDuplexLoop()
@@ -182,25 +170,25 @@ func (c *baseClient) stopCSCMissCoalescer() {
 }
 
 // stopWorkers signals every coalescer goroutine to exit; idempotent, does not
-// wait. Called by stopCSCMissCoalescer (Close) and by the GC cleanup for a
-// client dropped without Close — the workers retain the base client (cache,
-// pools), so leaving them running would leak all of it per forgotten client.
+// wait. Called by stopCSCMissCoalescer (Close) and by the GC cleanup for a client
+// dropped without Close — the sessions retain the base client (cache, pools), so
+// leaving them running leaks all of it per forgotten client.
 func (mc *cscMissCoalescer) stopWorkers() {
 	mc.stopOnce.Do(func() { close(mc.stop) })
 }
 
 // fetch hands a reserved miss to the coalescer and waits for the result. The
-// caller has already Reserved (shouldFetch==true) and this owns the token now.
-// Honors the caller's context: if it cancels while waiting, the batch still
-// settles the token and populates the cache (the fetch is not wasted), the
-// caller just returns early.
+// caller has already Reserved (shouldFetch==true); the coalescer owns the token
+// from here. Honors the caller's context: if it cancels while waiting, the
+// session still settles the token and populates the cache (the fetch is not
+// wasted), the caller just returns early.
 func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey string, token uint64) error {
 	req := &cscMissReq{cmd: cmd, cacheKey: cacheKey, token: token, done: make(chan error, 1)}
-	// Reject early if the coalescer is already shutting down, so a send does not
-	// win the select race against a closed mc.stop and land in mc.ch after the
-	// shutdown drain (where no worker would ever pick it up). This narrows — but
-	// cannot fully close — that race; the mc.stop case in the wait select below is
-	// what guarantees the caller never hangs on a post-drain req.
+	// Reject early if the coalescer is already stopping, so a send does not win the
+	// select race against a closed mc.stop and land in mc.ch after the shutdown
+	// drain, where nothing would pick it up. This narrows but cannot close that
+	// race; the mc.stop case in the wait select below is what guarantees the caller
+	// never hangs on a post-drain req.
 	select {
 	case <-mc.stop:
 		mc.c.csc.Cancel(cacheKey, token)
@@ -221,26 +209,24 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 		return err
 	case <-mc.stop:
 		// Close raced our enqueue: the req may have landed in mc.ch after the
-		// shutdown drain, so no worker will ever settle req.done. If we win the
-		// interlock (no worker is applying), cancel the reservation and return
-		// instead of hanging — a duplicate Cancel, if the drain also got this req,
-		// is a no-op on a settled token. If a worker already claimed cmd, it owns
-		// the write and will settle; wait for it so we do not touch cmd concurrently.
+		// shutdown drain, so nothing will settle req.done. Winning the interlock
+		// means no reply is being applied — cancel the reservation and return instead
+		// of hanging (a duplicate Cancel, if the drain also got this req, is a no-op
+		// on a settled token).
 		if req.claimAbandon() {
 			mc.c.csc.Cancel(cacheKey, token)
 			return pool.ErrClosed
 		}
-		// A worker already claimed cmd and is mid-write: wait for it to finish so we
-		// do not read/reuse cmd concurrently, then return the shutdown error (the
-		// receive is a happens-before edge, so the later cmd.SetErr is race-free).
+		// The reader claimed cmd and is mid-write: wait so we do not read/reuse cmd
+		// concurrently (the receive is a happens-before edge, so a later cmd.SetErr
+		// is race-free), then return the shutdown error.
 		<-req.done
 		return pool.ErrClosed
 	case <-ctx.Done():
-		// Caller stopped waiting. If we win the interlock the worker skips the cmd
-		// write but still settles the token and publishes to the cache (the fetch is
-		// not wasted); we just return early. If a worker already claimed cmd, it is
-		// mid-write — wait for it rather than race by reusing cmd. Either way return
-		// the context error, matching the non-coalesced path (processWithRetry), so a
+		// Caller stopped waiting. If we win the interlock the reader skips the cmd
+		// write but still settles the token and publishes to the cache; if it already
+		// claimed cmd, wait rather than race by reusing cmd. Either way return the
+		// context error, matching the non-coalesced path (processWithRetry), so a
 		// cancelled Get never returns a value depending on who won the CAS.
 		if !req.claimAbandon() {
 			<-req.done
@@ -249,16 +235,15 @@ func (mc *cscMissCoalescer) fetch(ctx context.Context, cmd Cmder, cacheKey strin
 	}
 }
 
-// applyAndSettle applies raw to the caller's command, publishes to the cache
-// when cacheable (under the reading connection's tracking generation), and wakes
-// the caller. Sends req.done exactly once.
+// applyAndSettle applies raw to the caller's command, publishes to the cache when
+// cacheable (under the reading connection's tracking generation), and wakes the
+// caller. Sends req.done exactly once.
 //
-// It first claims the cmd interlock: if the caller has abandoned the req (its
-// context was cancelled, or Close raced its enqueue) it has its Cmder back and
-// may be reading or reusing it, so the reply must NOT be written there. The
-// fetch is still not wasted — the reply is classified from a throwaway parse and,
-// when cacheable, published to the shared cache for the next reader; only the
-// caller's cmd write is skipped.
+// It claims the cmd interlock first: an abandoned caller (context cancelled, or
+// Close raced its enqueue) has its Cmder back and may be reading or reusing it,
+// so the reply must NOT be written there. The fetch is still not wasted — the
+// reply is classified from a throwaway parse and, when cacheable, published for
+// the next reader; only the caller's cmd write is skipped.
 func (mc *cscMissCoalescer) applyAndSettle(req *cscMissReq, raw []byte, connID, capturedGen uint64) {
 	c := mc.c
 	var applyErr error
@@ -285,14 +270,13 @@ func (mc *cscMissCoalescer) applyAndSettle(req *cscMissReq, raw []byte, connID, 
 	req.done <- applyErr
 }
 
-// batchBudget bounds one coalesced batch's write + reads (connection
-// acquisition is bounded separately by acquireCtx, which honors PoolTimeout and
-// is cancelled on stop). It honors the client's configured timeouts instead of
-// a fixed cap: a client that deliberately sets ReadTimeout/WriteTimeout high
-// for slow cacheable reads must not see only its coalesced misses cut off early
-// (WithReader clamps the read to min(ctx deadline, ReadTimeout), so a shorter
-// ctx would win). A 5s floor covers scheduling overhead when the configured
-// timeouts are tiny or disabled.
+// batchBudget bounds one coalesced batch's write + reads (connection acquisition
+// is bounded separately, by acquireCtx). It follows the client's configured
+// timeouts instead of a fixed cap: a client that deliberately sets
+// ReadTimeout/WriteTimeout high for slow cacheable reads must not see only its
+// coalesced misses cut off early (WithReader clamps the read to min(ctx deadline,
+// ReadTimeout), so a shorter ctx would win). The 5s floor covers scheduling
+// overhead when the configured timeouts are tiny or disabled.
 func (mc *cscMissCoalescer) batchBudget() time.Duration {
 	opt := mc.c.opt
 	var budget time.Duration
@@ -309,8 +293,8 @@ func (mc *cscMissCoalescer) batchBudget() time.Duration {
 }
 
 // countBatch records batch-size accounting. The max is a CAS loop: with
-// concurrent workers a plain load-then-store could commit a smaller value over
-// a larger one that landed in between, permanently underreporting the maximum.
+// concurrent sessions a load-then-store could commit a smaller value over a
+// larger one that landed in between, permanently underreporting the maximum.
 func (mc *cscMissCoalescer) countBatch(batch []*cscMissReq) {
 	mc.batches.Add(1)
 	mc.batched.Add(uint64(len(batch)))

--- a/csc_miss_coalesce.go
+++ b/csc_miss_coalesce.go
@@ -472,12 +472,18 @@ func (mc *cscMissCoalescer) batchBudget() time.Duration {
 	return budget
 }
 
-// countBatch records batch-size accounting.
+// countBatch records batch-size accounting. The max is a CAS loop: with
+// concurrent workers a plain load-then-store could commit a smaller value over
+// a larger one that landed in between, permanently underreporting the maximum.
 func (mc *cscMissCoalescer) countBatch(batch []*cscMissReq) {
 	mc.batches.Add(1)
 	mc.batched.Add(uint64(len(batch)))
-	if n := uint64(len(batch)); n > mc.maxBatchSz.Load() {
-		mc.maxBatchSz.Store(n)
+	n := uint64(len(batch))
+	for {
+		cur := mc.maxBatchSz.Load()
+		if n <= cur || mc.maxBatchSz.CompareAndSwap(cur, n) {
+			return
+		}
 	}
 }
 

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -366,14 +366,18 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 				// the reader is parked inside the handler). The adapter's Close
 				// signals and defers the blocking teardown to a goroutine.
 				// Drain server pushes before reading this request's reply, through the
-				// shared helper: the built-in processor uses the Buffered variant so a
-				// mid-frame error PROPAGATES, and a custom processor is handed only a
-				// confirmed push frame (peek first). FATAL, not log-and-continue: a
-				// drain error means bytes may have been consumed mid-frame, so
-				// continuing into ReadRawReply on a desynchronized stream could apply a
-				// push fragment as this request's reply and publish it to the cache
-				// under the wrong key. Fail the session so the connection is removed.
-				if e := c.drainPushFrames(sctx, cn, rd); e != nil {
+				// shared helper in BLOCKING mode: block on the socket and skip pushes
+				// until the reply is the next frame, so a second invalidation still on
+				// the socket ahead of the reply is not read by ReadRawReply as this
+				// request's reply. (The Buffered variant stopped at buffer-empty and let
+				// such a socket-pending push through, shifting the reply stream by one
+				// frame.) A custom processor is handed only a confirmed push frame (peek
+				// first). FATAL, not log-and-continue: a drain error means bytes may have
+				// been consumed mid-frame, so continuing into ReadRawReply on a
+				// desynchronized stream could apply a push fragment as this request's
+				// reply and publish it to the cache under the wrong key. Fail the session
+				// so the connection is removed.
+				if e := c.drainPushFrames(sctx, cn, rd, true); e != nil {
 					internal.Logger.Printf(sctx, "csc: miss-coalesce push drain: %v", e)
 					return e
 				}

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -195,6 +195,12 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 	gen := c.cscConnInitGen(connID)
 
 	inflight := make(chan *cscMissReq, cscFullDuplexDepth)
+	// readsDone counts replies the reader has fully consumed. The drain
+	// backstop samples it as its progress signal: unlike len(inflight), it sees
+	// the ACTIVE read too (the reader pops a request before reading its reply,
+	// so a lone deep read under a maintenance-relaxed timeout would otherwise
+	// look like a zero-progress stall and get its socket closed mid-reply).
+	var readsDone atomic.Uint64
 	sctx, scancel := context.WithCancel(context.Background())
 	defer scancel()
 
@@ -282,12 +288,33 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 			// per-op timeouts disabled a blocked read/write could then never be
 			// interrupted (the supervisor's conn-close is the backstop).
 			werr := cn.WithWriter(sctx, c.opt.WriteTimeout, func(wr *proto.Writer) error {
-				for _, r := range buf {
-					if e := writeCmd(wr, r.cmd); e != nil {
-						return e
+				// Claim each request (PENDING->WRITING) around its arg
+				// serialization: an abandoned caller owns its Cmder again and may
+				// be reusing mutable args (a []byte key), so args must never be
+				// read after fetch returned — and a mutated key must not be
+				// fetched and published under the original cache key. Abandoned
+				// requests are dropped here with their reservation cancelled
+				// (nothing will fetch them); the claim is released as soon as the
+				// args are copied into the write buffer, before the flush.
+				var e error
+				n := 0
+				for i, r := range buf {
+					if !r.claimWrite() {
+						mc.c.csc.Cancel(r.cacheKey, r.token)
+						continue
+					}
+					e = writeCmd(wr, r.cmd)
+					r.releaseWrite()
+					buf[n] = r
+					n++
+					if e != nil {
+						// Keep the unvisited tail so the error path settles it.
+						n += copy(buf[n:], buf[i+1:])
+						break
 					}
 				}
-				return nil
+				buf = buf[:n]
+				return e
 			})
 			if werr != nil {
 				fail(werr)
@@ -336,6 +363,7 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 				mc.settleErr(req, rerr)
 				return false
 			}
+			readsDone.Add(1)
 			return true
 		}
 
@@ -401,19 +429,29 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 	// force the I/O out with a conn close (else Close wedges in wg.Wait) — but a
 	// HEALTHY drain of a deep in-flight pipeline (up to cscFullDuplexDepth
 	// replies, ~in-flight × RTT, possibly under a maintenance-relaxed timeout)
-	// may legitimately exceed any fixed budget. Each budget interval that
-	// consumed at least one reply extends the wait; only a zero-progress
-	// interval closes the conn.
+	// may legitimately exceed any fixed budget. Progress is COMPLETED READS
+	// (readsDone), not queue length: the reader pops a request before reading
+	// its reply, so len(inflight) is blind to the active read and would call a
+	// lone deep read a stall. Each budget interval that completed at least one
+	// reply extends the wait; only a zero-progress interval closes the conn.
 	drainBackstop := func() {
-		prev := len(inflight)
+		prev := readsDone.Load()
 		for {
+			// One blocked read may legitimately wait out the conn's EFFECTIVE
+			// read timeout (a maintenance-relaxed timeout can far exceed the
+			// batch budget), so the zero-progress verdict must not fire sooner.
+			// Recomputed per interval: an expired relaxation shrinks it back.
+			interval := mc.batchBudget()
+			if rt := cn.EffectiveReadTimeout(c.opt.ReadTimeout); rt+time.Second > interval {
+				interval = rt + time.Second
+			}
 			select {
 			case <-superDone:
 				return
-			case <-time.After(mc.batchBudget()):
-				cur := len(inflight)
-				if cur < prev {
-					prev = cur // draining; give it another interval
+			case <-time.After(interval):
+				cur := readsDone.Load()
+				if cur != prev {
+					prev = cur // still consuming replies; give it another interval
 					continue
 				}
 				_ = cn.Close()

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -9,6 +9,7 @@ import (
 	"github.com/redis/go-redis/v9/internal"
 	"github.com/redis/go-redis/v9/internal/pool"
 	"github.com/redis/go-redis/v9/internal/proto"
+	"github.com/redis/go-redis/v9/push"
 )
 
 // The full-duplex miss-coalescer engine — THE engine behind
@@ -394,10 +395,21 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 				// Deliberately not in peekAndProcessPushNotifications: pooled paths
 				// have drainer coverage, and a blanket fallback perturbs sequenced
 				// push handling.
-				if cn.TakeCscPeriodicReadPending(cscFallbackProbeInterval) {
-					if e := c.timedPushDrain(sctx, cn); e != nil {
-						fail(e)
-						return
+				// Built-in processor ONLY: this probe reads speculatively (no
+				// readiness signal exists on an opaque transport), and the
+				// built-in processor swallows the no-data boundary timeout. A
+				// CUSTOM processor's contract documents being invoked when
+				// notifications are KNOWN present — a natural implementation
+				// surfaces the empty-probe timeout, which would fail (and
+				// redial) a healthy session on every idle probe. Custom +
+				// opaque conns forgo the speculative drain; their invalidations
+				// land on session end/recycle at the latest.
+				if _, builtin := c.pushProcessor.(*push.Processor); builtin {
+					if cn.TakeCscPeriodicReadPending(cscFallbackProbeInterval) {
+						if e := c.timedPushDrain(sctx, cn); e != nil {
+							fail(e)
+							return
+						}
 					}
 				}
 				if handoffWanted() {
@@ -434,19 +446,25 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 			// Recomputed per interval: an expired relaxation shrinks it back.
 			interval := mc.batchBudget()
 			rt := cn.EffectiveReadTimeout(c.opt.ReadTimeout)
+			wt := cn.EffectiveWriteTimeout(c.opt.WriteTimeout)
 			if rt+time.Second > interval {
 				interval = rt + time.Second
 			}
-			// Deadline-less reads (no active relaxation): the user explicitly
-			// disabled read deadlines, so the RECYCLE path must not cut a
-			// legitimately long reply that completes no read for an interval —
-			// wait for the session (or Close) instead. Close still terminates:
-			// once stop fires, the bounded zero-progress close below applies,
-			// which is the shutdown contract (Close never wedges). NOTE the
-			// <= 0: Options.init normalizes ReadTimeout -1 (indefinite) to 0
-			// and -2 (no deadline calls) to -1, so BOTH deadline-less modes
-			// land at rt <= 0 here.
-			if !stopping && rt <= 0 {
+			if wt+time.Second > interval {
+				interval = wt + time.Second
+			}
+			// Deadline-less I/O (no active relaxation): the user explicitly
+			// disabled the read and/or write deadline, so the RECYCLE path must
+			// not cut a session whose reader is in a legitimately long reply OR
+			// whose writer is blocked flushing a large request — readsDone
+			// cannot show progress before a reply exists, so a deadline-free
+			// blocked WRITE looks exactly like a stall. Wait for the session
+			// (or Close) instead. Close still terminates: once stop fires, the
+			// bounded zero-progress close below applies, which is the shutdown
+			// contract (Close never wedges). NOTE the <= 0: Options.init
+			// normalizes -1 (indefinite) to 0 and -2 (no deadline calls) to
+			// -1, so both deadline-less modes land at <= 0 here.
+			if !stopping && (rt <= 0 || wt <= 0) {
 				select {
 				case <-superDone:
 					return

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -299,11 +299,13 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
 				if e != nil {
 					return e
 				}
-				if cn.GetID() == connID && c.cscConnInitGen(connID) == gen {
-					mc.applyAndSettle(req, raw, connID, gen)
-				} else {
-					mc.settleErr(req, pool.ErrClosed)
-				}
+				// Deliver the reply the caller is waiting for and let applyAndSettle
+				// gate only the CACHE PUBLISH on the connection's id/generation
+				// (fulfillCached checks the captured gen) — matching the workers and
+				// pinned engines. Previously FD failed the caller with ErrClosed on a
+				// mid-flight id/gen change even though the reply was read fine, losing
+				// a good result (#3965).
+				mc.applyAndSettle(req, raw, connID, gen)
 				return nil
 			})
 			if rerr != nil {

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -288,33 +288,17 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 			// per-op timeouts disabled a blocked read/write could then never be
 			// interrupted (the supervisor's conn-close is the backstop).
 			werr := cn.WithWriter(sctx, c.opt.WriteTimeout, func(wr *proto.Writer) error {
-				// Claim each request (PENDING->WRITING) around its arg
-				// serialization: an abandoned caller owns its Cmder again and may
-				// be reusing mutable args (a []byte key), so args must never be
-				// read after fetch returned — and a mutated key must not be
-				// fetched and published under the original cache key. Abandoned
-				// requests are dropped here with their reservation cancelled
-				// (nothing will fetch them); the claim is released as soon as the
-				// args are copied into the write buffer, before the flush.
-				var e error
-				n := 0
-				for i, r := range buf {
-					if !r.claimWrite() {
-						mc.c.csc.Cancel(r.cacheKey, r.token)
-						continue
-					}
-					e = writeCmd(wr, r.cmd)
-					r.releaseWrite()
-					buf[n] = r
-					n++
-					if e != nil {
-						// Keep the unvisited tail so the error path settles it.
-						n += copy(buf[n:], buf[i+1:])
-						break
+				for _, r := range buf {
+					// r.wire was snapshotted at enqueue while the caller owned
+					// cmd (see cscMissReq.wire): the writer never reads cmd, so
+					// an abandoned caller's args are never touched here, and an
+					// abandoned fetch still completes — its reply publishes to
+					// the cache and settles the reservation.
+					if _, e := wr.Write(r.wire); e != nil {
+						return e
 					}
 				}
-				buf = buf[:n]
-				return e
+				return nil
 			})
 			if werr != nil {
 				fail(werr)
@@ -434,7 +418,7 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 	// its reply, so len(inflight) is blind to the active read and would call a
 	// lone deep read a stall. Each budget interval that completed at least one
 	// reply extends the wait; only a zero-progress interval closes the conn.
-	drainBackstop := func() {
+	drainBackstop := func(stopping bool) {
 		prev := readsDone.Load()
 		for {
 			// One blocked read may legitimately wait out the conn's EFFECTIVE
@@ -442,8 +426,24 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 			// batch budget), so the zero-progress verdict must not fire sooner.
 			// Recomputed per interval: an expired relaxation shrinks it back.
 			interval := mc.batchBudget()
-			if rt := cn.EffectiveReadTimeout(c.opt.ReadTimeout); rt+time.Second > interval {
+			rt := cn.EffectiveReadTimeout(c.opt.ReadTimeout)
+			if rt+time.Second > interval {
 				interval = rt + time.Second
+			}
+			// Deadline-less reads (negative ReadTimeout, no active relaxation):
+			// the user explicitly disabled read deadlines, so the RECYCLE path
+			// must not cut a legitimately long reply that completes no read for
+			// an interval — wait for the session (or Close) instead. Close still
+			// terminates: once stop fires, the bounded zero-progress close below
+			// applies, which is the shutdown contract (Close never wedges).
+			if !stopping && rt < 0 {
+				select {
+				case <-superDone:
+					return
+				case <-mc.stop:
+					stopping = true
+				}
+				continue
 			}
 			select {
 			case <-superDone:
@@ -465,10 +465,10 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 		case <-mc.stop:
 			stopFlag.Store(true)
 			doRecycle()
-			drainBackstop()
+			drainBackstop(true)
 		case <-recycleTimer.C:
 			doRecycle()
-			drainBackstop()
+			drainBackstop(false)
 		case <-sctx.Done(): // I/O error: unblock a reader/writer parked on the socket
 			_ = cn.Close()
 		case <-superDone:

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -78,7 +78,10 @@ func (mc *cscMissCoalescer) pinnedWorker() {
 				cn = got
 			}
 
-			ctx, cancel := opCtx()
+			// batchBudget, not opCtx: the flush includes the reply reads, which must
+			// honor a deliberately long configured ReadTimeout (opCtx's fixed 5s
+			// would clamp them; see batchBudget).
+			ctx, cancel := context.WithTimeout(context.Background(), mc.batchBudget())
 			settled, ferr := mc.flushBatch(ctx, cn, batch)
 			cancel()
 			if ferr != nil {

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -51,7 +51,9 @@ func (mc *cscMissCoalescer) acquireCtx() (context.Context, context.CancelFunc) {
 	if pt := opt.PoolTimeout; pt > d {
 		d = pt
 	}
-	// Options.init resolves the dial knobs to nonzero defaults.
+	// Options.init resolves the dial knobs to nonzero defaults. A custom
+	// DialerRetryBackoff returning delays beyond DialerRetryTimeout is not
+	// observable here; such configs should raise PoolTimeout to match.
 	if db := time.Duration(opt.DialerRetries)*(opt.DialTimeout+opt.DialerRetryTimeout) + opt.DialTimeout; db > d {
 		d = db
 	}
@@ -410,6 +412,16 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 			}
 		case <-recycleTimer.C:
 			doRecycle()
+			// Same bounded backstop as the stop path: with ReadTimeout disabled a
+			// reader blocked on a non-replying server never observes the recycle,
+			// and with the supervisor gone nothing would ever close the conn — a
+			// later Close would hang in wg.Wait. Force the I/O out if the session
+			// has not drained within the batch budget.
+			select {
+			case <-superDone:
+			case <-time.After(mc.batchBudget()):
+				_ = cn.Close()
+			}
 		case <-sctx.Done(): // I/O error: unblock a reader/writer parked on the socket
 			_ = cn.Close()
 		case <-superDone:

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -425,7 +425,9 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 	recycleTimer := time.NewTimer(c.fullDuplexRecycleAge())
 	defer recycleTimer.Stop()
 	superDone := make(chan struct{})
+	supDead := make(chan struct{}) // closed when the supervisor exits (joined before release)
 	go func() {
+		defer close(supDead)
 		select {
 		case <-mc.stop:
 			stopFlag.Store(true)
@@ -450,6 +452,13 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 
 	swg.Wait()
 	close(superDone)
+	// JOIN the supervisor before releasing the connection: the deferred scancel
+	// makes sctx.Done() ready at return, and if the supervisor were still parked
+	// in its select it could pick that case over the (also-ready) superDone and
+	// close a HEALTHY connection after it went back to the pool — possibly
+	// already acquired by an unrelated command. After this join the supervisor
+	// can no longer touch cn.
+	<-supDead
 
 	// Teardown. Error path: the socket was (or is being) closed; Remove it.
 	// Graceful path: the connection is clean (every written reply was read), so

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -151,16 +151,41 @@ func (mc *cscMissCoalescer) fullDuplexLoop() {
 func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
 	c := mc.c
 
+	// Do not hold a pool connection while idle: wait for the first miss BEFORE
+	// acquiring. An eagerly-held session connection would, at a small pool
+	// (PoolSize:1), starve non-cacheable commands (PING/SET/uncached reads) until
+	// PoolTimeout while the session sat waiting for work. The pulled miss is
+	// written first by the writer below.
+	var first *cscMissReq
+	select {
+	case <-mc.stop:
+		return true
+	case first = <-mc.ch:
+	}
+
 	getCtx, getCancel := opCtx()
 	cn, err := c.getConn(getCtx)
 	getCancel()
 	if err != nil {
-		// No connection: fail everything queued so a caller on a deadline-less
-		// context is not blocked forever and no reservation leaks IN_PROGRESS
-		// (mirrors pinnedWorker's getConn-failure handling). The caller backs off
-		// and retries; requests arriving during backoff are failed on the next
-		// attempt's drain.
+		// No connection: fail the first miss plus everything queued so a caller on
+		// a deadline-less context is not blocked forever and no reservation leaks
+		// IN_PROGRESS (mirrors pinnedWorker's getConn-failure handling). The caller
+		// backs off and retries; requests arriving during backoff are failed on the
+		// next attempt's drain.
+		mc.settleErr(first, err)
 		mc.drainQueueErr(err)
+		return false
+	}
+	// CSC serving may have been disabled after the miss was queued (e.g. a HELLO 3
+	// downgrade or CLIENT TRACKING rejected during initConn). Holding the conn to
+	// wait for more misses would be pointless — none get routed here once serving
+	// is off — and could tie up a small pool. Release it cleanly and fail pending.
+	if a := c.cscActive; a != nil && !a.Load() {
+		relCtx, relCancel := opCtx()
+		c.releaseConn(relCtx, cn, nil)
+		relCancel()
+		mc.settleErr(first, pool.ErrClosed)
+		mc.drainQueueErr(pool.ErrClosed)
 		return false
 	}
 	connID := cn.GetID()
@@ -189,7 +214,7 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
 		return pool.ErrClosed
 	}
 
-	var recycle chan struct{} = make(chan struct{})
+	recycle := make(chan struct{})
 	var recycleOnce sync.Once
 	doRecycle := func() { recycleOnce.Do(func() { close(recycle) }) }
 	var stopFlag atomic.Bool
@@ -211,20 +236,25 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
 		defer swg.Done()
 		defer close(inflight)
 		buf := make([]*cscMissReq, 0, cscMissBatchMax)
+		pending := first // the miss that woke the session; write it before blocking
 		for {
-			var first *cscMissReq
-			select {
-			case <-recycle:
-				return
-			case <-mc.stop:
-				stopFlag.Store(true)
-				doRecycle()
-				return
-			case <-sctx.Done():
-				return
-			case first = <-mc.ch:
+			var req *cscMissReq
+			if pending != nil {
+				req, pending = pending, nil
+			} else {
+				select {
+				case <-recycle:
+					return
+				case <-mc.stop:
+					stopFlag.Store(true)
+					doRecycle()
+					return
+				case <-sctx.Done():
+					return
+				case req = <-mc.ch:
+				}
 			}
-			buf = mc.grabInto(buf[:0], first)
+			buf = mc.grabInto(buf[:0], req)
 			mc.countBatch(buf)
 
 			werr := cn.WithWriter(c.context(sctx), c.opt.WriteTimeout, func(wr *proto.Writer) error {

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -2,7 +2,6 @@ package redis
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -172,22 +171,30 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 	cn, err := c.getConn(getCtx)
 	getCancel()
 	if err != nil {
-		// acquireCtx derives its context from context.Background() and is cancelled
-		// ONLY by mc.stop (its sole non-deadline cancel source), so a context.Canceled
-		// here means the coalescer is tearing down, not that the caller's context or the
-		// pool failed. Settle retry-uncached — like the other stop paths (fetch, the
-		// serving-disabled branch below, stopCSCMissCoalescer) — so processCached re-runs
-		// each read on the still-open pool instead of surfacing a spurious cancellation,
-		// and report stopped so the loop exits without backing off.
-		if errors.Is(err, context.Canceled) {
+		// Distinguish a teardown cancellation from a genuine acquire failure by
+		// checking mc.stop DIRECTLY, not by err's value: getConn runs the dialer,
+		// credentials callbacks, and init hooks, any of which can return
+		// context.Canceled from their OWN context while the coalescer is NOT
+		// stopping. mc.stop is closed only by stopWorkers, and close(mc.stop) is
+		// ordered before acquireCtx cancels its context (which is ordered before
+		// getConn returns), so a real teardown is always visible here.
+		select {
+		case <-mc.stop:
+			// Tearing down: settle retry-uncached — like the other stop paths (fetch,
+			// the serving-disabled branch below, stopCSCMissCoalescer) — so processCached
+			// re-runs each read on the still-open pool instead of surfacing a spurious
+			// cancellation, and report stopped so the loop exits without backing off.
 			mc.settleErr(first, errCSCRetryUncached)
 			mc.drainQueueErr(errCSCRetryUncached)
 			return true, false // stop requested: exit the loop
+		default:
 		}
-		// No connection: fail the first miss plus everything queued so a caller on
-		// a deadline-less context is not blocked forever and no reservation leaks
-		// IN_PROGRESS. The caller backs off and retries; requests arriving during
-		// backoff are failed on the next attempt's drain.
+		// Genuine acquire failure (dial error, pool exhaustion, an unrelated
+		// context.Canceled from a custom dialer/creds/init hook). Fail the first miss
+		// plus everything queued so a caller on a deadline-less context is not blocked
+		// forever and no reservation leaks IN_PROGRESS, then back off and retry so the
+		// sole worker stays alive — requests arriving during backoff are failed on the
+		// next attempt's drain.
 		mc.settleErr(first, err)
 		mc.drainQueueErr(err)
 		return false, true // error end: the loop backs off before re-acquiring

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -184,8 +184,11 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
 		relCtx, relCancel := opCtx()
 		c.releaseConn(relCtx, cn, nil)
 		relCancel()
-		mc.settleErr(first, pool.ErrClosed)
-		mc.drainQueueErr(pool.ErrClosed)
+		// CSC is off now, but the commands are fine — settle with the retry-uncached
+		// sentinel so processCached re-runs each on the normal path instead of
+		// surfacing a spurious pool.ErrClosed for a valid cacheable read.
+		mc.settleErr(first, errCSCRetryUncached)
+		mc.drainQueueErr(errCSCRetryUncached)
 		return false
 	}
 	connID := cn.GetID()

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -84,14 +84,26 @@ var cscFullDuplexIdleProbe = 5 * time.Millisecond
 // can tighten or disable it.
 var cscFullDuplexSessionIdle = time.Second
 
-// fullDuplexRecycleAge bounds how long a single session holds one connection,
-// so the held connection is returned to the pool periodically (a Put runs the
-// OnPut pool hooks: metrics, health, and any queued maintenance handoff). Honors
-// a shorter ConnMaxLifetime.
-func (c *baseClient) fullDuplexRecycleAge() time.Duration {
+// fullDuplexRecycleAge bounds how long a single session holds cn, so the held
+// connection is returned to the pool periodically (a Put runs the OnPut pool
+// hooks: metrics, health, and any queued maintenance handoff). Bounded by the
+// connection's REMAINING absolute lifetime (expiresAt includes
+// ConnMaxLifetimeJitter): an already-old pooled connection must not be held for
+// a fresh full recycle age past the expiry the pool's reaper enforces.
+func (c *baseClient) fullDuplexRecycleAge(cn *pool.Conn) time.Duration {
 	age := 30 * time.Second
 	if c.opt.ConnMaxLifetime > 0 && c.opt.ConnMaxLifetime < age {
 		age = c.opt.ConnMaxLifetime
+	}
+	if exp := cn.ExpiresAt(); !exp.IsZero() {
+		if remain := time.Until(exp); remain < age {
+			age = remain
+		}
+	}
+	// A conn at (or past) expiry still serves the session it was just leased
+	// for — recycle promptly rather than with a zero/negative timer.
+	if age < 10*time.Millisecond {
+		age = 10 * time.Millisecond
 	}
 	return age
 }
@@ -366,7 +378,7 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 
 	// Supervisor: request a graceful recycle on stop or when the session ages
 	// out. A handoff/close request comes from the reader via doRecycle().
-	recycleTimer := time.NewTimer(c.fullDuplexRecycleAge())
+	recycleTimer := time.NewTimer(c.fullDuplexRecycleAge(cn))
 	defer recycleTimer.Stop()
 	superDone := make(chan struct{})
 	supDead := make(chan struct{}) // closed when the supervisor exits (joined before release)

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -34,6 +34,28 @@ func opCtx() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), 5*time.Second)
 }
 
+// acquireCtx bounds a session/batch connection acquisition. Unlike opCtx's
+// fixed 5s it honors a configured PoolTimeout above that (the normal command
+// path and the workers engine via batchBudget both wait the full pool budget
+// under temporary saturation), and it is cancelled when the coalescer stops so
+// Close does not stall behind a Get blocked on a saturated pool.
+func (mc *cscMissCoalescer) acquireCtx() (context.Context, context.CancelFunc) {
+	d := 5 * time.Second
+	if pt := mc.c.opt.PoolTimeout; pt > d {
+		d = pt
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-mc.stop:
+			cancel()
+		case <-done:
+		}
+	}()
+	return ctx, func() { close(done); cancel() }
+}
+
 // pinnedWorker holds one tracked main-pool connection and flushes batches on it
 // one at a time (half-duplex). The connection is reused across batches and only
 // re-acquired after a connection error.
@@ -63,7 +85,7 @@ func (mc *cscMissCoalescer) pinnedWorker() {
 			mc.countBatch(batch)
 
 			if cn == nil {
-				ctx, cancel := opCtx()
+				ctx, cancel := mc.acquireCtx()
 				got, err := c.getConn(ctx)
 				cancel()
 				if err != nil {
@@ -176,7 +198,7 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
 	case first = <-mc.ch:
 	}
 
-	getCtx, getCancel := opCtx()
+	getCtx, getCancel := mc.acquireCtx()
 	cn, err := c.getConn(getCtx)
 	getCancel()
 	if err != nil {

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -359,11 +359,13 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 				// (fulfillCached checks the captured gen). Previously FD failed the
 				// caller with ErrClosed on a mid-flight id/gen change even though the
 				// reply was read fine, losing a good result (#3965).
+				req.servedBy = cn // before settle: done is the happens-before edge
 				mc.applyAndSettle(req, raw, connID, gen)
 				return nil
 			})
 			if rerr != nil {
 				fail(rerr)
+				req.servedBy = cn // attribute the failed read to the session conn
 				mc.settleErr(req, rerr)
 				return false
 			}

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -96,9 +96,11 @@ var cscFullDuplexSessionIdle = time.Second
 // be held past the expiry the pool's reaper enforces.
 func (c *baseClient) fullDuplexRecycleAge(cn *pool.Conn) time.Duration {
 	age := 30 * time.Second
-	if c.opt.ConnMaxLifetime > 0 && c.opt.ConnMaxLifetime < age {
-		age = c.opt.ConnMaxLifetime
-	}
+	// Lifetime is honored via the conn's ACTUAL absolute expiry only —
+	// ExpiresAt already includes ConnMaxLifetimeJitter. Capping at the raw
+	// ConnMaxLifetime first would collapse every positive-jitter connection
+	// back to the unjittered lifetime, re-synchronizing recycles across
+	// clients started together (the herd the jitter option exists to prevent).
 	if exp := cn.ExpiresAt(); !exp.IsZero() {
 		if remain := time.Until(exp); remain < age {
 			age = remain

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -286,6 +286,16 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 			buf = mc.grabInto(buf[:0], req)
 			mc.countBatch(buf)
 
+			// Attribute every request in this batch to the session connection up
+			// front. A write-side failure (WithWriter error, or ctx cancel during the
+			// inflight handoff below) settles via settleAllErr before the reply path
+			// runs, so without this the error metric and processCached would report a
+			// nil connection and zero attempts for commands that did reach cn. buf is
+			// []*cscMissReq, so this persists to the reply path (which re-sets it).
+			for _, r := range buf {
+				r.servedBy = cn
+			}
+
 			// sctx directly, NOT c.context(sctx): c.context() strips the engine's
 			// cancellable session ctx under ContextTimeoutEnabled=false, and with
 			// per-op timeouts disabled a blocked read/write could then never be

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -430,13 +430,16 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 			if rt+time.Second > interval {
 				interval = rt + time.Second
 			}
-			// Deadline-less reads (negative ReadTimeout, no active relaxation):
-			// the user explicitly disabled read deadlines, so the RECYCLE path
-			// must not cut a legitimately long reply that completes no read for
-			// an interval — wait for the session (or Close) instead. Close still
-			// terminates: once stop fires, the bounded zero-progress close below
-			// applies, which is the shutdown contract (Close never wedges).
-			if !stopping && rt < 0 {
+			// Deadline-less reads (no active relaxation): the user explicitly
+			// disabled read deadlines, so the RECYCLE path must not cut a
+			// legitimately long reply that completes no read for an interval —
+			// wait for the session (or Close) instead. Close still terminates:
+			// once stop fires, the bounded zero-progress close below applies,
+			// which is the shutdown contract (Close never wedges). NOTE the
+			// <= 0: Options.init normalizes ReadTimeout -1 (indefinite) to 0
+			// and -2 (no deadline calls) to -1, so BOTH deadline-less modes
+			// land at rt <= 0 here.
+			if !stopping && rt <= 0 {
 				select {
 				case <-superDone:
 					return
@@ -468,6 +471,13 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 			drainBackstop(true)
 		case <-recycleTimer.C:
 			doRecycle()
+			drainBackstop(false)
+		case <-recycle:
+			// Reader-triggered recycle (handoffWanted: unusable / handoff-marked /
+			// close-on-put). The writer exits, but replies may remain in flight —
+			// without a backstop a stalled read would hold the conn (and postpone
+			// the requested handoff) until Close. Same bounded drain as the timer
+			// path; doRecycle already ran (this channel IS the recycle signal).
 			drainBackstop(false)
 		case <-sctx.Done(): // I/O error: unblock a reader/writer parked on the socket
 			_ = cn.Close()

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -161,12 +161,17 @@ func (mc *cscMissCoalescer) fullDuplexLoop() {
 			return
 		default:
 		}
-		if mc.runFullDuplexSession() {
-			return // stop requested
+		stopped, errored := mc.runFullDuplexSession()
+		if stopped {
+			return
 		}
-		// Session ended on a connection error or a clean recycle. On error, back
-		// off briefly so a persistent dial failure does not hot-spin; a clean
-		// recycle continues immediately.
+		// Back off only after an ERROR end, so a persistent dial failure does not
+		// hot-spin; a clean idle/recycle end continues immediately — the next
+		// session blocks on the miss queue anyway, and sleeping here would add a
+		// flat cscModeBackoff of latency to a miss already waiting in mc.ch.
+		if !errored {
+			continue
+		}
 		select {
 		case <-mc.stop:
 			return
@@ -183,7 +188,7 @@ func (mc *cscMissCoalescer) fullDuplexLoop() {
 //     and any queued maintenance handoff).
 //
 // Returns true iff stop was requested (the loop should exit).
-func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
+func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 	c := mc.c
 
 	// Do not hold a pool connection while idle: wait for the first miss BEFORE
@@ -194,7 +199,7 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
 	var first *cscMissReq
 	select {
 	case <-mc.stop:
-		return true
+		return true, false
 	case first = <-mc.ch:
 	}
 
@@ -209,7 +214,7 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
 		// next attempt's drain.
 		mc.settleErr(first, err)
 		mc.drainQueueErr(err)
-		return false
+		return false, true // error end: the loop backs off before re-acquiring
 	}
 	// CSC serving may have been disabled after the miss was queued (e.g. a HELLO 3
 	// downgrade or CLIENT TRACKING rejected during initConn). Holding the conn to
@@ -224,7 +229,7 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
 		// surfacing a spurious pool.ErrClosed for a valid cacheable read.
 		mc.settleErr(first, errCSCRetryUncached)
 		mc.drainQueueErr(errCSCRetryUncached)
-		return false
+		return false, false // clean end: no new misses route here while serving is off
 	}
 	connID := cn.GetID()
 	gen := c.cscConnInitGen(connID)
@@ -451,11 +456,11 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
 		select {
 		case r, ok := <-inflight:
 			if !ok {
-				return stopFlag.Load()
+				return stopFlag.Load(), errored()
 			}
 			mc.settleErr(r, reasonErr())
 		default:
-			return stopFlag.Load()
+			return stopFlag.Load(), errored()
 		}
 	}
 }

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -365,18 +365,15 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 				// the raw client would self-deadlock (Close waits on mc.wg while
 				// the reader is parked inside the handler). The adapter's Close
 				// signals and defers the blocking teardown to a goroutine.
-				handlerCtx := c.pushNotificationHandlerContext(cn)
-				handlerCtx.Client = cscHandlerClient{baseClient: c}
-				if e := c.pushProcessor.ProcessPendingNotifications(sctx, handlerCtx, rd); e != nil {
-					// FATAL, not log-and-continue: a surfaced processor error
-					// means bytes may have been consumed mid-frame (the built-in
-					// processor swallows benign boundary timeouts and surfaces
-					// only mid-frame failures; a custom processor's contract
-					// cannot prove no bytes were consumed). Continuing into
-					// ReadRawReply on a desynchronized stream could apply a push
-					// fragment as this request's reply AND publish it to the
-					// cache. Same policy as drainPushNotifications: fail the
-					// session so the connection is closed and removed.
+				// Drain server pushes before reading this request's reply, through the
+				// shared helper: the built-in processor uses the Buffered variant so a
+				// mid-frame error PROPAGATES, and a custom processor is handed only a
+				// confirmed push frame (peek first). FATAL, not log-and-continue: a
+				// drain error means bytes may have been consumed mid-frame, so
+				// continuing into ReadRawReply on a desynchronized stream could apply a
+				// push fragment as this request's reply and publish it to the cache
+				// under the wrong key. Fail the session so the connection is removed.
+				if e := c.drainPushFrames(sctx, cn, rd); e != nil {
 					internal.Logger.Printf(sctx, "csc: miss-coalesce push drain: %v", e)
 					return e
 				}

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -338,7 +338,17 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 				handlerCtx := c.pushNotificationHandlerContext(cn)
 				handlerCtx.Client = cscHandlerClient{baseClient: c}
 				if e := c.pushProcessor.ProcessPendingNotifications(sctx, handlerCtx, rd); e != nil {
+					// FATAL, not log-and-continue: a surfaced processor error
+					// means bytes may have been consumed mid-frame (the built-in
+					// processor swallows benign boundary timeouts and surfaces
+					// only mid-frame failures; a custom processor's contract
+					// cannot prove no bytes were consumed). Continuing into
+					// ReadRawReply on a desynchronized stream could apply a push
+					// fragment as this request's reply AND publish it to the
+					// cache. Same policy as drainPushNotifications: fail the
+					// session so the connection is closed and removed.
 					internal.Logger.Printf(sctx, "csc: miss-coalesce push drain: %v", e)
+					return e
 				}
 				raw, e := rd.ReadRawReply()
 				if e != nil {

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -327,7 +327,14 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 
 		readOne := func(req *cscMissReq) bool { // false => fatal, reader must exit
 			rerr := cn.WithReader(sctx, c.opt.ReadTimeout, func(rd *proto.Reader) error {
-				if e := c.processPendingPushNotificationWithReader(sctx, cn, rd); e != nil {
+				// Push handling with the nonblocking Close adapter: this reader
+				// is part of mc.wg, so a custom push handler calling Close() on
+				// the raw client would self-deadlock (Close waits on mc.wg while
+				// the reader is parked inside the handler). The adapter's Close
+				// signals and defers the blocking teardown to a goroutine.
+				handlerCtx := c.pushNotificationHandlerContext(cn)
+				handlerCtx.Client = cscHandlerClient{baseClient: c}
+				if e := c.pushProcessor.ProcessPendingNotifications(sctx, handlerCtx, rd); e != nil {
 					internal.Logger.Printf(sctx, "csc: miss-coalesce push drain: %v", e)
 				}
 				raw, e := rd.ReadRawReply()

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -39,14 +39,21 @@ func opCtx() (context.Context, context.CancelFunc) {
 }
 
 // acquireCtx bounds a session connection acquisition. Unlike opCtx's fixed 5s
-// it honors a configured PoolTimeout above that (the normal command path waits
-// the full pool budget under temporary saturation), and it is cancelled when
-// the coalescer stops so Close does not stall behind a Get blocked on a
-// saturated pool.
+// it honors the larger of the configured PoolTimeout (a saturated pool may
+// legitimately make Get wait that long) and the pool's full dial budget
+// (DialerRetries attempts of DialTimeout plus backoffs — a shorter outer
+// deadline would cancel Get mid-dial-sequence and forfeit configured retries).
+// Cancelled when the coalescer stops, so Close does not stall behind a blocked
+// Get.
 func (mc *cscMissCoalescer) acquireCtx() (context.Context, context.CancelFunc) {
+	opt := mc.c.opt
 	d := 5 * time.Second
-	if pt := mc.c.opt.PoolTimeout; pt > d {
+	if pt := opt.PoolTimeout; pt > d {
 		d = pt
+	}
+	// Options.init resolves the dial knobs to nonzero defaults.
+	if db := time.Duration(opt.DialerRetries)*(opt.DialTimeout+opt.DialerRetryTimeout) + opt.DialTimeout; db > d {
+		d = db
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), d)
 	done := make(chan struct{})
@@ -74,22 +81,16 @@ const cscFullDuplexConnsDefault = 1
 // can disable the idle drain (set it huge) as a negative control.
 var cscFullDuplexIdleProbe = 5 * time.Millisecond
 
-// cscFullDuplexSessionIdle is how long a session's writer waits for the next
-// miss before ending the session and returning its held connection to the pool.
-// Without it a session sits on a pool connection for up to fullDuplexRecycleAge
-// (30s) with no miss in flight, and at a small pool (PoolSize:1) a non-cacheable
-// command (PING/SET/uncached read) blocks behind it. The next miss re-acquires —
-// runFullDuplexSession already waits for work BEFORE taking a connection. Under
-// steady miss load the timer is reset per batch and never fires. A var so tests
-// can tighten or disable it.
+// cscFullDuplexSessionIdle: a session with no miss for this long ends and
+// returns its held connection (at PoolSize:1 an idle hold would block
+// non-cacheable commands until PoolTimeout). The next miss re-acquires; under
+// steady load the timer never fires. Var for tests.
 var cscFullDuplexSessionIdle = time.Second
 
-// fullDuplexRecycleAge bounds how long a single session holds cn, so the held
-// connection is returned to the pool periodically (a Put runs the OnPut pool
-// hooks: metrics, health, and any queued maintenance handoff). Bounded by the
-// connection's REMAINING absolute lifetime (expiresAt includes
-// ConnMaxLifetimeJitter): an already-old pooled connection must not be held for
-// a fresh full recycle age past the expiry the pool's reaper enforces.
+// fullDuplexRecycleAge bounds how long a session holds cn so OnPut pool hooks
+// (metrics, health, queued maintenance handoff) run periodically. Capped by the
+// conn's REMAINING lifetime (ExpiresAt, jitter included): an old conn must not
+// be held past the expiry the pool's reaper enforces.
 func (c *baseClient) fullDuplexRecycleAge(cn *pool.Conn) time.Duration {
 	age := 30 * time.Second
 	if c.opt.ConnMaxLifetime > 0 && c.opt.ConnMaxLifetime < age {
@@ -274,12 +275,10 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 			buf = mc.grabInto(buf[:0], req)
 			mc.countBatch(buf)
 
-			// sctx directly, NOT c.context(sctx): sctx is the ENGINE's cancellable
-			// session context, and with the default ContextTimeoutEnabled=false
-			// c.context() would strip it to context.Background() — then, with the
-			// per-op timeout disabled too, a blocked write/read could not be
-			// interrupted and Close would hang in wg.Wait (see the supervisor's
-			// stop-deadline below, which closes the conn as the backstop).
+			// sctx directly, NOT c.context(sctx): c.context() strips the engine's
+			// cancellable session ctx under ContextTimeoutEnabled=false, and with
+			// per-op timeouts disabled a blocked read/write could then never be
+			// interrupted (the supervisor's conn-close is the backstop).
 			werr := cn.WithWriter(sctx, c.opt.WriteTimeout, func(wr *proto.Writer) error {
 				for _, r := range buf {
 					if e := writeCmd(wr, r.cmd); e != nil {
@@ -367,16 +366,13 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 					fail(e)
 					return
 				}
-				// Opaque-transport fallback, HELD-CONN ONLY: where socket readiness
-				// cannot be inspected (Windows; dialer wrappers exposing neither
-				// syscall.Conn nor NetConn) the readiness-gated peek above never
-				// fires, and unlike pooled connections nothing else ever drains this
-				// conn — a push would sit unread until the next reply. Run a
-				// throttled timed drain (at most once per cscFallbackProbeInterval;
-				// TakeCscPeriodicReadPending is a no-op on inspectable transports).
-				// Deliberately NOT inside peekAndProcessPushNotifications: pooled
-				// push paths have the drainer/health-check coverage, and a blanket
-				// fallback there perturbs sequenced push handling (mock-conn tests).
+				// Opaque-transport fallback, HELD-CONN ONLY: where readiness cannot
+				// be inspected (Windows; wrappers exposing neither syscall.Conn nor
+				// NetConn) the gated peek never fires and nothing else drains this
+				// conn. Throttled timed drain (no-op on inspectable transports).
+				// Deliberately not in peekAndProcessPushNotifications: pooled paths
+				// have drainer coverage, and a blanket fallback perturbs sequenced
+				// push handling.
 				if cn.TakeCscPeriodicReadPending(cscFallbackProbeInterval) {
 					if e := c.timedPushDrain(sctx, cn); e != nil {
 						fail(e)
@@ -404,11 +400,9 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 		case <-mc.stop:
 			stopFlag.Store(true)
 			doRecycle()
-			// Graceful drain first — but bounded: with ReadTimeout disabled a
-			// server that never replies would leave the reader blocked in a socket
-			// read that no context can interrupt, wedging stopCSCMissCoalescer's
-			// wg.Wait and therefore Client.Close. If the session has not ended
-			// within the batch budget, close the connection to force the I/O out.
+			// Bounded graceful drain: no context can interrupt a deadline-less
+			// socket read, so if the session has not ended within the batch budget,
+			// close the conn to force the I/O out (else Close wedges in wg.Wait).
 			select {
 			case <-superDone:
 			case <-time.After(mc.batchBudget()):
@@ -424,12 +418,9 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 
 	swg.Wait()
 	close(superDone)
-	// JOIN the supervisor before releasing the connection: the deferred scancel
-	// makes sctx.Done() ready at return, and if the supervisor were still parked
-	// in its select it could pick that case over the (also-ready) superDone and
-	// close a HEALTHY connection after it went back to the pool — possibly
-	// already acquired by an unrelated command. After this join the supervisor
-	// can no longer touch cn.
+	// JOIN the supervisor before releasing cn: the deferred scancel makes
+	// sctx.Done() ready, and a still-parked supervisor could pick it over the
+	// equally-ready superDone and close a healthy conn already back in the pool.
 	<-supDead
 
 	// Teardown. Error path: the socket was (or is being) closed; Remove it.

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -1,0 +1,374 @@
+package redis
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/redis/go-redis/v9/internal"
+	"github.com/redis/go-redis/v9/internal/pool"
+	"github.com/redis/go-redis/v9/internal/proto"
+)
+
+// Alternate miss-coalescer engines (PROTOTYPE, benchmark comparison).
+//
+//   - pinnedWorker: one held tracked connection, serial half-duplex batches.
+//     Removes pool Get/Put churn and connection-count contention, but each batch
+//     costs a full RTT before the next starts.
+//   - fullDuplexLoop: one held tracked connection with concurrent writer + reader
+//     goroutines. Commands stream out while replies stream back, so many commands
+//     are in flight on a single socket (the rueidis pipelining model). Hides RTT
+//     with one connection instead of N.
+//
+// Both hold a connection outside the normal pool Get/Put cycle and redial on
+// error. Correctness note: a held connection spans reconnects, so on ANY
+// connection error every in-flight request is failed (token cancelled, caller
+// woken) rather than matched to a reply across tracking generations, and a
+// published reply is gated on the reading connection's id+generation still
+// matching the one captured when the command was written.
+
+const cscModeBackoff = 5 * time.Millisecond
+
+func opCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 5*time.Second)
+}
+
+// pinnedWorker holds one tracked main-pool connection and flushes batches on it
+// one at a time (half-duplex). The connection is reused across batches and only
+// re-acquired after a connection error.
+func (mc *cscMissCoalescer) pinnedWorker() {
+	defer mc.wg.Done()
+	c := mc.c
+
+	var cn *pool.Conn
+	release := func(err error) {
+		if cn == nil {
+			return
+		}
+		ctx, cancel := opCtx()
+		c.releaseConn(ctx, cn, err)
+		cancel()
+		cn = nil
+	}
+	defer release(nil)
+
+	batch := make([]*cscMissReq, 0, cscMissBatchMax)
+	for {
+		select {
+		case <-mc.stop:
+			return
+		case req := <-mc.ch:
+			batch = mc.grabInto(batch[:0], req)
+			mc.countBatch(batch)
+
+			if cn == nil {
+				ctx, cancel := opCtx()
+				got, err := c.getConn(ctx)
+				cancel()
+				if err != nil {
+					mc.settleAllErr(batch, 0, err)
+					select {
+					case <-mc.stop:
+						return
+					case <-time.After(cscModeBackoff):
+					}
+					continue
+				}
+				cn = got
+			}
+
+			ctx, cancel := opCtx()
+			settled, ferr := mc.flushBatch(ctx, cn, batch)
+			cancel()
+			if ferr != nil {
+				release(ferr) // retire the bad connection; next batch re-acquires
+				mc.settleAllErr(batch, settled, ferr)
+			}
+		}
+	}
+}
+
+// ---- full-duplex engine (feature-complete) ----
+
+// cscFullDuplexConnsDefault is how many independent full-duplex sessions (each
+// its own held connection) the fullduplex engine runs. 1 keeps the footprint
+// minimal (optimal at high concurrency). More would shard the miss +
+// invalidation-drain load across connections, cutting the low-concurrency p99
+// tail. Order-free: coalesced misses are independent per-key fetches.
+const cscFullDuplexConnsDefault = 1
+
+// cscFullDuplexIdleProbe is how often the reader drains server-initiated pushes
+// on the held connection while no reply is pending. A var (not const) so a test
+// can disable the idle drain (set it huge) as a negative control.
+var cscFullDuplexIdleProbe = 5 * time.Millisecond
+
+// fullDuplexRecycleAge bounds how long a single session holds one connection,
+// so the held connection is returned to the pool periodically (a Put runs the
+// OnPut pool hooks: metrics, health, and any queued maintenance handoff). Honors
+// a shorter ConnMaxLifetime.
+func (c *baseClient) fullDuplexRecycleAge() time.Duration {
+	age := 30 * time.Second
+	if c.opt.ConnMaxLifetime > 0 && c.opt.ConnMaxLifetime < age {
+		age = c.opt.ConnMaxLifetime
+	}
+	return age
+}
+
+// fullDuplexLoop runs full-duplex sessions back to back: each session holds one
+// tracked connection until it errors, is recycled (handoff/close/age), or stop
+// is requested. Exits on stop.
+func (mc *cscMissCoalescer) fullDuplexLoop() {
+	defer mc.wg.Done()
+	for {
+		select {
+		case <-mc.stop:
+			return
+		default:
+		}
+		if mc.runFullDuplexSession() {
+			return // stop requested
+		}
+		// Session ended on a connection error or a clean recycle. On error, back
+		// off briefly so a persistent dial failure does not hot-spin; a clean
+		// recycle continues immediately.
+		select {
+		case <-mc.stop:
+			return
+		case <-time.After(cscModeBackoff):
+		}
+	}
+}
+
+// runFullDuplexSession acquires one tracked connection and pipelines misses on
+// it with concurrent writer and reader goroutines. It ends when:
+//   - a socket read/write errors (fail path: fail in-flight, Close + Remove);
+//   - the connection is marked for handoff/close, the session ages out, or stop
+//     is requested (graceful path: drain in-flight, Put so OnPut runs pool hooks
+//     and any queued maintenance handoff).
+//
+// Returns true iff stop was requested (the loop should exit).
+func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
+	c := mc.c
+
+	getCtx, getCancel := opCtx()
+	cn, err := c.getConn(getCtx)
+	getCancel()
+	if err != nil {
+		// No connection: fail everything queued so a caller on a deadline-less
+		// context is not blocked forever and no reservation leaks IN_PROGRESS
+		// (mirrors pinnedWorker's getConn-failure handling). The caller backs off
+		// and retries; requests arriving during backoff are failed on the next
+		// attempt's drain.
+		mc.drainQueueErr(err)
+		return false
+	}
+	connID := cn.GetID()
+	gen := c.cscConnInitGen(connID)
+
+	inflight := make(chan *cscMissReq, cscFullDuplexDepth)
+	sctx, scancel := context.WithCancel(context.Background())
+	defer scancel()
+
+	var sessErr atomic.Value // error, set only on I/O failure
+	var failOnce sync.Once
+	fail := func(e error) {
+		failOnce.Do(func() {
+			if e == nil {
+				e = pool.ErrClosed
+			}
+			sessErr.Store(e)
+			scancel()
+		})
+	}
+	errored := func() bool { _, ok := sessErr.Load().(error); return ok }
+	reasonErr := func() error {
+		if e, ok := sessErr.Load().(error); ok {
+			return e
+		}
+		return pool.ErrClosed
+	}
+
+	var recycle chan struct{} = make(chan struct{})
+	var recycleOnce sync.Once
+	doRecycle := func() { recycleOnce.Do(func() { close(recycle) }) }
+	var stopFlag atomic.Bool
+
+	// handoffWanted reports whether the connection should be returned to the pool
+	// so the OnPut hooks (including a queued maintenance handoff) can run.
+	handoffWanted := func() bool {
+		return !cn.IsUsable() || cn.ShouldHandoff() || cn.CloseOnPutReason() != ""
+	}
+
+	var swg sync.WaitGroup
+	swg.Add(2)
+
+	// Writer: pull a request (plus whatever else is queued), write the batch,
+	// then enqueue each written request to the reader in wire order. The writer
+	// is the SOLE closer of inflight and closes it as its last act on every exit
+	// path, which is how the reader learns the session drained.
+	go func() {
+		defer swg.Done()
+		defer close(inflight)
+		buf := make([]*cscMissReq, 0, cscMissBatchMax)
+		for {
+			var first *cscMissReq
+			select {
+			case <-recycle:
+				return
+			case <-mc.stop:
+				stopFlag.Store(true)
+				doRecycle()
+				return
+			case <-sctx.Done():
+				return
+			case first = <-mc.ch:
+			}
+			buf = mc.grabInto(buf[:0], first)
+			mc.countBatch(buf)
+
+			werr := cn.WithWriter(c.context(sctx), c.opt.WriteTimeout, func(wr *proto.Writer) error {
+				for _, r := range buf {
+					if e := writeCmd(wr, r.cmd); e != nil {
+						return e
+					}
+				}
+				return nil
+			})
+			if werr != nil {
+				fail(werr)
+				mc.settleAllErr(buf, 0, werr)
+				return
+			}
+			for i, r := range buf {
+				select {
+				case inflight <- r:
+				case <-sctx.Done():
+					mc.settleAllErr(buf, i, reasonErr())
+					return
+				}
+			}
+		}
+	}()
+
+	// Reader: settle replies in the order the writer enqueued them (== wire
+	// order), and drain server-initiated pushes (invalidations, maintenance)
+	// even while idle. Publishes only while the connection's id+generation still
+	// match the session's.
+	go func() {
+		defer swg.Done()
+		ticker := time.NewTicker(cscFullDuplexIdleProbe)
+		defer ticker.Stop()
+
+		readOne := func(req *cscMissReq) bool { // false => fatal, reader must exit
+			rerr := cn.WithReader(c.context(sctx), c.opt.ReadTimeout, func(rd *proto.Reader) error {
+				if e := c.processPendingPushNotificationWithReader(sctx, cn, rd); e != nil {
+					internal.Logger.Printf(sctx, "csc: miss-coalesce push drain: %v", e)
+				}
+				raw, e := rd.ReadRawReply()
+				if e != nil {
+					return e
+				}
+				if cn.GetID() == connID && c.cscConnInitGen(connID) == gen {
+					mc.applyAndSettle(req, raw, connID, gen)
+				} else {
+					mc.settleErr(req, pool.ErrClosed)
+				}
+				return nil
+			})
+			if rerr != nil {
+				fail(rerr)
+				mc.settleErr(req, rerr)
+				return false
+			}
+			return true
+		}
+
+		// handoff/close is a rare, non-latency-critical event, so it is checked off
+		// the per-reply hot path: on every idle tick, and once every readsPerHandoffCheck
+		// replies (~a few ms of traffic at any throughput).
+		const readsPerHandoffCheck = 128
+		reads := 0
+		for {
+			select {
+			case req, ok := <-inflight:
+				if !ok {
+					return // writer closed: session drained clean
+				}
+				if !readOne(req) {
+					return
+				}
+				reads++
+				if reads%readsPerHandoffCheck == 0 && handoffWanted() {
+					doRecycle()
+				}
+			case <-ticker.C:
+				// No reply was ready this tick: drain any server-initiated pushes
+				// (invalidations, MOVING, ...) unconditionally — the held connection
+				// is out of the pool, so the background drainer never visits it. Safe
+				// even if a reply is on the wire: the push processor peeks the reply
+				// type and consumes only push frames, leaving the reply for the next
+				// inflight read.
+				if e := c.peekAndProcessPushNotifications(sctx, cn); e != nil {
+					fail(e)
+					return
+				}
+				if handoffWanted() {
+					doRecycle()
+				}
+			case <-sctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Supervisor: request a graceful recycle on stop or when the session ages
+	// out. A handoff/close request comes from the reader via doRecycle().
+	recycleTimer := time.NewTimer(c.fullDuplexRecycleAge())
+	defer recycleTimer.Stop()
+	superDone := make(chan struct{})
+	go func() {
+		select {
+		case <-mc.stop:
+			stopFlag.Store(true)
+			doRecycle()
+		case <-recycleTimer.C:
+			doRecycle()
+		case <-sctx.Done(): // I/O error: unblock a reader/writer parked on the socket
+			_ = cn.Close()
+		case <-superDone:
+		}
+	}()
+
+	swg.Wait()
+	close(superDone)
+
+	// Teardown. Error path: the socket was (or is being) closed; Remove it.
+	// Graceful path: the connection is clean (every written reply was read), so
+	// Put it — OnPut runs the pool hooks and any queued maintenance handoff, and
+	// the handoff/reinit path evicts this connection's now-uncovered CSC entries.
+	relCtx, relCancel := opCtx()
+	if errored() {
+		_ = cn.Close()
+		c.releaseConn(relCtx, cn, reasonErr())
+	} else {
+		c.releaseConn(relCtx, cn, nil)
+	}
+	relCancel()
+
+	// Fail anything the writer enqueued that the reader never consumed (only
+	// possible on the error path; the graceful path drains inflight fully). The
+	// writer always closes inflight on exit, so a receive here can report the
+	// channel closed (ok=false) — do not settle a nil request.
+	for {
+		select {
+		case r, ok := <-inflight:
+			if !ok {
+				return stopFlag.Load()
+			}
+			mc.settleErr(r, reasonErr())
+		default:
+			return stopFlag.Load()
+		}
+	}
+}

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -396,32 +396,41 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 	defer recycleTimer.Stop()
 	superDone := make(chan struct{})
 	supDead := make(chan struct{}) // closed when the supervisor exits (joined before release)
+	// drainBackstop bounds a graceful drain by PROGRESS, not wall clock: no
+	// context can interrupt a deadline-less socket read, so a stalled drain must
+	// force the I/O out with a conn close (else Close wedges in wg.Wait) — but a
+	// HEALTHY drain of a deep in-flight pipeline (up to cscFullDuplexDepth
+	// replies, ~in-flight × RTT, possibly under a maintenance-relaxed timeout)
+	// may legitimately exceed any fixed budget. Each budget interval that
+	// consumed at least one reply extends the wait; only a zero-progress
+	// interval closes the conn.
+	drainBackstop := func() {
+		prev := len(inflight)
+		for {
+			select {
+			case <-superDone:
+				return
+			case <-time.After(mc.batchBudget()):
+				cur := len(inflight)
+				if cur < prev {
+					prev = cur // draining; give it another interval
+					continue
+				}
+				_ = cn.Close()
+				return
+			}
+		}
+	}
 	go func() {
 		defer close(supDead)
 		select {
 		case <-mc.stop:
 			stopFlag.Store(true)
 			doRecycle()
-			// Bounded graceful drain: no context can interrupt a deadline-less
-			// socket read, so if the session has not ended within the batch budget,
-			// close the conn to force the I/O out (else Close wedges in wg.Wait).
-			select {
-			case <-superDone:
-			case <-time.After(mc.batchBudget()):
-				_ = cn.Close()
-			}
+			drainBackstop()
 		case <-recycleTimer.C:
 			doRecycle()
-			// Same bounded backstop as the stop path: with ReadTimeout disabled a
-			// reader blocked on a non-replying server never observes the recycle,
-			// and with the supervisor gone nothing would ever close the conn — a
-			// later Close would hang in wg.Wait. Force the I/O out if the session
-			// has not drained within the batch budget.
-			select {
-			case <-superDone:
-			case <-time.After(mc.batchBudget()):
-				_ = cn.Close()
-			}
+			drainBackstop()
 		case <-sctx.Done(): // I/O error: unblock a reader/writer parked on the socket
 			_ = cn.Close()
 		case <-superDone:

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -367,6 +367,22 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 					fail(e)
 					return
 				}
+				// Opaque-transport fallback, HELD-CONN ONLY: where socket readiness
+				// cannot be inspected (Windows; dialer wrappers exposing neither
+				// syscall.Conn nor NetConn) the readiness-gated peek above never
+				// fires, and unlike pooled connections nothing else ever drains this
+				// conn — a push would sit unread until the next reply. Run a
+				// throttled timed drain (at most once per cscFallbackProbeInterval;
+				// TakeCscPeriodicReadPending is a no-op on inspectable transports).
+				// Deliberately NOT inside peekAndProcessPushNotifications: pooled
+				// push paths have the drainer/health-check coverage, and a blanket
+				// fallback there perturbs sequenced push handling (mock-conn tests).
+				if cn.TakeCscPeriodicReadPending(cscFallbackProbeInterval) {
+					if e := c.timedPushDrain(sctx, cn); e != nil {
+						fail(e)
+						return
+					}
+				}
 				if handoffWanted() {
 					doRecycle()
 				}

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -11,22 +11,26 @@ import (
 	"github.com/redis/go-redis/v9/internal/proto"
 )
 
-// Alternate miss-coalescer engines (PROTOTYPE, benchmark comparison).
+// The full-duplex miss-coalescer engine — THE engine behind
+// Options.ClientSideCacheCoalesceMisses (misses are caller-blocking, so the
+// latency-first streaming engine is the only one; see csc_miss_coalesce.go for
+// the removed alternatives).
 //
-//   - pinnedWorker: one held tracked connection, serial half-duplex batches.
-//     Removes pool Get/Put churn and connection-count contention, but each batch
-//     costs a full RTT before the next starts.
-//   - fullDuplexLoop: one held tracked connection with concurrent writer + reader
-//     goroutines. Commands stream out while replies stream back, so many commands
-//     are in flight on a single socket (the rueidis pipelining model). Hides RTT
-//     with one connection instead of N.
+// fullDuplexLoop runs sessions holding one tracked connection with concurrent
+// writer + reader goroutines: commands stream out while replies stream back, so
+// many commands are in flight on a single socket (the rueidis pipelining
+// model) — hides RTT with one connection instead of N.
 //
-// Both hold a connection outside the normal pool Get/Put cycle and redial on
-// error. Correctness note: a held connection spans reconnects, so on ANY
-// connection error every in-flight request is failed (token cancelled, caller
-// woken) rather than matched to a reply across tracking generations, and a
-// published reply is gated on the reading connection's id+generation still
+// A session holds its connection outside the normal pool Get/Put cycle and
+// redials on error. Correctness note: a held connection spans reconnects, so on
+// ANY connection error every in-flight request is failed (token cancelled,
+// caller woken) rather than matched to a reply across tracking generations, and
+// a published reply is gated on the reading connection's id+generation still
 // matching the one captured when the command was written.
+//
+// (An earlier "pinned" engine — one held conn, serial half-duplex batches, NO
+// idle invalidation drain — was a benchmark-only prototype and has been
+// removed: it could serve stale after an invalidation while idle.)
 
 const cscModeBackoff = 5 * time.Millisecond
 
@@ -34,11 +38,11 @@ func opCtx() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), 5*time.Second)
 }
 
-// acquireCtx bounds a session/batch connection acquisition. Unlike opCtx's
-// fixed 5s it honors a configured PoolTimeout above that (the normal command
-// path and the workers engine via batchBudget both wait the full pool budget
-// under temporary saturation), and it is cancelled when the coalescer stops so
-// Close does not stall behind a Get blocked on a saturated pool.
+// acquireCtx bounds a session connection acquisition. Unlike opCtx's fixed 5s
+// it honors a configured PoolTimeout above that (the normal command path waits
+// the full pool budget under temporary saturation), and it is cancelled when
+// the coalescer stops so Close does not stall behind a Get blocked on a
+// saturated pool.
 func (mc *cscMissCoalescer) acquireCtx() (context.Context, context.CancelFunc) {
 	d := 5 * time.Second
 	if pt := mc.c.opt.PoolTimeout; pt > d {
@@ -54,64 +58,6 @@ func (mc *cscMissCoalescer) acquireCtx() (context.Context, context.CancelFunc) {
 		}
 	}()
 	return ctx, func() { close(done); cancel() }
-}
-
-// pinnedWorker holds one tracked main-pool connection and flushes batches on it
-// one at a time (half-duplex). The connection is reused across batches and only
-// re-acquired after a connection error.
-func (mc *cscMissCoalescer) pinnedWorker() {
-	defer mc.wg.Done()
-	c := mc.c
-
-	var cn *pool.Conn
-	release := func(err error) {
-		if cn == nil {
-			return
-		}
-		ctx, cancel := opCtx()
-		c.releaseConn(ctx, cn, err)
-		cancel()
-		cn = nil
-	}
-	defer release(nil)
-
-	batch := make([]*cscMissReq, 0, cscMissBatchMax)
-	for {
-		select {
-		case <-mc.stop:
-			return
-		case req := <-mc.ch:
-			batch = mc.grabInto(batch[:0], req)
-			mc.countBatch(batch)
-
-			if cn == nil {
-				ctx, cancel := mc.acquireCtx()
-				got, err := c.getConn(ctx)
-				cancel()
-				if err != nil {
-					mc.settleAllErr(batch, 0, err)
-					select {
-					case <-mc.stop:
-						return
-					case <-time.After(cscModeBackoff):
-					}
-					continue
-				}
-				cn = got
-			}
-
-			// batchBudget, not opCtx: the flush includes the reply reads, which must
-			// honor a deliberately long configured ReadTimeout (opCtx's fixed 5s
-			// would clamp them; see batchBudget).
-			ctx, cancel := context.WithTimeout(context.Background(), mc.batchBudget())
-			settled, ferr := mc.flushBatch(ctx, cn, batch)
-			cancel()
-			if ferr != nil {
-				release(ferr) // retire the bad connection; next batch re-acquires
-				mc.settleAllErr(batch, settled, ferr)
-			}
-		}
-	}
 }
 
 // ---- full-duplex engine (feature-complete) ----
@@ -209,9 +155,8 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 	if err != nil {
 		// No connection: fail the first miss plus everything queued so a caller on
 		// a deadline-less context is not blocked forever and no reservation leaks
-		// IN_PROGRESS (mirrors pinnedWorker's getConn-failure handling). The caller
-		// backs off and retries; requests arriving during backoff are failed on the
-		// next attempt's drain.
+		// IN_PROGRESS. The caller backs off and retries; requests arriving during
+		// backoff are failed on the next attempt's drain.
 		mc.settleErr(first, err)
 		mc.drainQueueErr(err)
 		return false, true // error end: the loop backs off before re-acquiring
@@ -367,10 +312,9 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 				}
 				// Deliver the reply the caller is waiting for and let applyAndSettle
 				// gate only the CACHE PUBLISH on the connection's id/generation
-				// (fulfillCached checks the captured gen) — matching the workers and
-				// pinned engines. Previously FD failed the caller with ErrClosed on a
-				// mid-flight id/gen change even though the reply was read fine, losing
-				// a good result (#3965).
+				// (fulfillCached checks the captured gen). Previously FD failed the
+				// caller with ErrClosed on a mid-flight id/gen change even though the
+				// reply was read fine, losing a good result (#3965).
 				mc.applyAndSettle(req, raw, connID, gen)
 				return nil
 			})

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -171,6 +172,18 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 	cn, err := c.getConn(getCtx)
 	getCancel()
 	if err != nil {
+		// acquireCtx derives its context from context.Background() and is cancelled
+		// ONLY by mc.stop (its sole non-deadline cancel source), so a context.Canceled
+		// here means the coalescer is tearing down, not that the caller's context or the
+		// pool failed. Settle retry-uncached — like the other stop paths (fetch, the
+		// serving-disabled branch below, stopCSCMissCoalescer) — so processCached re-runs
+		// each read on the still-open pool instead of surfacing a spurious cancellation,
+		// and report stopped so the loop exits without backing off.
+		if errors.Is(err, context.Canceled) {
+			mc.settleErr(first, errCSCRetryUncached)
+			mc.drainQueueErr(errCSCRetryUncached)
+			return true, false // stop requested: exit the loop
+		}
 		// No connection: fail the first miss plus everything queued so a caller on
 		// a deadline-less context is not blocked forever and no reservation leaks
 		// IN_PROGRESS. The caller backs off and retries; requests arriving during

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -317,7 +317,13 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 			buf = mc.grabInto(buf[:0], req)
 			mc.countBatch(buf)
 
-			werr := cn.WithWriter(c.context(sctx), c.opt.WriteTimeout, func(wr *proto.Writer) error {
+			// sctx directly, NOT c.context(sctx): sctx is the ENGINE's cancellable
+			// session context, and with the default ContextTimeoutEnabled=false
+			// c.context() would strip it to context.Background() — then, with the
+			// per-op timeout disabled too, a blocked write/read could not be
+			// interrupted and Close would hang in wg.Wait (see the supervisor's
+			// stop-deadline below, which closes the conn as the backstop).
+			werr := cn.WithWriter(sctx, c.opt.WriteTimeout, func(wr *proto.Writer) error {
 				for _, r := range buf {
 					if e := writeCmd(wr, r.cmd); e != nil {
 						return e
@@ -351,7 +357,7 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 		defer ticker.Stop()
 
 		readOne := func(req *cscMissReq) bool { // false => fatal, reader must exit
-			rerr := cn.WithReader(c.context(sctx), c.opt.ReadTimeout, func(rd *proto.Reader) error {
+			rerr := cn.WithReader(sctx, c.opt.ReadTimeout, func(rd *proto.Reader) error {
 				if e := c.processPendingPushNotificationWithReader(sctx, cn, rd); e != nil {
 					internal.Logger.Printf(sctx, "csc: miss-coalesce push drain: %v", e)
 				}
@@ -424,6 +430,16 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped, backoff bool) {
 		case <-mc.stop:
 			stopFlag.Store(true)
 			doRecycle()
+			// Graceful drain first — but bounded: with ReadTimeout disabled a
+			// server that never replies would leave the reader blocked in a socket
+			// read that no context can interrupt, wedging stopCSCMissCoalescer's
+			// wg.Wait and therefore Client.Close. If the session has not ended
+			// within the batch budget, close the connection to force the I/O out.
+			select {
+			case <-superDone:
+			case <-time.After(mc.batchBudget()):
+				_ = cn.Close()
+			}
 		case <-recycleTimer.C:
 			doRecycle()
 		case <-sctx.Done(): // I/O error: unblock a reader/writer parked on the socket

--- a/csc_miss_coalesce_modes.go
+++ b/csc_miss_coalesce_modes.go
@@ -106,6 +106,16 @@ const cscFullDuplexConnsDefault = 1
 // can disable the idle drain (set it huge) as a negative control.
 var cscFullDuplexIdleProbe = 5 * time.Millisecond
 
+// cscFullDuplexSessionIdle is how long a session's writer waits for the next
+// miss before ending the session and returning its held connection to the pool.
+// Without it a session sits on a pool connection for up to fullDuplexRecycleAge
+// (30s) with no miss in flight, and at a small pool (PoolSize:1) a non-cacheable
+// command (PING/SET/uncached read) blocks behind it. The next miss re-acquires —
+// runFullDuplexSession already waits for work BEFORE taking a connection. Under
+// steady miss load the timer is reset per batch and never fires. A var so tests
+// can tighten or disable it.
+var cscFullDuplexSessionIdle = time.Second
+
 // fullDuplexRecycleAge bounds how long a single session holds one connection,
 // so the held connection is returned to the pool periodically (a Put runs the
 // OnPut pool hooks: metrics, health, and any queued maintenance handoff). Honors
@@ -241,6 +251,8 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
 	go func() {
 		defer swg.Done()
 		defer close(inflight)
+		idleT := time.NewTimer(cscFullDuplexSessionIdle)
+		defer idleT.Stop()
 		buf := make([]*cscMissReq, 0, cscMissBatchMax)
 		pending := first // the miss that woke the session; write it before blocking
 		for {
@@ -248,6 +260,13 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
 			if pending != nil {
 				req, pending = pending, nil
 			} else {
+				if !idleT.Stop() {
+					select {
+					case <-idleT.C:
+					default:
+					}
+				}
+				idleT.Reset(cscFullDuplexSessionIdle)
 				select {
 				case <-recycle:
 					return
@@ -256,6 +275,14 @@ func (mc *cscMissCoalescer) runFullDuplexSession() (stopped bool) {
 					doRecycle()
 					return
 				case <-sctx.Done():
+					return
+				case <-idleT.C:
+					// No miss for the grace period: end the session cleanly so the
+					// held connection goes back to the pool instead of blocking
+					// non-cacheable traffic at a small pool until the recycle age.
+					// The reader drains anything still in flight (close(inflight)
+					// is the graceful no-more signal); the next miss starts a fresh
+					// session, which acquires only when work is in hand.
 					return
 				case req = <-mc.ch:
 				}

--- a/csc_miss_coalesce_modes_test.go
+++ b/csc_miss_coalesce_modes_test.go
@@ -109,6 +109,59 @@ func fdIdleConverges(t *testing.T, key string) bool {
 	return false
 }
 
+// TestFullDuplexSessionReleasesIdleConn pins #3965: a full-duplex session must
+// return its held connection after the idle grace instead of sitting on it until
+// the 30s recycle age — at PoolSize:1 a non-cacheable command (PING) would
+// otherwise block behind the idle session until PoolTimeout and fail.
+func TestFullDuplexSessionReleasesIdleConn(t *testing.T) {
+	ctx := context.Background()
+	probe := NewClient(&Options{Addr: internalTestRedisAddr(), Protocol: 3})
+	if err := probe.Ping(ctx).Err(); err != nil {
+		probe.Close()
+		t.Skipf("no redis: %v", err)
+	}
+	probe.Close()
+
+	old := cscFullDuplexSessionIdle
+	cscFullDuplexSessionIdle = 50 * time.Millisecond
+	t.Cleanup(func() { cscFullDuplexSessionIdle = old })
+
+	cached := NewClient(&Options{
+		Addr:                          internalTestRedisAddr(),
+		Protocol:                      3,
+		PoolSize:                      1, // the FD session's held conn is the ONLY conn
+		PoolTimeout:                   2 * time.Second,
+		ClientSideCacheConfig:         &ClientSideCacheConfig{MaxEntries: 100},
+		ClientSideCacheCoalesceMisses: true,
+		ClientSideCacheCoalesceMode:   "fullduplex",
+	})
+	seeder := NewClient(&Options{Addr: internalTestRedisAddr(), Protocol: 3})
+	defer cached.Close()
+	defer seeder.Close()
+
+	key := "fdidlerel:k"
+	if err := seeder.Set(ctx, key, "v", 0).Err(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { seeder.Del(context.Background(), key) })
+	// Route a miss through the FD session so it acquires the pool's only conn.
+	if got, err := cached.Get(ctx, key).Result(); err != nil || got != "v" {
+		t.Fatalf("warm read = %q, %v", got, err)
+	}
+
+	// Past the grace the session must have released the conn; a non-cacheable
+	// PING then completes promptly. Without the release it blocks the full
+	// PoolTimeout and fails (the session held the conn toward the 30s recycle).
+	time.Sleep(200 * time.Millisecond)
+	start := time.Now()
+	if err := cached.Ping(ctx).Err(); err != nil {
+		t.Fatalf("PING after idle grace failed: %v — the idle FD session is still holding the pool's only conn", err)
+	}
+	if d := time.Since(start); d > time.Second {
+		t.Fatalf("PING took %v; want prompt (idle session should have released the conn)", d)
+	}
+}
+
 // TestClassifyCachedReply pins the abandoned-path reply classifier: it must agree
 // with isCacheableReplyResult on the error-vs-value axis (value and nil are
 // cacheable, a top-level RESP error is not) WITHOUT a caller command to populate.

--- a/csc_miss_coalesce_modes_test.go
+++ b/csc_miss_coalesce_modes_test.go
@@ -64,7 +64,6 @@ func fdIdleConverges(t *testing.T, key string) bool {
 		PoolSize:                      4,
 		ClientSideCacheConfig:         &ClientSideCacheConfig{MaxEntries: 1000},
 		ClientSideCacheCoalesceMisses: true,
-		ClientSideCacheCoalesceMode:   "fullduplex",
 	})
 	seeder := NewClient(&Options{Addr: internalTestRedisAddr(), Protocol: 3})
 	defer cached.Close()
@@ -72,8 +71,8 @@ func fdIdleConverges(t *testing.T, key string) bool {
 	if err := cached.Ping(ctx).Err(); err != nil {
 		t.Fatalf("ping: %v", err)
 	}
-	if mode := cached.CSCMissCoalesceStats().Mode; mode != "fullduplex" {
-		t.Fatalf("coalescer mode = %q; want fullduplex (config not honored?)", mode)
+	if !cached.CSCMissCoalesceStats().Active {
+		t.Fatal("coalescer not active (config not honored?)")
 	}
 	t.Cleanup(func() { seeder.Del(context.Background(), key) })
 
@@ -133,7 +132,6 @@ func TestFullDuplexSessionReleasesIdleConn(t *testing.T) {
 		PoolTimeout:                   2 * time.Second,
 		ClientSideCacheConfig:         &ClientSideCacheConfig{MaxEntries: 100},
 		ClientSideCacheCoalesceMisses: true,
-		ClientSideCacheCoalesceMode:   "fullduplex",
 	})
 	seeder := NewClient(&Options{Addr: internalTestRedisAddr(), Protocol: 3})
 	defer cached.Close()
@@ -319,7 +317,6 @@ func TestFullDuplexDisabledMidMissRetriesUncached(t *testing.T) {
 		PoolSize:                      4,
 		ClientSideCacheConfig:         &ClientSideCacheConfig{MaxEntries: 1000},
 		ClientSideCacheCoalesceMisses: true,
-		ClientSideCacheCoalesceMode:   "fullduplex",
 	})
 	seeder := NewClient(&Options{Addr: internalTestRedisAddr(), Protocol: 3})
 	defer cached.Close()
@@ -327,8 +324,8 @@ func TestFullDuplexDisabledMidMissRetriesUncached(t *testing.T) {
 	if err := cached.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
-	if mode := cached.CSCMissCoalesceStats().Mode; mode != "fullduplex" {
-		t.Fatalf("coalescer mode = %q; want fullduplex", mode)
+	if !cached.CSCMissCoalesceStats().Active {
+		t.Fatal("coalescer not active")
 	}
 
 	key := "fdmiss:disabled"

--- a/csc_miss_coalesce_modes_test.go
+++ b/csc_miss_coalesce_modes_test.go
@@ -1,0 +1,108 @@
+package redis
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestFullDuplexIdleInvalidation pins the feature-complete full-duplex engine's
+// idle push drain, WITH a negative control.
+//
+// The engine holds one connection out of the pool, so the background CSC drainer
+// never visits it; the session's reader must drain server-initiated pushes even
+// when no reply is pending, or an invalidation arriving while the coalescer is
+// idle is never processed and the entry serves stale until TTL.
+//
+//   - idle_drain_on_converges: with the drain at its default 5ms cadence, a key
+//     mutated from a second client while the coalescer is idle must converge —
+//     only possible if the idle reader processed the invalidation (a cache hit is
+//     served locally without touching the socket).
+//   - idle_drain_off_stays_stale: the NEGATIVE CONTROL. With the idle drain
+//     effectively disabled (probe set to ~1h), the same sequence must NOT
+//     converge. If it does, some other path drains the held connection and the
+//     positive case would prove nothing.
+func TestFullDuplexIdleInvalidation(t *testing.T) {
+	probe := NewClient(&Options{Addr: internalTestRedisAddr(), Protocol: 3})
+	if err := probe.Ping(context.Background()).Err(); err != nil {
+		probe.Close()
+		t.Skipf("no redis: %v", err)
+	}
+	probe.Close()
+
+	t.Run("idle_drain_on_converges", func(t *testing.T) {
+		if !fdIdleConverges(t, "fdidle:on") {
+			t.Fatal("with the idle drain ON, an invalidation on the held connection " +
+				"was never processed: the entry served stale")
+		}
+	})
+
+	t.Run("idle_drain_off_stays_stale", func(t *testing.T) {
+		old := cscFullDuplexIdleProbe
+		cscFullDuplexIdleProbe = time.Hour // idle drain effectively disabled
+		t.Cleanup(func() { cscFullDuplexIdleProbe = old })
+		if fdIdleConverges(t, "fdidle:off") {
+			t.Fatal("NEGATIVE CONTROL FAILED: with the idle drain disabled the key still " +
+				"converged, so something other than the idle reader drains the held " +
+				"connection — the positive case does not prove the idle-drain fix")
+		}
+	})
+}
+
+// fdIdleConverges warms a key through the full-duplex coalescer, lets the
+// coalescer go idle, mutates the key from a second client, and reports whether
+// the caching client converges to the new value within ~0.8s.
+func fdIdleConverges(t *testing.T, key string) bool {
+	t.Helper()
+	ctx := context.Background()
+
+	cached := NewClient(&Options{
+		Addr:                          internalTestRedisAddr(),
+		Protocol:                      3,
+		PoolSize:                      4,
+		ClientSideCacheConfig:         &ClientSideCacheConfig{MaxEntries: 1000},
+		ClientSideCacheCoalesceMisses: true,
+		ClientSideCacheCoalesceMode:   "fullduplex",
+	})
+	seeder := NewClient(&Options{Addr: internalTestRedisAddr(), Protocol: 3})
+	defer cached.Close()
+	defer seeder.Close()
+	if err := cached.Ping(ctx).Err(); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+	if mode := cached.CSCMissCoalesceStats().Mode; mode != "fullduplex" {
+		t.Fatalf("coalescer mode = %q; want fullduplex (config not honored?)", mode)
+	}
+	t.Cleanup(func() { seeder.Del(context.Background(), key) })
+
+	if err := seeder.Set(ctx, key, "v1", 0).Err(); err != nil {
+		t.Fatal(err)
+	}
+	// Warm through the coalescer: the miss is fetched on the held connection and
+	// publishes the entry tracked on that connection.
+	if got, err := cached.Get(ctx, key).Result(); err != nil || got != "v1" {
+		t.Fatalf("warm read = %q, %v; want v1", got, err)
+	}
+	if got, err := cached.Get(ctx, key).Result(); err != nil || got != "v1" {
+		t.Fatalf("second read = %q, %v; want v1 (should be a local hit)", got, err)
+	}
+	if cached.CSCMissCoalesceStats().Batches == 0 {
+		t.Fatal("coalescer never batched; the warm read did not route through it")
+	}
+
+	// Go idle, then invalidate from the second client. The push arrives on the
+	// held connection; only the session's reader can process it.
+	time.Sleep(60 * time.Millisecond)
+	if err := seeder.Set(ctx, key, "v2", 0).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(800 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if got, _ := cached.Get(ctx, key).Result(); got == "v2" {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}

--- a/csc_miss_coalesce_modes_test.go
+++ b/csc_miss_coalesce_modes_test.go
@@ -1,11 +1,14 @@
 package redis
 
 import (
+	"bytes"
 	"context"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/redis/go-redis/v9/internal/proto"
 )
 
 // TestFullDuplexIdleInvalidation pins the feature-complete full-duplex engine's
@@ -227,42 +230,30 @@ func TestCSCMissReqClaimInterlock(t *testing.T) {
 			t.Fatalf("iter %d: exactly one claim must win, got abandon=%v apply=%v", i, abandon, apply)
 		}
 	}
+}
 
-	// Writer claim: abandonOrWait must not resolve while the session writer is
-	// serializing cmd's args (WRITING), and must win right after releaseWrite —
-	// the caller may reuse mutable args the moment fetch returns, so the write
-	// claim is what keeps the serializer off them.
-	s := &cscMissReq{}
-	if !s.claimWrite() {
-		t.Fatal("first claimWrite must win from pending")
+// TestCSCMissWireSnapshotImmuneToArgMutation pins the fix for the abandoned-
+// args race: the wire form is snapshotted at enqueue while the caller owns
+// cmd, so a caller that abandons and then mutates a []byte arg can neither
+// change what goes on the wire nor cause a reply for the mutated key to be
+// published under the original cache key.
+func TestCSCMissWireSnapshotImmuneToArgMutation(t *testing.T) {
+	key := []byte("orig-key")
+	cmd := NewStringCmd(context.Background(), "get", key)
+
+	var wireBuf bytes.Buffer
+	if err := writeCmd(proto.NewWriter(&wireBuf), cmd); err != nil {
+		t.Fatalf("snapshot encode: %v", err)
 	}
-	if s.claimAbandon() {
-		t.Fatal("claimAbandon must lose while the writer holds the claim")
+	wire := wireBuf.Bytes()
+	if !bytes.Contains(wire, []byte("orig-key")) {
+		t.Fatalf("snapshot must contain the original key, got %q", wire)
 	}
-	got := make(chan bool, 1)
-	go func() { got <- s.abandonOrWait() }()
-	select {
-	case v := <-got:
-		t.Fatalf("abandonOrWait resolved (%v) while the request was WRITING", v)
-	case <-time.After(20 * time.Millisecond):
-	}
-	s.releaseWrite()
-	select {
-	case v := <-got:
-		if !v {
-			t.Fatal("abandonOrWait must win once the writer released the claim")
-		}
-	case <-time.After(time.Second):
-		t.Fatal("abandonOrWait did not resolve after releaseWrite")
-	}
-	// And a writer claim must lose against an abandoned request — that is the
-	// skip path that keeps abandoned args off the wire.
-	a := &cscMissReq{}
-	if !a.claimAbandon() {
-		t.Fatal("claimAbandon must win from pending")
-	}
-	if a.claimWrite() {
-		t.Fatal("claimWrite must lose after the caller abandoned")
+
+	copy(key, "MUTATED!") // caller reuses its buffer after abandoning
+
+	if !bytes.Contains(wire, []byte("orig-key")) || bytes.Contains(wire, []byte("MUTATED!")) {
+		t.Fatalf("wire snapshot changed after caller mutated its arg buffer: %q", wire)
 	}
 }
 

--- a/csc_miss_coalesce_modes_test.go
+++ b/csc_miss_coalesce_modes_test.go
@@ -373,7 +373,7 @@ func TestFullDuplexDisabledMidMissRetriesUncached(t *testing.T) {
 	cached.disableCSCServing(ctx, "test: force retry-uncached path")
 
 	cmd := NewStringCmd(ctx, "get", key)
-	if err := cached.cscMissCoalescer.Load().fetch(ctx, cmd, nsKey, token); err != errCSCRetryUncached {
+	if _, err := cached.cscMissCoalescer.Load().fetch(ctx, cmd, nsKey, token); err != errCSCRetryUncached {
 		t.Fatalf("fetch after CSC disabled = %v; want errCSCRetryUncached (should not surface ErrClosed)", err)
 	}
 	// The reservation must be released, or later readers block IN_PROGRESS until

--- a/csc_miss_coalesce_modes_test.go
+++ b/csc_miss_coalesce_modes_test.go
@@ -227,6 +227,43 @@ func TestCSCMissReqClaimInterlock(t *testing.T) {
 			t.Fatalf("iter %d: exactly one claim must win, got abandon=%v apply=%v", i, abandon, apply)
 		}
 	}
+
+	// Writer claim: abandonOrWait must not resolve while the session writer is
+	// serializing cmd's args (WRITING), and must win right after releaseWrite —
+	// the caller may reuse mutable args the moment fetch returns, so the write
+	// claim is what keeps the serializer off them.
+	s := &cscMissReq{}
+	if !s.claimWrite() {
+		t.Fatal("first claimWrite must win from pending")
+	}
+	if s.claimAbandon() {
+		t.Fatal("claimAbandon must lose while the writer holds the claim")
+	}
+	got := make(chan bool, 1)
+	go func() { got <- s.abandonOrWait() }()
+	select {
+	case v := <-got:
+		t.Fatalf("abandonOrWait resolved (%v) while the request was WRITING", v)
+	case <-time.After(20 * time.Millisecond):
+	}
+	s.releaseWrite()
+	select {
+	case v := <-got:
+		if !v {
+			t.Fatal("abandonOrWait must win once the writer released the claim")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("abandonOrWait did not resolve after releaseWrite")
+	}
+	// And a writer claim must lose against an abandoned request — that is the
+	// skip path that keeps abandoned args off the wire.
+	a := &cscMissReq{}
+	if !a.claimAbandon() {
+		t.Fatal("claimAbandon must win from pending")
+	}
+	if a.claimWrite() {
+		t.Fatal("claimWrite must lose after the caller abandoned")
+	}
 }
 
 // TestCSCMissCoalesceAbandonedFetchNoRace is a -race guard for #3965 :57: a caller

--- a/csc_miss_coalesce_modes_test.go
+++ b/csc_miss_coalesce_modes_test.go
@@ -71,7 +71,7 @@ func fdIdleConverges(t *testing.T, key string) bool {
 	if err := cached.Ping(ctx).Err(); err != nil {
 		t.Fatalf("ping: %v", err)
 	}
-	if !cached.CSCMissCoalesceStats().Active {
+	if cached.cscMissCoalescer.Load() == nil {
 		t.Fatal("coalescer not active (config not honored?)")
 	}
 	t.Cleanup(func() { seeder.Del(context.Background(), key) })
@@ -87,7 +87,7 @@ func fdIdleConverges(t *testing.T, key string) bool {
 	if got, err := cached.Get(ctx, key).Result(); err != nil || got != "v1" {
 		t.Fatalf("second read = %q, %v; want v1 (should be a local hit)", got, err)
 	}
-	if cached.CSCMissCoalesceStats().Batches == 0 {
+	if mcv := cached.cscMissCoalescer.Load(); mcv == nil || mcv.batches.Load() == 0 {
 		t.Fatal("coalescer never batched; the warm read did not route through it")
 	}
 
@@ -324,7 +324,7 @@ func TestFullDuplexDisabledMidMissRetriesUncached(t *testing.T) {
 	if err := cached.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
-	if !cached.CSCMissCoalesceStats().Active {
+	if cached.cscMissCoalescer.Load() == nil {
 		t.Fatal("coalescer not active")
 	}
 

--- a/csc_miss_coalesce_modes_test.go
+++ b/csc_miss_coalesce_modes_test.go
@@ -293,7 +293,7 @@ func TestCSCMissCoalesceAbandonedFetchNoRace(t *testing.T) {
 	// interlock window was never exercised, so a green -race proves nothing. Skip
 	// (don't pass) so the gap is visible. When it does land, this is the neutralize
 	// anchor — reverting claimApply to an unconditional write makes -race fire here.
-	if n := cached.cscMissCoalescer.abandonedApplies.Load(); n == 0 {
+	if n := cached.cscMissCoalescer.Load().abandonedApplies.Load(); n == 0 {
 		t.Skip("timing window never landed: no fetch was abandoned mid-flight; " +
 			"interlock not exercised this run")
 	}
@@ -348,7 +348,7 @@ func TestFullDuplexDisabledMidMissRetriesUncached(t *testing.T) {
 	cached.disableCSCServing(ctx, "test: force retry-uncached path")
 
 	cmd := NewStringCmd(ctx, "get", key)
-	if err := cached.cscMissCoalescer.fetch(ctx, cmd, nsKey, token); err != errCSCRetryUncached {
+	if err := cached.cscMissCoalescer.Load().fetch(ctx, cmd, nsKey, token); err != errCSCRetryUncached {
 		t.Fatalf("fetch after CSC disabled = %v; want errCSCRetryUncached (should not surface ErrClosed)", err)
 	}
 	// The reservation must be released, or later readers block IN_PROGRESS until

--- a/csc_miss_coalesce_modes_test.go
+++ b/csc_miss_coalesce_modes_test.go
@@ -2,6 +2,8 @@ package redis
 
 import (
 	"context"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 )
@@ -105,4 +107,200 @@ func fdIdleConverges(t *testing.T, key string) bool {
 		time.Sleep(10 * time.Millisecond)
 	}
 	return false
+}
+
+// TestClassifyCachedReply pins the abandoned-path reply classifier: it must agree
+// with isCacheableReplyResult on the error-vs-value axis (value and nil are
+// cacheable, a top-level RESP error is not) WITHOUT a caller command to populate.
+// This is what lets applyAndSettle still publish an abandoned request's reply to
+// the shared cache while skipping the caller's now-returned Cmder (#3965 :57).
+func TestClassifyCachedReply(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		cacheable bool
+	}{
+		{"bulk string", "$2\r\nOK\r\n", true},
+		{"integer", ":5\r\n", true},
+		{"resp2 nil", "$-1\r\n", true},
+		{"resp3 null", "_\r\n", true},
+		{"array", "*2\r\n$1\r\na\r\n$1\r\nb\r\n", true},
+		{"redis error", "-WRONGTYPE Operation against a key holding the wrong kind of value\r\n", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isCacheableReplyResult(classifyCachedReply([]byte(tc.raw)))
+			if got != tc.cacheable {
+				t.Fatalf("classifyCachedReply(%q) cacheable = %v; want %v", tc.raw, got, tc.cacheable)
+			}
+		})
+	}
+}
+
+// TestCSCMissReqClaimInterlock pins the cmd-ownership CAS used by the abandoned
+// path (#3965 :57): exactly one of the caller (claimAbandon) and the
+// worker/reader (claimApply) may win from the pending state, so the worker never
+// writes the caller's Cmder after the caller has returned and may be reusing it.
+func TestCSCMissReqClaimInterlock(t *testing.T) {
+	// Caller wins: a later apply claim must lose, so the worker skips the write.
+	r := &cscMissReq{}
+	if !r.claimAbandon() {
+		t.Fatal("first claimAbandon must win from pending")
+	}
+	if r.claimApply() {
+		t.Fatal("claimApply must lose after the caller abandoned")
+	}
+	if r.claimAbandon() {
+		t.Fatal("claimAbandon must be idempotent-losing on repeat")
+	}
+
+	// Worker wins: a later abandon claim must lose, so the caller waits.
+	w := &cscMissReq{}
+	if !w.claimApply() {
+		t.Fatal("first claimApply must win from pending")
+	}
+	if w.claimAbandon() {
+		t.Fatal("claimAbandon must lose after the worker started applying")
+	}
+
+	// Concurrent: exactly one side wins.
+	for i := 0; i < 2000; i++ {
+		rr := &cscMissReq{}
+		var abandon, apply bool
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); abandon = rr.claimAbandon() }()
+		go func() { defer wg.Done(); apply = rr.claimApply() }()
+		wg.Wait()
+		if abandon == apply {
+			t.Fatalf("iter %d: exactly one claim must win, got abandon=%v apply=%v", i, abandon, apply)
+		}
+	}
+}
+
+// TestCSCMissCoalesceAbandonedFetchNoRace is a -race guard for #3965 :57: a caller
+// whose context cancels mid-fetch returns and reads its Cmder while the coalescer
+// may still be settling the reply. The claim interlock must keep the worker from
+// writing the caller's Cmder after it returned. Probabilistic (timing-dependent),
+// so its value is under `go test -race`; a regression that drops the interlock
+// trips the detector.
+func TestCSCMissCoalesceAbandonedFetchNoRace(t *testing.T) {
+	probe := NewClient(&Options{Addr: internalTestRedisAddr(), Protocol: 3})
+	if err := probe.Ping(context.Background()).Err(); err != nil {
+		probe.Close()
+		t.Skipf("no redis: %v", err)
+	}
+	probe.Close()
+
+	cached := NewClient(&Options{
+		Addr:                          internalTestRedisAddr(),
+		Protocol:                      3,
+		PoolSize:                      4,
+		ClientSideCacheConfig:         &ClientSideCacheConfig{MaxEntries: 100000},
+		ClientSideCacheCoalesceMisses: true,
+	})
+	seeder := NewClient(&Options{Addr: internalTestRedisAddr(), Protocol: 3})
+	defer cached.Close()
+	defer seeder.Close()
+
+	const N = 400
+	keys := make([]string, N)
+	for i := range keys {
+		keys[i] = "cscabandon:" + strconv.Itoa(i)
+		if err := seeder.Set(context.Background(), keys[i], "v", 0).Err(); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		for _, k := range keys {
+			seeder.Del(context.Background(), k)
+		}
+	})
+
+	var wg sync.WaitGroup
+	for i, k := range keys {
+		wg.Add(1)
+		go func(k string, i int) {
+			defer wg.Done()
+			// Non-zero so ctx.Err() is nil at entry (the request reaches the
+			// coalescer) but small enough that many cancel while the fetch is in
+			// flight — the window the interlock guards.
+			d := time.Duration(40+(i%24)*20) * time.Microsecond
+			ctx, cancel := context.WithTimeout(context.Background(), d)
+			defer cancel()
+			cmd := cached.Get(ctx, k)
+			// Touch the cmd right after return; a worker writing it concurrently
+			// would be a data race.
+			_, _ = cmd.Result()
+		}(k, i)
+	}
+	wg.Wait()
+
+	// Guard against a silently-empty run: if no fetch was abandoned mid-flight the
+	// interlock window was never exercised, so a green -race proves nothing. Skip
+	// (don't pass) so the gap is visible. When it does land, this is the neutralize
+	// anchor — reverting claimApply to an unconditional write makes -race fire here.
+	if n := cached.cscMissCoalescer.abandonedApplies.Load(); n == 0 {
+		t.Skip("timing window never landed: no fetch was abandoned mid-flight; " +
+			"interlock not exercised this run")
+	}
+}
+
+// TestFullDuplexDisabledMidMissRetriesUncached pins #3965 :188: when CSC serving
+// is disabled after a miss is reserved (a RESP3 downgrade / CLIENT TRACKING
+// rejection), the full-duplex session must NOT surface pool.ErrClosed for a valid
+// cacheable read. It settles the reserved miss with the retry-uncached sentinel
+// (so processCached re-runs it on the normal path) and releases the reservation.
+func TestFullDuplexDisabledMidMissRetriesUncached(t *testing.T) {
+	ctx := context.Background()
+	probe := NewClient(&Options{Addr: internalTestRedisAddr(), Protocol: 3})
+	if err := probe.Ping(ctx).Err(); err != nil {
+		probe.Close()
+		t.Skipf("no redis: %v", err)
+	}
+	probe.Close()
+
+	cached := NewClient(&Options{
+		Addr:                          internalTestRedisAddr(),
+		Protocol:                      3,
+		PoolSize:                      4,
+		ClientSideCacheConfig:         &ClientSideCacheConfig{MaxEntries: 1000},
+		ClientSideCacheCoalesceMisses: true,
+		ClientSideCacheCoalesceMode:   "fullduplex",
+	})
+	seeder := NewClient(&Options{Addr: internalTestRedisAddr(), Protocol: 3})
+	defer cached.Close()
+	defer seeder.Close()
+	if err := cached.Ping(ctx).Err(); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
+	if mode := cached.CSCMissCoalesceStats().Mode; mode != "fullduplex" {
+		t.Fatalf("coalescer mode = %q; want fullduplex", mode)
+	}
+
+	key := "fdmiss:disabled"
+	if err := seeder.Set(ctx, key, "hello", 0).Err(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { seeder.Del(context.Background(), key) })
+
+	// Reserve the miss exactly as processCached would (namespaced), then disable CSC
+	// serving before handing it to the session — so the session's pre-start check
+	// sees serving off.
+	nsKey := cscNamespacedKey(cached.cscKeyPrefix, key)
+	token, shouldFetch := cached.csc.Reserve(nsKey, []string{nsKey})
+	if !shouldFetch {
+		t.Fatal("expected to own the reservation")
+	}
+	cached.disableCSCServing(ctx, "test: force retry-uncached path")
+
+	cmd := NewStringCmd(ctx, "get", key)
+	if err := cached.cscMissCoalescer.fetch(ctx, cmd, nsKey, token); err != errCSCRetryUncached {
+		t.Fatalf("fetch after CSC disabled = %v; want errCSCRetryUncached (should not surface ErrClosed)", err)
+	}
+	// The reservation must be released, or later readers block IN_PROGRESS until
+	// StaleTimeout: a fresh Reserve must again own the fetch.
+	if _, again := cached.csc.Reserve(nsKey, []string{nsKey}); !again {
+		t.Fatal("reservation left IN_PROGRESS after retry-uncached settle")
+	}
 }

--- a/csc_refresh_on_invalidate.go
+++ b/csc_refresh_on_invalidate.go
@@ -164,6 +164,7 @@ type cscRefreshQueue struct {
 	enqueued      atomic.Uint64
 	dropped       atomic.Uint64
 	refreshed     atomic.Uint64
+	refreshFailed atomic.Uint64
 	demandFlushes atomic.Uint64
 }
 
@@ -205,6 +206,12 @@ type CSCRefreshStats struct {
 	Dropped   uint64
 	Refreshed uint64
 
+	// RefreshFailed counts refresh round trips that errored (a connection or
+	// protocol failure during the batch). Those keys stay evicted and a later read
+	// repopulates them, so a rising count means refresh is degrading to plain
+	// eviction. Counted per errored batch, not per key.
+	RefreshFailed uint64
+
 	// DemandFlushes counts collection windows flushed early because a reader
 	// missed a key still sitting in the window (vs flushed by the window timer or
 	// the size cap). High relative to total flushes means the demand trigger is
@@ -231,6 +238,7 @@ func (c *Client) CSCRefreshStats() CSCRefreshStats {
 		Enqueued:      q.enqueued.Load(),
 		Dropped:       q.dropped.Load(),
 		Refreshed:     q.refreshed.Load(),
+		RefreshFailed: q.refreshFailed.Load(),
 		DemandFlushes: q.demandFlushes.Load(),
 	}
 	if lc, ok := c.baseClient.csc.(*LocalCache); ok {
@@ -351,10 +359,16 @@ func (c *baseClient) runCSCRefresher(h *cscRevalidateHandle, lc *LocalCache, q *
 			}
 			n, err := c.refreshInvalidatedBatch(ctx, targets[start:end])
 			q.refreshed.Add(uint64(n))
-			if err != nil && time.Since(lastWarn) > cscRefreshWarnEvery {
-				lastWarn = time.Now()
-				internal.Logger.Printf(context.Background(),
-					"csc: refresh-on-invalidate batch failed: %v", err)
+			if err != nil {
+				// One count per errored round trip: those keys were not refreshed and
+				// stay evicted (a reader repopulates them). This is the signal that
+				// refresh is degrading to plain eviction.
+				q.refreshFailed.Add(1)
+				if time.Since(lastWarn) > cscRefreshWarnEvery {
+					lastWarn = time.Now()
+					internal.Logger.Printf(context.Background(),
+						"csc: refresh-on-invalidate batch failed: %v", err)
+				}
 			}
 		}
 		cancel()

--- a/csc_refresh_on_invalidate.go
+++ b/csc_refresh_on_invalidate.go
@@ -2,8 +2,6 @@ package redis
 
 import (
 	"context"
-	"os"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -54,9 +52,9 @@ import (
 // operation — withPipelineConn takes whichever is free. Noted as a follow-up; it
 // is a robustness question, not a correctness or invalidation-count one.
 
-// cscNoRefreshOnInvalidate force-disables the feature so a benchmark can A/B it
-// against the same binary.
-var cscNoRefreshOnInvalidate = os.Getenv("GOREDIS_CSC_NO_REFRESH_ON_INVAL") != ""
+// cscNoRefreshOnInvalidate force-disables the feature. The gate is
+// Options.ClientSideCacheRefreshOnInvalidate; this stays constant false.
+const cscNoRefreshOnInvalidate = false
 
 const (
 	// cscRefreshQueueDepth bounds the pending-refresh backlog. Bounded, and it
@@ -83,8 +81,9 @@ const (
 // window is flushed early by demand (a reader touching a collected key) or by the
 // size cap; whichever comes first. Longer window = fewer, larger round trips (the
 // point: it lets refresh work at a small pipeline pool) at the cost of staleness
-// bounded by the window for keys nobody reads.
-var cscRefreshWindow = envDurationMs("GOREDIS_CSC_REFRESH_WINDOW_MS", 500*time.Millisecond)
+// bounded by the window for keys nobody reads. A var (not const) so a test can
+// take the timer out of the picture.
+var cscRefreshWindow = 500 * time.Millisecond
 
 // cscRefreshWindowMaxKeys flushes the window early once this many distinct keys
 // have collected, so a burst cannot outrun the window ahead of the queue's own
@@ -95,8 +94,8 @@ const cscRefreshWindowMaxKeys = 4 * cscRefreshBatchMax
 // sitting in the window flushes the whole window immediately, so an actively-read
 // batch refreshes in ~one RTT instead of waiting out the window, while an idle
 // batch waits the full window (and nobody is reading it, so the wait is free).
-// Off: window + size cap only — kept as an A/B knob to price the trigger.
-var cscDemandRefresh = os.Getenv("GOREDIS_CSC_REFRESH_DEMAND") != "0"
+// Off: window + size cap only. On by default.
+const cscDemandRefresh = true
 
 // cscRefreshCooldown optionally suppresses a refresh for an entry published within
 // this window. DEFAULT 0, meaning off — measurement said to leave it off.
@@ -124,23 +123,8 @@ var cscDemandRefresh = os.Getenv("GOREDIS_CSC_REFRESH_DEMAND") != "0"
 // (93.6% -> 93.0%). Doing the extra work was cheaper than skipping some of the
 // useful part.
 //
-// Left as a tunable (GOREDIS_CSC_REFRESH_COOLDOWN_MS) for a deployment that would
-// rather cap refresh traffic than maximise the hit rate.
-var cscRefreshCooldown = envDurationMs("GOREDIS_CSC_REFRESH_COOLDOWN_MS", 0)
-
-// envDurationMs reads a millisecond count from the environment, so the cooldown
-// can be swept (including to 0, which disables dedup) without a rebuild.
-func envDurationMs(name string, def time.Duration) time.Duration {
-	v := os.Getenv(name)
-	if v == "" {
-		return def
-	}
-	n, err := strconv.Atoi(v)
-	if err != nil || n < 0 {
-		return def
-	}
-	return time.Duration(n) * time.Millisecond
-}
+// Left defaulted to 0 (off); measurement said to leave it off.
+var cscRefreshCooldown time.Duration
 
 // cscRefreshTarget is one entry to re-fetch: the cache key doubles as the wire
 // form of the command that produced it, and redisKeys are already namespaced, so
@@ -471,7 +455,12 @@ func (c *baseClient) refreshInvalidatedBatch(ctx context.Context, targets []cscR
 	}()
 
 	published := 0
-	err := c.withPipelineConn(ctx, func(ctx context.Context, cn *pool.Conn) error {
+	// Publish on the MAIN pool (tracked). On this base the dedicated pipeline pool
+	// is deliberately EXCLUDED from CLIENT TRACKING (PR #3959), so a refetch
+	// published via withPipelineConn would be un-invalidatable and serve stale
+	// until TTL. withConn lands on a CLIENT TRACKING ON connection, same as the
+	// miss-coalescer.
+	err := c.withConn(ctx, func(ctx context.Context, cn *pool.Conn) error {
 		connID := cn.GetID()
 		// Coverage generation captured BEFORE the reads: if this conn loses
 		// tracking mid-batch, every reply is discarded rather than published, the

--- a/csc_refresh_on_invalidate.go
+++ b/csc_refresh_on_invalidate.go
@@ -406,8 +406,11 @@ func (c *baseClient) stopCSCRefresher() {
 		return
 	}
 	c.cscRefreshHandle = nil
+	// Clear only OUR binding: a sibling client sharing this cache/processor may
+	// have re-attached its own queue after ours, and an unconditional nil here
+	// would sever the survivor's refresher (see clearRefreshQueue).
 	if ih := lookupInvalidateHandler(c.opt.PushNotificationProcessor); ih != nil {
-		ih.setRefreshQueue(nil)
+		ih.clearRefreshQueue(c.cscRefreshQueue)
 	}
 	close(h.stop)
 	<-h.done

--- a/csc_refresh_on_invalidate.go
+++ b/csc_refresh_on_invalidate.go
@@ -489,8 +489,22 @@ func (c *baseClient) refreshInvalidatedBatch(ctx context.Context, targets []cscR
 			for i := range kept {
 				// Invalidation pushes share this connection with replies, so drain
 				// them first or a push frame would be read as a value and cached.
-				if err := c.processPendingPushNotificationWithReader(ctx, cn, rd); err != nil {
-					internal.Logger.Printf(ctx, "csc: refresh push drain: %v", err)
+				// Use the nonblocking Close adapter (like the miss-coalescer and
+				// background drainer): this reader is part of the refresher's
+				// waitgroup, so a custom push handler calling Close() on the raw
+				// client would self-deadlock (Close waits on the very goroutine
+				// parked in the handler). And PROPAGATE a processor error instead of
+				// logging and continuing: a surfaced error means bytes may have been
+				// consumed mid-frame, so reading the next reply on a desynced stream
+				// could publish a push fragment under the wrong cache key — abort so
+				// withConn retires the connection.
+				if c.opt.Protocol == 3 && c.pushProcessor != nil {
+					handlerCtx := c.pushNotificationHandlerContext(cn)
+					handlerCtx.Client = cscHandlerClient{baseClient: c}
+					if err := c.pushProcessor.ProcessPendingNotifications(ctx, handlerCtx, rd); err != nil {
+						internal.Logger.Printf(ctx, "csc: refresh push drain: %v", err)
+						return err
+					}
 				}
 				raw, err := rd.ReadRawReply()
 				if err != nil {

--- a/csc_refresh_on_invalidate.go
+++ b/csc_refresh_on_invalidate.go
@@ -124,6 +124,8 @@ const cscDemandRefresh = true
 // useful part.
 //
 // Left defaulted to 0 (off); measurement said to leave it off.
+//
+//nolint:unused // deliberately-off, kept as a documented measured knob (see above) for the follow-up that wires cooldown; referencing it now would misrepresent the shipped behavior.
 var cscRefreshCooldown time.Duration
 
 // cscRefreshTarget is one entry to re-fetch: the cache key doubles as the wire

--- a/csc_refresh_on_invalidate.go
+++ b/csc_refresh_on_invalidate.go
@@ -412,7 +412,7 @@ func (c *baseClient) stopCSCRefresher() {
 	if ih := lookupInvalidateHandler(c.opt.PushNotificationProcessor); ih != nil {
 		ih.clearRefreshQueue(c.cscRefreshQueue)
 	}
-	close(h.stop)
+	h.signalStop()
 	<-h.done
 }
 

--- a/csc_refresh_on_invalidate.go
+++ b/csc_refresh_on_invalidate.go
@@ -513,15 +513,17 @@ func (c *baseClient) refreshInvalidatedBatch(ctx context.Context, targets []cscR
 				// could publish a push fragment under the wrong cache key — abort so
 				// withConn retires the connection.
 				if c.opt.Protocol == 3 && c.pushProcessor != nil {
-					// Route through the shared helper: the built-in processor uses the
-					// Buffered variant so a mid-frame error PROPAGATES, and a custom
-					// processor is handed only a confirmed push frame (peek first). The
-					// raw unbuffered call swallowed a mid-frame DiscardNext desync on a
-					// fragmented attribute, after which ReadRawReply below read a shifted
-					// stream and could publish a push fragment under the wrong cache key.
-					// The helper sets no read deadline, so this reader's ReadRawReply is
-					// unaffected.
-					if err := c.drainPushFrames(ctx, cn, rd); err != nil {
+					// Route through the shared helper in BLOCKING mode: block on the
+					// socket and skip pushes until the refetch reply is the next frame, so
+					// a second invalidation still on the socket ahead of the reply is not
+					// read by ReadRawReply below and published under the wrong cache key.
+					// (The Buffered variant stopped at buffer-empty and let such a
+					// socket-pending push through.) A custom processor is handed only a
+					// confirmed push frame (peek first); PeekReplyType is attribute-aware,
+					// so a fragmented attribute prefix is handled without a separate
+					// buffered scan. The helper sets no read deadline, so this reader's
+					// ReadRawReply is unaffected.
+					if err := c.drainPushFrames(ctx, cn, rd, true); err != nil {
 						internal.Logger.Printf(ctx, "csc: refresh push drain: %v", err)
 						return err
 					}

--- a/csc_refresh_on_invalidate.go
+++ b/csc_refresh_on_invalidate.go
@@ -499,9 +499,15 @@ func (c *baseClient) refreshInvalidatedBatch(ctx context.Context, targets []cscR
 				// could publish a push fragment under the wrong cache key — abort so
 				// withConn retires the connection.
 				if c.opt.Protocol == 3 && c.pushProcessor != nil {
-					handlerCtx := c.pushNotificationHandlerContext(cn)
-					handlerCtx.Client = cscHandlerClient{baseClient: c}
-					if err := c.pushProcessor.ProcessPendingNotifications(ctx, handlerCtx, rd); err != nil {
+					// Route through the shared helper: the built-in processor uses the
+					// Buffered variant so a mid-frame error PROPAGATES, and a custom
+					// processor is handed only a confirmed push frame (peek first). The
+					// raw unbuffered call swallowed a mid-frame DiscardNext desync on a
+					// fragmented attribute, after which ReadRawReply below read a shifted
+					// stream and could publish a push fragment under the wrong cache key.
+					// The helper sets no read deadline, so this reader's ReadRawReply is
+					// unaffected.
+					if err := c.drainPushFrames(ctx, cn, rd); err != nil {
 						internal.Logger.Printf(ctx, "csc: refresh push drain: %v", err)
 						return err
 					}

--- a/csc_refresh_support.go
+++ b/csc_refresh_support.go
@@ -1,12 +1,21 @@
 package redis
 
+import "sync"
+
 // Support shims for refresh-on-invalidate and reader-miss coalescing, kept in
 // one file so the feature is a clean addition over the CSC base.
 
 // cscRevalidateHandle is the stop/join handle for a background CSC goroutine.
 type cscRevalidateHandle struct {
-	stop chan struct{}
-	done chan struct{}
+	stop     chan struct{}
+	done     chan struct{}
+	stopOnce sync.Once
+}
+
+// signalStop closes stop at most once (so stopCSCRefresher and the AddCleanup
+// safety net cannot double-close) and does not join — a GC cleanup must not block.
+func (h *cscRevalidateHandle) signalStop() {
+	h.stopOnce.Do(func() { close(h.stop) })
 }
 
 // LRUClock returns the current global recency token; the refresher uses it as

--- a/csc_refresh_support.go
+++ b/csc_refresh_support.go
@@ -1,24 +1,7 @@
 package redis
 
-import (
-	"os"
-	"strconv"
-)
-
 // Support shims for refresh-on-invalidate and reader-miss coalescing, kept in
 // one file so the feature is a clean addition over the CSC base.
-
-func envIntDefault(name string, def int) int {
-	v := os.Getenv(name)
-	if v == "" {
-		return def
-	}
-	n, err := strconv.Atoi(v)
-	if err != nil || n < 0 {
-		return def
-	}
-	return n
-}
 
 // cscRevalidateHandle is the stop/join handle for a background CSC goroutine.
 type cscRevalidateHandle struct {

--- a/csc_test.go
+++ b/csc_test.go
@@ -592,6 +592,90 @@ func TestSharedCacheSeparatesFixedCredentialIdentities(t *testing.T) {
 	}
 }
 
+// TestInvalBatchWindowRebuildOnChange pins #3965: a running batcher's window is
+// fixed at creation, so when a second client binds to the same shared handler
+// with a different window, setInvalBatchWindow must drop the running batcher so
+// the next invalidation starts a fresh one with the new (e.g. stricter) window.
+func TestInvalBatchWindowRebuildOnChange(t *testing.T) {
+	cache := NewLocalCache(CacheConfig{MaxEntries: 16})
+	h := &invalidateHandler{}
+	if err := h.bindTo(cache, "p:"); err != nil {
+		t.Fatalf("bindTo: %v", err)
+	}
+	t.Cleanup(func() { h.release() })
+
+	h.setInvalBatchWindow(time.Second)
+	b1 := h.ensureBatcher(time.Second)
+	if b1 == nil || b1.window != time.Second {
+		t.Fatalf("first batcher window = %v, want 1s", b1)
+	}
+
+	// Stricter window from a second binding: the running batcher must be dropped.
+	h.setInvalBatchWindow(10 * time.Millisecond)
+	h.mu.Lock()
+	running := h.batcher
+	h.mu.Unlock()
+	if running != nil {
+		t.Fatal("batcher not dropped on window change — the stale window would be kept")
+	}
+	b2 := h.ensureBatcher(10 * time.Millisecond)
+	if b2 == nil || b2.window != 10*time.Millisecond {
+		t.Fatalf("rebuilt batcher window = %v, want 10ms", b2)
+	}
+	if b2 == b1 {
+		t.Fatal("expected a fresh batcher after the window change")
+	}
+
+	// Same window again must not churn the batcher.
+	h.setInvalBatchWindow(10 * time.Millisecond)
+	h.mu.Lock()
+	same := h.batcher
+	h.mu.Unlock()
+	if same != b2 {
+		t.Fatal("setInvalBatchWindow with an unchanged window must not rebuild the batcher")
+	}
+}
+
+// TestInvalBatchDroppedOnFlush pins #3965: a full cache Flush (FLUSHDB/FLUSHALL)
+// must discard the batcher's queued per-key deletes, or a delete queued before
+// the flush fires afterward and evicts an entry repopulated post-flush.
+func TestInvalBatchDroppedOnFlush(t *testing.T) {
+	ctx := context.Background()
+	cache := NewLocalCache(CacheConfig{MaxEntries: 16})
+	h := &invalidateHandler{}
+	if err := h.bindTo(cache, "p:"); err != nil {
+		t.Fatalf("bindTo: %v", err)
+	}
+	t.Cleanup(func() { h.release() })
+	h.setInvalBatchWindow(80 * time.Millisecond) // batched; long enough not to fire before the flush
+
+	nsKey := cscNamespacedKey("p:", "x")
+	cacheKey := cscNamespacedKey("p:", "get:x")
+	if !cache.set(cacheKey, []string{nsKey}, []byte("v1")) {
+		t.Fatal("seed")
+	}
+
+	// Batched invalidation for x: queued, not yet applied (window not elapsed).
+	if err := h.HandlePushNotification(ctx, push.NotificationHandlerContext{},
+		[]interface{}{invalidatePushName, []interface{}{"x"}}); err != nil {
+		t.Fatalf("invalidate: %v", err)
+	}
+	// Full flush: clears the cache AND must drop the queued delete for x.
+	if err := h.HandlePushNotification(ctx, push.NotificationHandlerContext{},
+		[]interface{}{invalidatePushName, nil}); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	// Repopulate x after the flush, then wait past the window: the dropped delete
+	// must NOT fire and evict the fresh entry.
+	if !cache.set(cacheKey, []string{nsKey}, []byte("v2")) {
+		t.Fatal("repopulate")
+	}
+	time.Sleep(200 * time.Millisecond)
+	if v, ok := cache.Get(ctx, cacheKey); !ok || string(v) != "v2" {
+		t.Fatalf("repopulated entry evicted by a stale batched delete after flush: got %q ok=%v, want v2", v, ok)
+	}
+}
+
 func TestAttachCSC_HandlerConflictDoesNotEnableTracking(t *testing.T) {
 	proc := push.NewProcessor()
 	if err := proc.RegisterHandler(invalidatePushName, &recordingHandler{}, true); err != nil {

--- a/csc_test.go
+++ b/csc_test.go
@@ -605,7 +605,7 @@ func TestInvalBatchWindowRebuildOnChange(t *testing.T) {
 	t.Cleanup(func() { h.release() })
 
 	h.setInvalBatchWindow(time.Second)
-	b1 := h.ensureBatcher(time.Second)
+	b1 := h.ensureBatcher()
 	if b1 == nil || b1.window != time.Second {
 		t.Fatalf("first batcher window = %v, want 1s", b1)
 	}
@@ -618,7 +618,7 @@ func TestInvalBatchWindowRebuildOnChange(t *testing.T) {
 	if running != nil {
 		t.Fatal("batcher not dropped on window change — the stale window would be kept")
 	}
-	b2 := h.ensureBatcher(10 * time.Millisecond)
+	b2 := h.ensureBatcher()
 	if b2 == nil || b2.window != 10*time.Millisecond {
 		t.Fatalf("rebuilt batcher window = %v, want 10ms", b2)
 	}
@@ -633,6 +633,77 @@ func TestInvalBatchWindowRebuildOnChange(t *testing.T) {
 	h.mu.Unlock()
 	if same != b2 {
 		t.Fatal("setInvalBatchWindow with an unchanged window must not rebuild the batcher")
+	}
+
+	// LOOSER window from a later binding must NOT apply: the effective window is
+	// the strictest across attached clients, or the 10ms client's staleness bound
+	// would be silently violated by a 1s attach.
+	h.setInvalBatchWindow(time.Second)
+	h.mu.Lock()
+	kept, keptWindow := h.batcher, h.invalBatchWindow
+	h.mu.Unlock()
+	if kept != b2 || keptWindow != 10*time.Millisecond {
+		t.Fatalf("a looser window applied over a stricter one: batcher rebuilt=%v window=%v, want kept 10ms", kept != b2, keptWindow)
+	}
+
+	// Explicit 0 (batching off, inline deletes) is strictest of all and must win.
+	h.setInvalBatchWindow(0)
+	h.mu.Lock()
+	zeroWindow, zeroBatcher := h.invalBatchWindow, h.batcher
+	h.mu.Unlock()
+	if zeroWindow != 0 || zeroBatcher != nil {
+		t.Fatalf("explicit 0 window must win (inline) and drop the batcher: window=%v batcher=%v", zeroWindow, zeroBatcher)
+	}
+	// ...and a later nonzero window must not loosen past it.
+	h.setInvalBatchWindow(time.Second)
+	h.mu.Lock()
+	afterZero := h.invalBatchWindow
+	h.mu.Unlock()
+	if afterZero != 0 {
+		t.Fatalf("nonzero window applied over an explicit 0: window=%v, want 0 (inline stays strictest)", afterZero)
+	}
+}
+
+// TestInvalBatchStopAppliesQueuedDeletes pins #3965 (cursor High): stopping the
+// batcher — as a window-change rebuild does — must apply the deletes still
+// buffered in its channel, not just the in-progress batch, or the cache serves
+// pre-invalidation values until TTL/MaxStaleness.
+func TestInvalBatchStopAppliesQueuedDeletes(t *testing.T) {
+	ctx := context.Background()
+	cache := NewLocalCache(CacheConfig{MaxEntries: 16})
+	h := &invalidateHandler{}
+	if err := h.bindTo(cache, "p:"); err != nil {
+		t.Fatalf("bindTo: %v", err)
+	}
+	t.Cleanup(func() { h.release() })
+	h.setInvalBatchWindow(time.Hour) // never fires on its own in this test
+
+	nsKey := cscNamespacedKey("p:", "sq")
+	cacheKey := cscNamespacedKey("p:", "get:sq")
+	if !cache.set(cacheKey, []string{nsKey}, []byte("stale")) {
+		t.Fatal("seed")
+	}
+	// Queue the delete on the batcher (1h window: buffered, not applied).
+	if err := h.HandlePushNotification(ctx, push.NotificationHandlerContext{},
+		[]interface{}{invalidatePushName, []interface{}{"sq"}}); err != nil {
+		t.Fatalf("invalidate: %v", err)
+	}
+	if _, ok := cache.Get(ctx, cacheKey); !ok {
+		t.Fatal("delete applied before the window elapsed — batching not in effect, test proves nothing")
+	}
+
+	// Tighten the window: the rebuild stops the 1h batcher, whose stop path must
+	// drain + apply the queued delete.
+	h.setInvalBatchWindow(10 * time.Millisecond)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, ok := cache.Get(ctx, cacheKey); !ok {
+			break // delete applied
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("queued delete lost by the batcher stop/rebuild — entry still served")
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 

--- a/csc_test.go
+++ b/csc_test.go
@@ -2552,9 +2552,23 @@ func TestReleaseConnRemovesConnectionAfterPartialPushRead(t *testing.T) {
 	// runner the drain's short probe deadline can expire before consuming any
 	// byte — a benign timeout: nothing was read, the frame is intact in the
 	// socket, and re-pooling is safe (the next drain consumes it whole). Only a
-	// Put after bytes moved into the reader is the desync bug.
+	// Put after bytes moved into the reader is the desync bug. An empty reader
+	// buffer alone does NOT prove zero consumption (a partial parse can eat
+	// every available byte and still leave the buffer empty), so before
+	// skipping, prove the stream is intact: complete the frame and require the
+	// whole push to parse. A parse failure means a desynced conn was re-pooled
+	// — exactly the regression this test pins.
 	if cp.puts == 1 && cp.removes == 0 && !cn.HasBufferedData() {
-		t.Skip("probe timed out before consuming anything; conn re-pooled intact (safe) — mid-frame path not exercised this run")
+		if _, err := server.Write([]byte("o\r\n")); err != nil {
+			t.Fatalf("completing push frame: %v", err)
+		}
+		if err := cn.WithReader(context.Background(), 2*time.Second, func(rd *proto.Reader) error {
+			_, err := rd.ReadReply()
+			return err
+		}); err != nil {
+			t.Fatalf("re-pooled conn is desynced: completed push failed to parse: %v", err)
+		}
+		t.Skip("probe timed out before consuming anything; conn re-pooled intact (whole-frame parse verified) — mid-frame path not exercised this run")
 	}
 	if cp.removes != 1 || cp.puts != 0 {
 		t.Fatalf("partial push read must remove, not re-pool, the connection: removes=%d puts=%d",

--- a/csc_test.go
+++ b/csc_test.go
@@ -2576,6 +2576,74 @@ func TestReleaseConnRemovesConnectionAfterPartialPushRead(t *testing.T) {
 	}
 }
 
+// TestCSCMissReadDrainsSocketPendingPushBeforeReply pins Finding A: a
+// reply-expected CSC reader must block past a push that is still ON THE SOCKET
+// (not yet buffered) ahead of the command reply. The old Buffered drain stopped
+// the instant the reader buffer emptied, so a second invalidation arriving after
+// the first was consumed would be read by ReadRawReply as the command's reply and
+// cached under the wrong key. The blocking drain (drainPushFrames(..., true))
+// keeps skipping pushes until a non-push frame is next.
+func TestCSCMissReadDrainsSocketPendingPushBeforeReply(t *testing.T) {
+	server, client := newIdleTCPConnPair(t)
+	defer server.Close()
+	defer client.Close()
+
+	cn := pool.NewConn(client)
+	c := &baseClient{
+		opt:           &Options{Addr: "127.0.0.1:6379", Protocol: 3},
+		pushProcessor: push.NewProcessor(),
+	}
+
+	pushX := []byte(">2\r\n$10\r\ninvalidate\r\n*1\r\n$1\r\nx\r\n")
+	pushY := []byte(">2\r\n$10\r\ninvalidate\r\n*1\r\n$1\r\ny\r\n")
+	reply := []byte("$5\r\nhello\r\n")
+
+	type res struct {
+		raw []byte
+		err error
+	}
+	done := make(chan res, 1)
+	go func() {
+		var raw []byte
+		err := cn.WithReader(context.Background(), 5*time.Second, func(rd *proto.Reader) error {
+			if e := c.drainPushFrames(context.Background(), cn, rd, true); e != nil {
+				return e
+			}
+			var e error
+			raw, e = rd.ReadRawReply()
+			return e
+		})
+		done <- res{raw, err}
+	}()
+
+	// First push, then a pause long enough for the reader to consume it and EMPTY
+	// its buffer while blocked on the next frame — the exact window the Buffered
+	// drain used to return in. Then a SECOND push ahead of the real reply.
+	if _, err := server.Write(pushX); err != nil {
+		t.Fatalf("write first push: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if _, err := server.Write(pushY); err != nil {
+		t.Fatalf("write second push: %v", err)
+	}
+	if _, err := server.Write(reply); err != nil {
+		t.Fatalf("write reply: %v", err)
+	}
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("reader failed: %v", r.err)
+		}
+		if string(r.raw) != string(reply) {
+			t.Fatalf("blocking drain must skip both pushes and return the reply; got %q want %q",
+				r.raw, reply)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("reader did not complete")
+	}
+}
+
 // bufferedNetConn models a wrapper such as tls.Conn: bytes may already be
 // buffered inside the wrapper while NetConn's raw socket is empty.
 type bufferedNetConn struct {

--- a/csc_test.go
+++ b/csc_test.go
@@ -707,6 +707,38 @@ func TestInvalBatchStopAppliesQueuedDeletes(t *testing.T) {
 	}
 }
 
+// TestInvalBatchEnqueueAfterStopAppliesInline pins #3965 (cursor): a handler
+// goroutine can hold a batcher pointer across a concurrent stop (window-change
+// rebuild mid-enqueue-loop). enqueue on a stopped batcher must apply the delete
+// inline — a key parked in a channel nothing drains would serve
+// pre-invalidation values until TTL/MaxStaleness.
+func TestInvalBatchEnqueueAfterStopAppliesInline(t *testing.T) {
+	ctx := context.Background()
+	cache := NewLocalCache(CacheConfig{MaxEntries: 16})
+	h := &invalidateHandler{}
+	if err := h.bindTo(cache, "p:"); err != nil {
+		t.Fatalf("bindTo: %v", err)
+	}
+	t.Cleanup(func() { h.release() })
+	h.setInvalBatchWindow(time.Hour)
+	b := h.ensureBatcher()
+	if b == nil {
+		t.Fatal("no batcher")
+	}
+
+	nsKey := cscNamespacedKey("p:", "as")
+	cacheKey := cscNamespacedKey("p:", "get:as")
+	if !cache.set(cacheKey, []string{nsKey}, []byte("stale")) {
+		t.Fatal("seed")
+	}
+
+	b.stop()
+	b.enqueue(nsKey) // stopped: must delete inline, not park in b.ch
+	if _, ok := cache.Get(ctx, cacheKey); ok {
+		t.Fatal("enqueue on a stopped batcher parked the delete — entry still served")
+	}
+}
+
 // TestInvalBatchDroppedOnFlush pins #3965: a full cache Flush (FLUSHDB/FLUSHALL)
 // must discard the batcher's queued per-key deletes, or a delete queued before
 // the flush fires afterward and evicts an entry repopulated post-flush.

--- a/csc_test.go
+++ b/csc_test.go
@@ -2548,6 +2548,14 @@ func TestReleaseConnRemovesConnectionAfterPartialPushRead(t *testing.T) {
 	}
 	c.releaseConn(context.Background(), cn, nil)
 
+	// The invariant is no PARTIALLY-CONSUMED conn is ever re-pooled. On a loaded
+	// runner the drain's short probe deadline can expire before consuming any
+	// byte — a benign timeout: nothing was read, the frame is intact in the
+	// socket, and re-pooling is safe (the next drain consumes it whole). Only a
+	// Put after bytes moved into the reader is the desync bug.
+	if cp.puts == 1 && cp.removes == 0 && !cn.HasBufferedData() {
+		t.Skip("probe timed out before consuming anything; conn re-pooled intact (safe) — mid-frame path not exercised this run")
+	}
 	if cp.removes != 1 || cp.puts != 0 {
 		t.Fatalf("partial push read must remove, not re-pool, the connection: removes=%d puts=%d",
 			cp.removes, cp.puts)

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -574,6 +574,12 @@ func (cn *Conn) EffectiveReadTimeout(normalTimeout time.Duration) time.Duration 
 	return cn.getEffectiveReadTimeout(normalTimeout)
 }
 
+// EffectiveWriteTimeout is the write-side counterpart of EffectiveReadTimeout,
+// for callers bounding how long a blocked write may legitimately take.
+func (cn *Conn) EffectiveWriteTimeout(normalTimeout time.Duration) time.Duration {
+	return cn.getEffectiveWriteTimeout(normalTimeout)
+}
+
 // getEffectiveReadTimeout returns the timeout to use for read operations.
 // If relaxed timeout is set and not expired, it takes precedence over the provided timeout.
 // This method automatically clears expired relaxed timeouts using atomic operations.

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -980,10 +980,8 @@ func (cn *Conn) ClearHandoffState() {
 }
 
 // ExpiresAt returns the connection's absolute lifetime expiry (zero when no
-// ConnMaxLifetime applies). Set once at dial, before the conn is shared, so a
-// plain read is safe. Long-holding callers (the CSC full-duplex session) use it
-// to bound their hold by the REMAINING lifetime — including jitter — rather
-// than restarting a full lifetime the pool's reaper would not honor.
+// ConnMaxLifetime applies; jitter included). Set once at dial, so a plain read
+// is safe. Long-holding callers bound their hold by the REMAINING lifetime.
 func (cn *Conn) ExpiresAt() time.Time {
 	return cn.expiresAt
 }

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -979,6 +979,15 @@ func (cn *Conn) ClearHandoffState() {
 	cn.stateMachine.Transition(StateIdle)
 }
 
+// ExpiresAt returns the connection's absolute lifetime expiry (zero when no
+// ConnMaxLifetime applies). Set once at dial, before the conn is shared, so a
+// plain read is safe. Long-holding callers (the CSC full-duplex session) use it
+// to bound their hold by the REMAINING lifetime — including jitter — rather
+// than restarting a full lifetime the pool's reaper would not honor.
+func (cn *Conn) ExpiresAt() time.Time {
+	return cn.expiresAt
+}
+
 // HasBufferedData safely checks if the connection has buffered data.
 // This method is used to avoid data races when checking for push notifications.
 func (cn *Conn) HasBufferedData() bool {

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -1071,6 +1071,14 @@ func (cn *Conn) WithReader(
 		if err := netConn.SetReadDeadline(cn.deadline(ctx, effectiveTimeout)); err != nil {
 			return err
 		}
+	} else {
+		// A negative timeout skips SetReadDeadline, and thus deadline(), which is
+		// the only per-I/O usedAt update. Record usage anyway so a long
+		// deadline-free hold (e.g. a full-duplex CSC session under ReadTimeout=-2)
+		// is not misjudged as idle-expired by the pool on the next Get and
+		// needlessly closed + redialed. Cheap: one atomic store, only on the rare
+		// deadline-free path; harmless on a nil netConn.
+		cn.SetUsedAtNs(getCachedTimeNs())
 	}
 	return fn(cn.rd)
 }
@@ -1114,6 +1122,11 @@ func (cn *Conn) WithWriter(
 			// Connection is not available - return preallocated error
 			return errConnNotAvailableForWrite
 		}
+	} else {
+		// See WithReader: keep usedAt fresh on the deadline-free write path too so
+		// a long-held conn (ReadTimeout/WriteTimeout=-2) is not misjudged as
+		// idle-expired by the pool on the next Get.
+		cn.SetUsedAtNs(getCachedTimeNs())
 	}
 
 	// Reset the buffered writer if needed, should not happen

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -210,6 +210,7 @@ func NewConnWithBufferSize(netConn net.Conn, readBufSize, writeBufSize int) *Con
 func (cn *Conn) UsedAt() time.Time {
 	return time.Unix(0, cn.usedAt.Load())
 }
+
 func (cn *Conn) SetUsedAt(tm time.Time) {
 	cn.usedAt.Store(tm.UnixNano())
 }
@@ -217,6 +218,7 @@ func (cn *Conn) SetUsedAt(tm time.Time) {
 func (cn *Conn) UsedAtNs() int64 {
 	return cn.usedAt.Load()
 }
+
 func (cn *Conn) SetUsedAtNs(ns int64) {
 	cn.usedAt.Store(ns)
 }
@@ -224,6 +226,7 @@ func (cn *Conn) SetUsedAtNs(ns int64) {
 func (cn *Conn) LastPutAtNs() int64 {
 	return cn.lastPutAt.Load()
 }
+
 func (cn *Conn) SetLastPutAtNs(ns int64) {
 	cn.lastPutAt.Store(ns)
 }
@@ -559,6 +562,16 @@ func (cn *Conn) HasRelaxedTimeout() bool {
 
 	// If deadline is set, check if it's still in the future
 	return time.Now().UnixNano() < deadlineNs
+}
+
+// EffectiveReadTimeout reports the read timeout a read on this conn would use
+// right now: the active relaxed timeout (maintenance notifications) when set
+// and unexpired, else normalTimeout. Callers that bound how long a blocked
+// read may legitimately take (e.g. the CSC full-duplex drain backstop) must
+// use this rather than the configured ReadTimeout, or a relaxed read gets cut
+// short.
+func (cn *Conn) EffectiveReadTimeout(normalTimeout time.Duration) time.Duration {
+	return cn.getEffectiveReadTimeout(normalTimeout)
 }
 
 // getEffectiveReadTimeout returns the timeout to use for read operations.

--- a/internal/pool/conn_check.go
+++ b/internal/pool/conn_check.go
@@ -91,7 +91,13 @@ func maybeHasData(conn net.Conn) bool {
 func checkForData(conn net.Conn) (bool, error) {
 	// Unlike the general health check, CSC only uses this as a readiness hint
 	// before a bounded read, so unwrapping TLS is safe and avoids blocking.
-	_ = conn.SetDeadline(time.Time{})
+	//
+	// Deliberately NO SetDeadline reset here (unlike connCheck): this probe is a
+	// raw MSG_PEEK|MSG_DONTWAIT syscall that never touches net.Conn deadlines,
+	// and it runs CONCURRENTLY with command I/O on a held full-duplex connection
+	// — the reader's idle tick probes while the writer may be inside WithWriter
+	// with a write deadline armed. Clearing deadlines here would strip that
+	// concurrent write's bound and let a blocked write hang past its timeout.
 	sysConn, ok := underlyingSyscallConn(conn)
 	if !ok {
 		return false, nil

--- a/internal/pool/conn_check.go
+++ b/internal/pool/conn_check.go
@@ -89,11 +89,20 @@ func maybeHasData(conn net.Conn) bool {
 }
 
 func checkForData(conn net.Conn) (bool, error) {
-	// Readiness hint before a bounded read, so unwrapping TLS is safe.
-	// Deliberately NO SetDeadline reset (unlike connCheck): the raw
-	// MSG_PEEK|MSG_DONTWAIT syscall never touches net.Conn deadlines, and this
-	// runs CONCURRENTLY with command I/O on a held full-duplex connection —
-	// clearing here would strip an armed write deadline mid-write.
+	// Clear any residual READ deadline first: a prior command read (WithReader)
+	// leaves its deadline armed, and once it expires rawConn.Read fails fast
+	// with "raw-read ... i/o timeout" BEFORE the non-blocking peek runs — the
+	// caller would misread an idle-but-healthy conn as dead (the CSC drainer
+	// then removes it and evicts its cache coverage; with the full-duplex
+	// coalescer concentrating a cache's coverage on one held conn, that one
+	// spurious removal wipes the whole cache). Read-only on purpose, unlike the
+	// SetDeadline reset this replaced: checkForData runs CONCURRENTLY with
+	// command WRITES on a held full-duplex connection, and a full SetDeadline
+	// would strip an armed write deadline mid-write. No concurrent READ can
+	// race this: every caller either owns the conn's read side (FD session
+	// reader between reads) or holds the conn exclusively (drainer borrow,
+	// pool health check).
+	_ = conn.SetReadDeadline(time.Time{})
 	sysConn, ok := underlyingSyscallConn(conn)
 	if !ok {
 		return false, nil

--- a/internal/pool/conn_check.go
+++ b/internal/pool/conn_check.go
@@ -89,15 +89,11 @@ func maybeHasData(conn net.Conn) bool {
 }
 
 func checkForData(conn net.Conn) (bool, error) {
-	// Unlike the general health check, CSC only uses this as a readiness hint
-	// before a bounded read, so unwrapping TLS is safe and avoids blocking.
-	//
-	// Deliberately NO SetDeadline reset here (unlike connCheck): this probe is a
-	// raw MSG_PEEK|MSG_DONTWAIT syscall that never touches net.Conn deadlines,
-	// and it runs CONCURRENTLY with command I/O on a held full-duplex connection
-	// — the reader's idle tick probes while the writer may be inside WithWriter
-	// with a write deadline armed. Clearing deadlines here would strip that
-	// concurrent write's bound and let a blocked write hang past its timeout.
+	// Readiness hint before a bounded read, so unwrapping TLS is safe.
+	// Deliberately NO SetDeadline reset (unlike connCheck): the raw
+	// MSG_PEEK|MSG_DONTWAIT syscall never touches net.Conn deadlines, and this
+	// runs CONCURRENTLY with command I/O on a held full-duplex connection —
+	// clearing here would strip an armed write deadline mid-write.
 	sysConn, ok := underlyingSyscallConn(conn)
 	if !ok {
 		return false, nil

--- a/internal/pool/conn_check_test.go
+++ b/internal/pool/conn_check_test.go
@@ -144,4 +144,16 @@ var _ = Describe("tests conn_check with real conns", func() {
 		Expect(connCheck(conn)).NotTo(HaveOccurred())
 		Expect(conn.Close()).NotTo(HaveOccurred())
 	})
+
+	It("checkForData survives an expired residual read deadline", func() {
+		// A prior WithReader leaves its read deadline armed; once expired,
+		// rawConn.Read would fail fast with i/o timeout before the peek runs.
+		// checkForData must clear it and report the idle conn healthy — the CSC
+		// drainer removes the conn (evicting its cache coverage) on any error.
+		Expect(conn.SetReadDeadline(time.Now().Add(-time.Second))).NotTo(HaveOccurred())
+		hasData, err := checkForData(conn)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hasData).To(BeFalse())
+		Expect(conn.Close()).NotTo(HaveOccurred())
+	})
 })

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -2005,12 +2005,19 @@ func (p *ConnPool) isHealthyConn(cn *Conn, nowNs int64) bool {
 			// before the OnGet state check rejects it.
 			if replyType, err := cn.PeekReplyTypeForCheck(); err == nil && replyType == proto.RespPush {
 				// For RESP3 connections with push notifications, we allow some buffered data
-				// The client will process these notifications before using the connection
-				internal.Logger.Printf(
-					context.Background(),
-					"push: conn[%d] has buffered data, likely push notifications - will be processed by client",
-					cn.GetID(),
-				)
+				// The client will process these notifications before using the connection.
+				// This is the normal healthy path for any client with server-side
+				// invalidation or maintenance notifications (client-side caching parks
+				// an invalidate frame on idle conns after every tracked write), so it
+				// logs at debug level only — at default level it would flood the log
+				// on every pool Get under a write-heavy tracked workload.
+				if internal.LogLevel.DebugOrAbove() {
+					internal.Logger.Printf(
+						context.Background(),
+						"push: conn[%d] has buffered data, likely push notifications - will be processed by client",
+						cn.GetID(),
+					)
+				}
 
 				// Update timestamp for healthy connection
 				cn.SetUsedAtNs(nowNs)

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -502,7 +502,7 @@ func (r *Reader) ReadInt() (int64, error) {
 		if err != nil {
 			return 0, err
 		}
-		return util.ParseInt([]byte(s), 10, 64)
+		return strconv.ParseInt(s, 10, 64)
 	case RespBigInt:
 		b, err := r.readBigInt(line)
 		if err != nil {
@@ -529,7 +529,7 @@ func (r *Reader) ReadUint() (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		return util.ParseUint([]byte(s), 10, 64)
+		return strconv.ParseUint(s, 10, 64)
 	case RespBigInt:
 		b, err := r.readBigInt(line)
 		if err != nil {

--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -13,7 +13,7 @@ import (
 // Scan parses bytes `b` to `v` with appropriate type.
 //
 //nolint:gocyclo
-func Scan(b []byte, v interface{}) error {
+func Scan(b []byte, v any) error {
 	switch v := v.(type) {
 	case nil:
 		return fmt.Errorf("redis: Scan(nil)")
@@ -21,7 +21,9 @@ func Scan(b []byte, v interface{}) error {
 		*v = util.BytesToString(b)
 		return nil
 	case *[]byte:
-		*v = b
+		dest := make([]byte, len(b))
+		copy(dest, b)
+		*v = dest
 		return nil
 	case *int:
 		var err error
@@ -116,9 +118,13 @@ func Scan(b []byte, v interface{}) error {
 		*v = time.Duration(n)
 		return nil
 	case encoding.BinaryUnmarshaler:
-		return v.UnmarshalBinary(b)
+		dest := make([]byte, len(b))
+		copy(dest, b)
+		return v.UnmarshalBinary(dest)
 	case *net.IP:
-		*v = b
+		dest := make(net.IP, len(b))
+		copy(dest, b)
+		*v = dest
 		return nil
 	default:
 		return fmt.Errorf(
@@ -126,12 +132,12 @@ func Scan(b []byte, v interface{}) error {
 	}
 }
 
-func ScanSlice(data []string, slice interface{}) error {
+func ScanSlice(data []string, slice any) error {
 	v := reflect.ValueOf(slice)
 	if !v.IsValid() {
 		return fmt.Errorf("redis: ScanSlice(nil)")
 	}
-	if v.Kind() != reflect.Ptr {
+	if v.Kind() != reflect.Pointer {
 		return fmt.Errorf("redis: ScanSlice(non-pointer %T)", slice)
 	}
 	v = v.Elem()
@@ -142,7 +148,7 @@ func ScanSlice(data []string, slice interface{}) error {
 	next := makeSliceNextElemFunc(v)
 	for i, s := range data {
 		elem := next()
-		if err := Scan([]byte(s), elem.Addr().Interface()); err != nil {
+		if err := Scan(util.StringToBytes(s), elem.Addr().Interface()); err != nil {
 			err = fmt.Errorf("redis: ScanSlice index=%d value=%q failed: %w", i, s, err)
 			return err
 		}
@@ -154,32 +160,25 @@ func ScanSlice(data []string, slice interface{}) error {
 func makeSliceNextElemFunc(v reflect.Value) func() reflect.Value {
 	elemType := v.Type().Elem()
 
-	if elemType.Kind() == reflect.Ptr {
+	next := func() reflect.Value {
+		if v.Len() == v.Cap() {
+			v.Grow(1)
+		}
+
+		v.SetLen(v.Len() + 1)
+		return v.Index(v.Len() - 1)
+	}
+
+	if elemType.Kind() == reflect.Pointer {
 		elemType = elemType.Elem()
 		return func() reflect.Value {
-			if v.Len() < v.Cap() {
-				v.Set(v.Slice(0, v.Len()+1))
-				elem := v.Index(v.Len() - 1)
-				if elem.IsNil() {
-					elem.Set(reflect.New(elemType))
-				}
-				return elem.Elem()
+			elem := next()
+			if elem.IsNil() {
+				elem.Set(reflect.New(elemType))
 			}
-
-			elem := reflect.New(elemType)
-			v.Set(reflect.Append(v, elem))
 			return elem.Elem()
 		}
 	}
 
-	zero := reflect.Zero(elemType)
-	return func() reflect.Value {
-		if v.Len() < v.Cap() {
-			v.Set(v.Slice(0, v.Len()+1))
-			return v.Index(v.Len() - 1)
-		}
-
-		v.Set(reflect.Append(v, zero))
-		return v.Index(v.Len() - 1)
-	}
+	return next
 }

--- a/internal/proto/scan_test.go
+++ b/internal/proto/scan_test.go
@@ -2,6 +2,10 @@ package proto_test
 
 import (
 	"encoding/json"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
 
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"
@@ -48,3 +52,325 @@ var _ = Describe("ScanSlice", func() {
 		}))
 	})
 })
+
+// ScanSlice hands its input to Scan as a []byte aliasing the string's backing
+// array, so the branches where b escapes (*[]byte, *net.IP,
+// encoding.BinaryUnmarshaler) have to copy. These specs pin that down: they
+// fail if those branches ever go back to passing b along directly, and they
+// distinguish make+copy from append(T(nil), b...), which yields nil rather
+// than an empty slice.
+var _ = Describe("ScanSlice copy semantics", func() {
+	It("does not alias the source strings for [][]byte", func() {
+		src := []string{strings.Repeat("a", 8), strings.Repeat("b", 8)}
+
+		var slice [][]byte
+		err := proto.ScanSlice(src, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([][]byte{[]byte("aaaaaaaa"), []byte("bbbbbbbb")}))
+
+		slice[0][0] = 'Z'
+		slice[1][0] = 'Z'
+		Expect(src).To(Equal([]string{"aaaaaaaa", "bbbbbbbb"}))
+	})
+
+	It("does not alias the source strings for []net.IP", func() {
+		src := []string{string(net.IPv4(10, 0, 0, 1).To4())}
+
+		var slice []net.IP
+		err := proto.ScanSlice(src, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]net.IP{net.IPv4(10, 0, 0, 1).To4()}))
+
+		slice[0][3] = 9
+		Expect(src).To(Equal([]string{string(net.IPv4(10, 0, 0, 1).To4())}))
+	})
+
+	It("scans an empty element into an empty, non-nil []byte", func() {
+		var slice [][]byte
+		err := proto.ScanSlice([]string{""}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(HaveLen(1))
+		Expect(slice[0]).NotTo(BeNil())
+		Expect(slice[0]).To(HaveLen(0))
+	})
+
+	It("scans an empty element into an empty, non-nil net.IP", func() {
+		var slice []net.IP
+		err := proto.ScanSlice([]string{""}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(HaveLen(1))
+		Expect(slice[0]).NotTo(BeNil())
+		Expect(slice[0]).To(HaveLen(0))
+	})
+})
+
+// makeSliceNextElemFunc extends the destination in place when it already has
+// spare capacity, and reuses non-nil pointer elements found in that capacity
+// rather than allocating new ones. These specs cover that branch: scanning
+// twice into the same backing array, which the benchmarks exercise but never
+// assert on.
+var _ = Describe("ScanSlice capacity reuse", func() {
+	It("reuses the backing array of a []string", func() {
+		var slice []string
+		err := proto.ScanSlice([]string{"a", "b", "c"}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]string{"a", "b", "c"}))
+
+		capBefore, firstElem := cap(slice), &slice[0]
+
+		slice = slice[:0]
+		err = proto.ScanSlice([]string{"x", "y", "z"}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]string{"x", "y", "z"}))
+		// Same array, so the in-place path really was taken.
+		Expect(cap(slice)).To(Equal(capBefore))
+		Expect(&slice[0]).To(BeIdenticalTo(firstElem))
+	})
+
+	It("does not leave stale elements when the second scan is shorter", func() {
+		var slice []string
+		err := proto.ScanSlice([]string{"a", "b", "c"}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+
+		slice = slice[:0]
+		err = proto.ScanSlice([]string{"z"}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]string{"z"}))
+	})
+
+	It("scans into a preallocated slice without growing it", func() {
+		slice := make([]int64, 0, 4)
+		err := proto.ScanSlice([]string{"1", "2", "3"}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]int64{1, 2, 3}))
+		Expect(cap(slice)).To(Equal(4))
+	})
+
+	It("reuses existing pointers for []*testScanSliceStruct", func() {
+		var slice []*testScanSliceStruct
+		err := proto.ScanSlice([]string{
+			`{"ID":1,"Name":"one"}`,
+			`{"ID":2,"Name":"two"}`,
+		}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]*testScanSliceStruct{{1, "one"}, {2, "two"}}))
+
+		capBefore := cap(slice)
+		reused := []*testScanSliceStruct{slice[0], slice[1]}
+
+		slice = slice[:0]
+		err = proto.ScanSlice([]string{
+			`{"ID":3,"Name":"three"}`,
+			`{"ID":4,"Name":"four"}`,
+		}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]*testScanSliceStruct{{3, "three"}, {4, "four"}}))
+		Expect(cap(slice)).To(Equal(capBefore))
+		// The pointers in the recycled capacity are scanned into, not replaced.
+		Expect(slice[0]).To(BeIdenticalTo(reused[0]))
+		Expect(slice[1]).To(BeIdenticalTo(reused[1]))
+	})
+
+	It("allocates pointers for nil elements in recycled capacity", func() {
+		slice := make([]*testScanSliceStruct, 0, 2)
+		err := proto.ScanSlice([]string{`{"ID":1,"Name":"one"}`}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]*testScanSliceStruct{{1, "one"}}))
+		Expect(slice[0]).NotTo(BeNil())
+	})
+})
+
+// benchScanSliceElems is the element count per benchmark iteration. Divide
+// allocs/op and ns/op by it to get the per-element cost.
+const benchScanSliceElems = 1024
+
+// benchStrings builds n deterministic strings of the given byte length.
+func benchStrings(n, size int) []string {
+	data := make([]string, n)
+	for i := range data {
+		// Vary the prefix so the strings are distinct but equally sized.
+		prefix := strconv.Itoa(i)
+		if len(prefix) > size {
+			prefix = prefix[:size]
+		}
+		data[i] = prefix + strings.Repeat("x", size-len(prefix))
+	}
+	return data
+}
+
+// benchNumbers builds n deterministic base-10 integer strings.
+func benchNumbers(n int) []string {
+	data := make([]string, n)
+	for i := range data {
+		data[i] = strconv.Itoa(1234567890 + i)
+	}
+	return data
+}
+
+var benchElemSizes = []int{8, 64, 512}
+
+// The destination slices below are allocated once and reset to zero length
+// between iterations, so makeSliceNextElemFunc reuses the existing capacity.
+// That keeps slice growth out of the measurement and leaves the per-element
+// string -> []byte conversion inside Scan as the dominant cost.
+
+func BenchmarkScanSliceString(b *testing.B) {
+	for _, size := range benchElemSizes {
+		b.Run("size="+strconv.Itoa(size), func(b *testing.B) {
+			data := benchStrings(benchScanSliceElems, size)
+			dst := make([]string, 0, benchScanSliceElems)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				dst = dst[:0]
+				if err := proto.ScanSlice(data, &dst); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkScanSliceBytes covers Scan's *[]byte branch, which hands b to the
+// caller and therefore has to copy regardless of how b was produced.
+func BenchmarkScanSliceBytes(b *testing.B) {
+	for _, size := range benchElemSizes {
+		b.Run("size="+strconv.Itoa(size), func(b *testing.B) {
+			data := benchStrings(benchScanSliceElems, size)
+			dst := make([][]byte, 0, benchScanSliceElems)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				dst = dst[:0]
+				if err := proto.ScanSlice(data, &dst); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkScanSliceInt64(b *testing.B) {
+	data := benchNumbers(benchScanSliceElems)
+	dst := make([]int64, 0, benchScanSliceElems)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		dst = dst[:0]
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkScanSliceFloat64(b *testing.B) {
+	data := benchNumbers(benchScanSliceElems)
+	dst := make([]float64, 0, benchScanSliceElems)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		dst = dst[:0]
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkScanSliceIP covers Scan's *net.IP branch, the other place b escapes.
+func BenchmarkScanSliceIP(b *testing.B) {
+	data := make([]string, benchScanSliceElems)
+	for i := range data {
+		data[i] = string(net.IPv4(10, 0, byte(i>>8), byte(i)).To4())
+	}
+	dst := make([]net.IP, 0, benchScanSliceElems)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		dst = dst[:0]
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// benchJSON builds n deterministic JSON objects for testScanSliceStruct.
+func benchJSON(n int) []string {
+	data := make([]string, n)
+	for i := range data {
+		id := strconv.Itoa(i)
+		data[i] = `{"ID":` + id + `,"Name":"name-` + id + `"}`
+	}
+	return data
+}
+
+// BenchmarkScanSliceBinaryUnmarshaler is the realistic mixed case: Scan copies
+// b before handing it to UnmarshalBinary (so implementations may mutate or
+// retain it), and json.Unmarshal dominates on top of that copy.
+func BenchmarkScanSliceBinaryUnmarshaler(b *testing.B) {
+	data := benchJSON(benchScanSliceElems)
+	dst := make([]testScanSliceStruct, 0, benchScanSliceElems)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		dst = dst[:0]
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkScanSlicePtr covers pointer element types where the capacity already
+// holds non-nil pointers: makeSliceNextElemFunc reuses them, so reflect.New
+// never runs and the refill should allocate nothing beyond json.Unmarshal.
+func BenchmarkScanSlicePtr(b *testing.B) {
+	data := benchJSON(benchScanSliceElems)
+	dst := make([]*testScanSliceStruct, 0, benchScanSliceElems)
+
+	// Populate the capacity first so the measured loop takes the reuse path.
+	if err := proto.ScanSlice(data, &dst); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		dst = dst[:0]
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkScanSlicePtrGrow is the same pointer element type starting from a nil
+// slice, so every element pays a reflect.New on top of the slice growth.
+func BenchmarkScanSlicePtrGrow(b *testing.B) {
+	data := benchJSON(benchScanSliceElems)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		var dst []*testScanSliceStruct
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkScanSliceGrow starts from a nil slice, so it includes the slice
+// growth cost a first-time caller actually pays.
+func BenchmarkScanSliceGrow(b *testing.B) {
+	data := benchStrings(benchScanSliceElems, 64)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		var dst []string
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/options.go
+++ b/options.go
@@ -475,6 +475,11 @@ type Options struct {
 	// larger than the cache MaxStaleness: deferring a delete by up to the window
 	// lets a reader see the pre-invalidation value for up to that long.
 	//
+	// Requires the built-in cache (ClientSideCacheConfig, or ClientSideCache set
+	// to a *LocalCache), like ClientSideCacheCoalesceMisses: the batcher's
+	// hot-entry refresh integration is LocalCache-specific. With a custom Cache
+	// implementation the window is ignored and deletes apply inline.
+	//
 	// Experimental: this API may change in a minor release.
 	ClientSideCacheInvalidationBatchWindow time.Duration
 }

--- a/options.go
+++ b/options.go
@@ -437,6 +437,40 @@ type Options struct {
 	// ClientSideCacheRefreshOnInvalidate re-fetches recently-read keys as soon as
 	// their invalidation arrives, instead of waiting for a reader to miss.
 	ClientSideCacheRefreshOnInvalidate bool
+
+	// ClientSideCacheCoalesceMisses coalesces concurrent cache misses of the same
+	// key so they share one fetch instead of each taking a connection: the missed
+	// commands are pipelined onto a small set of tracked connections, cutting pool
+	// contention (and the churn p99 tail) at a small pool.
+	//
+	// Experimental: this API may change in a minor release.
+	ClientSideCacheCoalesceMisses bool
+
+	// ClientSideCacheCoalesceMode selects the miss-coalescing engine; it is read
+	// only when ClientSideCacheCoalesceMisses is set. "" or "workers" (default)
+	// runs a small pinned pool of workers, each holding one tracked connection for
+	// a half-duplex batch; "fullduplex" holds a single connection with a
+	// concurrent writer+reader pair so many commands stream in flight on one
+	// socket.
+	//
+	// Experimental: this API may change in a minor release.
+	ClientSideCacheCoalesceMode string
+
+	// ClientSideCacheCoalesceWorkers sets the worker count for the "workers"
+	// coalescing mode. 0 (default) uses the built-in default. Ignored by other
+	// modes and when ClientSideCacheCoalesceMisses is unset.
+	//
+	// Experimental: this API may change in a minor release.
+	ClientSideCacheCoalesceWorkers int
+
+	// ClientSideCacheInvalidationBatchWindow coalesces invalidation-driven cache
+	// deletes into windowed background batches instead of applying them inline on
+	// the connection reader. 0 (default) applies invalidations inline. Set it no
+	// larger than the cache MaxStaleness: deferring a delete by up to the window
+	// lets a reader see the pre-invalidation value for up to that long.
+	//
+	// Experimental: this API may change in a minor release.
+	ClientSideCacheInvalidationBatchWindow time.Duration
 }
 
 // CSCStrategy selects the client-side caching invalidation architecture. Set via

--- a/options.go
+++ b/options.go
@@ -438,10 +438,13 @@ type Options struct {
 	// their invalidation arrives, instead of waiting for a reader to miss.
 	ClientSideCacheRefreshOnInvalidate bool
 
-	// ClientSideCacheCoalesceMisses coalesces concurrent cache misses of the same
-	// key so they share one fetch instead of each taking a connection: the missed
-	// commands are pipelined onto a small set of tracked connections, cutting pool
-	// contention (and the churn p99 tail) at a small pool.
+	// ClientSideCacheCoalesceMisses coalesces concurrent cache misses so they
+	// stream on a held tracked full-duplex connection instead of each taking a
+	// pool connection: a lone miss is written immediately (no batching delay —
+	// the caller is waiting), concurrent misses share writes opportunistically,
+	// and new misses go out while earlier replies are still in flight (~1 RTT
+	// per miss, no batch phase-lock). Cuts pool contention and the churn p99
+	// tail at a small pool.
 	//
 	// Requires the built-in cache (ClientSideCacheConfig, or ClientSideCache set
 	// to a *LocalCache): the coalescer's publish path (fetch capture, refresh
@@ -451,23 +454,6 @@ type Options struct {
 	//
 	// Experimental: this API may change in a minor release.
 	ClientSideCacheCoalesceMisses bool
-
-	// ClientSideCacheCoalesceMode selects the miss-coalescing engine; it is read
-	// only when ClientSideCacheCoalesceMisses is set. "" or "workers" (default)
-	// runs a small pool of workers, each acquiring a tracked connection per
-	// half-duplex batch (it is not held across batches); "fullduplex" holds a
-	// single connection with a concurrent writer+reader pair so many commands
-	// stream in flight on one socket.
-	//
-	// Experimental: this API may change in a minor release.
-	ClientSideCacheCoalesceMode string
-
-	// ClientSideCacheCoalesceWorkers sets the worker count for the "workers"
-	// coalescing mode. 0 (default) uses the built-in default. Ignored by other
-	// modes and when ClientSideCacheCoalesceMisses is unset.
-	//
-	// Experimental: this API may change in a minor release.
-	ClientSideCacheCoalesceWorkers int
 
 	// ClientSideCacheInvalidationBatchWindow coalesces invalidation-driven cache
 	// deletes into windowed background batches instead of applying them inline on

--- a/options.go
+++ b/options.go
@@ -457,6 +457,14 @@ type Options struct {
 	// PoolSize for that held connection — with PoolSize 1, continuous misses
 	// can make unrelated non-cacheable commands wait on the pool.
 	//
+	// Limiter: a coalescer session holds ONE connection and serves MANY misses on
+	// it, so Options.Limiter is admitted (Allow/ReportResult) once PER SESSION —
+	// per held connection — not per coalesced miss, unlike the plain per-command
+	// path. This is inherent to the held-connection model (a per-miss Allow would
+	// defeat the coalescing and re-admit a connection already held). A caller that
+	// needs strict per-command admission or circuit-breaking should not enable
+	// miss coalescing.
+	//
 	// Experimental: this API may change in a minor release.
 	ClientSideCacheCoalesceMisses bool
 

--- a/options.go
+++ b/options.go
@@ -443,6 +443,12 @@ type Options struct {
 	// commands are pipelined onto a small set of tracked connections, cutting pool
 	// contention (and the churn p99 tail) at a small pool.
 	//
+	// Requires the built-in cache (ClientSideCacheConfig, or ClientSideCache set
+	// to a *LocalCache): the coalescer's publish path (fetch capture, refresh
+	// integration, hot-entry collection) is LocalCache-specific. With a custom
+	// Cache implementation the option is ignored and every miss fetches on its
+	// caller's connection as usual.
+	//
 	// Experimental: this API may change in a minor release.
 	ClientSideCacheCoalesceMisses bool
 

--- a/options.go
+++ b/options.go
@@ -514,6 +514,20 @@ func (opt *Options) init() {
 			opt.ClientSideCacheStrategy)
 		opt.ClientSideCacheStrategy = CSCStrategySharedTracking
 	}
+	// Deferring invalidation deletes by more than the cache's MaxStaleness lets a
+	// reader see a value past the point a received invalidation should have evicted
+	// it — beyond the staleness contract. Warn (not clamp): the field is
+	// experimental and a caller may accept it knowingly, but a window larger than
+	// MaxStaleness is almost always a misconfiguration. Only checkable for the
+	// built-in cache; a custom Cache has no MaxStaleness to compare against.
+	if opt.ClientSideCacheInvalidationBatchWindow > 0 && opt.ClientSideCacheConfig != nil &&
+		opt.ClientSideCacheConfig.MaxStaleness > 0 &&
+		opt.ClientSideCacheInvalidationBatchWindow > opt.ClientSideCacheConfig.MaxStaleness {
+		internal.Logger.Printf(context.Background(),
+			"redis: ClientSideCacheInvalidationBatchWindow (%s) exceeds the cache MaxStaleness (%s); "+
+				"invalidations can be deferred past the staleness bound, serving stale values",
+			opt.ClientSideCacheInvalidationBatchWindow, opt.ClientSideCacheConfig.MaxStaleness)
+	}
 	if opt.Network == "" {
 		if strings.HasPrefix(opt.Addr, "/") {
 			opt.Network = "unix"

--- a/options.go
+++ b/options.go
@@ -452,6 +452,11 @@ type Options struct {
 	// Cache implementation the option is ignored and every miss fetches on its
 	// caller's connection as usual.
 	//
+	// Pool sizing: under sustained miss traffic the engine holds one pool
+	// connection (released after a 1s idle gap and at the recycle age). Size
+	// PoolSize for that held connection — with PoolSize 1, continuous misses
+	// can make unrelated non-cacheable commands wait on the pool.
+	//
 	// Experimental: this API may change in a minor release.
 	ClientSideCacheCoalesceMisses bool
 

--- a/options.go
+++ b/options.go
@@ -574,13 +574,15 @@ func (opt *Options) init() {
 
 	opt.MaintNotificationsConfig = opt.MaintNotificationsConfig.ApplyDefaultsWithPoolConfig(opt.PoolSize, opt.MaxActiveConns)
 
-	// auto-detect endpoint type if not specified
-	endpointType := opt.MaintNotificationsConfig.EndpointType
-	if endpointType == "" || endpointType == maintnotifications.EndpointTypeAuto {
-		// Auto-detect endpoint type if not specified
-		endpointType = maintnotifications.DetectEndpointType(opt.Addr, opt.TLSConfig != nil)
+	// skip endpoint detection when maint notifications are disabled.
+	if opt.MaintNotificationsConfig.Mode != maintnotifications.ModeDisabled {
+		endpointType := opt.MaintNotificationsConfig.EndpointType
+		// auto-detect endpoint type if not specified
+		if endpointType == "" || endpointType == maintnotifications.EndpointTypeAuto {
+			endpointType = maintnotifications.DetectEndpointType(opt.Addr, opt.TLSConfig != nil)
+		}
+		opt.MaintNotificationsConfig.EndpointType = endpointType
 	}
-	opt.MaintNotificationsConfig.EndpointType = endpointType
 }
 
 func (opt *Options) clone() *Options {

--- a/options.go
+++ b/options.go
@@ -448,10 +448,10 @@ type Options struct {
 
 	// ClientSideCacheCoalesceMode selects the miss-coalescing engine; it is read
 	// only when ClientSideCacheCoalesceMisses is set. "" or "workers" (default)
-	// runs a small pinned pool of workers, each holding one tracked connection for
-	// a half-duplex batch; "fullduplex" holds a single connection with a
-	// concurrent writer+reader pair so many commands stream in flight on one
-	// socket.
+	// runs a small pool of workers, each acquiring a tracked connection per
+	// half-duplex batch (it is not held across batches); "fullduplex" holds a
+	// single connection with a concurrent writer+reader pair so many commands
+	// stream in flight on one socket.
 	//
 	// Experimental: this API may change in a minor release.
 	ClientSideCacheCoalesceMode string

--- a/options_test.go
+++ b/options_test.go
@@ -541,6 +541,71 @@ func TestOptionsCloneMaintNotificationsRace(t *testing.T) {
 	wg.Wait()
 }
 
+// TestOptionsInitSkipsEndpointDetectWhenMaintDisabled ensures Options.init does
+// not call DetectEndpointType when maintenance notifications are disabled.
+// DetectEndpointType never returns EndpointTypeAuto, so leaving Auto unchanged
+// is a deterministic signal that detection was skipped (no wall-clock bound).
+func TestOptionsInitSkipsEndpointDetectWhenMaintDisabled(t *testing.T) {
+	const addr = "go-redis-maint-disabled-must-not-resolve.invalid:6379"
+
+	t.Run("disabled leaves EndpointTypeAuto", func(t *testing.T) {
+		opt := &Options{
+			Addr: addr,
+			MaintNotificationsConfig: &maintnotifications.Config{
+				Mode:         maintnotifications.ModeDisabled,
+				EndpointType: maintnotifications.EndpointTypeAuto,
+			},
+		}
+		opt.init()
+		if got := opt.MaintNotificationsConfig.EndpointType; got != maintnotifications.EndpointTypeAuto {
+			t.Fatalf("EndpointType = %q, want %q (unchanged when ModeDisabled)", got, maintnotifications.EndpointTypeAuto)
+		}
+	})
+
+	t.Run("auto replaces EndpointTypeAuto", func(t *testing.T) {
+		opt := &Options{
+			Addr: addr,
+			MaintNotificationsConfig: &maintnotifications.Config{
+				Mode:         maintnotifications.ModeAuto,
+				EndpointType: maintnotifications.EndpointTypeAuto,
+			},
+		}
+		opt.init()
+		if got := opt.MaintNotificationsConfig.EndpointType; got == "" || got == maintnotifications.EndpointTypeAuto {
+			t.Fatalf("EndpointType = %q, want a concrete type after DetectEndpointType", got)
+		}
+	})
+
+	t.Run("explicit EndpointType is preserved", func(t *testing.T) {
+		opt := &Options{
+			Addr: addr,
+			MaintNotificationsConfig: &maintnotifications.Config{
+				Mode:         maintnotifications.ModeAuto,
+				EndpointType: maintnotifications.EndpointTypeInternalFQDN,
+			},
+		}
+		opt.init()
+		if got := opt.MaintNotificationsConfig.EndpointType; got != maintnotifications.EndpointTypeInternalFQDN {
+			t.Fatalf("EndpointType = %q, want %q", got, maintnotifications.EndpointTypeInternalFQDN)
+		}
+	})
+}
+
+func TestNewClientSkipsEndpointDetectWhenMaintDisabled(t *testing.T) {
+	c := NewClient(&Options{
+		Addr: "go-redis-maint-disabled-must-not-resolve.invalid:6379",
+		MaintNotificationsConfig: &maintnotifications.Config{
+			Mode:         maintnotifications.ModeDisabled,
+			EndpointType: maintnotifications.EndpointTypeAuto,
+		},
+	})
+	defer c.Close()
+
+	if got := c.Options().MaintNotificationsConfig.EndpointType; got != maintnotifications.EndpointTypeAuto {
+		t.Fatalf("EndpointType = %q, want %q", got, maintnotifications.EndpointTypeAuto)
+	}
+}
+
 func TestClientSideCacheRESP2Warning(t *testing.T) {
 	origLogger := internal.Logger
 	defer func() { internal.Logger = origLogger }()

--- a/redis.go
+++ b/redis.go
@@ -406,7 +406,11 @@ type baseClient struct {
 	// Refresh-on-invalidate + reader-miss coalescing (owner-only, nil unless enabled).
 	cscRefreshQueue  *cscRefreshQueue
 	cscRefreshHandle *cscRevalidateHandle
-	cscMissCoalescer *cscMissCoalescer
+	// cscMissCoalescer is atomic because a cache miss (processCached) races
+	// Client.Close (stopCSCMissCoalescer nils it): a plain field double-load
+	// could observe non-nil then call fetch on nil — a panic and a data race.
+	// Readers Load once; Close Swaps to nil so stop runs exactly once.
+	cscMissCoalescer atomic.Pointer[cscMissCoalescer]
 
 	// allowClientTracking exempts a client from the CLIENT TRACKING guard (see
 	// process and generalProcessPipeline). Set only on initConn's internal conn

--- a/redis.go
+++ b/redis.go
@@ -471,6 +471,12 @@ func (c *baseClient) clone() *baseClient {
 		cscActive:    c.cscActive,
 		cscKeyPrefix: c.cscKeyPrefix,
 	}
+	// The miss coalescer travels with the cache too (an atomic.Pointer cannot be
+	// listed above): without this a WithTimeout clone would silently lose miss
+	// coalescing — its zero-valued pointer makes every miss fall back to a
+	// per-caller fetch. The clone shares the OWNER's coalescer (whose lifecycle
+	// stays owner-only: a clone's Close does not stop it).
+	clone.cscMissCoalescer.Store(c.cscMissCoalescer.Load())
 	return clone
 }
 

--- a/redis.go
+++ b/redis.go
@@ -406,10 +406,9 @@ type baseClient struct {
 	// Refresh-on-invalidate + reader-miss coalescing (owner-only, nil unless enabled).
 	cscRefreshQueue  *cscRefreshQueue
 	cscRefreshHandle *cscRevalidateHandle
-	// cscMissCoalescer is atomic because a cache miss (processCached) races
-	// Client.Close (stopCSCMissCoalescer nils it): a plain field double-load
-	// could observe non-nil then call fetch on nil — a panic and a data race.
-	// Readers Load once; Close Swaps to nil so stop runs exactly once.
+	// cscMissCoalescer is atomic: a miss (processCached) races Close, which
+	// Swaps it to nil — readers Load once (a double-load could call fetch on a
+	// nil receiver) and exactly one closer wins the Swap.
 	cscMissCoalescer atomic.Pointer[cscMissCoalescer]
 
 	// allowClientTracking exempts a client from the CLIENT TRACKING guard (see
@@ -471,11 +470,9 @@ func (c *baseClient) clone() *baseClient {
 		cscActive:    c.cscActive,
 		cscKeyPrefix: c.cscKeyPrefix,
 	}
-	// The miss coalescer travels with the cache too (an atomic.Pointer cannot be
-	// listed above): without this a WithTimeout clone would silently lose miss
-	// coalescing — its zero-valued pointer makes every miss fall back to a
-	// per-caller fetch. The clone shares the OWNER's coalescer (whose lifecycle
-	// stays owner-only: a clone's Close does not stop it).
+	// The miss coalescer travels with the cache (an atomic.Pointer cannot appear
+	// in the literal above); a clone shares the OWNER's coalescer, whose
+	// lifecycle stays owner-only — a clone's Close does not stop it.
 	clone.cscMissCoalescer.Store(c.cscMissCoalescer.Load())
 	return clone
 }
@@ -2580,12 +2577,9 @@ func (c *baseClient) timedPushDrain(ctx context.Context, cn *pool.Conn) error {
 		handlerCtx := c.pushNotificationHandlerContext(cn)
 		return c.pushProcessor.ProcessPendingNotifications(ctx, handlerCtx, rd)
 	})
-	// A NEGATIVE ReadTimeout means "never touch the socket deadline": every
-	// subsequent WithReader skips SetReadDeadline, so the 1ms probe deadline
-	// above would otherwise stay installed and poison the next reply read
-	// (surfacing a spurious i/o timeout on a held full-duplex connection, or on
-	// a pooled conn reused right after a drain). Clear it back to no-deadline
-	// for those callers; timeout>=0 callers re-arm their own on the next read.
+	// A NEGATIVE ReadTimeout never re-arms deadlines, so the 1ms probe deadline
+	// would stay installed and poison the next read — clear it back to
+	// no-deadline for those callers (timeout>=0 callers re-arm on the next read).
 	if c.opt.ReadTimeout < 0 {
 		if clearErr := cn.WithReader(context.Background(), 0, func(*proto.Reader) error {
 			return nil
@@ -2626,15 +2620,10 @@ func (c *baseClient) drainPushNotifications(cn *pool.Conn) (processorSucceeded b
 		return false, nil
 	}
 
-	// The hard-deadline reads below (the probe and the drain) leave their
-	// deadline armed on the socket. Clients with a NEGATIVE ReadTimeout never
-	// re-arm (WithReader skips SetReadDeadline), so without this explicit clear
-	// a drained conn reused within the residue window would fail its first read
-	// with a spurious timeout. (checkForData used to clear deadlines
-	// incidentally on the next drainer tick; that reset was removed because it
-	// clobbered a concurrent writer's deadline on held full-duplex connections —
-	// this is the explicit, correctly-scoped replacement.) A removed conn makes
-	// the clear a no-op.
+	// The hard-deadline reads below (probe and drain) leave their deadline armed.
+	// A NEGATIVE ReadTimeout never re-arms (WithReader skips SetReadDeadline), so
+	// without this clear a drained conn reused within the residue window fails
+	// its first read with a spurious timeout. No-op on a removed conn.
 	defer func() {
 		if c.opt.ReadTimeout < 0 {
 			_ = cn.WithReader(context.Background(), 0, func(*proto.Reader) error { return nil })

--- a/redis.go
+++ b/redis.go
@@ -2580,13 +2580,37 @@ func (c *baseClient) peekAndProcessPushNotifications(ctx context.Context, cn *po
 		return nil
 	}
 
-	// Also drain when the reader already has buffered bytes (HasBufferedData),
-	// not just when the socket is readable (MaybeHasData): a reply and a trailing
-	// invalidation can arrive in one socket read, leaving the invalidation in the
-	// reader buffer with an empty socket — MaybeHasData alone would skip it and
-	// serve stale until the next miss/MaxStaleness (#3965).
-	if !cn.MaybeHasData() && !cn.HasBufferedData() {
+	// Also drain when the reader already holds buffered bytes (HasBufferedData),
+	// not only when the socket is readable (MaybeHasData). A reply and a trailing
+	// invalidation can arrive in one socket read. The invalidation then stays in
+	// the reader buffer while the socket is empty. MaybeHasData alone would skip
+	// it and serve stale data until the next miss or MaxStaleness (#3965).
+	buffered := cn.HasBufferedData()
+	if !buffered && !cn.MaybeHasData() {
 		return nil
+	}
+
+	// Use the bare-socket-readiness path only for the built-in processor.
+	// HasBufferedData means the proto reader already holds a decoded frame. These
+	// are real RESP bytes, and any TLS is already unwrapped. Such a frame is a real
+	// push notification and is safe for any processor. MaybeHasData without
+	// buffered data proves only that the raw socket is readable. Over TLS that can
+	// be a post-handshake control record with zero RESP bytes. (conn_check.go's
+	// connCheck refuses to unwrap TLS for this reason. maybeHasData does unwrap
+	// it.) A custom processor that gets such input under the hard cap can time out
+	// on an empty read. The FD session reader treats that timeout as fatal and
+	// closes a healthy connection, and its in-flight misses fail. The built-in
+	// buffered processor accepts the empty read. So a custom processor drains only
+	// on real buffered data. Tradeoff: a push notification that arrives as bare
+	// socket readiness on a custom and idle FD session waits for the next reply
+	// read, the session recycle, or the MaxStaleness backstop. The connection
+	// stays open. This tick is the only drainer for such a session. This mirrors
+	// the built-in-only guard on the opaque-transport probe in the FD session tick
+	// (csc_miss_coalesce_modes.go).
+	if !buffered {
+		if _, builtin := c.pushProcessor.(*push.Processor); !builtin {
+			return nil
+		}
 	}
 
 	// Readiness is established, so a frame is (probably) present: drain under the

--- a/redis.go
+++ b/redis.go
@@ -2663,11 +2663,21 @@ func (c *baseClient) pushDrainWithin(ctx context.Context, cn *pool.Conn, d time.
 		// only push frames, but the NotificationProcessor interface does not promise
 		// that. On the buffered path the buffered bytes can be a coalesced REPLY, not
 		// a push (HasBufferedData is true after a prior reply read). So peek the frame
-		// type first. If it is not a push, return without a read. A custom processor
-		// that read here could consume the reply, cache it under the wrong key, and
-		// desync the stream. This peek is bounded by the hard read deadline of this
-		// closure, so it is safe even if it must touch the socket.
-		if t, err := rd.PeekReplyType(); err != nil || t != proto.RespPush {
+		// type first. This peek is bounded by the hard read deadline of this closure.
+		t, err := rd.PeekReplyType()
+		if err != nil {
+			// Propagate the error; do not swallow it. PeekReplyType can partially
+			// consume a fragmented RESP3 attribute (DiscardNext) before it errors,
+			// which desyncs the stream. The session must then fail and drop the
+			// connection, as the built-in buffered path does. Returning nil here would
+			// reuse a desynced connection, and later fragments could be read as a
+			// command reply and cached under the wrong key.
+			return err
+		}
+		if t != proto.RespPush {
+			// A real reply, not a push. Leave it for the caller's read. A custom
+			// processor that read here could consume the reply and cache it under the
+			// wrong key.
 			return nil
 		}
 		return c.pushProcessor.ProcessPendingNotifications(ctx, handlerCtx, rd)

--- a/redis.go
+++ b/redis.go
@@ -502,6 +502,16 @@ func (c *baseClient) withTimeout(timeout time.Duration) *baseClient {
 	clone := c.clone()
 	clone.opt = opt
 
+	// Do not route the clone's misses through the OWNER's coalescer when the
+	// timeouts diverge: the shared engine's writer/reader/acquire budgets and
+	// backstops all read the owner's options, so a coalesced miss would honor
+	// the owner's deadlines, not the clone's — defeating WithTimeout's whole
+	// point. The clone still serves cache hits and still caches its uncached
+	// fetches (the pre-coalescer CSC path); only miss COALESCING is bypassed.
+	if timeout != c.opt.ReadTimeout || timeout != c.opt.WriteTimeout {
+		clone.cscMissCoalescer.Store(nil)
+	}
+
 	return clone
 }
 

--- a/redis.go
+++ b/redis.go
@@ -2570,10 +2570,24 @@ func (c *baseClient) peekAndProcessPushNotifications(ctx context.Context, cn *po
 	// consumed, the processor treated that as "no pending data", and a
 	// connection with buffered push bytes was returned to the pool instead
 	// of being drained (or removed, when the frame turns out partial).
-	return cn.WithReader(ctx, time.Millisecond, func(rd *proto.Reader) error {
+	err := cn.WithReader(ctx, time.Millisecond, func(rd *proto.Reader) error {
 		handlerCtx := c.pushNotificationHandlerContext(cn)
 		return c.pushProcessor.ProcessPendingNotifications(ctx, handlerCtx, rd)
 	})
+	// A NEGATIVE ReadTimeout means "never touch the socket deadline": every
+	// subsequent WithReader skips SetReadDeadline, so the 1ms probe deadline
+	// above would otherwise stay installed and poison the next reply read
+	// (surfacing a spurious i/o timeout on a held full-duplex connection, or on
+	// a pooled conn reused right after a drain). Clear it back to no-deadline
+	// for those callers; timeout>=0 callers re-arm their own on the next read.
+	if c.opt.ReadTimeout < 0 {
+		if clearErr := cn.WithReader(context.Background(), 0, func(*proto.Reader) error {
+			return nil
+		}); clearErr != nil && err == nil {
+			err = clearErr
+		}
+	}
+	return err
 }
 
 // cscFallbackProbeInterval bounds how often an idle connection without a

--- a/redis.go
+++ b/redis.go
@@ -2558,8 +2558,15 @@ func (c *baseClient) peekAndProcessPushNotifications(ctx context.Context, cn *po
 	// not just when the socket is readable (MaybeHasData): a reply and a trailing
 	// invalidation can arrive in one socket read, leaving the invalidation in the
 	// reader buffer with an empty socket — MaybeHasData alone would skip it and
-	// serve stale until the next miss/MaxStaleness (#3965).
-	if !cn.MaybeHasData() && !cn.HasBufferedData() {
+	// serve stale until the next miss/MaxStaleness (#3965). On transports where
+	// socket readiness cannot be inspected at all (Windows; custom dialer
+	// wrappers exposing neither syscall.Conn nor NetConn) MaybeHasData is always
+	// false, so fall back to a throttled timed drain (at most once per
+	// cscFallbackProbeInterval, the same discipline as the CSC drainer) — without
+	// it a push addressed to a held full-duplex connection would sit unread
+	// until the next reply.
+	if !cn.MaybeHasData() && !cn.HasBufferedData() &&
+		!cn.TakeCscPeriodicReadPending(cscFallbackProbeInterval) {
 		return nil
 	}
 

--- a/redis.go
+++ b/redis.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"weak"
 
 	"github.com/redis/go-redis/v9/auth"
 	"github.com/redis/go-redis/v9/internal"
@@ -406,6 +407,13 @@ type baseClient struct {
 	// Refresh-on-invalidate + reader-miss coalescing (owner-only, nil unless enabled).
 	cscRefreshQueue  *cscRefreshQueue
 	cscRefreshHandle *cscRevalidateHandle
+	// cscClientWeak points (weakly) back at the canonical *Client wrapper, so
+	// the CSC push-handler adapter can close through Client.Close — which also
+	// stops the cached autopipeliners — instead of baseClient.Close. WEAK on
+	// purpose: a strong back-reference would make the wrapper reachable from
+	// the drainer goroutine and the drop-without-Close cleanup
+	// (cscRegisterCleanups) could never fire.
+	cscClientWeak weak.Pointer[Client]
 	// cscMissCoalescer is atomic: a miss (processCached) races Close, which
 	// Swaps it to nil — readers Load once (a double-load could call fetch on a
 	// nil receiver) and exactly one closer wins the Swap.

--- a/redis.go
+++ b/redis.go
@@ -2624,6 +2624,17 @@ func (c *baseClient) pushDrainWithin(ctx context.Context, cn *pool.Conn, d time.
 		// Close waits on the coalescer's WaitGroup, which includes the very
 		// goroutine parked in the handler.
 		handlerCtx.Client = cscHandlerClient{baseClient: c}
+		// Built-in processor: use the Buffered variant (as drainPushNotifications
+		// does) so an error AFTER partially consuming a fragmented frame — e.g. a
+		// RESP3 attribute whose remainder arrives slower than the hard cap — is
+		// PROPAGATED, not swallowed. A swallowed mid-frame error would leave the
+		// connection desynchronized and later fragments could be misread as command
+		// replies and cached under the wrong key. Custom processors keep the
+		// unbuffered call (their contract is "invoked when notifications are known
+		// present").
+		if processor, ok := c.pushProcessor.(*push.Processor); ok {
+			return processor.ProcessPendingNotificationsBuffered(ctx, handlerCtx, rd)
+		}
 		return c.pushProcessor.ProcessPendingNotifications(ctx, handlerCtx, rd)
 	})
 }

--- a/redis.go
+++ b/redis.go
@@ -1362,9 +1362,21 @@ func (c *baseClient) _process(ctx context.Context, cmd Cmder, attempt int, captu
 	var retryTimeout atomic.Uint32
 	if err := c.withConn(ctx, func(ctx context.Context, cn *pool.Conn) error {
 		usedConn = cn
-		// Process any pending push notifications before executing the command
+		// Process any pending push notifications before executing the command. A
+		// non-nil error means the drain may have stopped mid-frame (a fragmented
+		// push straddling its hard read cap), leaving the reader desynced. Do NOT
+		// ignore it: reading this command's reply on the conn would then return
+		// shifted bytes — a wrong result, or a wrong-key cache on the CSC capture
+		// path. Close the conn so releaseConn removes it, mark the error retryable,
+		// and let processWithRetry re-run on a fresh conn. Benign cases return nil
+		// (peekAndProcessPushNotifications gates on MaybeHasData; the built-in
+		// processor propagates only genuine mid-frame errors and a custom processor
+		// is peeked first), so this fires only on a real desync.
 		if err := c.processPushNotifications(ctx, cn); err != nil {
-			internal.Logger.Printf(ctx, "push: error processing pending notifications before command: %v", err)
+			internal.Logger.Printf(ctx, "push: pre-command drain failed, retiring conn: %v", err)
+			_ = cn.Close()
+			retryTimeout.Store(1)
+			return err
 		}
 
 		// HIMPORT bookkeeping: pending discards for this session and the

--- a/redis.go
+++ b/redis.go
@@ -2752,15 +2752,13 @@ func (c *baseClient) drainPushNotifications(cn *pool.Conn) (processorSucceeded b
 		return false, nil
 	}
 
-	// The hard-deadline reads below (probe and drain) leave their deadline armed.
-	// A NEGATIVE ReadTimeout never re-arms (WithReader skips SetReadDeadline), so
-	// without this clear a drained conn reused within the residue window fails
-	// its first read with a spurious timeout. No-op on a removed conn.
-	defer func() {
-		if c.opt.ReadTimeout < 0 {
-			_ = cn.WithReader(context.Background(), 0, func(*proto.Reader) error { return nil })
-		}
-	}()
+	// No deadline cleanup is needed here: WithReaderHardDeadline (the probe and
+	// drain reads below) already restores a cleared read deadline in its own defer
+	// (SetReadDeadline(time.Time{}) — see its doc). A previous WithReader(ctx, 0)
+	// cleanup here was both redundant and wrong: under an active relaxed
+	// maintenance timeout it re-armed a relaxed deadline (getEffectiveReadTimeout
+	// returns the relaxed value even for timeout 0), which a ReadTimeout<0 conn
+	// then never clears on its next read, causing a spurious timeout later.
 
 	if !hasData {
 		// TLS and opaque wrappers can hide bytes from the socket readiness

--- a/redis.go
+++ b/redis.go
@@ -2581,6 +2581,12 @@ func (c *baseClient) timedPushDrain(ctx context.Context, cn *pool.Conn) error {
 	// deadline-less read either.
 	return cn.WithReaderHardDeadline(time.Millisecond, func(rd *proto.Reader) error {
 		handlerCtx := c.pushNotificationHandlerContext(cn)
+		// Nonblocking Close adapter, like the background drainer's: this drain
+		// runs on CSC-held paths (the FD session tick among them), where a
+		// custom handler calling Close() on the raw client would deadlock —
+		// Close waits on the coalescer's WaitGroup, which includes the very
+		// goroutine parked in the handler.
+		handlerCtx.Client = cscHandlerClient{baseClient: c}
 		return c.pushProcessor.ProcessPendingNotifications(ctx, handlerCtx, rd)
 	})
 }

--- a/redis.go
+++ b/redis.go
@@ -2653,7 +2653,9 @@ func (c *baseClient) timedPushDrain(ctx context.Context, cn *pool.Conn) error {
 // no residue poisons a later deadline-less read.
 func (c *baseClient) pushDrainWithin(ctx context.Context, cn *pool.Conn, d time.Duration) error {
 	return cn.WithReaderHardDeadline(d, func(rd *proto.Reader) error {
-		return c.drainPushFrames(ctx, cn, rd)
+		// A speculative probe on a possibly-idle conn: stop when the reader buffer
+		// empties (Buffered variant) rather than block waiting for a reply.
+		return c.drainPushFrames(ctx, cn, rd, false)
 	})
 }
 
@@ -2662,19 +2664,42 @@ func (c *baseClient) pushDrainWithin(ctx context.Context, cn *pool.Conn, d time.
 // helper does not set one, so it is safe to call from a reader that must keep
 // reading afterward (the CSC miss reader reads the command reply next).
 //
-// The built-in processor uses the Buffered variant so an error AFTER partially
-// consuming a fragmented frame — e.g. a RESP3 attribute whose remainder arrives
-// slowly — is PROPAGATED, not swallowed. A swallowed mid-frame error would leave
-// the connection desynchronized and later fragments could be read as a command
-// reply and cached under the wrong key.
+// blocking selects the built-in processor's drain discipline:
 //
-// A custom processor is handed only a confirmed push frame: the interface does
-// not promise the built-in's peek-and-consume-only-push behavior, and on a
-// buffered path the next frame can be a coalesced REPLY. Peek the type first,
-// propagate the peek error (PeekReplyType can partially consume an attribute via
-// DiscardNext before it errors), and skip a non-push frame so a custom processor
-// cannot consume the reply.
-func (c *baseClient) drainPushFrames(ctx context.Context, cn *pool.Conn, rd *proto.Reader) error {
+//   - blocking=true (reply-expected readers: the CSC miss and refresh readers):
+//     block on the socket and skip push frames until a NON-push frame — the
+//     command reply — is next, then return leaving it buffered. This is the same
+//     non-buffered discipline the full-duplex reader already uses. The Buffered
+//     variant instead stops the instant the reader buffer empties; if a second
+//     invalidation is still on the socket ahead of the reply, the caller's
+//     ReadRawReply would then read THAT push as the reply and cache it under the
+//     wrong key — a one-frame shift that cascades to every later reply. Note
+//     PeekReplyType is attribute-aware (it discards a RESP3 attribute prefix and
+//     recurses), so a fragmented attribute needs no separate buffered scan. A
+//     boundary-peek TIMEOUT the non-buffered loop swallows is caught by the
+//     caller's shared read deadline: ReadRawReply hits the same expired deadline
+//     and fails the session. This is the same non-buffered discipline the
+//     full-duplex reader already runs; a swallowed NON-timeout peek error would
+//     need a malformed RESP3 attribute mid-push (a server protocol bug), so this
+//     path is no weaker than that one. Pub/sub-named pushes, which the drain
+//     leaves buffered, cannot reach a CSC-held conn: subscriptions route to
+//     PubSub-owned connections.
+//
+//   - blocking=false (readiness-established probes: pushDrainWithin, the FD
+//     session tick, the background drainer): use the Buffered variant, which
+//     drains the current batch and stops when the reader buffer empties so the
+//     probe never blocks waiting for a reply that will not come on an idle conn.
+//     An error AFTER partially consuming a fragmented frame is PROPAGATED, not
+//     swallowed, so a mid-frame desync cannot later be read as a command reply.
+//
+// A custom processor is handed only a confirmed push frame in either mode: the
+// interface does not promise the built-in's peek-and-consume-only-push behavior,
+// and the next frame can be a coalesced REPLY. Peek the type first, propagate the
+// peek error (PeekReplyType can partially consume an attribute via DiscardNext
+// before it errors), and skip a non-push frame so a custom processor cannot
+// consume the reply; ProcessPendingNotifications then blocks and skips pushes
+// until a non-push is next, matching the built-in blocking discipline.
+func (c *baseClient) drainPushFrames(ctx context.Context, cn *pool.Conn, rd *proto.Reader, blocking bool) error {
 	handlerCtx := c.pushNotificationHandlerContext(cn)
 	// Nonblocking Close adapter: this drain runs on CSC-held paths (the FD
 	// session reader and tick among them), where a custom handler calling Close()
@@ -2682,6 +2707,9 @@ func (c *baseClient) drainPushFrames(ctx context.Context, cn *pool.Conn, rd *pro
 	// WaitGroup, which includes the very goroutine parked in the handler.
 	handlerCtx.Client = cscHandlerClient{baseClient: c}
 	if processor, ok := c.pushProcessor.(*push.Processor); ok {
+		if blocking {
+			return processor.ProcessPendingNotifications(ctx, handlerCtx, rd)
+		}
 		return processor.ProcessPendingNotificationsBuffered(ctx, handlerCtx, rd)
 	}
 	t, err := rd.PeekReplyType()

--- a/redis.go
+++ b/redis.go
@@ -2558,25 +2558,24 @@ func (c *baseClient) peekAndProcessPushNotifications(ctx context.Context, cn *po
 	// not just when the socket is readable (MaybeHasData): a reply and a trailing
 	// invalidation can arrive in one socket read, leaving the invalidation in the
 	// reader buffer with an empty socket — MaybeHasData alone would skip it and
-	// serve stale until the next miss/MaxStaleness (#3965). On transports where
-	// socket readiness cannot be inspected at all (Windows; custom dialer
-	// wrappers exposing neither syscall.Conn nor NetConn) MaybeHasData is always
-	// false, so fall back to a throttled timed drain (at most once per
-	// cscFallbackProbeInterval, the same discipline as the CSC drainer) — without
-	// it a push addressed to a held full-duplex connection would sit unread
-	// until the next reply.
-	if !cn.MaybeHasData() && !cn.HasBufferedData() &&
-		!cn.TakeCscPeriodicReadPending(cscFallbackProbeInterval) {
+	// serve stale until the next miss/MaxStaleness (#3965).
+	if !cn.MaybeHasData() && !cn.HasBufferedData() {
 		return nil
 	}
 
-	// Short read timeout: MaybeHasData/HasBufferedData confirmed bytes, so
-	// the first read returns immediately — the deadline only needs to cover
-	// scheduler pauses, not network waits. 10us was routinely lost to
-	// scheduling on loaded machines: the peek then timed out with nothing
-	// consumed, the processor treated that as "no pending data", and a
-	// connection with buffered push bytes was returned to the pool instead
-	// of being drained (or removed, when the frame turns out partial).
+	return c.timedPushDrain(ctx, cn)
+}
+
+// timedPushDrain runs one short-deadline push drain on cn. The 1ms read
+// deadline only needs to cover scheduler pauses, not network waits, when the
+// caller has established data is (probably) present: 10us was routinely lost to
+// scheduling on loaded machines — the peek then timed out with nothing
+// consumed, the processor treated that as "no pending data", and a connection
+// with buffered push bytes was returned to the pool instead of being drained
+// (or removed, when the frame turns out partial). Callers without a readiness
+// signal (the opaque-transport fallback on a held full-duplex connection) pay
+// at most the 1ms when nothing is pending.
+func (c *baseClient) timedPushDrain(ctx context.Context, cn *pool.Conn) error {
 	err := cn.WithReader(ctx, time.Millisecond, func(rd *proto.Reader) error {
 		handlerCtx := c.pushNotificationHandlerContext(cn)
 		return c.pushProcessor.ProcessPendingNotifications(ctx, handlerCtx, rd)
@@ -2626,6 +2625,22 @@ func (c *baseClient) drainPushNotifications(cn *pool.Conn) (processorSucceeded b
 	if !readPending && !periodicReadPending && !hasData {
 		return false, nil
 	}
+
+	// The hard-deadline reads below (the probe and the drain) leave their
+	// deadline armed on the socket. Clients with a NEGATIVE ReadTimeout never
+	// re-arm (WithReader skips SetReadDeadline), so without this explicit clear
+	// a drained conn reused within the residue window would fail its first read
+	// with a spurious timeout. (checkForData used to clear deadlines
+	// incidentally on the next drainer tick; that reset was removed because it
+	// clobbered a concurrent writer's deadline on held full-duplex connections —
+	// this is the explicit, correctly-scoped replacement.) A removed conn makes
+	// the clear a no-op.
+	defer func() {
+		if c.opt.ReadTimeout < 0 {
+			_ = cn.WithReader(context.Background(), 0, func(*proto.Reader) error { return nil })
+		}
+	}()
+
 	if !hasData {
 		// TLS and opaque wrappers can hide bytes from the socket readiness
 		// check. Probe one byte without consuming it under a tiny deadline;

--- a/redis.go
+++ b/redis.go
@@ -2641,47 +2641,45 @@ func (c *baseClient) timedPushDrain(ctx context.Context, cn *pool.Conn) error {
 // no residue poisons a later deadline-less read.
 func (c *baseClient) pushDrainWithin(ctx context.Context, cn *pool.Conn, d time.Duration) error {
 	return cn.WithReaderHardDeadline(d, func(rd *proto.Reader) error {
-		handlerCtx := c.pushNotificationHandlerContext(cn)
-		// Nonblocking Close adapter, like the background drainer's: this drain
-		// runs on CSC-held paths (the FD session tick among them), where a
-		// custom handler calling Close() on the raw client would deadlock —
-		// Close waits on the coalescer's WaitGroup, which includes the very
-		// goroutine parked in the handler.
-		handlerCtx.Client = cscHandlerClient{baseClient: c}
-		// Built-in processor: use the Buffered variant (as drainPushNotifications
-		// does) so an error AFTER partially consuming a fragmented frame — e.g. a
-		// RESP3 attribute whose remainder arrives slower than the hard cap — is
-		// PROPAGATED, not swallowed. A swallowed mid-frame error would leave the
-		// connection desynchronized and later fragments could be misread as command
-		// replies and cached under the wrong key. Custom processors keep the
-		// unbuffered call (their contract is "invoked when notifications are known
-		// present").
-		if processor, ok := c.pushProcessor.(*push.Processor); ok {
-			return processor.ProcessPendingNotificationsBuffered(ctx, handlerCtx, rd)
-		}
-		// Custom processor. The built-in processor peeks the frame type and consumes
-		// only push frames, but the NotificationProcessor interface does not promise
-		// that. On the buffered path the buffered bytes can be a coalesced REPLY, not
-		// a push (HasBufferedData is true after a prior reply read). So peek the frame
-		// type first. This peek is bounded by the hard read deadline of this closure.
-		t, err := rd.PeekReplyType()
-		if err != nil {
-			// Propagate the error; do not swallow it. PeekReplyType can partially
-			// consume a fragmented RESP3 attribute (DiscardNext) before it errors,
-			// which desyncs the stream. The session must then fail and drop the
-			// connection, as the built-in buffered path does. Returning nil here would
-			// reuse a desynced connection, and later fragments could be read as a
-			// command reply and cached under the wrong key.
-			return err
-		}
-		if t != proto.RespPush {
-			// A real reply, not a push. Leave it for the caller's read. A custom
-			// processor that read here could consume the reply and cache it under the
-			// wrong key.
-			return nil
-		}
-		return c.pushProcessor.ProcessPendingNotifications(ctx, handlerCtx, rd)
+		return c.drainPushFrames(ctx, cn, rd)
 	})
+}
+
+// drainPushFrames processes pending push notifications on rd. The caller already
+// holds rd under a read deadline (WithReader or WithReaderHardDeadline); this
+// helper does not set one, so it is safe to call from a reader that must keep
+// reading afterward (the CSC miss reader reads the command reply next).
+//
+// The built-in processor uses the Buffered variant so an error AFTER partially
+// consuming a fragmented frame — e.g. a RESP3 attribute whose remainder arrives
+// slowly — is PROPAGATED, not swallowed. A swallowed mid-frame error would leave
+// the connection desynchronized and later fragments could be read as a command
+// reply and cached under the wrong key.
+//
+// A custom processor is handed only a confirmed push frame: the interface does
+// not promise the built-in's peek-and-consume-only-push behavior, and on a
+// buffered path the next frame can be a coalesced REPLY. Peek the type first,
+// propagate the peek error (PeekReplyType can partially consume an attribute via
+// DiscardNext before it errors), and skip a non-push frame so a custom processor
+// cannot consume the reply.
+func (c *baseClient) drainPushFrames(ctx context.Context, cn *pool.Conn, rd *proto.Reader) error {
+	handlerCtx := c.pushNotificationHandlerContext(cn)
+	// Nonblocking Close adapter: this drain runs on CSC-held paths (the FD
+	// session reader and tick among them), where a custom handler calling Close()
+	// on the raw client would deadlock — Close waits on the coalescer's
+	// WaitGroup, which includes the very goroutine parked in the handler.
+	handlerCtx.Client = cscHandlerClient{baseClient: c}
+	if processor, ok := c.pushProcessor.(*push.Processor); ok {
+		return processor.ProcessPendingNotificationsBuffered(ctx, handlerCtx, rd)
+	}
+	t, err := rd.PeekReplyType()
+	if err != nil {
+		return err
+	}
+	if t != proto.RespPush {
+		return nil
+	}
+	return c.pushProcessor.ProcessPendingNotifications(ctx, handlerCtx, rd)
 }
 
 // cscFallbackProbeInterval bounds how often an idle connection without a

--- a/redis.go
+++ b/redis.go
@@ -2573,21 +2573,16 @@ func (c *baseClient) peekAndProcessPushNotifications(ctx context.Context, cn *po
 // signal (the opaque-transport fallback on a held full-duplex connection) pay
 // at most the 1ms when nothing is pending.
 func (c *baseClient) timedPushDrain(ctx context.Context, cn *pool.Conn) error {
-	err := cn.WithReader(ctx, time.Millisecond, func(rd *proto.Reader) error {
+	// HARD deadline: WithReader would let an active maintenance-relaxed timeout
+	// REPLACE the 1ms probe cap, and a no-data probe would then block the
+	// caller (the FD session tick) for the relaxed duration while holding the
+	// conn — starving a small pool. WithReaderHardDeadline bypasses relaxation
+	// and clears the deadline on exit, so no residue poisons a later
+	// deadline-less read either.
+	return cn.WithReaderHardDeadline(time.Millisecond, func(rd *proto.Reader) error {
 		handlerCtx := c.pushNotificationHandlerContext(cn)
 		return c.pushProcessor.ProcessPendingNotifications(ctx, handlerCtx, rd)
 	})
-	// A NEGATIVE ReadTimeout never re-arms deadlines, so the 1ms probe deadline
-	// would stay installed and poison the next read — clear it back to
-	// no-deadline for those callers (timeout>=0 callers re-arm on the next read).
-	if c.opt.ReadTimeout < 0 {
-		if clearErr := cn.WithReader(context.Background(), 0, func(*proto.Reader) error {
-			return nil
-		}); clearErr != nil && err == nil {
-			err = clearErr
-		}
-	}
-	return err
 }
 
 // cscFallbackProbeInterval bounds how often an idle connection without a
@@ -2651,7 +2646,8 @@ func (c *baseClient) drainPushNotifications(cn *pool.Conn) (processorSucceeded b
 	err = cn.WithReaderHardDeadline(cscDrainHardReadCap, func(rd *proto.Reader) error {
 		if processor, ok := c.pushProcessor.(*push.Processor); ok {
 			return processor.ProcessPendingNotificationsBuffered(
-				context.Background(), handlerCtx, rd)
+				context.Background(), handlerCtx, rd,
+			)
 		}
 		return c.pushProcessor.ProcessPendingNotifications(context.Background(), handlerCtx, rd)
 	})

--- a/redis.go
+++ b/redis.go
@@ -2659,6 +2659,17 @@ func (c *baseClient) pushDrainWithin(ctx context.Context, cn *pool.Conn, d time.
 		if processor, ok := c.pushProcessor.(*push.Processor); ok {
 			return processor.ProcessPendingNotificationsBuffered(ctx, handlerCtx, rd)
 		}
+		// Custom processor. The built-in processor peeks the frame type and consumes
+		// only push frames, but the NotificationProcessor interface does not promise
+		// that. On the buffered path the buffered bytes can be a coalesced REPLY, not
+		// a push (HasBufferedData is true after a prior reply read). So peek the frame
+		// type first. If it is not a push, return without a read. A custom processor
+		// that read here could consume the reply, cache it under the wrong key, and
+		// desync the stream. This peek is bounded by the hard read deadline of this
+		// closure, so it is safe even if it must touch the socket.
+		if t, err := rd.PeekReplyType(); err != nil || t != proto.RespPush {
+			return nil
+		}
 		return c.pushProcessor.ProcessPendingNotifications(ctx, handlerCtx, rd)
 	})
 }

--- a/redis.go
+++ b/redis.go
@@ -2544,11 +2544,16 @@ func (c *baseClient) peekAndProcessPushNotifications(ctx context.Context, cn *po
 		return nil
 	}
 
-	if !cn.MaybeHasData() {
+	// Also drain when the reader already has buffered bytes (HasBufferedData),
+	// not just when the socket is readable (MaybeHasData): a reply and a trailing
+	// invalidation can arrive in one socket read, leaving the invalidation in the
+	// reader buffer with an empty socket — MaybeHasData alone would skip it and
+	// serve stale until the next miss/MaxStaleness (#3965).
+	if !cn.MaybeHasData() && !cn.HasBufferedData() {
 		return nil
 	}
 
-	// Short read timeout: MaybeHasData confirmed kernel-buffered bytes, so
+	// Short read timeout: MaybeHasData/HasBufferedData confirmed bytes, so
 	// the first read returns immediately — the deadline only needs to cover
 	// scheduler pauses, not network waits. 10us was routinely lost to
 	// scheduling on loaded machines: the peek then timed out with nothing

--- a/redis.go
+++ b/redis.go
@@ -2105,6 +2105,17 @@ func (c *Client) WithTimeout(timeout time.Duration) *Client {
 		clone.cscLifecycleOwner = c
 	}
 	clone.baseClient = c.baseClient.withTimeout(timeout)
+	// Route the clone's CSC push-handler Close through the OWNER wrapper.
+	// clone() copies neither cscDrainHandle nor cscClientWeak, so without this a
+	// custom push handler calling Close() on the cscHandlerClient installed for a
+	// held-conn drain on this clone would fall through to baseClient.Close —
+	// closing the SHARED pools while the owner's drainer and cached autopipeliners
+	// keep running against them. cscLifecycleOwner is the canonical wrapper and is
+	// kept alive by this clone's strong ref, so closeCanonical resolves it and
+	// calls owner.Close() (the full CSC + autopipeliner teardown).
+	if clone.cscLifecycleOwner != nil {
+		clone.baseClient.cscClientWeak = weak.Make(clone.cscLifecycleOwner)
+	}
 	clone.init()
 	return &clone
 }
@@ -2578,26 +2589,34 @@ func (c *baseClient) peekAndProcessPushNotifications(ctx context.Context, cn *po
 		return nil
 	}
 
-	return c.timedPushDrain(ctx, cn)
+	// Readiness is established, so a frame is (probably) present: drain under the
+	// longer fragmented-frame budget the background drainer uses, NOT the 1ms
+	// no-data probe cap. A push can arrive in fragments more than 1ms apart —
+	// notably over TLS, where MaybeHasData only proves that some ciphertext is
+	// readable — and the 1ms cap would then time out after consuming the prefix,
+	// which is treated as fatal and fatally closes a healthy session (failing its
+	// in-flight misses). The 1ms cap is reserved for speculative no-data probes
+	// (timedPushDrain, the opaque-transport fallback).
+	return c.pushDrainWithin(ctx, cn, cscDrainHardReadCap)
 }
 
-// timedPushDrain runs one short-deadline push drain on cn. The 1ms read
-// deadline only needs to cover scheduler pauses, not network waits, when the
-// caller has established data is (probably) present: 10us was routinely lost to
-// scheduling on loaded machines — the peek then timed out with nothing
-// consumed, the processor treated that as "no pending data", and a connection
-// with buffered push bytes was returned to the pool instead of being drained
-// (or removed, when the frame turns out partial). Callers without a readiness
-// signal (the opaque-transport fallback on a held full-duplex connection) pay
-// at most the 1ms when nothing is pending.
+// timedPushDrain runs a speculative no-data push probe under a 1ms hard read
+// deadline: for callers WITHOUT a readiness signal (the opaque-transport
+// fallback on a held full-duplex connection), which pay at most 1ms when
+// nothing is pending. Callers that HAVE established readiness use
+// pushDrainWithin(cscDrainHardReadCap) instead, to tolerate fragmented frames.
 func (c *baseClient) timedPushDrain(ctx context.Context, cn *pool.Conn) error {
-	// HARD deadline: WithReader would let an active maintenance-relaxed timeout
-	// REPLACE the 1ms probe cap, and a no-data probe would then block the
-	// caller (the FD session tick) for the relaxed duration while holding the
-	// conn — starving a small pool. WithReaderHardDeadline bypasses relaxation
-	// and clears the deadline on exit, so no residue poisons a later
-	// deadline-less read either.
-	return cn.WithReaderHardDeadline(time.Millisecond, func(rd *proto.Reader) error {
+	return c.pushDrainWithin(ctx, cn, time.Millisecond)
+}
+
+// pushDrainWithin runs one push drain on cn under a HARD read deadline of d.
+// HARD (not WithReader): a maintenance-relaxed timeout would otherwise REPLACE
+// the cap, blocking the caller (e.g. the FD session tick) for the relaxed
+// duration while holding the conn and starving a small pool.
+// WithReaderHardDeadline bypasses relaxation and clears the deadline on exit, so
+// no residue poisons a later deadline-less read.
+func (c *baseClient) pushDrainWithin(ctx context.Context, cn *pool.Conn, d time.Duration) error {
+	return cn.WithReaderHardDeadline(d, func(rd *proto.Reader) error {
 		handlerCtx := c.pushNotificationHandlerContext(cn)
 		// Nonblocking Close adapter, like the background drainer's: this drain
 		// runs on CSC-held paths (the FD session tick among them), where a

--- a/search_commands.go
+++ b/search_commands.go
@@ -3152,9 +3152,35 @@ func parseFTHybrid(data []interface{}, withCursor bool) (FTHybridResult, *FTHybr
 }
 
 func (cmd *FTHybridCmd) readReply(rd *proto.Reader) (err error) {
-	data, err := rd.ReadSlice()
+	readType, err := rd.PeekReplyType()
 	if err != nil {
 		return err
+	}
+
+	// RESP3 returns a map, RESP2 returns an array. ReadSlice reads a map
+	// header's declared length as an element count, so it consumes only half
+	// the key/value frames and leaves the rest on the connection; ReadReply
+	// consumes the whole map. Flatten it into the key/value list parseFTHybrid
+	// expects, matching AggregateCmd/FTSearchCmd/FTSpellCheckCmd/FTSynDumpCmd.
+	var data []interface{}
+	if readType == proto.RespMap {
+		cmd.rawVal, err = rd.ReadReply()
+		if err != nil {
+			return err
+		}
+		rawMap, ok := cmd.rawVal.(map[interface{}]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected RESP3 response type: %T", cmd.rawVal)
+		}
+		data = make([]interface{}, 0, len(rawMap)*2)
+		for k, v := range rawMap {
+			data = append(data, k, v)
+		}
+	} else {
+		data, err = rd.ReadSlice()
+		if err != nil {
+			return err
+		}
 	}
 
 	result, cursorResult, err := parseFTHybrid(data, cmd.withCursor)

--- a/search_hybrid_desync_test.go
+++ b/search_hybrid_desync_test.go
@@ -1,0 +1,68 @@
+package redis
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/redis/go-redis/v9/internal/proto"
+)
+
+// FT.HYBRID replies with a RESP3 map on a RESP3 connection, like the other
+// FT.* commands. FTHybridCmd.readReply must consume the whole map: reading it
+// with ReadSlice treats the map header's declared length as an ELEMENT count,
+// so only half the key/value frames are consumed and the rest are left on the
+// connection. readReply then returns nil (success), the connection is pooled
+// desynced, and the next command reads a stray map frame as its own reply.
+func TestFTHybridRESP3MapNoDesync(t *testing.T) {
+	// A 4-pair RESP3 map, followed by the next command's reply on the wire.
+	const reply = "%4\r\n" +
+		"$13\r\ntotal_results\r\n:5\r\n" +
+		"$7\r\nresults\r\n*0\r\n" +
+		"$6\r\nformat\r\n$6\r\nSTRING\r\n" +
+		"$7\r\nwarning\r\n*0\r\n"
+	const next = ":99\r\n"
+
+	rd := proto.NewReader(strings.NewReader(reply + next))
+	cmd := newFTHybridCmd(context.Background(), nil)
+	if err := cmd.readReply(rd); err != nil {
+		t.Fatalf("readReply: %v", err)
+	}
+	if cmd.val.TotalResults != 5 {
+		t.Fatalf("TotalResults = %d, want 5", cmd.val.TotalResults)
+	}
+
+	// The whole map must have been consumed: the next reply on the wire is the
+	// following command's integer 99, not a leftover map frame.
+	got, err := rd.ReadReply()
+	if err != nil {
+		t.Fatalf("reading next reply: %v", err)
+	}
+	if n, ok := got.(int64); !ok || n != 99 {
+		t.Fatalf("connection desynced: next reply = %#v, want int64(99)", got)
+	}
+}
+
+// The RESP2 flat-array form must still parse and stay in sync.
+func TestFTHybridRESP2ArrayStillParses(t *testing.T) {
+	const reply = "*4\r\n" +
+		"$13\r\ntotal_results\r\n:7\r\n" +
+		"$7\r\nresults\r\n*0\r\n"
+	const next = ":42\r\n"
+
+	rd := proto.NewReader(strings.NewReader(reply + next))
+	cmd := newFTHybridCmd(context.Background(), nil)
+	if err := cmd.readReply(rd); err != nil {
+		t.Fatalf("readReply: %v", err)
+	}
+	if cmd.val.TotalResults != 7 {
+		t.Fatalf("TotalResults = %d, want 7", cmd.val.TotalResults)
+	}
+	got, err := rd.ReadReply()
+	if err != nil {
+		t.Fatalf("reading next reply: %v", err)
+	}
+	if n, ok := got.(int64); !ok || n != 42 {
+		t.Fatalf("connection desynced: next reply = %#v, want int64(42)", got)
+	}
+}

--- a/universal.go
+++ b/universal.go
@@ -174,6 +174,36 @@ type UniversalOptions struct {
 	//
 	// Experimental: this API may change in a minor release.
 	ClientSideCacheStrategy CSCStrategy
+
+	// ClientSideCacheRefreshOnInvalidate re-fetches recently-read keys as soon as
+	// their invalidation arrives. See Options.ClientSideCacheRefreshOnInvalidate.
+	//
+	// Experimental: this API may change in a minor release.
+	ClientSideCacheRefreshOnInvalidate bool
+
+	// ClientSideCacheCoalesceMisses coalesces concurrent cache misses of the same
+	// key so they share one fetch. See Options.ClientSideCacheCoalesceMisses.
+	//
+	// Experimental: this API may change in a minor release.
+	ClientSideCacheCoalesceMisses bool
+
+	// ClientSideCacheCoalesceMode selects the miss-coalescing engine. See
+	// Options.ClientSideCacheCoalesceMode.
+	//
+	// Experimental: this API may change in a minor release.
+	ClientSideCacheCoalesceMode string
+
+	// ClientSideCacheCoalesceWorkers sets the worker count for "workers" mode. See
+	// Options.ClientSideCacheCoalesceWorkers.
+	//
+	// Experimental: this API may change in a minor release.
+	ClientSideCacheCoalesceWorkers int
+
+	// ClientSideCacheInvalidationBatchWindow batches invalidation-driven deletes.
+	// See Options.ClientSideCacheInvalidationBatchWindow.
+	//
+	// Experimental: this API may change in a minor release.
+	ClientSideCacheInvalidationBatchWindow time.Duration
 }
 
 // Cluster returns cluster options created from the universal options.
@@ -366,6 +396,12 @@ func (o *UniversalOptions) Simple() *Options {
 		ClientSideCacheConfig:     o.ClientSideCacheConfig,
 		ClientSideCache:           o.ClientSideCache,
 		ClientSideCacheStrategy:   o.ClientSideCacheStrategy,
+
+		ClientSideCacheRefreshOnInvalidate:     o.ClientSideCacheRefreshOnInvalidate,
+		ClientSideCacheCoalesceMisses:          o.ClientSideCacheCoalesceMisses,
+		ClientSideCacheCoalesceMode:            o.ClientSideCacheCoalesceMode,
+		ClientSideCacheCoalesceWorkers:         o.ClientSideCacheCoalesceWorkers,
+		ClientSideCacheInvalidationBatchWindow: o.ClientSideCacheInvalidationBatchWindow,
 	}
 }
 

--- a/universal.go
+++ b/universal.go
@@ -181,23 +181,11 @@ type UniversalOptions struct {
 	// Experimental: this API may change in a minor release.
 	ClientSideCacheRefreshOnInvalidate bool
 
-	// ClientSideCacheCoalesceMisses coalesces concurrent cache misses of the same
-	// key so they share one fetch. See Options.ClientSideCacheCoalesceMisses.
+	// ClientSideCacheCoalesceMisses coalesces concurrent cache misses onto a held
+	// full-duplex connection. See Options.ClientSideCacheCoalesceMisses.
 	//
 	// Experimental: this API may change in a minor release.
 	ClientSideCacheCoalesceMisses bool
-
-	// ClientSideCacheCoalesceMode selects the miss-coalescing engine. See
-	// Options.ClientSideCacheCoalesceMode.
-	//
-	// Experimental: this API may change in a minor release.
-	ClientSideCacheCoalesceMode string
-
-	// ClientSideCacheCoalesceWorkers sets the worker count for "workers" mode. See
-	// Options.ClientSideCacheCoalesceWorkers.
-	//
-	// Experimental: this API may change in a minor release.
-	ClientSideCacheCoalesceWorkers int
 
 	// ClientSideCacheInvalidationBatchWindow batches invalidation-driven deletes.
 	// See Options.ClientSideCacheInvalidationBatchWindow.
@@ -399,8 +387,6 @@ func (o *UniversalOptions) Simple() *Options {
 
 		ClientSideCacheRefreshOnInvalidate:     o.ClientSideCacheRefreshOnInvalidate,
 		ClientSideCacheCoalesceMisses:          o.ClientSideCacheCoalesceMisses,
-		ClientSideCacheCoalesceMode:            o.ClientSideCacheCoalesceMode,
-		ClientSideCacheCoalesceWorkers:         o.ClientSideCacheCoalesceWorkers,
 		ClientSideCacheInvalidationBatchWindow: o.ClientSideCacheInvalidationBatchWindow,
 	}
 }


### PR DESCRIPTION
## Full-duplex reader-miss coalescing + invalidation batching

Builds on the CSC **refresh-on-invalidate + base reader-miss coalescing** PR
(`feature/csc-refresh-and-miss-coalescing`). Two additions, both config-driven.

### 1. Full-duplex miss coalescing (reader-miss path)

Concurrent cache misses of the **same key** are already deduped to a single fetch
via a per-key reservation (one owner fetches; the rest block on it and share the
result). This PR adds the engine that dispatches the owners' fetches: a **held
tracked connection with a writer + reader goroutine pair** that pipelines
reserved misses — commands stream out while replies stream back.

Misses are **caller-blocking** (a real request waits on every fetch), so the
engine is latency-first:

- a lone miss is written **immediately** — batching is opportunistic (packs only
  what is already queued), never waited-for;
- new misses stream out while earlier replies are in flight: **~1 RTT per miss**,
  no batch phase-lock, no pool `Get` on the hot path;
- the session releases its connection after an idle grace and re-acquires on the
  next miss, so an idle coalescer holds **zero** connections;
- the session's reader drains RESP3 pushes (invalidations, maintenance) on the
  held connection even while idle, and returns the connection to the pool for
  handoff/lifetime/pool-hook processing (idle grace, recycle age bounded by the
  connection's remaining `ConnMaxLifetime`, `ShouldHandoff` checks).

**Ordering is preserved.** Each caller blocks on its own request's completion,
so a goroutine never issues its next command until this value is in hand — the
engine only overlaps *independent* callers' fetches on the wire.

Earlier engine variants ("workers": N pooled connections with half-duplex
batches; "pinned": a benchmark prototype) were removed during review: the
per-batch round trip added tail latency to exactly the path where a caller is
waiting, and the batching advantage is preserved by the writer's opportunistic
packing. One engine, no tuning surface.

### 2. Invalidation batching

Coalesce invalidation-driven cache deletes within a configurable window instead
of one delete per push frame — smooths bursty invalidation churn. Background
traffic is batching-first by design (nobody waits on it): windowed, deduped,
with the delete queue preserved across batcher rebuilds and dropped on
`FLUSHDB`/`FLUSHALL` (a full flush supersedes queued per-key deletes).

### Config (no environment variables)

New `Options` fields (flat `ClientSideCache*`, matching
`ClientSideCacheRefreshOnInvalidate`), mirrored in `UniversalOptions`:

- `ClientSideCacheCoalesceMisses bool` — enables the coalescer (requires the
  built-in `LocalCache`; ignored for custom `Cache` implementations).
- `ClientSideCacheInvalidationBatchWindow time.Duration` — 0 (default) applies
  invalidations inline; a nonzero window batches them (set it no larger than the
  cache `MaxStaleness`). Shared-handler clients fold windows strictest-wins.

Observability rides the client's normal telemetry: coalesced misses fire the
otel operation-duration and error callbacks like any other command path (no
separate stats API — the engine's internal counters are test-only).

### Hardening (from review)

The review rounds hardened the engine's lifecycle and edge behavior, including:
single-flight token settlement on every path (no caller ever hangs, no
reservation leaks); a CAS ownership interlock so a ctx-cancelled caller's `Cmder`
is never written concurrently; `Close` interruption of blocked acquisitions and
socket reads (bounded drain, then conn close); retry-uncached fallback when CSC
is disabled mid-miss; GC cleanup for clients dropped without `Close`;
`WithTimeout` clones sharing the coalescer; and held-connection probe safety
(no deadline clobbering of concurrent I/O; opaque-transport idle-drain fallback).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes hot paths for RESP3 client-side caching, push draining, and connection reuse; regressions can serve stale cache entries or corrupt pooled connection reply streams.
> 
> **Overview**
> Adds **config-driven** client-side cache tuning via `ClientSideCacheCoalesceMisses` and `ClientSideCacheInvalidationBatchWindow` on `Options` and `UniversalOptions` (replacing env-gated prototypes). Miss coalescing uses a **full-duplex held connection** (writer + reader) to pipeline reserved misses with latency-first packing; invalidations can be **batched off the read path** by a background worker with epoch-aware flush handling.
> 
> Shared invalidate handlers now fold batch windows **strictest-wins**, stack refresh queues so sibling clients keep refresh-on-invalidate, and tear down coalescer/refresher/batcher on `Close` and GC cleanup. Mid-teardown and cancel paths settle with **`errCSCRetryUncached`** instead of spurious `ErrClosed`, with CAS-guarded `Cmder` ownership and wire snapshots for abandoned fetches. Push handling is tightened: **blocking `drainPushFrames`** before reply reads, pre-command drains **retire** desynced conns, refresh refetches use the **tracked main pool**, and pool peek/`checkForData` fixes reduce false unhealthy removals on held CSC connections.
> 
> Also fixes **FT.HYBRID** RESP3 map parsing (no connection desync), **`proto.Scan`/`ScanSlice`** copy semantics and capacity reuse, skips maint **endpoint auto-detect** when notifications are disabled, adds **`SECURITY.md`** and updated vulnerability reporting, and bumps CI spellcheck/govulncheck settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9001bd81537cd7203c02aa7109ac82e469a4541b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->