### PR TITLE
perf(autopipeline): halve full-duplex allocations

### DIFF
--- a/autopipeline.go
+++ b/autopipeline.go
@@ -436,6 +436,14 @@ type apBatch struct {
 	// registered — which is every standalone batch, always, and a cluster
 	// batch outside its node fan-out window.
 	nodeCount atomic.Int32
+	// pooled marks a batch drawn from fdBlockingBatchPool: its done channel is
+	// buffered(1) and completion signals via a non-blocking SEND (see close) so
+	// the channel is reusable, instead of the close()-once unbuffered channel
+	// every other batch uses. Only the full-duplex BLOCKING face produces these
+	// — the one path where the batch is a single-waiter completion signal that
+	// is never installed on the command (no setReady) and is discarded after
+	// Wait. Immutable for the batch's lifecycle; set at construction.
+	pooled bool
 }
 
 // enterNodeDispatch registers the calling goroutine as an executor of this
@@ -539,9 +547,63 @@ func registerBatchExecutors(cmds []Cmder) func() {
 
 func newAPBatch() *apBatch { return &apBatch{done: make(chan struct{})} }
 
-// close completes the batch exactly once, waking every waiter.
+// fdBlockingBatchPool recycles apBatch objects for the full-duplex BLOCKING
+// face — the single path where a batch is a pure, single-waiter completion
+// signal: that face never setReady()s the command (so the batch is invisible to
+// await/readyBatch/resultReady — verified: those all read cmd.ready, set only by
+// setReady) and discards the batch right after Wait returns. Pooled batches use
+// a buffered(1) done channel signalled by a non-blocking SEND (see close), so
+// the channel — the bulk of newAPBatch's ~190 B/op — is reused rather than
+// closed and thrown away. Every other batch (async face, shared flush batches
+// with many/repeat readers) keeps the unbuffered close()-once channel.
+var fdBlockingBatchPool = sync.Pool{
+	New: func() any { return &apBatch{done: make(chan struct{}, 1), pooled: true} },
+}
+
+// getFDBlockingBatch returns a reset pooled batch. Fields are cleared
+// individually (go vet copylocks forbids *b = apBatch{} because of nodeMu); a
+// stale closed=true would make the next completion signal a no-op and park the
+// caller forever, so the reset is not optional.
+func getFDBlockingBatch() *apBatch {
+	b := fdBlockingBatchPool.Get().(*apBatch)
+	b.closed.Store(false)
+	b.dispGid.Store(0)
+	b.nodeCount.Store(0)
+	b.nodeGids = nil
+	// Drain any stray signal so the reused channel starts empty. Insurance: the
+	// blocking face always drains done in Wait, so this is normally a no-op.
+	select {
+	case <-b.done:
+	default:
+	}
+	return b
+}
+
+// putFDBlockingBatch returns a pooled batch after its single waiter has woken.
+// Safe only once the batch is complete and unreferenced (see processBlocking).
+func putFDBlockingBatch(b *apBatch) {
+	if b == nil || !b.pooled {
+		return
+	}
+	fdBlockingBatchPool.Put(b)
+}
+
+// close completes the batch exactly once, waking its waiter(s).
 func (b *apBatch) close() {
 	if b.closed.CompareAndSwap(false, true) {
+		if b.pooled {
+			// Buffered(1) done: signal with a non-blocking send so the channel
+			// stays reusable (a closed channel cannot be reused). The CAS makes
+			// exactly one send and cap 1 makes it never block; the one blocking
+			// waiter (AutoFuture.Wait) drains it. Every completer — reader,
+			// failReqs, shutdownFlush, flushBacklogForClose — funnels through
+			// here, so this single branch covers them all.
+			select {
+			case b.done <- struct{}{}:
+			default:
+			}
+			return
+		}
 		close(b.done)
 	}
 }
@@ -1601,7 +1663,20 @@ func (ap *AutoPipeliner) processAsync(ctx context.Context, cmd Cmder) error {
 // MaxConcurrentBatches: a caller cannot issue its next command until this one
 // returns, so its commands execute in submit order.
 func (ap *AutoPipeliner) processBlocking(ctx context.Context, cmd Cmder) error {
-	return ap.submit(ctx, cmd).Wait()
+	f := ap.submit(ctx, cmd)
+	err := f.Wait()
+	// Recycle the pooled completion batch. After Wait the batch is complete and
+	// unreferenced: the blocking face never installs it on the command (no
+	// setReady), and the reader drops its fdReq — and with it the batch pointer —
+	// as it advances past the just-completed command, so processBlocking is the
+	// last holder. Gate on pooled (excludes completedBatch and every non-FD /
+	// diverted / async path, all of which use newAPBatch) and dispGid==0
+	// (insurance: a stamped dispatcher gid would mean an executor-goroutine Wait
+	// path that can return without draining done).
+	if b := f.batch; b != nil && b.pooled && b.dispGid.Load() == 0 {
+		putFDBlockingBatch(b)
+	}
+	return err
 }
 
 // completedBatch is a reusable already-completed batch: returned both for

--- a/autopipeline_fdpool_test.go
+++ b/autopipeline_fdpool_test.go
@@ -1,0 +1,87 @@
+package redis
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestFDBlockingBatchPoolReuse exercises the pooled-batch lifecycle directly:
+// get → signal (as the reader would, via close) → wait → recycle, thousands of
+// times with concurrent get/put churn. Run under -race: a mis-delivered wakeup
+// from a recycled channel, a missed reset, or a double-signal surfaces as a race
+// or a hang here without needing a live server.
+func TestFDBlockingBatchPoolReuse(t *testing.T) {
+	const workers = 32
+	const iters = 5000
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				b := getFDBlockingBatch()
+				if !b.pooled {
+					t.Errorf("pooled batch lost its pooled flag")
+					return
+				}
+				if b.closed.Load() {
+					t.Errorf("recycled batch came back already closed")
+					return
+				}
+				// A completer (the reader) signals on its own goroutine while the
+				// "caller" waits — the real submit/complete/Wait shape.
+				done := make(chan struct{})
+				go func() {
+					b.close() // buffered send for pooled batches
+					close(done)
+				}()
+				<-b.done // the caller's Wait drains the signal
+				<-done
+				// close is idempotent: a second completer (e.g. a racing failReqs)
+				// must not send a second value or panic.
+				b.close()
+				select {
+				case <-b.done:
+					t.Errorf("second close signalled a recycled channel")
+					return
+				default:
+				}
+				putFDBlockingBatch(b)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestFDBlockingBatchPoolResets guards the individual-field reset: a batch put
+// back dirty must come out clean, or the next caller's completion is a no-op.
+func TestFDBlockingBatchPoolResets(t *testing.T) {
+	b := getFDBlockingBatch()
+	// Dirty every field the reset must clear.
+	b.closed.Store(true)
+	b.dispGid.Store(999)
+	b.nodeCount.Store(3)
+	b.nodeGids = []int64{1, 2, 3}
+	// Leave a stray signal in the buffered channel.
+	select {
+	case b.done <- struct{}{}:
+	default:
+	}
+	putFDBlockingBatch(b)
+
+	// The pool may hand back a different object, so loop until we observe ours
+	// (or give up after a bounded number of gets) — either way every returned
+	// batch must be clean.
+	for i := 0; i < 64; i++ {
+		g := getFDBlockingBatch()
+		if g.closed.Load() || g.dispGid.Load() != 0 || g.nodeCount.Load() != 0 || g.nodeGids != nil {
+			t.Fatalf("getFDBlockingBatch returned a dirty batch")
+		}
+		select {
+		case <-g.done:
+			t.Fatalf("getFDBlockingBatch returned a batch with a stray signal")
+		default:
+		}
+		putFDBlockingBatch(g)
+	}
+}

--- a/autopipeline_fdring_test.go
+++ b/autopipeline_fdring_test.go
@@ -116,6 +116,24 @@ func TestFDInflightRingGrowWhileWrapped(t *testing.T) {
 	}
 }
 
+// TestFDInflightRingAdvanceEmpty guards against a divide-by-zero in advance on a
+// never-grown ring (nil backing buffer): n>0 clamps to 0, and the modulo update
+// must not run. Regression for the copilot review on #3970.
+func TestFDInflightRingAdvanceEmpty(t *testing.T) {
+	f := newFDInflight() // zero-cap: buf is nil until first push
+	f.advance(5)         // must be a no-op, not a panic
+	if f.len() != 0 {
+		t.Fatalf("len=%d after advance on empty ring, want 0", f.len())
+	}
+	// Also after draining a grown ring back to empty.
+	f.pushBatch([]fdReq{mkReq(), mkReq()})
+	f.advance(2)
+	f.advance(3) // over-advance on an empty (but grown) ring: no-op, no panic
+	if f.len() != 0 {
+		t.Fatalf("len=%d after over-advance, want 0", f.len())
+	}
+}
+
 // TestFDInflightRingZeroesConsumed guards the load-bearing zeroing in advance:
 // popped slots must be cleared so drained entries don't pin cmd/ctx/batch for
 // the life of the session.

--- a/autopipeline_fdring_test.go
+++ b/autopipeline_fdring_test.go
@@ -1,0 +1,132 @@
+package redis
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// mkReq returns an fdReq tagged with a unique *apBatch pointer used as identity
+// in the model comparison.
+func mkReq() fdReq { return fdReq{batch: newAPBatch()} }
+
+// TestFDInflightRingModel compares the ring buffer against a reference []fdReq
+// model over a long randomized sequence of push / advance / frontBatch /
+// takeRemaining, deliberately driving the head around the array so growth and
+// snapshots straddle the wrap seam — the one place a ring breaks and that no
+// existing FD test targets.
+func TestFDInflightRingModel(t *testing.T) {
+	rng := rand.New(rand.NewSource(12345))
+	for trial := 0; trial < 200; trial++ {
+		f := newFDInflightCap(rng.Intn(8)) // mix of presized and grow-from-zero
+		var model []fdReq
+		var scratch []fdReq
+
+		for step := 0; step < 400; step++ {
+			switch rng.Intn(3) {
+			case 0: // push a batch
+				k := 1 + rng.Intn(20)
+				reqs := make([]fdReq, k)
+				for i := range reqs {
+					reqs[i] = mkReq()
+				}
+				f.pushBatch(reqs)
+				model = append(model, reqs...)
+			case 1: // advance (pop front)
+				if len(model) == 0 {
+					continue
+				}
+				n := rng.Intn(len(model) + 1)
+				f.advance(n)
+				model = model[n:]
+			case 2: // frontBatch snapshot must equal model front prefix, in order
+				if len(model) == 0 {
+					continue // frontBatch blocks by contract on an empty, open ring
+				}
+				scratch, _ = f.frontBatch(scratch)
+				want := len(model)
+				if want > fdReadBatch {
+					want = fdReadBatch
+				}
+				if len(scratch) != want {
+					t.Fatalf("trial %d step %d: frontBatch len=%d want=%d", trial, step, len(scratch), want)
+				}
+				for i := 0; i < want; i++ {
+					if scratch[i].batch != model[i].batch {
+						t.Fatalf("trial %d step %d: frontBatch[%d] mismatch", trial, step, i)
+					}
+				}
+			}
+			if f.len() != len(model) {
+				t.Fatalf("trial %d step %d: len=%d want=%d", trial, step, f.len(), len(model))
+			}
+			if f.empty() != (len(model) == 0) {
+				t.Fatalf("trial %d step %d: empty=%v want=%v", trial, step, f.empty(), len(model) == 0)
+			}
+		}
+
+		// takeRemaining must return exactly the model tail, in order.
+		rem := f.takeRemaining()
+		if len(rem) != len(model) {
+			t.Fatalf("trial %d: takeRemaining len=%d want=%d", trial, len(rem), len(model))
+		}
+		for i := range rem {
+			if rem[i].batch != model[i].batch {
+				t.Fatalf("trial %d: takeRemaining[%d] mismatch", trial, i)
+			}
+		}
+	}
+}
+
+// TestFDInflightRingGrowWhileWrapped forces the specific hazard: grow the ring
+// while the live window straddles the end of the backing array (head > 0 and
+// the tail has wrapped to the front), then verify order is preserved end to end.
+func TestFDInflightRingGrowWhileWrapped(t *testing.T) {
+	f := newFDInflightCap(8)
+	var model []fdReq
+
+	push := func(k int) {
+		reqs := make([]fdReq, k)
+		for i := range reqs {
+			reqs[i] = mkReq()
+		}
+		f.pushBatch(reqs)
+		model = append(model, reqs...)
+	}
+	adv := func(n int) { f.advance(n); model = model[n:] }
+
+	push(8)  // fill: head=0 count=8 cap=8
+	adv(5)   // head=5 count=3
+	push(4)  // tail wraps past end: entries at 5,6,7,0,... head=5 count=7 cap=8 (still fits)
+	adv(2)   // head=7 count=5
+	push(10) // count 15 > cap 8 -> grow WHILE wrapped (head=7)
+	// Advance across what was the old wrap seam and verify order throughout.
+	for f.len() > 0 {
+		var snap []fdReq
+		snap, _ = f.frontBatch(snap)
+		if snap[0].batch != model[0].batch {
+			t.Fatalf("front mismatch after wrapped grow")
+		}
+		adv(1)
+	}
+	if len(model) != 0 {
+		t.Fatalf("model not drained: %d left", len(model))
+	}
+	if rem := f.takeRemaining(); rem != nil {
+		t.Fatalf("takeRemaining after drain should be nil, got %d", len(rem))
+	}
+}
+
+// TestFDInflightRingZeroesConsumed guards the load-bearing zeroing in advance:
+// popped slots must be cleared so drained entries don't pin cmd/ctx/batch for
+// the life of the session.
+func TestFDInflightRingZeroesConsumed(t *testing.T) {
+	f := newFDInflightCap(4)
+	reqs := []fdReq{mkReq(), mkReq(), mkReq(), mkReq()}
+	f.pushBatch(reqs)
+	f.advance(4)
+	for i := range f.buf {
+		if f.buf[i].batch != nil {
+			t.Fatalf("buf[%d] not zeroed after advance: %#v", i, f.buf[i])
+		}
+	}
+}

--- a/autopipeline_fdsparse_test.go
+++ b/autopipeline_fdsparse_test.go
@@ -1,0 +1,102 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestFullDuplexSparseTrafficPooledBatch drives the blocking full-duplex face
+// with intentionally sparse traffic: each caller pauses longer than the idle
+// timeout between commands, so the engine returns its connection to the pool and
+// re-leases on the next command — every command runs in its own single-entry
+// batch, repeatedly. This is the path where the pooled completion batch (buffered
+// done, recycled after Wait) and the idle-return/re-lease machinery meet, so it
+// guards against a mis-delivered wakeup from a recycled batch under intermittent
+// execution. Correctness checks: ECHO round-trips its own token (no
+// misattribution) and per-caller INCR is strictly sequential (no lost or
+// duplicated completion); nothing hangs.
+func TestFullDuplexSparseTrafficPooledBatch(t *testing.T) {
+	ctx := context.Background()
+
+	c := fdTestClient(":6379")
+	defer c.Close()
+	if err := c.Ping(ctx).Err(); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
+	ap, err := c.AutoPipelineWithOptions(&AutoPipelineOptions{
+		FullDuplex:            true,
+		Unordered:             false,
+		MaxConcurrentBatches:  1,
+		FullDuplexIdleTimeout: 40 * time.Millisecond,
+		FullDuplexMaxHold:     10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("AutoPipeline: %v", err)
+	}
+	defer ap.Close()
+	if ap.fd == nil {
+		t.Fatal("full-duplex engine not active")
+	}
+
+	const workers = 4
+	const opsPerWorker = 12 // ~12 * 70ms ~= 0.85s per worker, run in parallel
+	for i := 0; i < workers; i++ {
+		if err := ap.Del(ctx, fmt.Sprintf("fd:sparse:%d", i)).Err(); err != nil {
+			t.Fatalf("del: %v", err)
+		}
+	}
+
+	done := make(chan error, workers)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			key := fmt.Sprintf("fd:sparse:%d", id)
+			for op := 0; op < opsPerWorker; op++ {
+				// Pause past the 40ms idle timeout so the conn is returned and
+				// re-leased for this command (the sparse / intermittent case).
+				time.Sleep(70 * time.Millisecond)
+
+				token := fmt.Sprintf("w%d-op%d", id, op)
+				if got, err := ap.Echo(ctx, token).Result(); err != nil {
+					done <- fmt.Errorf("worker %d op %d: echo: %w", id, op, err)
+					return
+				} else if got != token {
+					done <- fmt.Errorf("worker %d op %d: ECHO misattribution: sent %q got %q", id, op, token, got)
+					return
+				}
+
+				want := int64(op + 1)
+				if got, err := ap.Incr(ctx, key).Result(); err != nil {
+					done <- fmt.Errorf("worker %d op %d: incr: %w", id, op, err)
+					return
+				} else if got != want {
+					done <- fmt.Errorf("worker %d op %d: INCR out of order: got %d want %d", id, op, got, want)
+					return
+				}
+			}
+			done <- nil
+		}(i)
+	}
+
+	// Watchdog: sparse traffic must still complete promptly (each op is ~1 RTT +
+	// the 70ms pause). A recycled-batch mis-wakeup that dropped a completion would
+	// hang a caller here.
+	finished := make(chan struct{})
+	go func() { wg.Wait(); close(finished) }()
+	select {
+	case <-finished:
+	case <-time.After(30 * time.Second):
+		t.Fatal("sparse-traffic workers did not finish (possible dropped completion)")
+	}
+
+	for i := 0; i < workers; i++ {
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/autopipeline_fullduplex.go
+++ b/autopipeline_fullduplex.go
@@ -284,6 +284,14 @@ func (f *fdInflight) advance(n int) {
 	if n > f.count {
 		n = f.count
 	}
+	if n == 0 {
+		// Nothing to drop (empty ring, or clamped away). Return before the modulo
+		// below, which divides by len(f.buf) and would panic on a never-grown ring
+		// (nil buf). The slice implementation tolerated advance on an empty queue;
+		// preserve that.
+		f.mu.Unlock()
+		return
+	}
 	// Zero each consumed entry before dropping it: the ring keeps its backing
 	// array for the whole session (curInflight holds the deque while the engine
 	// idles), so otherwise a drained burst retains a window's worth of completed

--- a/autopipeline_fullduplex.go
+++ b/autopipeline_fullduplex.go
@@ -167,9 +167,16 @@ type fdInflight struct {
 //nolint:unused // used by the full-duplex tests; lint runs with tests:false.
 func newFDInflight() *fdInflight { return newFDInflightCap(0) }
 
-// newFDInflightCap presizes the ring so a session at the configured batch size
-// takes no reallocations in steady state (session passes maxBatch). Tests use
-// the zero-cap no-arg form and let it grow.
+// newFDInflightCap presizes the ring so a busy session avoids repeated early
+// reallocations, capping the initial size at min(maxBatch, window). The window is
+// the hard ceiling on live count — the writer blocks once in-flight reaches it
+// and caps each drain by the remaining window room — so a MaxBatchSize larger
+// than the window (MaxBatchSize is an uncapped soft per-flush threshold) must not
+// presize beyond it: a huge MaxBatchSize with a small window would otherwise
+// allocate that many entries up front (tens of MB, or an OOM) and again after
+// every idle/recycle. Capping at maxBatch as well keeps the common small-batch
+// default unchanged. grow() is the backstop up to the window as load ramps. Tests
+// use the zero-cap no-arg form and let it grow.
 func newFDInflightCap(initialCap int) *fdInflight {
 	f := &fdInflight{room: make(chan struct{}, 1)}
 	if initialCap > 0 {
@@ -478,6 +485,10 @@ func (fd *fdEngine) submit(ctx context.Context, cmd Cmder) *apBatch {
 	fd.submitMu.RLock()
 	if fd.closed {
 		fd.submitMu.RUnlock()
+		// Recycle the pooled completion batch drawn above but never admitted, so a
+		// rejection does not discard one pooled batch + channel per command (a no-op
+		// for the newAPBatch shape, which is not pooled).
+		putFDBlockingBatch(b)
 		cmd.SetErr(ErrClosed)
 		// Submit-time rejection: return the shared completedBatch sentinel (no host
 		// was started) so processAsync surfaces the error from raw Process(ctx,cmd),
@@ -502,10 +513,12 @@ func (fd *fdEngine) submit(ctx context.Context, cmd Cmder) *apBatch {
 		// started, so this is a submit-time failure — return the completedBatch sentinel
 		// so raw Process(ctx,cmd) reports the ctx error.
 		fd.submitMu.RUnlock()
+		putFDBlockingBatch(b) // recycle the unadmitted pooled batch (no-op if not pooled)
 		cmd.SetErr(ctx.Err())
 		return completedBatch
 	case <-fd.ap.ctx.Done():
 		fd.submitMu.RUnlock()
+		putFDBlockingBatch(b) // recycle the unadmitted pooled batch (no-op if not pooled)
 		cmd.SetErr(ErrClosed)
 		return completedBatch
 	}
@@ -928,9 +941,9 @@ func (fd *fdEngine) attempt(bg context.Context, carry []fdReq) (unacked []fdReq,
 // session runs the writer (this goroutine) + reader (spawned) on one connection
 // until Close (graceful) or a connection error (returns the unacked tail).
 func (fd *fdEngine) session(bg context.Context, cn *pool.Conn, carry []fdReq) (unacked []fdReq, result fdResult, aerr error) {
-	inflight := newFDInflightCap(fd.maxBatch)
-	fd.curInflight.Store(inflight) // test observability (peak in-flight)
-	fd.curConn.Store(cn)           // test observability (handoff)
+	inflight := newFDInflightCap(min(fd.maxBatch, fd.window)) // capped by the window (peak) and the batch; grow() backstops
+	fd.curInflight.Store(inflight)                            // test observability (peak in-flight)
+	fd.curConn.Store(cn)                                      // test observability (handoff)
 	defer fd.curConn.Store(nil)
 	readerDone := make(chan struct{})
 

--- a/autopipeline_fullduplex.go
+++ b/autopipeline_fullduplex.go
@@ -146,36 +146,78 @@ func (r fdReq) complete() {
 //   - recover: hard stop; the reader abandons the remaining, which are returned
 //     to the retry loop for replay.
 type fdInflight struct {
-	mu         sync.Mutex
-	cond       *sync.Cond
-	q          []fdReq
+	mu   sync.Mutex
+	cond *sync.Cond
+	// buf is a ring buffer of in-flight entries: the writer appends at the back
+	// (head+count), the reader pops from the front (head). A grow-only slice
+	// (append + reslice-off-front) reallocated its backing array on every window
+	// churn — the single largest allocation source under load — because the
+	// popped-off prefix was never reused. The ring reuses the whole array for the
+	// life of the session; it only grows when live count would exceed capacity.
+	buf        []fdReq
+	head       int           // index of the front (oldest) live entry
+	count      int           // number of live entries
 	noMorePush bool          // graceful: drain remaining then reader exits
 	hardClosed bool          // recover: reader stops immediately, remaining replayed
 	room       chan struct{} // cap-1 signal: the reader popped, so there is room
-	peak       int           // high-water mark of len(q); observability for the backpressure test
+	peak       int           // high-water mark of live count; observability for the backpressure test
 	advanced   int           // total entries the reader completed this session (progress signal)
 }
 
-func newFDInflight() *fdInflight {
+func newFDInflight() *fdInflight { return newFDInflightCap(0) }
+
+// newFDInflightCap presizes the ring so a session at the configured batch size
+// takes no reallocations in steady state (session passes maxBatch). Tests use
+// the zero-cap no-arg form and let it grow.
+func newFDInflightCap(initialCap int) *fdInflight {
 	f := &fdInflight{room: make(chan struct{}, 1)}
+	if initialCap > 0 {
+		f.buf = make([]fdReq, initialCap)
+	}
 	f.cond = sync.NewCond(&f.mu)
 	return f
 }
 
 func (f *fdInflight) len() int {
 	f.mu.Lock()
-	n := len(f.q)
+	n := f.count
 	f.mu.Unlock()
 	return n
+}
+
+// grow ensures the ring can hold at least need entries, preserving FIFO order
+// and normalizing the front to index 0. Caller holds f.mu.
+func (f *fdInflight) grow(need int) {
+	if need <= len(f.buf) {
+		return
+	}
+	nc := len(f.buf) * 2
+	if nc < need {
+		nc = need
+	}
+	if nc < 8 {
+		nc = 8
+	}
+	nb := make([]fdReq, nc)
+	// Unwrap the live entries into the new buffer starting at 0.
+	for i := 0; i < f.count; i++ {
+		nb[i] = f.buf[(f.head+i)%len(f.buf)]
+	}
+	f.buf = nb
+	f.head = 0
 }
 
 // pushBatch appends a whole write batch under one lock (fewer lock ops than
 // per-command push — matters at loopback op rates).
 func (f *fdInflight) pushBatch(reqs []fdReq) {
 	f.mu.Lock()
-	f.q = append(f.q, reqs...)
-	if len(f.q) > f.peak {
-		f.peak = len(f.q)
+	f.grow(f.count + len(reqs))
+	for _, r := range reqs {
+		f.buf[(f.head+f.count)%len(f.buf)] = r
+		f.count++
+	}
+	if f.count > f.peak {
+		f.peak = f.count
 	}
 	f.cond.Signal()
 	f.mu.Unlock()
@@ -199,22 +241,34 @@ const fdReadBatch = 256
 
 // frontBatch blocks until entries are available (or the deque is closing) and
 // returns a snapshot of the front (up to fdReadBatch). ok=false means the reader
-// should exit. The writer only ever appends, so this prefix stays the front
-// until the reader advance()s it.
+// should exit. The writer only ever appends at the back, so this prefix stays the
+// front until the reader advance()s it. The snapshot is copied into the caller's
+// buf (may span the ring's wrap seam as two segments), so it never aliases the
+// backing array.
 func (f *fdInflight) frontBatch(buf []fdReq) ([]fdReq, bool) {
 	f.mu.Lock()
-	for len(f.q) == 0 && !f.noMorePush && !f.hardClosed {
+	for f.count == 0 && !f.noMorePush && !f.hardClosed {
 		f.cond.Wait()
 	}
-	if f.hardClosed || len(f.q) == 0 {
+	if f.hardClosed || f.count == 0 {
 		f.mu.Unlock()
 		return buf[:0], false
 	}
-	n := len(f.q)
+	n := f.count
 	if n > fdReadBatch {
 		n = fdReadBatch
 	}
-	buf = append(buf[:0], f.q[:n]...)
+	buf = buf[:0]
+	// First segment: head .. min(end-of-array, head+n).
+	seg := len(f.buf) - f.head
+	if seg > n {
+		seg = n
+	}
+	buf = append(buf, f.buf[f.head:f.head+seg]...)
+	if seg < n {
+		// Wrapped: remainder from the start of the array.
+		buf = append(buf, f.buf[:n-seg]...)
+	}
 	f.mu.Unlock()
 	return buf, true
 }
@@ -226,17 +280,19 @@ func (f *fdInflight) advance(n int) {
 		return
 	}
 	f.mu.Lock()
-	if n > len(f.q) {
-		n = len(f.q)
+	if n > f.count {
+		n = f.count
 	}
-	// Zero the consumed prefix before reslicing: the reslice keeps the backing
-	// array (curInflight holds the deque while the engine idles), so otherwise a
-	// drained burst retains a window's worth of completed fdReq values — command
-	// args, caller contexts, batches — until the next session overwrites them.
+	// Zero each consumed entry before dropping it: the ring keeps its backing
+	// array for the whole session (curInflight holds the deque while the engine
+	// idles), so otherwise a drained burst retains a window's worth of completed
+	// fdReq values — command args, caller contexts, batches — until the slot is
+	// overwritten by a later push.
 	for i := 0; i < n; i++ {
-		f.q[i] = fdReq{}
+		f.buf[(f.head+i)%len(f.buf)] = fdReq{}
 	}
-	f.q = f.q[n:]
+	f.head = (f.head + n) % len(f.buf)
+	f.count -= n
 	f.advanced += n
 	f.mu.Unlock()
 	select {
@@ -258,7 +314,7 @@ func (f *fdInflight) advancedTotal() int {
 
 func (f *fdInflight) empty() bool {
 	f.mu.Lock()
-	n := len(f.q)
+	n := f.count
 	f.mu.Unlock()
 	return n == 0
 }
@@ -287,11 +343,25 @@ func (f *fdInflight) hardClose() {
 // takeRemaining returns the entries the reader left unacknowledged, in order,
 // and clears the queue. Call ONLY after the reader has exited (<-readerDone):
 // the reader advance()s every command it completes, so what remains is exactly
-// the unacked tail, and with the reader gone there is no concurrent access.
+// the unacked tail, and with the reader gone there is no concurrent access. The
+// live entries are unwrapped into a fresh contiguous slice (they may span the
+// ring's wrap seam); the ring is terminal for the session, so the backing array
+// is dropped.
 func (f *fdInflight) takeRemaining() []fdReq {
 	f.mu.Lock()
-	rem := f.q
-	f.q = nil
+	if f.count == 0 {
+		f.buf = nil
+		f.head = 0
+		f.mu.Unlock()
+		return nil
+	}
+	rem := make([]fdReq, f.count)
+	for i := 0; i < f.count; i++ {
+		rem[i] = f.buf[(f.head+i)%len(f.buf)]
+	}
+	f.buf = nil
+	f.head = 0
+	f.count = 0
 	f.mu.Unlock()
 	return rem
 }
@@ -839,7 +909,7 @@ func (fd *fdEngine) attempt(bg context.Context, carry []fdReq) (unacked []fdReq,
 // session runs the writer (this goroutine) + reader (spawned) on one connection
 // until Close (graceful) or a connection error (returns the unacked tail).
 func (fd *fdEngine) session(bg context.Context, cn *pool.Conn, carry []fdReq) (unacked []fdReq, result fdResult, aerr error) {
-	inflight := newFDInflight()
+	inflight := newFDInflightCap(fd.maxBatch)
 	fd.curInflight.Store(inflight) // test observability (peak in-flight)
 	fd.curConn.Store(cn)           // test observability (handoff)
 	defer fd.curConn.Store(nil)

--- a/autopipeline_fullduplex.go
+++ b/autopipeline_fullduplex.go
@@ -443,10 +443,20 @@ func (fd *fdEngine) submit(ctx context.Context, cmd Cmder) *apBatch {
 		cmd.SetErr(ErrClosed)
 		return completedBatch
 	}
-	b := newAPBatch()
 	var hookDone chan struct{}
 	if fd.ap.pipeliner.hookCount() > 0 {
 		hookDone = make(chan struct{})
+	}
+	// Hook-free blocking face: the batch is a single-waiter completion signal
+	// discarded after Wait, so draw it from the pool (buffered done, recycled in
+	// processBlocking). Every other shape — the async face (batch installed on
+	// the command, read repeatedly) and the hooked path (host goroutine owns
+	// completion) — needs the close()-once channel.
+	var b *apBatch
+	if hookDone == nil && fd.ap.blocking {
+		b = getFDBlockingBatch()
+	} else {
+		b = newAPBatch()
 	}
 	req := fdReq{cmd: cmd, batch: b, hookDone: hookDone, ctx: ctx, attempts: 1}
 

--- a/autopipeline_fullduplex.go
+++ b/autopipeline_fullduplex.go
@@ -164,6 +164,7 @@ type fdInflight struct {
 	advanced   int           // total entries the reader completed this session (progress signal)
 }
 
+//nolint:unused // used by the full-duplex tests; lint runs with tests:false.
 func newFDInflight() *fdInflight { return newFDInflightCap(0) }
 
 // newFDInflightCap presizes the ring so a session at the configured batch size


### PR DESCRIPTION
## Full-duplex allocation optimizations

Follow-up to #3964, targeting only the full-duplex hot path. From profiling the
blocking FD engine under load (RTT 1 ms, 2,048 sync callers, ~890k ops/s):
allocation was ~770 B/op and GC ran ~10–15% of CPU. This PR removes the two
largest allocation sites; **throughput and latency are unchanged — it is a pure
allocation/GC win.**

### Two logical changes (reviewable independently)

1. **Ring-buffer the in-flight FIFO (`fdInflight`)** — was a grow-only slice
   (append at back, reslice off front) whose backing array reallocated on every
   window churn (31% of per-op bytes). Now a ring reusing one array per session,
   growing only when live count exceeds capacity. No observable semantic change.
2. **Pool the blocking-face completion batch (`apBatch`)** — the blocking face
   allocated a struct + `done` channel per command (23% of per-op bytes). That
   face is the one place a batch is a pure single-waiter signal never installed
   on the command (no `setReady`) and discarded after `Wait`. Pooled batches use
   a reusable buffered(1) `done` (non-blocking send instead of `close`); `close()`
   branches on an immutable `pooled` flag so every completer stays correct through
   one entry point; recycled in `processBlocking` after `Wait`, gated on
   `pooled && dispGid==0`. Async face and shared flush batches are untouched.

If preferred, change 1 can be merged alone: it is ~31% of the win at near-zero
risk (private data structure, single writer/reader under the existing mutex).

### Results (standalone bench, 1 ms, 90% GET / 10% SET, sync callers)

| callers | before | after | Δ |
|---|---|---|---|
| 256 | 677 B/op | 354 B/op | −48% |
| 2048 | ~770 B/op | 353 B/op | −54% |

CPU/op 7.9 → 6.6 µs at 256 callers; throughput flat (917k @ 2048 before and
after). Alloc profile confirms `pushBatch` and `newAPBatch` are gone from the FD
hot path.

### Testing

- New unit tests, both under `-race`: a ring model test (randomized
  push/advance/takeRemaining vs a reference slice, driving snapshots and growth
  across the wrap seam) and a concurrent batch-pool reuse test (32×5000
  get/signal/wait/recycle with concurrent completion).
- Full FD race suite green, including the ownership-partition, hard-close,
  max-hold-recycle, no-goroutine-leak, and close-waits-hooks tests.
- The fault-injection exactly-once / ECHO-misattribution / no-hang harness
  (whose Process path is `processBlocking`, exercising the recycle directly)
  matches the pre-change baseline: clean run 1.6M ops and a retries-disabled
  fault run 2.1M ops, both with zero misattribution, zero hang, zero race.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 05aab9cb214c2d8ee813fa8ee42ae6e744455808. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->