### PR TITLE
test(autopipeline): use suite DB in Ginkgo specs

### DIFF
--- a/autopipeline_test.go
+++ b/autopipeline_test.go
@@ -240,9 +240,7 @@ var _ = Describe("AutoPipeline Blocking Commands", func() {
 	var ap *redis.AutoPipeliner
 
 	BeforeEach(func() {
-		client = redis.NewClient(&redis.Options{
-			Addr: apTestAddr(),
-		})
+		client = redis.NewClient(redisOptions())
 		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 
 		var err error
@@ -471,9 +469,7 @@ var _ = Describe("AutoPipeline Cmdable Interface", func() {
 	var ap *redis.AutoPipeliner
 
 	BeforeEach(func() {
-		client = redis.NewClient(&redis.Options{
-			Addr: apTestAddr(),
-		})
+		client = redis.NewClient(redisOptions())
 		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 
 		var err error
@@ -2151,15 +2147,14 @@ var _ = Describe("AutoPipeline", func() {
 	var ap *redis.AutoPipeliner
 
 	BeforeEach(func() {
-		client = redis.NewClient(&redis.Options{
-			Addr: apTestAddr(),
-			AutoPipelineOptions: &redis.AutoPipelineOptions{
-				MaxBatchSize:         10,
-				MaxFlushDelay:        50 * time.Millisecond,
-				MaxConcurrentBatches: 5,
-				Unordered:            true,
-			},
-		})
+		opt := redisOptions()
+		opt.AutoPipelineOptions = &redis.AutoPipelineOptions{
+			MaxBatchSize:         10,
+			MaxFlushDelay:        50 * time.Millisecond,
+			MaxConcurrentBatches: 5,
+			Unordered:            true,
+		}
+		client = redis.NewClient(opt)
 		Expect(client.FlushDB(ctx).Err()).NotTo(HaveOccurred())
 
 		var err error
@@ -2372,15 +2367,14 @@ var _ = Describe("AutoPipeline", func() {
 
 	It("should respect MaxConcurrentBatches", func() {
 		// Create autopipeliner with low concurrency limit
-		client2 := redis.NewClient(&redis.Options{
-			Addr: apTestAddr(),
-			AutoPipelineOptions: &redis.AutoPipelineOptions{
-				MaxBatchSize:         5,
-				MaxFlushDelay:        10 * time.Millisecond,
-				MaxConcurrentBatches: 2,
-				Unordered:            true,
-			},
-		})
+		opt := redisOptions()
+		opt.AutoPipelineOptions = &redis.AutoPipelineOptions{
+			MaxBatchSize:         5,
+			MaxFlushDelay:        10 * time.Millisecond,
+			MaxConcurrentBatches: 2,
+			Unordered:            true,
+		}
+		client2 := redis.NewClient(opt)
 		defer client2.Close()
 
 		ap2, err := client2.AutoPipeline()


### PR DESCRIPTION
The three `AutoPipeline` Ginkgo `Describe` blocks built their client from
`&redis.Options{Addr: apTestAddr()}`, hard-wired to `:6379` (or `REDIS_PORT`).
Against a Redis Enterprise endpoint (`RE_CLUSTER=true`, as the go-redis RE
integration workflow runs) the real address, credentials and TLS come from
`redisOptions()`/`BeforeSuite` (`reConn.Addr` via `applyREConnection`), so those
specs dialed `:6379` and failed with `dial tcp :6379: connect: connection refused`.

This bases the Ginkgo clients on `redisOptions()` like the rest of the suite so
they reach the proper database. `apTestAddr()` is left for the plain `go test`
functions, which run without `BeforeSuite` and self-skip when Redis is unreachable.

Verified red->green locally by driving the RE code path against a standalone
Redis: unfixed the specs dial the wrong port and fail with the same
`connection refused`; fixed, all 22 AutoPipeline specs pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only wiring change; no production code paths. Low risk aside from CI behavior now depending on `redisOptions()`/`BeforeSuite` for those Ginkgo specs.
> 
> **Overview**
> **Fixes AutoPipeline Ginkgo specs** that failed against Redis Enterprise / suite-configured endpoints because they built clients with `Addr: apTestAddr()` (`:6379` or `REDIS_PORT`) instead of the shared suite connection.
> 
> The three Ginkgo `Describe` blocks (**AutoPipeline Blocking Commands**, **Cmdable Interface**, and **AutoPipeline**) now create clients via **`redisOptions()`**, matching `BeforeSuite` wiring (address, credentials, TLS when `RE_CLUSTER=true`). Specs that need custom **`AutoPipelineOptions`** copy options from `redisOptions()` and set fields on that struct before `NewClient(opt)`.
> 
> **`apTestAddr()` is unchanged** for plain `go test` functions that run without Ginkgo `BeforeSuite` and self-skip when Redis is unreachable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c30f09dc5bcf376ea4a2e1db00ec2b150ceb8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->