### PR TITLE
perf(proto): add zero-copy semantics to scan, remove redundant data c…

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -29,12 +29,11 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
-          check-latest: true
+          go-version: "stable"
           cache: true
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.2.0
 
       - name: Run govulncheck (all modules)
         shell: bash

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -3,7 +3,7 @@ name: govulncheck
 
 on:
   pull_request:
-    branches: [master, v9, v9.7, v9.8, "ndyakov/**", "ofekshenawa/**", "ce/**", "feature/**"]
+    branches: [master, v9, v9.7, v9.8, "ndyakov/**", "ofekshenawa/**","vkotsev/**", "ce/**", "feature/**"]
   push:
     branches: [master, v9, "v9.*"]
   schedule:
@@ -33,7 +33,7 @@ jobs:
           cache: true
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.2.0
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
       - name: Run govulncheck (all modules)
         shell: bash

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-go@v7
         with:
           go-version: "1.26.x"
+          check-latest: true
           cache: true
 
       - name: Install govulncheck

--- a/command.go
+++ b/command.go
@@ -1875,7 +1875,7 @@ func (cmd *StringCmd) Scan(val interface{}) error {
 	if cmd.err != nil {
 		return cmd.err
 	}
-	return proto.Scan([]byte(cmd.val), val)
+	return proto.Scan(util.StringToBytes(cmd.val), val)
 }
 
 func (cmd *StringCmd) String() string {

--- a/internal/proto/reader.go
+++ b/internal/proto/reader.go
@@ -502,7 +502,7 @@ func (r *Reader) ReadInt() (int64, error) {
 		if err != nil {
 			return 0, err
 		}
-		return util.ParseInt([]byte(s), 10, 64)
+		return strconv.ParseInt(s, 10, 64)
 	case RespBigInt:
 		b, err := r.readBigInt(line)
 		if err != nil {
@@ -529,7 +529,7 @@ func (r *Reader) ReadUint() (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		return util.ParseUint([]byte(s), 10, 64)
+		return strconv.ParseUint(s, 10, 64)
 	case RespBigInt:
 		b, err := r.readBigInt(line)
 		if err != nil {

--- a/internal/proto/scan.go
+++ b/internal/proto/scan.go
@@ -13,7 +13,7 @@ import (
 // Scan parses bytes `b` to `v` with appropriate type.
 //
 //nolint:gocyclo
-func Scan(b []byte, v interface{}) error {
+func Scan(b []byte, v any) error {
 	switch v := v.(type) {
 	case nil:
 		return fmt.Errorf("redis: Scan(nil)")
@@ -21,7 +21,9 @@ func Scan(b []byte, v interface{}) error {
 		*v = util.BytesToString(b)
 		return nil
 	case *[]byte:
-		*v = b
+		dest := make([]byte, len(b))
+		copy(dest, b)
+		*v = dest
 		return nil
 	case *int:
 		var err error
@@ -116,9 +118,13 @@ func Scan(b []byte, v interface{}) error {
 		*v = time.Duration(n)
 		return nil
 	case encoding.BinaryUnmarshaler:
-		return v.UnmarshalBinary(b)
+		dest := make([]byte, len(b))
+		copy(dest, b)
+		return v.UnmarshalBinary(dest)
 	case *net.IP:
-		*v = b
+		dest := make(net.IP, len(b))
+		copy(dest, b)
+		*v = dest
 		return nil
 	default:
 		return fmt.Errorf(
@@ -126,12 +132,12 @@ func Scan(b []byte, v interface{}) error {
 	}
 }
 
-func ScanSlice(data []string, slice interface{}) error {
+func ScanSlice(data []string, slice any) error {
 	v := reflect.ValueOf(slice)
 	if !v.IsValid() {
 		return fmt.Errorf("redis: ScanSlice(nil)")
 	}
-	if v.Kind() != reflect.Ptr {
+	if v.Kind() != reflect.Pointer {
 		return fmt.Errorf("redis: ScanSlice(non-pointer %T)", slice)
 	}
 	v = v.Elem()
@@ -142,7 +148,7 @@ func ScanSlice(data []string, slice interface{}) error {
 	next := makeSliceNextElemFunc(v)
 	for i, s := range data {
 		elem := next()
-		if err := Scan([]byte(s), elem.Addr().Interface()); err != nil {
+		if err := Scan(util.StringToBytes(s), elem.Addr().Interface()); err != nil {
 			err = fmt.Errorf("redis: ScanSlice index=%d value=%q failed: %w", i, s, err)
 			return err
 		}
@@ -154,32 +160,25 @@ func ScanSlice(data []string, slice interface{}) error {
 func makeSliceNextElemFunc(v reflect.Value) func() reflect.Value {
 	elemType := v.Type().Elem()
 
-	if elemType.Kind() == reflect.Ptr {
+	next := func() reflect.Value {
+		if v.Len() == v.Cap() {
+			v.Grow(1)
+		}
+
+		v.SetLen(v.Len() + 1)
+		return v.Index(v.Len() - 1)
+	}
+
+	if elemType.Kind() == reflect.Pointer {
 		elemType = elemType.Elem()
 		return func() reflect.Value {
-			if v.Len() < v.Cap() {
-				v.Set(v.Slice(0, v.Len()+1))
-				elem := v.Index(v.Len() - 1)
-				if elem.IsNil() {
-					elem.Set(reflect.New(elemType))
-				}
-				return elem.Elem()
+			elem := next()
+			if elem.IsNil() {
+				elem.Set(reflect.New(elemType))
 			}
-
-			elem := reflect.New(elemType)
-			v.Set(reflect.Append(v, elem))
 			return elem.Elem()
 		}
 	}
 
-	zero := reflect.Zero(elemType)
-	return func() reflect.Value {
-		if v.Len() < v.Cap() {
-			v.Set(v.Slice(0, v.Len()+1))
-			return v.Index(v.Len() - 1)
-		}
-
-		v.Set(reflect.Append(v, zero))
-		return v.Index(v.Len() - 1)
-	}
+	return next
 }

--- a/internal/proto/scan_test.go
+++ b/internal/proto/scan_test.go
@@ -2,6 +2,10 @@ package proto_test
 
 import (
 	"encoding/json"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
 
 	. "github.com/bsm/ginkgo/v2"
 	. "github.com/bsm/gomega"
@@ -48,3 +52,325 @@ var _ = Describe("ScanSlice", func() {
 		}))
 	})
 })
+
+// ScanSlice hands its input to Scan as a []byte aliasing the string's backing
+// array, so the branches where b escapes (*[]byte, *net.IP,
+// encoding.BinaryUnmarshaler) have to copy. These specs pin that down: they
+// fail if those branches ever go back to passing b along directly, and they
+// distinguish make+copy from append(T(nil), b...), which yields nil rather
+// than an empty slice.
+var _ = Describe("ScanSlice copy semantics", func() {
+	It("does not alias the source strings for [][]byte", func() {
+		src := []string{strings.Repeat("a", 8), strings.Repeat("b", 8)}
+
+		var slice [][]byte
+		err := proto.ScanSlice(src, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([][]byte{[]byte("aaaaaaaa"), []byte("bbbbbbbb")}))
+
+		slice[0][0] = 'Z'
+		slice[1][0] = 'Z'
+		Expect(src).To(Equal([]string{"aaaaaaaa", "bbbbbbbb"}))
+	})
+
+	It("does not alias the source strings for []net.IP", func() {
+		src := []string{string(net.IPv4(10, 0, 0, 1).To4())}
+
+		var slice []net.IP
+		err := proto.ScanSlice(src, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]net.IP{net.IPv4(10, 0, 0, 1).To4()}))
+
+		slice[0][3] = 9
+		Expect(src).To(Equal([]string{string(net.IPv4(10, 0, 0, 1).To4())}))
+	})
+
+	It("scans an empty element into an empty, non-nil []byte", func() {
+		var slice [][]byte
+		err := proto.ScanSlice([]string{""}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(HaveLen(1))
+		Expect(slice[0]).NotTo(BeNil())
+		Expect(slice[0]).To(HaveLen(0))
+	})
+
+	It("scans an empty element into an empty, non-nil net.IP", func() {
+		var slice []net.IP
+		err := proto.ScanSlice([]string{""}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(HaveLen(1))
+		Expect(slice[0]).NotTo(BeNil())
+		Expect(slice[0]).To(HaveLen(0))
+	})
+})
+
+// makeSliceNextElemFunc extends the destination in place when it already has
+// spare capacity, and reuses non-nil pointer elements found in that capacity
+// rather than allocating new ones. These specs cover that branch: scanning
+// twice into the same backing array, which the benchmarks exercise but never
+// assert on.
+var _ = Describe("ScanSlice capacity reuse", func() {
+	It("reuses the backing array of a []string", func() {
+		var slice []string
+		err := proto.ScanSlice([]string{"a", "b", "c"}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]string{"a", "b", "c"}))
+
+		capBefore, firstElem := cap(slice), &slice[0]
+
+		slice = slice[:0]
+		err = proto.ScanSlice([]string{"x", "y", "z"}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]string{"x", "y", "z"}))
+		// Same array, so the in-place path really was taken.
+		Expect(cap(slice)).To(Equal(capBefore))
+		Expect(&slice[0]).To(BeIdenticalTo(firstElem))
+	})
+
+	It("does not leave stale elements when the second scan is shorter", func() {
+		var slice []string
+		err := proto.ScanSlice([]string{"a", "b", "c"}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+
+		slice = slice[:0]
+		err = proto.ScanSlice([]string{"z"}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]string{"z"}))
+	})
+
+	It("scans into a preallocated slice without growing it", func() {
+		slice := make([]int64, 0, 4)
+		err := proto.ScanSlice([]string{"1", "2", "3"}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]int64{1, 2, 3}))
+		Expect(cap(slice)).To(Equal(4))
+	})
+
+	It("reuses existing pointers for []*testScanSliceStruct", func() {
+		var slice []*testScanSliceStruct
+		err := proto.ScanSlice([]string{
+			`{"ID":1,"Name":"one"}`,
+			`{"ID":2,"Name":"two"}`,
+		}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]*testScanSliceStruct{{1, "one"}, {2, "two"}}))
+
+		capBefore := cap(slice)
+		reused := []*testScanSliceStruct{slice[0], slice[1]}
+
+		slice = slice[:0]
+		err = proto.ScanSlice([]string{
+			`{"ID":3,"Name":"three"}`,
+			`{"ID":4,"Name":"four"}`,
+		}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]*testScanSliceStruct{{3, "three"}, {4, "four"}}))
+		Expect(cap(slice)).To(Equal(capBefore))
+		// The pointers in the recycled capacity are scanned into, not replaced.
+		Expect(slice[0]).To(BeIdenticalTo(reused[0]))
+		Expect(slice[1]).To(BeIdenticalTo(reused[1]))
+	})
+
+	It("allocates pointers for nil elements in recycled capacity", func() {
+		slice := make([]*testScanSliceStruct, 0, 2)
+		err := proto.ScanSlice([]string{`{"ID":1,"Name":"one"}`}, &slice)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slice).To(Equal([]*testScanSliceStruct{{1, "one"}}))
+		Expect(slice[0]).NotTo(BeNil())
+	})
+})
+
+// benchScanSliceElems is the element count per benchmark iteration. Divide
+// allocs/op and ns/op by it to get the per-element cost.
+const benchScanSliceElems = 1024
+
+// benchStrings builds n deterministic strings of the given byte length.
+func benchStrings(n, size int) []string {
+	data := make([]string, n)
+	for i := range data {
+		// Vary the prefix so the strings are distinct but equally sized.
+		prefix := strconv.Itoa(i)
+		if len(prefix) > size {
+			prefix = prefix[:size]
+		}
+		data[i] = prefix + strings.Repeat("x", size-len(prefix))
+	}
+	return data
+}
+
+// benchNumbers builds n deterministic base-10 integer strings.
+func benchNumbers(n int) []string {
+	data := make([]string, n)
+	for i := range data {
+		data[i] = strconv.Itoa(1234567890 + i)
+	}
+	return data
+}
+
+var benchElemSizes = []int{8, 64, 512}
+
+// The destination slices below are allocated once and reset to zero length
+// between iterations, so makeSliceNextElemFunc reuses the existing capacity.
+// That keeps slice growth out of the measurement and leaves the per-element
+// string -> []byte conversion inside Scan as the dominant cost.
+
+func BenchmarkScanSliceString(b *testing.B) {
+	for _, size := range benchElemSizes {
+		b.Run("size="+strconv.Itoa(size), func(b *testing.B) {
+			data := benchStrings(benchScanSliceElems, size)
+			dst := make([]string, 0, benchScanSliceElems)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				dst = dst[:0]
+				if err := proto.ScanSlice(data, &dst); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkScanSliceBytes covers Scan's *[]byte branch, which hands b to the
+// caller and therefore has to copy regardless of how b was produced.
+func BenchmarkScanSliceBytes(b *testing.B) {
+	for _, size := range benchElemSizes {
+		b.Run("size="+strconv.Itoa(size), func(b *testing.B) {
+			data := benchStrings(benchScanSliceElems, size)
+			dst := make([][]byte, 0, benchScanSliceElems)
+
+			b.ReportAllocs()
+			for b.Loop() {
+				dst = dst[:0]
+				if err := proto.ScanSlice(data, &dst); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkScanSliceInt64(b *testing.B) {
+	data := benchNumbers(benchScanSliceElems)
+	dst := make([]int64, 0, benchScanSliceElems)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		dst = dst[:0]
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkScanSliceFloat64(b *testing.B) {
+	data := benchNumbers(benchScanSliceElems)
+	dst := make([]float64, 0, benchScanSliceElems)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		dst = dst[:0]
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkScanSliceIP covers Scan's *net.IP branch, the other place b escapes.
+func BenchmarkScanSliceIP(b *testing.B) {
+	data := make([]string, benchScanSliceElems)
+	for i := range data {
+		data[i] = string(net.IPv4(10, 0, byte(i>>8), byte(i)).To4())
+	}
+	dst := make([]net.IP, 0, benchScanSliceElems)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		dst = dst[:0]
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// benchJSON builds n deterministic JSON objects for testScanSliceStruct.
+func benchJSON(n int) []string {
+	data := make([]string, n)
+	for i := range data {
+		id := strconv.Itoa(i)
+		data[i] = `{"ID":` + id + `,"Name":"name-` + id + `"}`
+	}
+	return data
+}
+
+// BenchmarkScanSliceBinaryUnmarshaler is the realistic mixed case: Scan copies
+// b before handing it to UnmarshalBinary (so implementations may mutate or
+// retain it), and json.Unmarshal dominates on top of that copy.
+func BenchmarkScanSliceBinaryUnmarshaler(b *testing.B) {
+	data := benchJSON(benchScanSliceElems)
+	dst := make([]testScanSliceStruct, 0, benchScanSliceElems)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		dst = dst[:0]
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkScanSlicePtr covers pointer element types where the capacity already
+// holds non-nil pointers: makeSliceNextElemFunc reuses them, so reflect.New
+// never runs and the refill should allocate nothing beyond json.Unmarshal.
+func BenchmarkScanSlicePtr(b *testing.B) {
+	data := benchJSON(benchScanSliceElems)
+	dst := make([]*testScanSliceStruct, 0, benchScanSliceElems)
+
+	// Populate the capacity first so the measured loop takes the reuse path.
+	if err := proto.ScanSlice(data, &dst); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		dst = dst[:0]
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkScanSlicePtrGrow is the same pointer element type starting from a nil
+// slice, so every element pays a reflect.New on top of the slice growth.
+func BenchmarkScanSlicePtrGrow(b *testing.B) {
+	data := benchJSON(benchScanSliceElems)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		var dst []*testScanSliceStruct
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkScanSliceGrow starts from a nil slice, so it includes the slice
+// growth cost a first-time caller actually pays.
+func BenchmarkScanSliceGrow(b *testing.B) {
+	data := benchStrings(benchScanSliceElems, 64)
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		var dst []string
+		if err := proto.ScanSlice(data, &dst); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`ScanSlice` (and `StringCmd.Scan`) copied every input string into a fresh
`[]byte` before handing it to `proto.Scan`, and `makeSliceNextElemFunc`
allocated a new slice header via `v.Set(v.Slice(...))` for every element. That
cost 2 heap allocations per element on every path, even for destinations that
only parse the bytes (`*int64`, `*float64`, `*string`, `*time.Time`, …).

This PR moves the copy to where it is actually needed:

- Callers now pass the input zero-copy via `util.StringToBytes`.
- The `Scan` branches where `b` escapes — `*[]byte`, `*net.IP`, and
  `encoding.BinaryUnmarshaler` — copy at the point of escape, so no caller ever
  receives (or hands user code) bytes aliasing a string's backing array.
- `makeSliceNextElemFunc` extends the destination in place with
  `reflect.Value.Grow`/`SetLen` instead of allocating a slice header per
  element, and the pointer/non-pointer variants are collapsed into one helper.

Net effect: parsing destinations are now allocation-free per element, escaping
destinations pay exactly the one copy they always needed, and existing
semantics are preserved and now pinned by tests.

## Safety notes

- `*string` aliases the input string's bytes (string → string, both
  immutable) — safe and copy-free.
- `*[]byte` / `*net.IP` copy, since the caller receives a mutable slice.
- `encoding.BinaryUnmarshaler` receives a private copy, so implementations
  that mutate or retain their input keep working exactly as before.
- New specs assert the no-aliasing guarantees (mutating results does not
  affect source strings), empty-input semantics, in-place capacity reuse, and
  pointer-element recycling.

Also includes mechanical modernization in `internal/proto`:
`interface{}` → `any`, `reflect.Ptr` → `reflect.Pointer` and
direct `strconv.ParseInt`/`ParseUint` calls in `ReadInt`/`ReadUint` (dropping
a pointless string → `[]byte` round-trip).

## Benchmarks

`go test ./internal/proto/ -bench BenchmarkScanSlice` — linux/amd64,
Intel Core Ultra 7 155U. 1024 elements per op; destinations are reset to zero
length between iterations (except the `Grow` benchmarks, which start from a
nil slice).

| Benchmark | old ns/op | new ns/op | Δ speed | old allocs/op | new allocs/op |
|---|---:|---:|---:|---:|---:|
| ScanSliceString/size=8 | 58,676 | 14,189 | 4.1× | 2,049 | 1 |
| ScanSliceString/size=64 | 76,157 | 14,139 | 5.4× | 2,049 | 1 |
| ScanSliceString/size=512 | 174,061 | 14,303 | 12.2× | 2,049 | 1 |
| ScanSliceBytes/size=8 | 59,903 | 24,928 | 2.4× | 2,049 | 1,025 |
| ScanSliceBytes/size=64 | 75,273 | 38,506 | 2.0× | 2,049 | 1,025 |
| ScanSliceBytes/size=512 | 177,868 | 144,223 | 1.2× | 2,049 | 1,025 |
| ScanSliceInt64 | 78,344 | 29,451 | 2.7× | 2,049 | 1 |
| ScanSliceFloat64 | 97,469 | 42,548 | 2.3× | 2,049 | 1 |
| ScanSliceIP | 59,449 | 22,681 | 2.6× | 2,049 | 1,025 |
| ScanSliceBinaryUnmarshaler | 599,576 | 556,226 | 1.1× | 7,169 | 6,145 |
| ScanSlicePtr | 602,739 | 554,816 | 1.1× | 7,169 | 6,146 |
| ScanSlicePtrGrow | 668,708 | 602,002 | 1.1× | 8,206 | 7,183 |
| ScanSliceGrow | 86,760 | 31,044 | 2.8× | 2,062 | 14 |

Highlights:

- Parsing paths drop from 2 allocs/element to **1 alloc per entire scan**; the
  string path is now flat across element sizes (zero-copy) and up to 12×
  faster.
- Escaping paths (`*[]byte`, `*net.IP`) halve their allocations — the
  per-element reflect slice-header allocation is gone; only the mandatory
  copy remains.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core reply-scanning paths used by many commands; behavior is intended to stay the same but relies on careful copy-vs-alias rules and new test coverage rather than a trivial change.
> 
> **Overview**
> **Performance-focused changes** to how Redis string replies are scanned into Go values. `ScanSlice` and `StringCmd.Scan` now pass input into `proto.Scan` via `util.StringToBytes` instead of allocating a `[]byte` per element, and `makeSliceNextElemFunc` grows destination slices in place with `reflect.Value.Grow`/`SetLen` rather than a new slice header per element.
> 
> **Safety is preserved** by copying only where the scanned bytes escape the caller: `*[]byte`, `*net.IP`, and `encoding.BinaryUnmarshaler` each get a private `make`+`copy`. `ReadInt`/`ReadUint` in `internal/proto/reader.go` parse string bulk replies with `strconv` directly (no string→`[]byte` round-trip). Types are modernized (`any`, `reflect.Pointer`).
> 
> **Tests and benchmarks** in `internal/proto/scan_test.go` lock in non-aliasing, empty-slice semantics, capacity reuse, and pointer recycling.
> 
> **CI**: `govulncheck` runs on PRs to `vkotsev/**` and uses Go `stable` instead of `1.26.x`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b3c2d5f64aea42d04cadb02000fc32052ce52c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->