### PR TITLE
fix(maintnotifications): skip endpoint DNS detect when mode is disabled

### DIFF
--- a/options.go
+++ b/options.go
@@ -574,13 +574,17 @@ func (opt *Options) init() {
 
 	opt.MaintNotificationsConfig = opt.MaintNotificationsConfig.ApplyDefaultsWithPoolConfig(opt.PoolSize, opt.MaxActiveConns)
 
-	// auto-detect endpoint type if not specified
-	endpointType := opt.MaintNotificationsConfig.EndpointType
-	if endpointType == "" || endpointType == maintnotifications.EndpointTypeAuto {
-		// Auto-detect endpoint type if not specified
-		endpointType = maintnotifications.DetectEndpointType(opt.Addr, opt.TLSConfig != nil)
+	// EndpointType is only consumed when sending CLIENT MAINT_NOTIFICATIONS.
+	// Skip DNS-backed auto-detection when maintenance notifications are disabled
+	// so client construction cannot stall on resolver timeouts. This is especially
+	// costly for cluster clients, which construct Options once per node.
+	if opt.MaintNotificationsConfig.Mode != maintnotifications.ModeDisabled {
+		endpointType := opt.MaintNotificationsConfig.EndpointType
+		if endpointType == "" || endpointType == maintnotifications.EndpointTypeAuto {
+			endpointType = maintnotifications.DetectEndpointType(opt.Addr, opt.TLSConfig != nil)
+		}
+		opt.MaintNotificationsConfig.EndpointType = endpointType
 	}
-	opt.MaintNotificationsConfig.EndpointType = endpointType
 }
 
 func (opt *Options) clone() *Options {

--- a/options.go
+++ b/options.go
@@ -574,7 +574,7 @@ func (opt *Options) init() {
 
 	opt.MaintNotificationsConfig = opt.MaintNotificationsConfig.ApplyDefaultsWithPoolConfig(opt.PoolSize, opt.MaxActiveConns)
 
-	// Skip endpoint auto-detection when maint notifications are disabled.
+	// skip endpoint detection when maint notifications are disabled.
 	if opt.MaintNotificationsConfig.Mode != maintnotifications.ModeDisabled {
 		endpointType := opt.MaintNotificationsConfig.EndpointType
 		// auto-detect endpoint type if not specified

--- a/options.go
+++ b/options.go
@@ -574,12 +574,10 @@ func (opt *Options) init() {
 
 	opt.MaintNotificationsConfig = opt.MaintNotificationsConfig.ApplyDefaultsWithPoolConfig(opt.PoolSize, opt.MaxActiveConns)
 
-	// EndpointType is only consumed when sending CLIENT MAINT_NOTIFICATIONS.
-	// Skip DNS-backed auto-detection when maintenance notifications are disabled
-	// so client construction cannot stall on resolver timeouts. This is especially
-	// costly for cluster clients, which construct Options once per node.
+	// Skip endpoint auto-detection when maint notifications are disabled.
 	if opt.MaintNotificationsConfig.Mode != maintnotifications.ModeDisabled {
 		endpointType := opt.MaintNotificationsConfig.EndpointType
+		// auto-detect endpoint type if not specified
 		if endpointType == "" || endpointType == maintnotifications.EndpointTypeAuto {
 			endpointType = maintnotifications.DetectEndpointType(opt.Addr, opt.TLSConfig != nil)
 		}

--- a/options_test.go
+++ b/options_test.go
@@ -541,6 +541,93 @@ func TestOptionsCloneMaintNotificationsRace(t *testing.T) {
 	wg.Wait()
 }
 
+// TestOptionsInitSkipsEndpointDetectWhenMaintDisabled ensures Options.init does
+// not call DetectEndpointType (DNS) when maintenance notifications are disabled.
+// EndpointType is only used for CLIENT MAINT_NOTIFICATIONS; resolving hostnames
+// during client construction stalls NewClient / per-node cluster setup when DNS
+// is slow or broken.
+func TestOptionsInitSkipsEndpointDetectWhenMaintDisabled(t *testing.T) {
+	// NXDOMAIN / non-resolvable name. DetectEndpointType bounds lookups at 2s;
+	// if detection still ran, construction would take on the order of that timeout
+	// rather than completing immediately.
+	const unresolvable = "go-redis-maint-disabled-must-not-resolve.invalid:6379"
+
+	t.Run("disabled leaves EndpointTypeAuto without DNS", func(t *testing.T) {
+		opt := &Options{
+			Addr: unresolvable,
+			MaintNotificationsConfig: &maintnotifications.Config{
+				Mode:         maintnotifications.ModeDisabled,
+				EndpointType: maintnotifications.EndpointTypeAuto,
+			},
+		}
+		start := time.Now()
+		opt.init()
+		elapsed := time.Since(start)
+
+		if elapsed > 200*time.Millisecond {
+			t.Fatalf("Options.init stalled for %v with ModeDisabled; DetectEndpointType should not run", elapsed)
+		}
+		if got := opt.MaintNotificationsConfig.EndpointType; got != maintnotifications.EndpointTypeAuto {
+			t.Fatalf("EndpointType = %q, want %q (unchanged when ModeDisabled)", got, maintnotifications.EndpointTypeAuto)
+		}
+	})
+
+	t.Run("auto still detects and does not stay Auto", func(t *testing.T) {
+		opt := &Options{
+			Addr: unresolvable,
+			MaintNotificationsConfig: &maintnotifications.Config{
+				Mode:         maintnotifications.ModeAuto,
+				EndpointType: maintnotifications.EndpointTypeAuto,
+			},
+		}
+		opt.init()
+		if got := opt.MaintNotificationsConfig.EndpointType; got == "" || got == maintnotifications.EndpointTypeAuto {
+			t.Fatalf("EndpointType = %q, want a concrete type after DetectEndpointType", got)
+		}
+	})
+
+	t.Run("explicit EndpointType still skips detect", func(t *testing.T) {
+		opt := &Options{
+			Addr: unresolvable,
+			MaintNotificationsConfig: &maintnotifications.Config{
+				Mode:         maintnotifications.ModeAuto,
+				EndpointType: maintnotifications.EndpointTypeInternalFQDN,
+			},
+		}
+		start := time.Now()
+		opt.init()
+		elapsed := time.Since(start)
+		if elapsed > 200*time.Millisecond {
+			t.Fatalf("Options.init stalled for %v with explicit EndpointType", elapsed)
+		}
+		if got := opt.MaintNotificationsConfig.EndpointType; got != maintnotifications.EndpointTypeInternalFQDN {
+			t.Fatalf("EndpointType = %q, want %q", got, maintnotifications.EndpointTypeInternalFQDN)
+		}
+	})
+}
+
+func TestNewClientSkipsEndpointDetectWhenMaintDisabled(t *testing.T) {
+	const unresolvable = "go-redis-maint-disabled-must-not-resolve.invalid:6379"
+
+	start := time.Now()
+	c := NewClient(&Options{
+		Addr: unresolvable,
+		MaintNotificationsConfig: &maintnotifications.Config{
+			Mode:         maintnotifications.ModeDisabled,
+			EndpointType: maintnotifications.EndpointTypeAuto,
+		},
+	})
+	elapsed := time.Since(start)
+	defer c.Close()
+
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("NewClient stalled for %v with ModeDisabled; DetectEndpointType should not run", elapsed)
+	}
+	if got := c.Options().MaintNotificationsConfig.EndpointType; got != maintnotifications.EndpointTypeAuto {
+		t.Fatalf("EndpointType = %q, want %q", got, maintnotifications.EndpointTypeAuto)
+	}
+}
+
 func TestClientSideCacheRESP2Warning(t *testing.T) {
 	origLogger := internal.Logger
 	defer func() { internal.Logger = origLogger }()

--- a/options_test.go
+++ b/options_test.go
@@ -542,39 +542,29 @@ func TestOptionsCloneMaintNotificationsRace(t *testing.T) {
 }
 
 // TestOptionsInitSkipsEndpointDetectWhenMaintDisabled ensures Options.init does
-// not call DetectEndpointType (DNS) when maintenance notifications are disabled.
-// EndpointType is only used for CLIENT MAINT_NOTIFICATIONS; resolving hostnames
-// during client construction stalls NewClient / per-node cluster setup when DNS
-// is slow or broken.
+// not call DetectEndpointType when maintenance notifications are disabled.
+// DetectEndpointType never returns EndpointTypeAuto, so leaving Auto unchanged
+// is a deterministic signal that detection was skipped (no wall-clock bound).
 func TestOptionsInitSkipsEndpointDetectWhenMaintDisabled(t *testing.T) {
-	// NXDOMAIN / non-resolvable name. DetectEndpointType bounds lookups at 2s;
-	// if detection still ran, construction would take on the order of that timeout
-	// rather than completing immediately.
-	const unresolvable = "go-redis-maint-disabled-must-not-resolve.invalid:6379"
+	const addr = "go-redis-maint-disabled-must-not-resolve.invalid:6379"
 
-	t.Run("disabled leaves EndpointTypeAuto without DNS", func(t *testing.T) {
+	t.Run("disabled leaves EndpointTypeAuto", func(t *testing.T) {
 		opt := &Options{
-			Addr: unresolvable,
+			Addr: addr,
 			MaintNotificationsConfig: &maintnotifications.Config{
 				Mode:         maintnotifications.ModeDisabled,
 				EndpointType: maintnotifications.EndpointTypeAuto,
 			},
 		}
-		start := time.Now()
 		opt.init()
-		elapsed := time.Since(start)
-
-		if elapsed > 200*time.Millisecond {
-			t.Fatalf("Options.init stalled for %v with ModeDisabled; DetectEndpointType should not run", elapsed)
-		}
 		if got := opt.MaintNotificationsConfig.EndpointType; got != maintnotifications.EndpointTypeAuto {
 			t.Fatalf("EndpointType = %q, want %q (unchanged when ModeDisabled)", got, maintnotifications.EndpointTypeAuto)
 		}
 	})
 
-	t.Run("auto still detects and does not stay Auto", func(t *testing.T) {
+	t.Run("auto replaces EndpointTypeAuto", func(t *testing.T) {
 		opt := &Options{
-			Addr: unresolvable,
+			Addr: addr,
 			MaintNotificationsConfig: &maintnotifications.Config{
 				Mode:         maintnotifications.ModeAuto,
 				EndpointType: maintnotifications.EndpointTypeAuto,
@@ -586,20 +576,15 @@ func TestOptionsInitSkipsEndpointDetectWhenMaintDisabled(t *testing.T) {
 		}
 	})
 
-	t.Run("explicit EndpointType still skips detect", func(t *testing.T) {
+	t.Run("explicit EndpointType is preserved", func(t *testing.T) {
 		opt := &Options{
-			Addr: unresolvable,
+			Addr: addr,
 			MaintNotificationsConfig: &maintnotifications.Config{
 				Mode:         maintnotifications.ModeAuto,
 				EndpointType: maintnotifications.EndpointTypeInternalFQDN,
 			},
 		}
-		start := time.Now()
 		opt.init()
-		elapsed := time.Since(start)
-		if elapsed > 200*time.Millisecond {
-			t.Fatalf("Options.init stalled for %v with explicit EndpointType", elapsed)
-		}
 		if got := opt.MaintNotificationsConfig.EndpointType; got != maintnotifications.EndpointTypeInternalFQDN {
 			t.Fatalf("EndpointType = %q, want %q", got, maintnotifications.EndpointTypeInternalFQDN)
 		}
@@ -607,22 +592,15 @@ func TestOptionsInitSkipsEndpointDetectWhenMaintDisabled(t *testing.T) {
 }
 
 func TestNewClientSkipsEndpointDetectWhenMaintDisabled(t *testing.T) {
-	const unresolvable = "go-redis-maint-disabled-must-not-resolve.invalid:6379"
-
-	start := time.Now()
 	c := NewClient(&Options{
-		Addr: unresolvable,
+		Addr: "go-redis-maint-disabled-must-not-resolve.invalid:6379",
 		MaintNotificationsConfig: &maintnotifications.Config{
 			Mode:         maintnotifications.ModeDisabled,
 			EndpointType: maintnotifications.EndpointTypeAuto,
 		},
 	})
-	elapsed := time.Since(start)
 	defer c.Close()
 
-	if elapsed > 200*time.Millisecond {
-		t.Fatalf("NewClient stalled for %v with ModeDisabled; DetectEndpointType should not run", elapsed)
-	}
 	if got := c.Options().MaintNotificationsConfig.EndpointType; got != maintnotifications.EndpointTypeAuto {
 		t.Fatalf("EndpointType = %q, want %q", got, maintnotifications.EndpointTypeAuto)
 	}


### PR DESCRIPTION
## Summary

This is especially costly for cluster clients, which run Options.init once per node, so detect latency scales with cluster size.

`Options.init` always runs `DetectEndpointType` when `EndpointType` is empty or `auto`. That does a synchronous DNS lookup (`LookupIPAddr`, bounded at 2s) to classify internal vs external endpoints for `CLIENT MAINT_NOTIFICATIONS`.

`EndpointType` is only used when maintenance notifications are enabled (see `initConn`). When `Mode` is `disabled`, the value is never read, but every `NewClient` still paid for detection. Cluster clients construct options once per node, so a slow or broken resolver can stall startup by many seconds (N nodes × detect timeout).

Manager construction and the maint handshake are already skipped when mode is disabled. This change only skips the unused DNS-backed auto-detection in `Options.init`.

## Change

- If `MaintNotificationsConfig.Mode == ModeDisabled`, do not call `DetectEndpointType`; leave `EndpointType` unchanged.
- If mode is `enabled` / `auto`, keep existing behavior (detect when type is empty/`auto`).

## Test plan

- [x] `go test ./ -run 'TestOptionsInitSkipsEndpointDetectWhenMaintDisabled|TestNewClientSkipsEndpointDetectWhenMaintDisabled'`
- [ ] CI

## Notes / follow-up

Default config is still `ModeAuto` + `EndpointTypeAuto`, so callers that never set `MaintNotificationsConfig` still run detection. A possible follow-up is lazy detection at handshake time so `Options.init` never does DNS. However, the first operation could cause a timeout in this case.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard on disabled maint mode only; enabled/auto paths unchanged and covered by new tests.
> 
> **Overview**
> **`Options.init` no longer runs DNS-backed `DetectEndpointType` when maintenance notifications are disabled**, so client construction avoids synchronous resolver work that was unused because `EndpointType` is only consumed when maint mode is enabled.
> 
> When `MaintNotificationsConfig.Mode` is `enabled` or `auto`, behavior is unchanged: empty or `auto` `EndpointType` still triggers detection; an explicit type is left as-is. Tests assert that disabled mode keeps `EndpointTypeAuto` on an unresolvable address (proving detection was skipped) and that `NewClient` behaves the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc446b8633ccfa9784573f60eb85d445fab54bdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->