### PR TITLE
fix(command): tolerate unknown CLIENT INFO flags

### DIFF
--- a/client_info_internal_test.go
+++ b/client_info_internal_test.go
@@ -1,0 +1,34 @@
+package redis
+
+import "testing"
+
+// TestParseClientInfoForwardCompatFlags pins that parseClientInfo (shared by
+// CLIENT INFO and CLIENT LIST) tolerates client-flag characters it does not
+// recognize instead of failing the whole reply. Previously an unrecognized
+// flag character produced "redis: unexpected client info flags(...)" and broke
+// CLIENT TRACKING tests. New flag characters can appear over time, so the
+// parser must skip the ones it does not map while keeping the ones it does.
+func TestParseClientInfoForwardCompatFlags(t *testing.T) {
+	cases := []struct {
+		name  string
+		flags string
+		want  ClientFlags // bits that must be set; unknown flags must not error
+	}{
+		{"single unknown", "m", 0},
+		{"multiple unknown", "go", 0},
+		{"known plus unknown", "tm", ClientTracking},
+		{"known combo plus unknown", "Btm", ClientTrackingBCAST | ClientTracking},
+		{"no-flag sentinel", "N", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			info, err := parseClientInfo("id=1 addr=127.0.0.1:6379 flags=" + tc.flags + " db=0")
+			if err != nil {
+				t.Fatalf("parseClientInfo(flags=%q) errored: %v", tc.flags, err)
+			}
+			if info.Flags&tc.want != tc.want {
+				t.Fatalf("flags=%q: Flags=%b, want bits %b set", tc.flags, info.Flags, tc.want)
+			}
+		})
+	}
+}

--- a/command.go
+++ b/command.go
@@ -8012,7 +8012,12 @@ func parseClientInfo(txt string) (info *ClientInfo, err error) {
 				case 'T':
 					info.Flags |= ClientNoTouch
 				default:
-					return nil, fmt.Errorf("redis: unexpected client info flags(%s)", string(val[i]))
+					// Forward compatibility: servers can return client-flag
+					// characters this client does not recognize (new flags are
+					// added over time). Skip them instead of failing, as the
+					// CLIENT LIST/INFO docs advise for version-safe parsing, and
+					// matching the "skip unknown fields" behaviour of the field
+					// switch below.
 				}
 			}
 		case "db":


### PR DESCRIPTION
`parseClientInfo` (shared by `CLIENT INFO` and `CLIENT LIST`) failed the whole
reply on any client-flag character it did not recognize:

```
redis: unexpected client info flags(...)
```

New flag characters can appear over time, so a version-safe client must handle
them gracefully — the [CLIENT LIST/INFO docs](https://redis.io/docs/latest/commands/client-list/)
say as much, and the field switch in the same function already skips unknown
fields (`default: // skip unknown fields`).

**Fix**: skip unrecognized flag characters instead of erroring; known flags still
set their bits. Covers both `CLIENT INFO` and `CLIENT LIST` (same parser).

**Verification**: new internal unit test `TestParseClientInfoForwardCompatFlags`
feeds unrecognized flag characters, alone and mixed with recognized ones — before
the fix these error with the signature above; after, they parse and the known
flag bits are still set. This fixes `CLIENT TRACKING` specs that were failing on
the parse error, not on a missing bit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized parser change that makes replies more tolerant; known flag bits are unchanged and covered by new tests.
> 
> **Overview**
> **`parseClientInfo`** no longer fails the whole reply when the server sends client **flag characters** the client does not map. Unrecognized characters are **skipped**; known flags still set their bits. This matches forward-compatible parsing for **`CLIENT INFO`** / **`CLIENT LIST`**-style replies and aligns with how unknown **fields** are already ignored in the same function.
> 
> Adds **`TestParseClientInfoForwardCompatFlags`** to lock in behavior for unknown-only flags, mixes of known and unknown flags, and the **`N`** sentinel—fixing failures such as **`CLIENT TRACKING`** tests that hit `redis: unexpected client info flags(...)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985657cede942751604288cce18b98cf5f2d7967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->