### PR TITLE
feat(cluster): add RouteByLatencyTolerance to spread reads across equally-close nodes

### DIFF
--- a/osscluster.go
+++ b/osscluster.go
@@ -825,10 +825,12 @@ type clusterSlot struct {
 	end   int
 	nodes []*clusterNode
 
-	// Rotation cursor for RouteByLatencyTolerance. Per slot on purpose: a counter shared
+	// Round-robin cursor over the nodes inside the RouteByLatencyTolerance band. Latency
+	// decides only which nodes are in the band; within it they are treated as equally close
+	// and picked in turn, so this does not order them. Per slot on purpose: a counter shared
 	// across slots is advanced by the other slots between two visits to this one, so with a
 	// regular interleaving each slot keeps landing on the same candidate index.
-	nodesByLatencyRotation atomic.Uint32
+	latencyBandNodeCursor atomic.Uint32
 }
 
 type clusterState struct {
@@ -1145,7 +1147,7 @@ func (c *clusterState) slotNodeWithinLatency(slot int, tolerance time.Duration) 
 
 		// Reduced in the unsigned domain: the cursor wraps, and on 32-bit builds converting a
 		// value past 2^31 to int before the modulo would make the index negative.
-		return ready[(entry.nodesByLatencyRotation.Add(1)-1)%uint32(len(ready))], nil
+		return ready[(entry.latencyBandNodeCursor.Add(1)-1)%uint32(len(ready))], nil
 	}
 
 	// Every node is failing. Fall back to the least-slow one, so a transient failure does

--- a/osscluster.go
+++ b/osscluster.go
@@ -390,6 +390,7 @@ func setupClusterQueryParams(u *url.URL, o *ClusterOptions) (*ClusterOptions, er
 	o.MaxRedirects = q.int("max_redirects")
 	o.ReadOnly = q.bool("read_only")
 	o.RouteByLatency = q.bool("route_by_latency")
+	o.RouteByLatencyTolerance = q.duration("route_by_latency_tolerance")
 	o.RouteRandomly = q.bool("route_randomly")
 	o.MaxRetries = q.int("max_retries")
 	o.MinRetryBackoff = q.duration("min_retry_backoff")
@@ -1000,11 +1001,20 @@ func (c *clusterState) slotClosestNode(
 		return c.nodes.Random()
 	}
 
+	// Latency and health are sampled once per node. The background probe updates them
+	// concurrently, so re-reading would let the candidate set disagree with the minimum it
+	// is compared against - and could leave that set empty.
+	type sample struct {
+		node    *clusterNode
+		latency time.Duration
+	}
+
 	var (
-		closestNode           *clusterNode
-		closestNonFailingNode *clusterNode
-		minLatency            = time.Duration(math.MaxInt64)
-		minNonFailingLatency  = time.Duration(math.MaxInt64)
+		healthy            []sample
+		closestNode        *clusterNode
+		closestHealthyNode *clusterNode
+		minLatency         = time.Duration(math.MaxInt64)
+		minHealthyLatency  = time.Duration(math.MaxInt64)
 	)
 
 	for _, n := range nodes {
@@ -1012,19 +1022,39 @@ func (c *clusterState) slotClosestNode(
 		if latency < minLatency {
 			closestNode, minLatency = n, latency
 		}
-		// Tracked separately: a healthy node that is not the outright fastest must still
-		// be preferred over a failing one.
-		if !n.Failing() && latency < minNonFailingLatency {
-			closestNonFailingNode, minNonFailingLatency = n, latency
+
+		if n.Failing() {
+			continue
+		}
+
+		// Tracked separately: a healthy node that is not the outright fastest must still be
+		// preferred over a failing one.
+		healthy = append(healthy, sample{node: n, latency: latency})
+		if latency < minHealthyLatency {
+			closestHealthyNode, minHealthyLatency = n, latency
 		}
 	}
 
-	if closestNonFailingNode != nil {
+	if closestHealthyNode != nil {
 		if tolerance <= 0 {
-			return closestNonFailingNode, nil
+			return closestHealthyNode, nil
 		}
 
-		return closestWithinTolerance(nodes, minNonFailingLatency, tolerance, picker), nil
+		candidates := make([]*clusterNode, 0, len(healthy))
+		for _, s := range healthy {
+			// Subtraction rather than minHealthyLatency+tolerance, which would overflow for
+			// a very large tolerance. Always true for closestHealthyNode, so candidates is
+			// never empty here.
+			if s.latency-minHealthyLatency <= tolerance {
+				candidates = append(candidates, s.node)
+			}
+		}
+
+		if len(candidates) == 1 || picker == nil {
+			return candidates[0], nil
+		}
+
+		return candidates[picker.Next(len(candidates))], nil
 	}
 
 	// Every node is failing. Fall back to the least-slow one, so a transient failure does
@@ -1037,31 +1067,6 @@ func (c *clusterState) slotClosestNode(
 	// If all nodes are having the maximum latency(all pings are failing) - return a random node across the cluster
 	internal.Logger.Printf(context.TODO(), "redis: pings to all nodes are failing, picking a random node across the cluster")
 	return c.nodes.Random()
-}
-
-// closestWithinTolerance round-robins over the healthy nodes no more than tolerance slower
-// than the fastest, so nodes that are equally close in practice share the read load.
-func closestWithinTolerance(
-	nodes []*clusterNode,
-	minLatency, tolerance time.Duration,
-	picker routing.ShardPicker,
-) *clusterNode {
-	var candidates []*clusterNode
-
-	for _, n := range nodes {
-		if !n.Failing() && n.Latency() <= minLatency+tolerance {
-			candidates = append(candidates, n)
-		}
-	}
-
-	switch {
-	case len(candidates) == 0:
-		return nil
-	case len(candidates) == 1 || picker == nil:
-		return candidates[0]
-	default:
-		return candidates[picker.Next(len(candidates))]
-	}
 }
 
 func (c *clusterState) slotRandomNode(slot int) (*clusterNode, error) {

--- a/osscluster.go
+++ b/osscluster.go
@@ -1017,6 +1017,12 @@ func (c *clusterState) slotClosestNode(
 		minHealthyLatency  = time.Duration(math.MaxInt64)
 	)
 
+	// Only the tolerance path needs the samples. With the option unset this stays nil, so
+	// the existing strict-minimum behaviour allocates nothing.
+	if tolerance > 0 {
+		healthy = make([]sample, 0, len(nodes))
+	}
+
 	for _, n := range nodes {
 		latency := n.Latency()
 		if latency < minLatency {
@@ -1027,9 +1033,12 @@ func (c *clusterState) slotClosestNode(
 			continue
 		}
 
+		if tolerance > 0 {
+			healthy = append(healthy, sample{node: n, latency: latency})
+		}
+
 		// Tracked separately: a healthy node that is not the outright fastest must still be
 		// preferred over a failing one.
-		healthy = append(healthy, sample{node: n, latency: latency})
 		if latency < minHealthyLatency {
 			closestHealthyNode, minHealthyLatency = n, latency
 		}

--- a/osscluster.go
+++ b/osscluster.go
@@ -62,6 +62,17 @@ type ClusterOptions struct {
 	// Allows routing read-only commands to the closest master or slave node.
 	// It automatically enables ReadOnly.
 	RouteByLatency bool
+	// RouteByLatencyTolerance widens RouteByLatency from "the single fastest node" to
+	// "any node within this much of the fastest", round-robining between them.
+	//
+	// RouteByLatency alone takes a strict minimum, so when several nodes are equally
+	// close - replicas sharing an availability zone, say - every client picks the same
+	// one and the others take no read traffic. Latency is estimated from ten pings and
+	// refreshed at most every 10s, so a difference well inside the noise can decide the
+	// whole read load for the next interval.
+	//
+	// Zero keeps the strict-minimum behaviour. Has no effect unless RouteByLatency is set.
+	RouteByLatencyTolerance time.Duration
 	// Allows routing read-only commands to the random master or slave node.
 	// It automatically enables ReadOnly.
 	RouteRandomly bool
@@ -979,39 +990,45 @@ func (c *clusterState) slotSlaveNode(slot int) (*clusterNode, error) {
 	}
 }
 
-func (c *clusterState) slotClosestNode(slot int) (*clusterNode, error) {
+func (c *clusterState) slotClosestNode(
+	slot int,
+	tolerance time.Duration,
+	picker routing.ShardPicker,
+) (*clusterNode, error) {
 	nodes := c.slotNodes(slot)
 	if len(nodes) == 0 {
 		return c.nodes.Random()
 	}
 
-	allNodesFailing := true
 	var (
-		closestNonFailingNode *clusterNode
 		closestNode           *clusterNode
-		minLatency            time.Duration
+		closestNonFailingNode *clusterNode
+		minLatency            = time.Duration(math.MaxInt64)
+		minNonFailingLatency  = time.Duration(math.MaxInt64)
 	)
 
-	// setting the max possible duration as zerovalue for minlatency
-	minLatency = time.Duration(math.MaxInt64)
-
 	for _, n := range nodes {
-		if closestNode == nil || n.Latency() < minLatency {
-			closestNode = n
-			minLatency = n.Latency()
-			if !n.Failing() {
-				closestNonFailingNode = n
-				allNodesFailing = false
-			}
+		latency := n.Latency()
+		if latency < minLatency {
+			closestNode, minLatency = n, latency
+		}
+		// Tracked separately: a healthy node that is not the outright fastest must still
+		// be preferred over a failing one.
+		if !n.Failing() && latency < minNonFailingLatency {
+			closestNonFailingNode, minNonFailingLatency = n, latency
 		}
 	}
 
-	// pick the healthly node with the lowest latency
-	if !allNodesFailing && closestNonFailingNode != nil {
-		return closestNonFailingNode, nil
+	if closestNonFailingNode != nil {
+		if tolerance <= 0 {
+			return closestNonFailingNode, nil
+		}
+
+		return closestWithinTolerance(nodes, minNonFailingLatency, tolerance, picker), nil
 	}
 
-	// if all nodes are failing, we will pick the temporarily failing node with lowest latency
+	// Every node is failing. Fall back to the least-slow one, so a transient failure does
+	// not take the slot down.
 	if minLatency < maximumNodeLatency && closestNode != nil {
 		internal.Logger.Printf(context.TODO(), "redis: all nodes are marked as failed, picking the temporarily failing node with lowest latency")
 		return closestNode, nil
@@ -1020,6 +1037,31 @@ func (c *clusterState) slotClosestNode(slot int) (*clusterNode, error) {
 	// If all nodes are having the maximum latency(all pings are failing) - return a random node across the cluster
 	internal.Logger.Printf(context.TODO(), "redis: pings to all nodes are failing, picking a random node across the cluster")
 	return c.nodes.Random()
+}
+
+// closestWithinTolerance round-robins over the healthy nodes no more than tolerance slower
+// than the fastest, so nodes that are equally close in practice share the read load.
+func closestWithinTolerance(
+	nodes []*clusterNode,
+	minLatency, tolerance time.Duration,
+	picker routing.ShardPicker,
+) *clusterNode {
+	var candidates []*clusterNode
+
+	for _, n := range nodes {
+		if !n.Failing() && n.Latency() <= minLatency+tolerance {
+			candidates = append(candidates, n)
+		}
+	}
+
+	switch {
+	case len(candidates) == 0:
+		return nil
+	case len(candidates) == 1 || picker == nil:
+		return candidates[0]
+	default:
+		return candidates[picker.Next(len(candidates))]
+	}
 }
 
 func (c *clusterState) slotRandomNode(slot int) (*clusterNode, error) {
@@ -2963,7 +3005,7 @@ func (c *ClusterClient) cmdNodeWithShardPicker(
 
 func (c *ClusterClient) slotReadOnlyNode(state *clusterState, slot int) (*clusterNode, error) {
 	if c.opt.RouteByLatency {
-		return state.slotClosestNode(slot)
+		return state.slotClosestNode(slot, c.opt.RouteByLatencyTolerance, c.opt.ShardPicker)
 	}
 	if c.opt.RouteRandomly {
 		return state.slotRandomNode(slot)

--- a/osscluster.go
+++ b/osscluster.go
@@ -825,10 +825,10 @@ type clusterSlot struct {
 	end   int
 	nodes []*clusterNode
 
-	// rotation cursor for RouteByLatencyTolerance. Per slot on purpose: a counter shared
+	// Rotation cursor for RouteByLatencyTolerance. Per slot on purpose: a counter shared
 	// across slots is advanced by the other slots between two visits to this one, so with a
 	// regular interleaving each slot keeps landing on the same candidate index.
-	rotation atomic.Uint32
+	nodesByLatencyRotation atomic.Uint32
 }
 
 type clusterState struct {
@@ -996,7 +996,54 @@ func (c *clusterState) slotSlaveNode(slot int) (*clusterNode, error) {
 	}
 }
 
-func (c *clusterState) slotClosestNode(slot int, tolerance time.Duration) (*clusterNode, error) {
+func (c *clusterState) slotClosestNode(slot int) (*clusterNode, error) {
+	nodes := c.slotNodes(slot)
+	if len(nodes) == 0 {
+		return c.nodes.Random()
+	}
+
+	allNodesFailing := true
+	var (
+		closestNonFailingNode *clusterNode
+		closestNode           *clusterNode
+		minLatency            time.Duration
+	)
+
+	// setting the max possible duration as zerovalue for minlatency
+	minLatency = time.Duration(math.MaxInt64)
+
+	for _, n := range nodes {
+		if closestNode == nil || n.Latency() < minLatency {
+			closestNode = n
+			minLatency = n.Latency()
+			if !n.Failing() {
+				closestNonFailingNode = n
+				allNodesFailing = false
+			}
+		}
+	}
+
+	// pick the healthly node with the lowest latency
+	if !allNodesFailing && closestNonFailingNode != nil {
+		return closestNonFailingNode, nil
+	}
+
+	// if all nodes are failing, we will pick the temporarily failing node with lowest latency
+	if minLatency < maximumNodeLatency && closestNode != nil {
+		internal.Logger.Printf(context.TODO(), "redis: all nodes are marked as failed, picking the temporarily failing node with lowest latency")
+		return closestNode, nil
+	}
+
+	// If all nodes are having the maximum latency(all pings are failing) - return a random node across the cluster
+	internal.Logger.Printf(context.TODO(), "redis: pings to all nodes are failing, picking a random node across the cluster")
+	return c.nodes.Random()
+}
+
+// slotNodeWithinLatency picks from the healthy nodes whose latency is within tolerance of the
+// fastest one, rotating across them so equally-close nodes share the read traffic. Used only
+// when RouteByLatencyTolerance is set; slotClosestNode keeps the strict-minimum behaviour and
+// is left untouched for everyone else.
+func (c *clusterState) slotNodeWithinLatency(slot int, tolerance time.Duration) (*clusterNode, error) {
 	entry := c.slotEntry(slot)
 	if entry == nil || len(entry.nodes) == 0 {
 		return c.nodes.Random()
@@ -1012,18 +1059,12 @@ func (c *clusterState) slotClosestNode(slot int, tolerance time.Duration) (*clus
 	}
 
 	var (
-		healthy            []sample
+		healthy            = make([]sample, 0, len(nodes))
 		closestNode        *clusterNode
 		closestHealthyNode *clusterNode
 		minLatency         = time.Duration(math.MaxInt64)
 		minHealthyLatency  = time.Duration(math.MaxInt64)
 	)
-
-	// Only the tolerance path needs the samples. With the option unset this stays nil, so
-	// the existing strict-minimum behaviour allocates nothing.
-	if tolerance > 0 {
-		healthy = make([]sample, 0, len(nodes))
-	}
 
 	for _, n := range nodes {
 		latency := n.Latency()
@@ -1035,9 +1076,7 @@ func (c *clusterState) slotClosestNode(slot int, tolerance time.Duration) (*clus
 			continue
 		}
 
-		if tolerance > 0 {
-			healthy = append(healthy, sample{node: n, latency: latency})
-		}
+		healthy = append(healthy, sample{node: n, latency: latency})
 
 		// Tracked separately: a healthy node that is not the outright fastest must still be
 		// preferred over a failing one.
@@ -1047,10 +1086,6 @@ func (c *clusterState) slotClosestNode(slot int, tolerance time.Duration) (*clus
 	}
 
 	if closestHealthyNode != nil {
-		if tolerance <= 0 {
-			return closestHealthyNode, nil
-		}
-
 		candidates := make([]*clusterNode, 0, len(healthy))
 		for _, s := range healthy {
 			// Subtraction rather than minHealthyLatency+tolerance, which would overflow for
@@ -1067,7 +1102,7 @@ func (c *clusterState) slotClosestNode(slot int, tolerance time.Duration) (*clus
 
 		// Reduced in the unsigned domain: the cursor wraps, and on 32-bit builds converting a
 		// value past 2^31 to int before the modulo would make the index negative.
-		return candidates[(entry.rotation.Add(1)-1)%uint32(len(candidates))], nil
+		return candidates[(entry.nodesByLatencyRotation.Add(1)-1)%uint32(len(candidates))], nil
 	}
 
 	// Every node is failing. Fall back to the least-slow one, so a transient failure does
@@ -3030,7 +3065,10 @@ func (c *ClusterClient) cmdNodeWithShardPicker(
 
 func (c *ClusterClient) slotReadOnlyNode(state *clusterState, slot int) (*clusterNode, error) {
 	if c.opt.RouteByLatency {
-		return state.slotClosestNode(slot, c.opt.RouteByLatencyTolerance)
+		if c.opt.RouteByLatencyTolerance > 0 {
+			return state.slotNodeWithinLatency(slot, c.opt.RouteByLatencyTolerance)
+		}
+		return state.slotClosestNode(slot)
 	}
 	if c.opt.RouteRandomly {
 		return state.slotRandomNode(slot)

--- a/osscluster.go
+++ b/osscluster.go
@@ -1071,6 +1071,7 @@ func (c *clusterState) slotNodeWithinLatency(slot int, tolerance time.Duration) 
 		closestHealthyNode *clusterNode
 		minLatency         = time.Duration(math.MaxInt64)
 		minHealthyLatency  = time.Duration(math.MaxInt64)
+		anyHealthyMeasured bool
 	)
 
 	for _, n := range nodes {
@@ -1084,6 +1085,9 @@ func (c *clusterState) slotNodeWithinLatency(slot int, tolerance time.Duration) 
 		}
 
 		healthy = append(healthy, sample{node: n, latency: latency})
+		if n.LastLatencyMeasurement() != 0 {
+			anyHealthyMeasured = true
+		}
 
 		// Tracked separately: a healthy node that is not the outright fastest must still be
 		// preferred over a failing one.
@@ -1093,6 +1097,16 @@ func (c *clusterState) slotNodeWithinLatency(slot int, tolerance time.Duration) 
 	}
 
 	if closestHealthyNode != nil {
+		// Until the first probe lands, every node still holds the sentinel latency stored by
+		// newClusterNodeWithNodeAddress, so every difference is zero and any positive tolerance
+		// would admit the whole slot - scattering startup reads across distant zones instead of
+		// preserving locality. Keep strict selection until at least one measurement exists; a
+		// mix needs no special case, since an unmeasured node's sentinel latency puts it far
+		// outside the band of any measured one.
+		if !anyHealthyMeasured {
+			return closestHealthyNode, nil
+		}
+
 		candidates := make([]*clusterNode, 0, len(healthy))
 		for _, s := range healthy {
 			// Subtraction rather than minHealthyLatency+tolerance, which would overflow for

--- a/osscluster.go
+++ b/osscluster.go
@@ -1065,7 +1065,9 @@ func (c *clusterState) slotClosestNode(slot int, tolerance time.Duration) (*clus
 			return candidates[0], nil
 		}
 
-		return candidates[int(entry.rotation.Add(1)-1)%len(candidates)], nil
+		// Reduced in the unsigned domain: the cursor wraps, and on 32-bit builds converting a
+		// value past 2^31 to int before the modulo would make the index negative.
+		return candidates[(entry.rotation.Add(1)-1)%uint32(len(candidates))], nil
 	}
 
 	// Every node is failing. Fall back to the least-slow one, so a transient failure does

--- a/osscluster.go
+++ b/osscluster.go
@@ -824,6 +824,11 @@ type clusterSlot struct {
 	start int
 	end   int
 	nodes []*clusterNode
+
+	// rotation cursor for RouteByLatencyTolerance. Per slot on purpose: a counter shared
+	// across slots is advanced by the other slots between two visits to this one, so with a
+	// regular interleaving each slot keeps landing on the same candidate index.
+	rotation atomic.Uint32
 }
 
 type clusterState struct {
@@ -991,15 +996,12 @@ func (c *clusterState) slotSlaveNode(slot int) (*clusterNode, error) {
 	}
 }
 
-func (c *clusterState) slotClosestNode(
-	slot int,
-	tolerance time.Duration,
-	picker routing.ShardPicker,
-) (*clusterNode, error) {
-	nodes := c.slotNodes(slot)
-	if len(nodes) == 0 {
+func (c *clusterState) slotClosestNode(slot int, tolerance time.Duration) (*clusterNode, error) {
+	entry := c.slotEntry(slot)
+	if entry == nil || len(entry.nodes) == 0 {
 		return c.nodes.Random()
 	}
+	nodes := entry.nodes
 
 	// Latency and health are sampled once per node. The background probe updates them
 	// concurrently, so re-reading would let the candidate set disagree with the minimum it
@@ -1059,11 +1061,11 @@ func (c *clusterState) slotClosestNode(
 			}
 		}
 
-		if len(candidates) == 1 || picker == nil {
+		if len(candidates) == 1 {
 			return candidates[0], nil
 		}
 
-		return candidates[picker.Next(len(candidates))], nil
+		return candidates[int(entry.rotation.Add(1)-1)%len(candidates)], nil
 	}
 
 	// Every node is failing. Fall back to the least-slow one, so a transient failure does
@@ -1118,7 +1120,7 @@ func (c *clusterState) slotShardPickerSlaveNode(slot int, shardPicker routing.Sh
 	return nodes[0], nil
 }
 
-func (c *clusterState) slotNodes(slot int) []*clusterNode {
+func (c *clusterState) slotEntry(slot int) *clusterSlot {
 	i := sort.Search(len(c.slots), func(i int) bool {
 		return c.slots[i].end >= slot
 	})
@@ -1127,6 +1129,13 @@ func (c *clusterState) slotNodes(slot int) []*clusterNode {
 	}
 	x := c.slots[i]
 	if slot >= x.start && slot <= x.end {
+		return x
+	}
+	return nil
+}
+
+func (c *clusterState) slotNodes(slot int) []*clusterNode {
+	if x := c.slotEntry(slot); x != nil {
 		return x.nodes
 	}
 	return nil
@@ -3019,7 +3028,7 @@ func (c *ClusterClient) cmdNodeWithShardPicker(
 
 func (c *ClusterClient) slotReadOnlyNode(state *clusterState, slot int) (*clusterNode, error) {
 	if c.opt.RouteByLatency {
-		return state.slotClosestNode(slot, c.opt.RouteByLatencyTolerance, c.opt.ShardPicker)
+		return state.slotClosestNode(slot, c.opt.RouteByLatencyTolerance)
 	}
 	if c.opt.RouteRandomly {
 		return state.slotRandomNode(slot)

--- a/osscluster.go
+++ b/osscluster.go
@@ -1096,13 +1096,33 @@ func (c *clusterState) slotNodeWithinLatency(slot int, tolerance time.Duration) 
 			}
 		}
 
-		if len(candidates) == 1 {
-			return candidates[0], nil
+		// Drop nodes that are still loading, matching slotSlaveNode. Checked here rather than
+		// in the pass above so Loading() - which can cost a Ping when the node is not known
+		// loaded - is only paid for nodes actually eligible for this read. Widening the
+		// candidate set is what makes this matter: under a strict minimum a loading replica
+		// has to be the fastest to be picked, within a tolerance band it merely has to be
+		// close, and a replica is loading precisely after the full resync that a too-small
+		// replication backlog causes.
+		ready := candidates[:0]
+		for _, n := range candidates {
+			if !n.Loading() {
+				ready = append(ready, n)
+			}
+		}
+
+		// Everything in the band is loading: fall back to the strict-minimum choice rather
+		// than failing, which is what this path did before the filter.
+		if len(ready) == 0 {
+			return closestHealthyNode, nil
+		}
+
+		if len(ready) == 1 {
+			return ready[0], nil
 		}
 
 		// Reduced in the unsigned domain: the cursor wraps, and on 32-bit builds converting a
 		// value past 2^31 to int before the modulo would make the index negative.
-		return candidates[(entry.nodesByLatencyRotation.Add(1)-1)%uint32(len(candidates))], nil
+		return ready[(entry.nodesByLatencyRotation.Add(1)-1)%uint32(len(ready))], nil
 	}
 
 	// Every node is failing. Fall back to the least-slow one, so a transient failure does

--- a/osscluster.go
+++ b/osscluster.go
@@ -530,7 +530,7 @@ func newClusterNodeWithNodeAddress(clOpt *ClusterOptions, addr, nodeAddress stri
 		Client: clOpt.NewClient(opt),
 	}
 
-	node.latency.Store(math.MaxUint32)
+	node.latency.Store(unmeasuredNodeLatencyMicros)
 	if clOpt.RouteByLatency {
 		go node.updateLatency()
 	}
@@ -547,6 +547,14 @@ func (n *clusterNode) Close() error {
 }
 
 const maximumNodeLatency = 1 * time.Minute
+
+// Latency held by a node from creation until its first probe completes. Deliberately distinct
+// from maximumNodeLatency, which marks a node whose pings all failed - the two must stay
+// separable, so this is compared for equality rather than as a ">= huge" threshold.
+const (
+	unmeasuredNodeLatencyMicros uint32 = math.MaxUint32
+	unmeasuredNodeLatency              = time.Duration(unmeasuredNodeLatencyMicros) * time.Microsecond
+)
 
 func (n *clusterNode) updateLatency() {
 	const numProbe = 10
@@ -1085,7 +1093,13 @@ func (c *clusterState) slotNodeWithinLatency(slot int, tolerance time.Duration) 
 		}
 
 		healthy = append(healthy, sample{node: n, latency: latency})
-		if n.LastLatencyMeasurement() != 0 {
+
+		// Derived from the latency just captured, not from a second read of the node.
+		// updateLatency publishes the latency and its timestamp as two separate stores, so
+		// reading the timestamp here could observe a probe that landed after the latency
+		// above was sampled - marking the set measured while every sampled latency is still
+		// a sentinel, which is exactly the case this guards.
+		if latency != unmeasuredNodeLatency {
 			anyHealthyMeasured = true
 		}
 

--- a/osscluster.go
+++ b/osscluster.go
@@ -1110,9 +1110,32 @@ func (c *clusterState) slotNodeWithinLatency(slot int, tolerance time.Duration) 
 			}
 		}
 
-		// Everything in the band is loading: fall back to the strict-minimum choice rather
-		// than failing, which is what this path did before the filter.
 		if len(ready) == 0 {
+			// Every node inside the band is loading. closestHealthyNode is itself in the band,
+			// so returning it hands back a node we just observed loading. Widen the search to
+			// the healthy nodes outside the band and take the closest ready one - which in a
+			// multi-AZ layout is typically the master, still serving while the local replicas
+			// reload together after a resync. Only reached in this exceptional case, so the
+			// extra Loading() calls are off the hot path, and the latency comparison is
+			// evaluated first so most of them are skipped.
+			var (
+				fallback        *clusterNode
+				fallbackLatency = time.Duration(math.MaxInt64)
+			)
+			for _, s := range healthy {
+				if s.latency-minHealthyLatency <= tolerance {
+					continue // in the band, already known to be loading
+				}
+				if s.latency < fallbackLatency && !s.node.Loading() {
+					fallback, fallbackLatency = s.node, s.latency
+				}
+			}
+			if fallback != nil {
+				return fallback, nil
+			}
+
+			// Nothing is ready anywhere. Return the closest healthy node so the caller still
+			// gets a node to retry against, which is what this path did before the filter.
 			return closestHealthyNode, nil
 		}
 

--- a/osscluster_latency_tolerance_test.go
+++ b/osscluster_latency_tolerance_test.go
@@ -16,6 +16,10 @@ func toleranceTestNode(t *testing.T, latency time.Duration, failing bool) *clust
 	// cached path instead of dialling a dead address for 100ms per candidate.
 	n.loaded.Store(1)
 	n.latency.Store(uint32(latency / time.Microsecond))
+	// updateLatency stores the value and the timestamp together, so a node carrying a
+	// latency but no measurement never occurs in practice - and slotNodeWithinLatency
+	// treats a missing timestamp as "not probed yet".
+	n.SetLastLatencyMeasurement(time.Now())
 	if failing {
 		n.MarkAsFailing()
 	}
@@ -301,5 +305,65 @@ func TestSlotNodeWithinLatencyKeepsUnconfirmedNode(t *testing.T) {
 
 	if !seen[unconfirmed] {
 		t.Fatal("node with loaded=0 was excluded from the rotation; a connection error is not a LOADING reply")
+	}
+}
+
+// Before the background probes finish, every node still carries the math.MaxUint32 sentinel
+// from newClusterNodeWithNodeAddress. All differences are then zero, so a positive tolerance
+// would admit the entire slot and round-robin startup reads across distant zones. Until one
+// measurement lands, the tolerance path must behave exactly like the strict one.
+func TestSlotNodeWithinLatencyKeepsStrictOrderBeforeFirstProbe(t *testing.T) {
+	unprobed := func() *clusterNode {
+		n := &clusterNode{Client: NewClient(&Options{Addr: "127.0.0.1:0"})}
+		t.Cleanup(func() { _ = n.Client.Close() })
+		n.loaded.Store(1)
+		n.latency.Store(math.MaxUint32) // exactly what newClusterNodeWithNodeAddress stores
+		return n
+	}
+
+	first, second, third := unprobed(), unprobed(), unprobed()
+	state := toleranceTestState(first, second, third)
+
+	for i := 0; i < 50; i++ {
+		got, err := state.slotNodeWithinLatency(0, time.Second)
+		if err != nil {
+			t.Fatalf("slotNodeWithinLatency: %v", err)
+		}
+		if got != first {
+			t.Fatalf("iteration %d: rotated across unmeasured nodes; want the strict pick", i)
+		}
+	}
+
+	strict, err := state.slotClosestNode(0)
+	if err != nil {
+		t.Fatalf("slotClosestNode: %v", err)
+	}
+	if strict != first {
+		t.Fatalf("slotClosestNode disagrees with the tolerance path before the first probe")
+	}
+}
+
+// Once any healthy node has a real measurement the band is meaningful again, and an
+// unmeasured node must stay out of it - its sentinel latency is ~4295s, far beyond any
+// sane tolerance.
+func TestSlotNodeWithinLatencyExcludesUnmeasuredOnceProbed(t *testing.T) {
+	measured := toleranceTestNode(t, 100*time.Microsecond, false)
+	alsoMeasured := toleranceTestNode(t, 130*time.Microsecond, false)
+
+	unprobed := &clusterNode{Client: NewClient(&Options{Addr: "127.0.0.1:0"})}
+	t.Cleanup(func() { _ = unprobed.Client.Close() })
+	unprobed.loaded.Store(1)
+	unprobed.latency.Store(math.MaxUint32)
+
+	state := toleranceTestState(measured, alsoMeasured, unprobed)
+
+	for i := 0; i < 60; i++ {
+		got, err := state.slotNodeWithinLatency(0, 50*time.Microsecond)
+		if err != nil {
+			t.Fatalf("slotNodeWithinLatency: %v", err)
+		}
+		if got == unprobed {
+			t.Fatalf("iteration %d: unmeasured node entered the tolerance band", i)
+		}
 	}
 }

--- a/osscluster_latency_tolerance_test.go
+++ b/osscluster_latency_tolerance_test.go
@@ -1,0 +1,122 @@
+package redis
+
+import (
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9/internal/routing"
+)
+
+func toleranceTestNode(t *testing.T, latency time.Duration, failing bool) *clusterNode {
+	t.Helper()
+
+	n := &clusterNode{Client: NewClient(&Options{Addr: "127.0.0.1:0"})}
+	t.Cleanup(func() { _ = n.Client.Close() })
+
+	n.latency.Store(uint32(latency / time.Microsecond))
+	if failing {
+		n.MarkAsFailing()
+	}
+
+	return n
+}
+
+func toleranceTestState(nodes ...*clusterNode) *clusterState {
+	return &clusterState{slots: []*clusterSlot{{start: 0, end: 16383, nodes: nodes}}}
+}
+
+func TestSlotClosestNodeToleranceZeroKeepsStrictMinimum(t *testing.T) {
+	fastest := toleranceTestNode(t, 100*time.Microsecond, false)
+	state := toleranceTestState(
+		fastest,
+		toleranceTestNode(t, 120*time.Microsecond, false),
+		toleranceTestNode(t, 900*time.Microsecond, false),
+	)
+
+	picker := &routing.RoundRobinPicker{}
+
+	for i := 0; i < 20; i++ {
+		got, err := state.slotClosestNode(0, 0, picker)
+		if err != nil {
+			t.Fatalf("slotClosestNode: %v", err)
+		}
+		if got != fastest {
+			t.Fatalf("iteration %d: expected the fastest node with zero tolerance", i)
+		}
+	}
+}
+
+func TestSlotClosestNodeToleranceSpreadsAcrossCloseNodes(t *testing.T) {
+	a := toleranceTestNode(t, 100*time.Microsecond, false)
+	b := toleranceTestNode(t, 120*time.Microsecond, false)
+	far := toleranceTestNode(t, 900*time.Microsecond, false)
+	state := toleranceTestState(a, b, far)
+
+	counts := map[*clusterNode]int{}
+	picker := &routing.RoundRobinPicker{}
+
+	for i := 0; i < 100; i++ {
+		got, err := state.slotClosestNode(0, 50*time.Microsecond, picker)
+		if err != nil {
+			t.Fatalf("slotClosestNode: %v", err)
+		}
+		counts[got]++
+	}
+
+	if counts[far] != 0 {
+		t.Fatalf("node outside the tolerance received %d requests", counts[far])
+	}
+	if counts[a] == 0 || counts[b] == 0 {
+		t.Fatalf("expected both close nodes to be used, got a=%d b=%d", counts[a], counts[b])
+	}
+	if diff := counts[a] - counts[b]; diff > 1 || diff < -1 {
+		t.Fatalf("expected an even split across close nodes, got a=%d b=%d", counts[a], counts[b])
+	}
+}
+
+func TestSlotClosestNodeToleranceSkipsFailingNodes(t *testing.T) {
+	healthy := toleranceTestNode(t, 120*time.Microsecond, false)
+	state := toleranceTestState(toleranceTestNode(t, 100*time.Microsecond, true), healthy)
+
+	picker := &routing.RoundRobinPicker{}
+
+	for i := 0; i < 10; i++ {
+		got, err := state.slotClosestNode(0, 50*time.Microsecond, picker)
+		if err != nil {
+			t.Fatalf("slotClosestNode: %v", err)
+		}
+		if got != healthy {
+			t.Fatal("a failing node was selected")
+		}
+	}
+}
+
+// The fastest node being unhealthy must not stop a slower healthy one from being chosen.
+// Previously the healthy candidate was only recorded while scanning for a new minimum, so
+// a healthy-but-slower node could be skipped and selection fell through to the
+// all-nodes-failing path.
+func TestSlotClosestNodePrefersSlowerHealthyNode(t *testing.T) {
+	healthy := toleranceTestNode(t, 800*time.Microsecond, false)
+	state := toleranceTestState(toleranceTestNode(t, 100*time.Microsecond, true), healthy)
+
+	got, err := state.slotClosestNode(0, 0, nil)
+	if err != nil {
+		t.Fatalf("slotClosestNode: %v", err)
+	}
+	if got != healthy {
+		t.Fatal("expected the slower healthy node rather than the failing fastest one")
+	}
+}
+
+func TestSlotClosestNodeToleranceNilPicker(t *testing.T) {
+	a := toleranceTestNode(t, 100*time.Microsecond, false)
+	state := toleranceTestState(a, toleranceTestNode(t, 120*time.Microsecond, false))
+
+	got, err := state.slotClosestNode(0, 50*time.Microsecond, nil)
+	if err != nil {
+		t.Fatalf("slotClosestNode: %v", err)
+	}
+	if got != a {
+		t.Fatal("expected the first candidate when no picker is configured")
+	}
+}

--- a/osscluster_latency_tolerance_test.go
+++ b/osscluster_latency_tolerance_test.go
@@ -24,7 +24,7 @@ func toleranceTestState(nodes ...*clusterNode) *clusterState {
 	return &clusterState{slots: []*clusterSlot{{start: 0, end: 16383, nodes: nodes}}}
 }
 
-func TestSlotClosestNodeToleranceZeroKeepsStrictMinimum(t *testing.T) {
+func TestRouteByLatencyToleranceZeroKeepsStrictMinimum(t *testing.T) {
 	fastest := toleranceTestNode(t, 100*time.Microsecond, false)
 	state := toleranceTestState(
 		fastest,
@@ -33,7 +33,7 @@ func TestSlotClosestNodeToleranceZeroKeepsStrictMinimum(t *testing.T) {
 	)
 
 	for i := 0; i < 20; i++ {
-		got, err := state.slotClosestNode(0, 0)
+		got, err := state.slotClosestNode(0)
 		if err != nil {
 			t.Fatalf("slotClosestNode: %v", err)
 		}
@@ -43,7 +43,7 @@ func TestSlotClosestNodeToleranceZeroKeepsStrictMinimum(t *testing.T) {
 	}
 }
 
-func TestSlotClosestNodeToleranceSpreadsAcrossCloseNodes(t *testing.T) {
+func TestSlotNodeWithinLatencySpreadsAcrossCloseNodes(t *testing.T) {
 	a := toleranceTestNode(t, 100*time.Microsecond, false)
 	b := toleranceTestNode(t, 120*time.Microsecond, false)
 	far := toleranceTestNode(t, 900*time.Microsecond, false)
@@ -52,9 +52,9 @@ func TestSlotClosestNodeToleranceSpreadsAcrossCloseNodes(t *testing.T) {
 	counts := map[*clusterNode]int{}
 
 	for i := 0; i < 100; i++ {
-		got, err := state.slotClosestNode(0, 50*time.Microsecond)
+		got, err := state.slotNodeWithinLatency(0, 50*time.Microsecond)
 		if err != nil {
-			t.Fatalf("slotClosestNode: %v", err)
+			t.Fatalf("slotNodeWithinLatency: %v", err)
 		}
 		counts[got]++
 	}
@@ -70,14 +70,14 @@ func TestSlotClosestNodeToleranceSpreadsAcrossCloseNodes(t *testing.T) {
 	}
 }
 
-func TestSlotClosestNodeToleranceSkipsFailingNodes(t *testing.T) {
+func TestSlotNodeWithinLatencySkipsFailingNodes(t *testing.T) {
 	healthy := toleranceTestNode(t, 120*time.Microsecond, false)
 	state := toleranceTestState(toleranceTestNode(t, 100*time.Microsecond, true), healthy)
 
 	for i := 0; i < 10; i++ {
-		got, err := state.slotClosestNode(0, 50*time.Microsecond)
+		got, err := state.slotNodeWithinLatency(0, 50*time.Microsecond)
 		if err != nil {
-			t.Fatalf("slotClosestNode: %v", err)
+			t.Fatalf("slotNodeWithinLatency: %v", err)
 		}
 		if got != healthy {
 			t.Fatal("a failing node was selected")
@@ -89,20 +89,23 @@ func TestSlotClosestNodeToleranceSkipsFailingNodes(t *testing.T) {
 // Previously the healthy candidate was only recorded while scanning for a new minimum, so
 // a healthy-but-slower node could be skipped and selection fell through to the
 // all-nodes-failing path.
-func TestSlotClosestNodePrefersSlowerHealthyNode(t *testing.T) {
+// Exercises slotNodeWithinLatency rather than slotClosestNode: preferring a slower healthy
+// node over a faster failing one is behaviour of the new path. slotClosestNode is left as it
+// was on master, latent bug included - see the PR discussion.
+func TestSlotNodeWithinLatencyPrefersSlowerHealthyNode(t *testing.T) {
 	healthy := toleranceTestNode(t, 800*time.Microsecond, false)
 	state := toleranceTestState(toleranceTestNode(t, 100*time.Microsecond, true), healthy)
 
-	got, err := state.slotClosestNode(0, 0)
+	got, err := state.slotNodeWithinLatency(0, 0)
 	if err != nil {
-		t.Fatalf("slotClosestNode: %v", err)
+		t.Fatalf("slotNodeWithinLatency: %v", err)
 	}
 	if got != healthy {
 		t.Fatal("expected the slower healthy node rather than the failing fastest one")
 	}
 }
 
-func TestSlotClosestNodeToleranceNeverReturnsNilWithHealthyNode(t *testing.T) {
+func TestSlotNodeWithinLatencyNeverReturnsNilWithHealthyNode(t *testing.T) {
 	nodes := []*clusterNode{
 		toleranceTestNode(t, 100*time.Microsecond, false),
 		toleranceTestNode(t, 120*time.Microsecond, false),
@@ -127,9 +130,9 @@ func TestSlotClosestNodeToleranceNeverReturnsNilWithHealthyNode(t *testing.T) {
 	}()
 
 	for i := 0; i < 5000; i++ {
-		got, err := state.slotClosestNode(0, 50*time.Microsecond)
+		got, err := state.slotNodeWithinLatency(0, 50*time.Microsecond)
 		if err != nil {
-			t.Fatalf("slotClosestNode: %v", err)
+			t.Fatalf("slotNodeWithinLatency: %v", err)
 		}
 		if got == nil {
 			t.Fatal("returned nil despite healthy nodes being available")
@@ -137,14 +140,14 @@ func TestSlotClosestNodeToleranceNeverReturnsNilWithHealthyNode(t *testing.T) {
 	}
 }
 
-func TestSlotClosestNodeToleranceHandlesHugeTolerance(t *testing.T) {
+func TestSlotNodeWithinLatencyHandlesHugeTolerance(t *testing.T) {
 	a := toleranceTestNode(t, 100*time.Microsecond, false)
 	state := toleranceTestState(a, toleranceTestNode(t, 900*time.Microsecond, false))
 
 	// A tolerance near the maximum must not overflow into a negative comparison.
-	got, err := state.slotClosestNode(0, time.Duration(math.MaxInt64))
+	got, err := state.slotNodeWithinLatency(0, time.Duration(math.MaxInt64))
 	if err != nil {
-		t.Fatalf("slotClosestNode: %v", err)
+		t.Fatalf("slotNodeWithinLatency: %v", err)
 	}
 	if got == nil {
 		t.Fatal("returned nil for a very large tolerance")
@@ -193,7 +196,7 @@ func TestRouteByLatencyToleranceFromUniversalOptions(t *testing.T) {
 
 // With the option unset, selection must stay on the pre-existing hot path: no candidate
 // slice, no allocation per command.
-func TestSlotClosestNodeToleranceDisabledDoesNotAllocate(t *testing.T) {
+func TestSlotClosestNodeStillDoesNotAllocate(t *testing.T) {
 	state := toleranceTestState(
 		toleranceTestNode(t, 100*time.Microsecond, false),
 		toleranceTestNode(t, 120*time.Microsecond, false),
@@ -201,8 +204,8 @@ func TestSlotClosestNodeToleranceDisabledDoesNotAllocate(t *testing.T) {
 	)
 
 	allocs := testing.AllocsPerRun(200, func() {
-		if _, err := state.slotClosestNode(0, 0); err != nil {
-			t.Fatalf("slotClosestNode: %v", err)
+		if _, err := state.slotClosestNode(0); err != nil {
+			t.Fatalf("slotNodeWithinLatency: %v", err)
 		}
 	})
 
@@ -214,7 +217,7 @@ func TestSlotClosestNodeToleranceDisabledDoesNotAllocate(t *testing.T) {
 // Rotation state is per slot. A counter shared across slots is advanced by the other slots
 // between two visits to this one, so with a regular interleaving each slot keeps landing on
 // the same candidate index and one replica per shard takes all of that shard's reads.
-func TestSlotClosestNodeToleranceRotatesPerSlot(t *testing.T) {
+func TestSlotNodeWithinLatencyRotatesPerSlot(t *testing.T) {
 	nodesFor := func() []*clusterNode {
 		return []*clusterNode{
 			toleranceTestNode(t, 100*time.Microsecond, false),
@@ -230,9 +233,9 @@ func TestSlotClosestNodeToleranceRotatesPerSlot(t *testing.T) {
 	counts := map[*clusterNode]int{}
 	for i := 0; i < 100; i++ {
 		for _, slot := range []int{50, 150} { // alternate slots, the interleaving that breaks a shared counter
-			got, err := state.slotClosestNode(slot, 50*time.Microsecond)
+			got, err := state.slotNodeWithinLatency(slot, 50*time.Microsecond)
 			if err != nil {
-				t.Fatalf("slotClosestNode: %v", err)
+				t.Fatalf("slotNodeWithinLatency: %v", err)
 			}
 			counts[got]++
 		}
@@ -248,17 +251,17 @@ func TestSlotClosestNodeToleranceRotatesPerSlot(t *testing.T) {
 // The rotation cursor is a uint32 and wraps. Reducing it to an index must stay in the unsigned
 // domain: on 32-bit builds int is 32 bits, so converting a cursor past 2^31 before the modulo
 // yields a negative index and panics. Run with GOARCH=386 to exercise that.
-func TestSlotClosestNodeToleranceRotationPastIntMax(t *testing.T) {
+func TestSlotNodeWithinLatencyRotationPastIntMax(t *testing.T) {
 	first := toleranceTestNode(t, 100*time.Microsecond, false)
 	second := toleranceTestNode(t, 110*time.Microsecond, false)
 	state := toleranceTestState(first, second)
-	state.slots[0].rotation.Store(math.MaxInt32)
+	state.slots[0].nodesByLatencyRotation.Store(math.MaxInt32)
 
 	seen := map[*clusterNode]int{}
 	for i := 0; i < 8; i++ {
-		got, err := state.slotClosestNode(0, 50*time.Microsecond)
+		got, err := state.slotNodeWithinLatency(0, 50*time.Microsecond)
 		if err != nil {
-			t.Fatalf("slotClosestNode: %v", err)
+			t.Fatalf("slotNodeWithinLatency: %v", err)
 		}
 		if got != first && got != second {
 			t.Fatalf("unexpected node %p", got)

--- a/osscluster_latency_tolerance_test.go
+++ b/osscluster_latency_tolerance_test.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -118,5 +119,98 @@ func TestSlotClosestNodeToleranceNilPicker(t *testing.T) {
 	}
 	if got != a {
 		t.Fatal("expected the first candidate when no picker is configured")
+	}
+}
+
+// The candidate set is built from latencies captured in the same pass that computes the
+// minimum. Re-reading Latency() would let the background probe empty the set between the
+// two reads, and slotClosestNode would then return (nil, nil) for callers to dereference.
+func TestSlotClosestNodeToleranceNeverReturnsNilWithHealthyNode(t *testing.T) {
+	nodes := []*clusterNode{
+		toleranceTestNode(t, 100*time.Microsecond, false),
+		toleranceTestNode(t, 120*time.Microsecond, false),
+		toleranceTestNode(t, 900*time.Microsecond, false),
+	}
+	state := toleranceTestState(nodes...)
+	picker := &routing.RoundRobinPicker{}
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	// Churn the latencies while selection runs, including pushing the fastest node above
+	// the band it established.
+	go func() {
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			nodes[i%len(nodes)].latency.Store(uint32(100 + (i*37)%5000))
+		}
+	}()
+
+	for i := 0; i < 5000; i++ {
+		got, err := state.slotClosestNode(0, 50*time.Microsecond, picker)
+		if err != nil {
+			t.Fatalf("slotClosestNode: %v", err)
+		}
+		if got == nil {
+			t.Fatal("returned nil despite healthy nodes being available")
+		}
+	}
+}
+
+func TestSlotClosestNodeToleranceHandlesHugeTolerance(t *testing.T) {
+	a := toleranceTestNode(t, 100*time.Microsecond, false)
+	state := toleranceTestState(a, toleranceTestNode(t, 900*time.Microsecond, false))
+
+	// A tolerance near the maximum must not overflow into a negative comparison.
+	got, err := state.slotClosestNode(0, time.Duration(math.MaxInt64), &routing.RoundRobinPicker{})
+	if err != nil {
+		t.Fatalf("slotClosestNode: %v", err)
+	}
+	if got == nil {
+		t.Fatal("returned nil for a very large tolerance")
+	}
+}
+
+func TestRouteByLatencyToleranceFromClusterURL(t *testing.T) {
+	o, err := ParseClusterURL("redis://localhost:6379?route_by_latency=true&route_by_latency_tolerance=250us")
+	if err != nil {
+		t.Fatalf("ParseClusterURL: %v", err)
+	}
+	if !o.RouteByLatency {
+		t.Fatal("RouteByLatency not parsed")
+	}
+	if o.RouteByLatencyTolerance != 250*time.Microsecond {
+		t.Fatalf("tolerance = %v, want 250us", o.RouteByLatencyTolerance)
+	}
+}
+
+func TestRouteByLatencyToleranceFromFailoverURL(t *testing.T) {
+	o, err := ParseFailoverURL("redis://localhost:26379?master_name=mymaster&route_by_latency=true&route_by_latency_tolerance=1ms")
+	if err != nil {
+		t.Fatalf("ParseFailoverURL: %v", err)
+	}
+	if o.RouteByLatencyTolerance != time.Millisecond {
+		t.Fatalf("tolerance = %v, want 1ms", o.RouteByLatencyTolerance)
+	}
+}
+
+func TestRouteByLatencyToleranceFromUniversalOptions(t *testing.T) {
+	o := &UniversalOptions{
+		Addrs:                   []string{"localhost:6379"},
+		RouteByLatency:          true,
+		RouteByLatencyTolerance: 300 * time.Microsecond,
+	}
+
+	if got := o.Cluster().RouteByLatencyTolerance; got != 300*time.Microsecond {
+		t.Fatalf("Cluster() tolerance = %v, want 300us", got)
+	}
+
+	o.MasterName = "mymaster"
+	if got := o.Failover().RouteByLatencyTolerance; got != 300*time.Microsecond {
+		t.Fatalf("Failover() tolerance = %v, want 300us", got)
 	}
 }

--- a/osscluster_latency_tolerance_test.go
+++ b/osscluster_latency_tolerance_test.go
@@ -244,3 +244,29 @@ func TestSlotClosestNodeToleranceRotatesPerSlot(t *testing.T) {
 		}
 	}
 }
+
+// The rotation cursor is a uint32 and wraps. Reducing it to an index must stay in the unsigned
+// domain: on 32-bit builds int is 32 bits, so converting a cursor past 2^31 before the modulo
+// yields a negative index and panics. Run with GOARCH=386 to exercise that.
+func TestSlotClosestNodeToleranceRotationPastIntMax(t *testing.T) {
+	first := toleranceTestNode(t, 100*time.Microsecond, false)
+	second := toleranceTestNode(t, 110*time.Microsecond, false)
+	state := toleranceTestState(first, second)
+	state.slots[0].rotation.Store(math.MaxInt32)
+
+	seen := map[*clusterNode]int{}
+	for i := 0; i < 8; i++ {
+		got, err := state.slotClosestNode(0, 50*time.Microsecond)
+		if err != nil {
+			t.Fatalf("slotClosestNode: %v", err)
+		}
+		if got != first && got != second {
+			t.Fatalf("unexpected node %p", got)
+		}
+		seen[got]++
+	}
+
+	if len(seen) != 2 {
+		t.Fatalf("rotation stalled across the uint32 boundary: %v", seen)
+	}
+}

--- a/osscluster_latency_tolerance_test.go
+++ b/osscluster_latency_tolerance_test.go
@@ -12,6 +12,9 @@ func toleranceTestNode(t *testing.T, latency time.Duration, failing bool) *clust
 	n := &clusterNode{Client: NewClient(&Options{Addr: "127.0.0.1:0"})}
 	t.Cleanup(func() { _ = n.Client.Close() })
 
+	// Steady state: the node has answered a PING at least once, so Loading() takes its
+	// cached path instead of dialling a dead address for 100ms per candidate.
+	n.loaded.Store(1)
 	n.latency.Store(uint32(latency / time.Microsecond))
 	if failing {
 		n.MarkAsFailing()
@@ -271,5 +274,32 @@ func TestSlotNodeWithinLatencyRotationPastIntMax(t *testing.T) {
 
 	if len(seen) != 2 {
 		t.Fatalf("rotation stalled across the uint32 boundary: %v", seen)
+	}
+}
+
+// A node that has not yet been confirmed loaded must still be selectable: Loading() only
+// reports true for an actual LOADING reply, and a connection error is not one. Guards
+// against the tolerance filter over-excluding and shrinking the rotation to nothing.
+func TestSlotNodeWithinLatencyKeepsUnconfirmedNode(t *testing.T) {
+	fast := toleranceTestNode(t, 100*time.Microsecond, false)
+	unconfirmed := toleranceTestNode(t, 110*time.Microsecond, false)
+	unconfirmed.loaded.Store(0)
+
+	state := toleranceTestState(fast, unconfirmed)
+
+	seen := map[*clusterNode]bool{}
+	for i := 0; i < 8; i++ {
+		got, err := state.slotNodeWithinLatency(0, 50*time.Microsecond)
+		if err != nil {
+			t.Fatalf("slotNodeWithinLatency: %v", err)
+		}
+		if got == nil {
+			t.Fatal("slotNodeWithinLatency returned nil")
+		}
+		seen[got] = true
+	}
+
+	if !seen[unconfirmed] {
+		t.Fatal("node with loaded=0 was excluded from the rotation; a connection error is not a LOADING reply")
 	}
 }

--- a/osscluster_latency_tolerance_test.go
+++ b/osscluster_latency_tolerance_test.go
@@ -16,10 +16,6 @@ func toleranceTestNode(t *testing.T, latency time.Duration, failing bool) *clust
 	// cached path instead of dialling a dead address for 100ms per candidate.
 	n.loaded.Store(1)
 	n.latency.Store(uint32(latency / time.Microsecond))
-	// updateLatency stores the value and the timestamp together, so a node carrying a
-	// latency but no measurement never occurs in practice - and slotNodeWithinLatency
-	// treats a missing timestamp as "not probed yet".
-	n.SetLastLatencyMeasurement(time.Now())
 	if failing {
 		n.MarkAsFailing()
 	}
@@ -317,7 +313,7 @@ func TestSlotNodeWithinLatencyKeepsStrictOrderBeforeFirstProbe(t *testing.T) {
 		n := &clusterNode{Client: NewClient(&Options{Addr: "127.0.0.1:0"})}
 		t.Cleanup(func() { _ = n.Client.Close() })
 		n.loaded.Store(1)
-		n.latency.Store(math.MaxUint32) // exactly what newClusterNodeWithNodeAddress stores
+		n.latency.Store(unmeasuredNodeLatencyMicros) // as newClusterNodeWithNodeAddress does
 		return n
 	}
 
@@ -353,7 +349,7 @@ func TestSlotNodeWithinLatencyExcludesUnmeasuredOnceProbed(t *testing.T) {
 	unprobed := &clusterNode{Client: NewClient(&Options{Addr: "127.0.0.1:0"})}
 	t.Cleanup(func() { _ = unprobed.Client.Close() })
 	unprobed.loaded.Store(1)
-	unprobed.latency.Store(math.MaxUint32)
+	unprobed.latency.Store(unmeasuredNodeLatencyMicros)
 
 	state := toleranceTestState(measured, alsoMeasured, unprobed)
 
@@ -365,5 +361,54 @@ func TestSlotNodeWithinLatencyExcludesUnmeasuredOnceProbed(t *testing.T) {
 		if got == unprobed {
 			t.Fatalf("iteration %d: unmeasured node entered the tolerance band", i)
 		}
+	}
+}
+
+// updateLatency publishes the latency and its timestamp as two separate stores, so a probe can
+// land between selection sampling a node's latency and reading its measurement timestamp. That
+// interleaving is observable as "sentinel latency, timestamp set" - and must still count as
+// unmeasured, or the band widens to the whole slot while every sampled latency is a sentinel.
+func TestSlotNodeWithinLatencyIgnoresTimestampWithoutLatency(t *testing.T) {
+	interleaved := func() *clusterNode {
+		n := &clusterNode{Client: NewClient(&Options{Addr: "127.0.0.1:0"})}
+		t.Cleanup(func() { _ = n.Client.Close() })
+		n.loaded.Store(1)
+		n.latency.Store(unmeasuredNodeLatencyMicros)
+		// The half-published state: timestamp visible, latency not yet stored.
+		n.SetLastLatencyMeasurement(time.Now())
+		return n
+	}
+
+	first, second, third := interleaved(), interleaved(), interleaved()
+	state := toleranceTestState(first, second, third)
+
+	for i := 0; i < 50; i++ {
+		got, err := state.slotNodeWithinLatency(0, time.Second)
+		if err != nil {
+			t.Fatalf("slotNodeWithinLatency: %v", err)
+		}
+		if got != first {
+			t.Fatalf("iteration %d: a set timestamp widened the band while latencies were sentinels", i)
+		}
+	}
+}
+
+// maximumNodeLatency (all pings failed) must not be mistaken for the unmeasured sentinel: such a
+// node has a real measurement, so the band applies normally rather than collapsing to strict.
+func TestSlotNodeWithinLatencyTreatsFailedPingsAsMeasured(t *testing.T) {
+	a := toleranceTestNode(t, maximumNodeLatency, false)
+	b := toleranceTestNode(t, maximumNodeLatency, false)
+	state := toleranceTestState(a, b)
+
+	counts := map[*clusterNode]int{}
+	for i := 0; i < 80; i++ {
+		got, err := state.slotNodeWithinLatency(0, time.Millisecond)
+		if err != nil {
+			t.Fatalf("slotNodeWithinLatency: %v", err)
+		}
+		counts[got]++
+	}
+	if counts[a] == 0 || counts[b] == 0 {
+		t.Fatalf("expected rotation across both measured nodes, got a=%d b=%d", counts[a], counts[b])
 	}
 }

--- a/osscluster_latency_tolerance_test.go
+++ b/osscluster_latency_tolerance_test.go
@@ -214,3 +214,23 @@ func TestRouteByLatencyToleranceFromUniversalOptions(t *testing.T) {
 		t.Fatalf("Failover() tolerance = %v, want 300us", got)
 	}
 }
+
+// With the option unset, selection must stay on the pre-existing hot path: no candidate
+// slice, no allocation per command.
+func TestSlotClosestNodeToleranceDisabledDoesNotAllocate(t *testing.T) {
+	state := toleranceTestState(
+		toleranceTestNode(t, 100*time.Microsecond, false),
+		toleranceTestNode(t, 120*time.Microsecond, false),
+		toleranceTestNode(t, 900*time.Microsecond, false),
+	)
+
+	allocs := testing.AllocsPerRun(200, func() {
+		if _, err := state.slotClosestNode(0, 0, nil); err != nil {
+			t.Fatalf("slotClosestNode: %v", err)
+		}
+	})
+
+	if allocs != 0 {
+		t.Fatalf("zero tolerance allocated %.0f times per call, want 0", allocs)
+	}
+}

--- a/osscluster_latency_tolerance_test.go
+++ b/osscluster_latency_tolerance_test.go
@@ -258,7 +258,7 @@ func TestSlotNodeWithinLatencyRotationPastIntMax(t *testing.T) {
 	first := toleranceTestNode(t, 100*time.Microsecond, false)
 	second := toleranceTestNode(t, 110*time.Microsecond, false)
 	state := toleranceTestState(first, second)
-	state.slots[0].nodesByLatencyRotation.Store(math.MaxInt32)
+	state.slots[0].latencyBandNodeCursor.Store(math.MaxInt32)
 
 	seen := map[*clusterNode]int{}
 	for i := 0; i < 8; i++ {

--- a/osscluster_latency_tolerance_test.go
+++ b/osscluster_latency_tolerance_test.go
@@ -4,8 +4,6 @@ import (
 	"math"
 	"testing"
 	"time"
-
-	"github.com/redis/go-redis/v9/internal/routing"
 )
 
 func toleranceTestNode(t *testing.T, latency time.Duration, failing bool) *clusterNode {
@@ -34,10 +32,8 @@ func TestSlotClosestNodeToleranceZeroKeepsStrictMinimum(t *testing.T) {
 		toleranceTestNode(t, 900*time.Microsecond, false),
 	)
 
-	picker := &routing.RoundRobinPicker{}
-
 	for i := 0; i < 20; i++ {
-		got, err := state.slotClosestNode(0, 0, picker)
+		got, err := state.slotClosestNode(0, 0)
 		if err != nil {
 			t.Fatalf("slotClosestNode: %v", err)
 		}
@@ -54,10 +50,9 @@ func TestSlotClosestNodeToleranceSpreadsAcrossCloseNodes(t *testing.T) {
 	state := toleranceTestState(a, b, far)
 
 	counts := map[*clusterNode]int{}
-	picker := &routing.RoundRobinPicker{}
 
 	for i := 0; i < 100; i++ {
-		got, err := state.slotClosestNode(0, 50*time.Microsecond, picker)
+		got, err := state.slotClosestNode(0, 50*time.Microsecond)
 		if err != nil {
 			t.Fatalf("slotClosestNode: %v", err)
 		}
@@ -79,10 +74,8 @@ func TestSlotClosestNodeToleranceSkipsFailingNodes(t *testing.T) {
 	healthy := toleranceTestNode(t, 120*time.Microsecond, false)
 	state := toleranceTestState(toleranceTestNode(t, 100*time.Microsecond, true), healthy)
 
-	picker := &routing.RoundRobinPicker{}
-
 	for i := 0; i < 10; i++ {
-		got, err := state.slotClosestNode(0, 50*time.Microsecond, picker)
+		got, err := state.slotClosestNode(0, 50*time.Microsecond)
 		if err != nil {
 			t.Fatalf("slotClosestNode: %v", err)
 		}
@@ -100,7 +93,7 @@ func TestSlotClosestNodePrefersSlowerHealthyNode(t *testing.T) {
 	healthy := toleranceTestNode(t, 800*time.Microsecond, false)
 	state := toleranceTestState(toleranceTestNode(t, 100*time.Microsecond, true), healthy)
 
-	got, err := state.slotClosestNode(0, 0, nil)
+	got, err := state.slotClosestNode(0, 0)
 	if err != nil {
 		t.Fatalf("slotClosestNode: %v", err)
 	}
@@ -109,22 +102,6 @@ func TestSlotClosestNodePrefersSlowerHealthyNode(t *testing.T) {
 	}
 }
 
-func TestSlotClosestNodeToleranceNilPicker(t *testing.T) {
-	a := toleranceTestNode(t, 100*time.Microsecond, false)
-	state := toleranceTestState(a, toleranceTestNode(t, 120*time.Microsecond, false))
-
-	got, err := state.slotClosestNode(0, 50*time.Microsecond, nil)
-	if err != nil {
-		t.Fatalf("slotClosestNode: %v", err)
-	}
-	if got != a {
-		t.Fatal("expected the first candidate when no picker is configured")
-	}
-}
-
-// The candidate set is built from latencies captured in the same pass that computes the
-// minimum. Re-reading Latency() would let the background probe empty the set between the
-// two reads, and slotClosestNode would then return (nil, nil) for callers to dereference.
 func TestSlotClosestNodeToleranceNeverReturnsNilWithHealthyNode(t *testing.T) {
 	nodes := []*clusterNode{
 		toleranceTestNode(t, 100*time.Microsecond, false),
@@ -132,7 +109,6 @@ func TestSlotClosestNodeToleranceNeverReturnsNilWithHealthyNode(t *testing.T) {
 		toleranceTestNode(t, 900*time.Microsecond, false),
 	}
 	state := toleranceTestState(nodes...)
-	picker := &routing.RoundRobinPicker{}
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -151,7 +127,7 @@ func TestSlotClosestNodeToleranceNeverReturnsNilWithHealthyNode(t *testing.T) {
 	}()
 
 	for i := 0; i < 5000; i++ {
-		got, err := state.slotClosestNode(0, 50*time.Microsecond, picker)
+		got, err := state.slotClosestNode(0, 50*time.Microsecond)
 		if err != nil {
 			t.Fatalf("slotClosestNode: %v", err)
 		}
@@ -166,7 +142,7 @@ func TestSlotClosestNodeToleranceHandlesHugeTolerance(t *testing.T) {
 	state := toleranceTestState(a, toleranceTestNode(t, 900*time.Microsecond, false))
 
 	// A tolerance near the maximum must not overflow into a negative comparison.
-	got, err := state.slotClosestNode(0, time.Duration(math.MaxInt64), &routing.RoundRobinPicker{})
+	got, err := state.slotClosestNode(0, time.Duration(math.MaxInt64))
 	if err != nil {
 		t.Fatalf("slotClosestNode: %v", err)
 	}
@@ -225,12 +201,46 @@ func TestSlotClosestNodeToleranceDisabledDoesNotAllocate(t *testing.T) {
 	)
 
 	allocs := testing.AllocsPerRun(200, func() {
-		if _, err := state.slotClosestNode(0, 0, nil); err != nil {
+		if _, err := state.slotClosestNode(0, 0); err != nil {
 			t.Fatalf("slotClosestNode: %v", err)
 		}
 	})
 
 	if allocs != 0 {
 		t.Fatalf("zero tolerance allocated %.0f times per call, want 0", allocs)
+	}
+}
+
+// Rotation state is per slot. A counter shared across slots is advanced by the other slots
+// between two visits to this one, so with a regular interleaving each slot keeps landing on
+// the same candidate index and one replica per shard takes all of that shard's reads.
+func TestSlotClosestNodeToleranceRotatesPerSlot(t *testing.T) {
+	nodesFor := func() []*clusterNode {
+		return []*clusterNode{
+			toleranceTestNode(t, 100*time.Microsecond, false),
+			toleranceTestNode(t, 120*time.Microsecond, false),
+		}
+	}
+	a, b := nodesFor(), nodesFor()
+	state := &clusterState{slots: []*clusterSlot{
+		{start: 0, end: 100, nodes: a},
+		{start: 101, end: 200, nodes: b},
+	}}
+
+	counts := map[*clusterNode]int{}
+	for i := 0; i < 100; i++ {
+		for _, slot := range []int{50, 150} { // alternate slots, the interleaving that breaks a shared counter
+			got, err := state.slotClosestNode(slot, 50*time.Microsecond)
+			if err != nil {
+				t.Fatalf("slotClosestNode: %v", err)
+			}
+			counts[got]++
+		}
+	}
+
+	for name, nodes := range map[string][]*clusterNode{"slot 0-100": a, "slot 101-200": b} {
+		if counts[nodes[0]] == 0 || counts[nodes[1]] == 0 {
+			t.Fatalf("%s did not rotate: %d / %d", name, counts[nodes[0]], counts[nodes[1]])
+		}
 	}
 }

--- a/osscluster_test.go
+++ b/osscluster_test.go
@@ -1770,6 +1770,93 @@ var _ = Describe("ClusterClient", func() {
 		assertClusterClient()
 	})
 
+	Describe("ClusterClient with RouteByLatencyTolerance", func() {
+		BeforeEach(func() {
+			opt = redisClusterOptions()
+			opt.RouteByLatency = true
+			// Far wider than any intra-cluster spread, so every healthy node for a slot is a
+			// candidate and the per-slot rotation is the thing under test.
+			opt.RouteByLatencyTolerance = time.Second
+			client = cluster.newClusterClient(ctx, opt)
+
+			err := client.ForEachMaster(ctx, func(ctx context.Context, master *redis.Client) error {
+				return master.FlushDB(ctx).Err()
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = client.ForEachSlave(ctx, func(ctx context.Context, slave *redis.Client) error {
+				Eventually(func() int64 {
+					return client.DBSize(ctx).Val()
+				}, 30*time.Second).Should(Equal(int64(0)))
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err := client.ForEachSlave(ctx, func(ctx context.Context, slave *redis.Client) error {
+				return slave.ReadWrite(ctx).Err()
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = client.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should read keys from distinct shards", func() {
+			// Discovered rather than hardcoded: keyN does not spread over the three masters
+			// (key2 and key3 both hash into 0-5460), and hardcoded keys would silently stop
+			// covering multiple shards if the slot ranges ever moved.
+			keys := make([]string, 0, 3)
+			slots := map[int64]string{}
+			masters := map[string]string{}
+
+			for i := 0; len(masters) < 3 && i < 100; i++ {
+				key := fmt.Sprintf("tolerance-key-%d", i)
+
+				nodes, err := client.Nodes(ctx, key)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nodes).NotTo(BeEmpty())
+
+				master := nodes[0].Client.Options().Addr
+				if _, seen := masters[master]; seen {
+					continue
+				}
+				masters[master] = key
+
+				slot := client.ClusterKeySlot(ctx, key).Val()
+				Expect(slots).NotTo(HaveKey(slot))
+				slots[slot] = key
+				keys = append(keys, key)
+			}
+			Expect(masters).To(HaveLen(3), "could not find keys on three distinct masters: %v", masters)
+
+			for _, key := range keys {
+				Expect(client.Set(ctx, key, "VALUE-"+key, 0).Err()).NotTo(HaveOccurred())
+			}
+
+			// Reads go to whichever in-band node the rotation picks, including replicas that
+			// may not have caught up yet, so poll rather than failing on the first attempt.
+			for _, key := range keys {
+				Eventually(func() string {
+					return client.Get(ctx, key).Val()
+				}, 30*time.Second).Should(Equal("VALUE-" + key))
+			}
+
+			// Repeated reads must keep resolving to a usable node for every slot. This is what
+			// regressed when the rotation cursor was shared across slots.
+			for i := 0; i < 50; i++ {
+				for _, key := range keys {
+					Eventually(func() string {
+						return client.Get(ctx, key).Val()
+					}, 30*time.Second).Should(Equal("VALUE-" + key))
+				}
+			}
+		})
+
+		assertClusterClient()
+	})
+
 	Describe("ClusterClient with ClusterSlots", func() {
 		BeforeEach(func() {
 			failover = true

--- a/sentinel.go
+++ b/sentinel.go
@@ -48,6 +48,8 @@ type FailoverOptions struct {
 	// Allows routing read-only commands to the closest master or replica node.
 	// This option only works with NewFailoverClusterClient.
 	RouteByLatency bool
+	// RouteByLatencyTolerance is passed through to ClusterOptions; see its documentation.
+	RouteByLatencyTolerance time.Duration
 	// Allows routing read-only commands to the random master or replica node.
 	// This option only works with NewFailoverClusterClient.
 	RouteRandomly bool
@@ -328,9 +330,10 @@ func (opt *FailoverOptions) clusterOptions() *ClusterOptions {
 
 		MaxRedirects: opt.MaxRetries,
 
-		ReadOnly:       opt.ReplicaOnly,
-		RouteByLatency: opt.RouteByLatency,
-		RouteRandomly:  opt.RouteRandomly,
+		ReadOnly:                opt.ReplicaOnly,
+		RouteByLatency:          opt.RouteByLatency,
+		RouteByLatencyTolerance: opt.RouteByLatencyTolerance,
+		RouteRandomly:           opt.RouteRandomly,
 
 		MinRetryBackoff: opt.MinRetryBackoff,
 		MaxRetryBackoff: opt.MaxRetryBackoff,

--- a/sentinel.go
+++ b/sentinel.go
@@ -465,6 +465,7 @@ func setupFailoverConnParams(u *url.URL, o *FailoverOptions) (*FailoverOptions, 
 	o.MasterName = q.string("master_name")
 	o.ClientName = q.string("client_name")
 	o.RouteByLatency = q.bool("route_by_latency")
+	o.RouteByLatencyTolerance = q.duration("route_by_latency_tolerance")
 	o.RouteRandomly = q.bool("route_randomly")
 	o.ReplicaOnly = q.bool("replica_only")
 	o.UseDisconnectedReplicas = q.bool("use_disconnected_replicas")

--- a/universal.go
+++ b/universal.go
@@ -112,7 +112,10 @@ type UniversalOptions struct {
 	MaxRedirects   int
 	ReadOnly       bool
 	RouteByLatency bool
-	RouteRandomly  bool
+	// RouteByLatencyTolerance is passed through to ClusterOptions and FailoverOptions;
+	// see ClusterOptions.RouteByLatencyTolerance.
+	RouteByLatencyTolerance time.Duration
+	RouteRandomly           bool
 
 	// MasterName is the sentinel master name.
 	// Only for failover clients.
@@ -195,10 +198,11 @@ func (o *UniversalOptions) Cluster() *ClusterOptions {
 		CredentialsProviderContext:   o.CredentialsProviderContext,
 		StreamingCredentialsProvider: o.StreamingCredentialsProvider,
 
-		MaxRedirects:   o.MaxRedirects,
-		ReadOnly:       o.ReadOnly,
-		RouteByLatency: o.RouteByLatency,
-		RouteRandomly:  o.RouteRandomly,
+		MaxRedirects:            o.MaxRedirects,
+		ReadOnly:                o.ReadOnly,
+		RouteByLatency:          o.RouteByLatency,
+		RouteByLatencyTolerance: o.RouteByLatencyTolerance,
+		RouteRandomly:           o.RouteRandomly,
 
 		MaxRetries:      o.MaxRetries,
 		MinRetryBackoff: o.MinRetryBackoff,
@@ -264,8 +268,9 @@ func (o *UniversalOptions) Failover() *FailoverOptions {
 		SentinelUsername: o.SentinelUsername,
 		SentinelPassword: o.SentinelPassword,
 
-		RouteByLatency: o.RouteByLatency,
-		RouteRandomly:  o.RouteRandomly,
+		RouteByLatency:          o.RouteByLatency,
+		RouteByLatencyTolerance: o.RouteByLatencyTolerance,
+		RouteRandomly:           o.RouteRandomly,
 
 		MaxRetries:      o.MaxRetries,
 		MinRetryBackoff: o.MinRetryBackoff,


### PR DESCRIPTION
Fixes #3974

## Problem

`RouteByLatency` selects the strict minimum in `slotClosestNode`. When several nodes are
effectively equidistant, every client converges on the same one and the rest take no read
traffic at all.

The estimate driving that choice is coarse: the mean of ten `PING`s of a sub-millisecond
operation, refreshed at most every 10s (`minLatencyMeasurementInterval`). A difference well
inside the measurement noise therefore decides the entire read load for the next interval,
and there is no tolerance band to absorb it.

Measured on a sentinel-backed `NewFailoverClusterClient` spread across three availability
zones. `GET`s per second across a five-replica set:

```
97.7   71.4   7.6   4.3   0.17        -> 590x spread
per-pod CPU: 38m 34m 39m 26m 27m      -> flat
```

CPU is flat because the split tracks the latency ranking, not any real difference in
capacity. Zone locality was working — cross-AZ transfer dropped ~70% when we enabled
`RouteByLatency` — but the distribution *within* a zone did not, and one replica of five was
serving 0.17 reads/s. Egress showed the same imbalance (4.81 vs 1.73 Gbit/s), which matters
because the busiest node was then at 77% of its instance's sustained network baseline.

## Change

`ClusterOptions.RouteByLatencyTolerance` (a `time.Duration`) widens the selection from *the*
fastest node to *any* node within that much of the fastest, round-robining between them with
the existing `ShardPicker`.

- **Locality is preserved.** A node an availability zone away is roughly 4x further off
  (~0.6ms vs ~0.15ms in our case), far outside any sensible tolerance, so it never enters
  the candidate set.
- **Default is zero**, which keeps the current strict-minimum behaviour exactly. No effect
  unless `RouteByLatency` is set.
- Plumbed through `FailoverOptions` so sentinel users can reach it.

```go
rdb := redis.NewFailoverClusterClient(&redis.FailoverOptions{
    MasterName:              "mymaster",
    SentinelAddrs:           []string{":26379"},
    RouteByLatency:          true,
    RouteByLatencyTolerance: 200 * time.Microsecond,
})
```

## Also: a latent bug in the same function

`closestNonFailingNode` was only assigned inside the `n.Latency() < minLatency` branch:

```go
for _, n := range nodes {
    if closestNode == nil || n.Latency() < minLatency {
        closestNode = n
        minLatency = n.Latency()
        if !n.Failing() {
            closestNonFailingNode = n
            allNodesFailing = false
        }
    }
}
```

If the fastest node is failing and a healthy node is slower, the healthy one is never
recorded — it cannot enter the `if` — so `closestNonFailingNode` stays `nil` and selection
falls through to the "all nodes are marked as failed" path even though a healthy node
existed. The rewrite tracks the healthy minimum and the overall minimum separately.
`TestSlotClosestNodePrefersSlowerHealthyNode` covers it and fails on the previous
implementation.

## Tests

Added `osscluster_latency_tolerance_test.go`:

- zero tolerance keeps the strict minimum
- a tolerance spreads evenly across close nodes and never selects one outside the band
- failing nodes are excluded from the band
- a slower healthy node beats a failing faster one (the bug above)
- a nil `ShardPicker` degrades to the first candidate rather than panicking

These are in-package unit tests over a synthetic `clusterState` and need no Redis. I ran them
plus `go vet ./...` and the existing non-Docker cluster unit tests. I could **not** run the
full `make test` suite — it needs Docker, which wasn't available in my environment — so CI
coverage there would be welcome.

## Compatibility

Additive. One new field on `ClusterOptions` and one on `FailoverOptions`; the zero value is
the current behaviour. The only behavioural change without the option set is the bug fix,
which turns a fallback-to-failing-node into selecting an available healthy node.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path read routing for cluster/failover clients when RouteByLatencyTolerance is set; mis-tuned tolerance could skew replica load or hit loading nodes, though defaults preserve prior behavior.
> 
> **Overview**
> Adds **`RouteByLatencyTolerance`** on cluster, failover, and universal options (plus URL query `route_by_latency_tolerance`). When **`RouteByLatency`** is enabled and tolerance is **> 0**, read routing uses a new **`slotNodeWithinLatency`** path instead of **`slotClosestNode`**: healthy nodes within the tolerance of the fastest healthy peer are eligible, then chosen via **per-slot round-robin** (`latencyBandNodeCursor` on **`clusterSlot`**).
> 
> **Zero tolerance** keeps the existing strict-minimum **`slotClosestNode`** path with no extra per-read allocations.
> 
> The tolerance path handles **unmeasured** latency sentinels (strict pick until any real probe), **failing** nodes, **loading** replicas (with fallback outside the band), huge tolerances without overflow, and concurrent latency updates via single-sample reads.
> 
> **`slotEntry`** is introduced and **`slotNodes`** delegates to it so rotation state lives on the slot entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7300694ff644961d184e004f59c4aeab28e9d63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->