### PR TITLE
perf(autopipeline): gated fast-submit for the full-duplex path

### DIFF
--- a/autopipeline.go
+++ b/autopipeline.go
@@ -164,6 +164,21 @@ type AutoPipelineOptions struct {
 	// value is rejected by Validate.
 	FullDuplexMaxHold time.Duration
 
+	// FullDuplexFastSubmit skips the blocking three-arm select in the submit hot
+	// path with a non-blocking send while the submit queue is shallow, cutting the
+	// selectgo cost (~40% of submit CPU) that dominates at high producer counts on
+	// low-RTT links. The fast path is queue-depth gated: it engages only while the
+	// submit channel is under ~10% full, so once the queue bursts deep the fair
+	// blocking select takes over and the p99 tail is preserved. Measured (FD
+	// blocking, 1-5 ms RTT, >=1k concurrent callers, DEFAULT window): +15-33%
+	// throughput at 1 ms and +6-18% at 5 ms with the tail equal-or-better; a no-op
+	// on high-RTT links (RTT-bound) and harmless at low concurrency. The gate
+	// scales with FullDuplexWindow (the submit channel is min(window,4096) deep),
+	// so a small FullDuplexWindow leaves a shallow channel and effectively disables
+	// the fast path — the measured gains are at the default window. Only used when
+	// FullDuplex is set. Off by default.
+	FullDuplexFastSubmit bool
+
 	// contentSharded is set internally by cluster wiring when commands are
 	// routed to shards by content (slot), so same-key commands always share a
 	// shard and per-key order holds even with several shards. It exempts that

--- a/autopipeline_fullduplex.go
+++ b/autopipeline_fullduplex.go
@@ -392,9 +392,10 @@ type fdEngine struct {
 	idle     time.Duration // return the conn after this idle gap (0 = never)
 	maxHold  time.Duration // force a clean return at least this often (0 = never)
 
-	recycles    atomic.Int64               // clean returns (idle + max-hold); observability/tests
-	curInflight atomic.Pointer[fdInflight] // current session's in-flight deque; test observability
-	curConn     atomic.Pointer[pool.Conn]  // current session's held conn; test observability (handoff)
+	recycles       atomic.Int64               // clean returns (idle + max-hold); observability/tests
+	curInflight    atomic.Pointer[fdInflight] // current session's in-flight deque; test observability
+	curConn        atomic.Pointer[pool.Conn]  // current session's held conn; test observability (handoff)
+	fastSubmitTake atomic.Int64               // fast-path submits taken; test observability
 
 	submitMu sync.RWMutex // guards closed; RLock across the submit send, WLock to close the gate
 	closed   bool         // set once run() is tearing down; submit then rejects new work
@@ -402,7 +403,22 @@ type fdEngine struct {
 	retryWg  sync.WaitGroup // tracks off-pipe retries diverted to the normal client path; run() waits it so Close does too
 	retrySem chan struct{}  // caps concurrent off-pipe retries at the window (see retryOnNormalConn)
 	hostWg   sync.WaitGroup // tracks per-command hook-host goroutines (see hostHook); run() waits it so Close does not return while a post-next ProcessHook is still running
+
+	// fastSubmit tries a non-blocking channel send before the blocking three-arm
+	// select in submit (from AutoPipelineOptions.FullDuplexFastSubmit). Gated on
+	// submit-queue depth (fdFastSubmitGatePct) so it only runs while the queue is
+	// shallow; a deep/bursting queue falls to the fair blocking select.
+	fastSubmit bool
 }
+
+// fdFastSubmitGatePct bounds fastSubmit to when the submit channel is below this
+// percent full. The non-blocking send cuts the submit-path selectgo cost, but
+// past saturation it would let producers that find room jump ahead of producers
+// blocked on a full channel, starving them and inflating p99. Gating on len(ch)
+// closes the fast path exactly as that backup starts, so contended traffic uses
+// the fair blocking select and the tail is preserved. 10% is the measured
+// tail-safe point (looser gates leave the tail elevated; see FD perf notes).
+const fdFastSubmitGatePct = 10
 
 func newFDEngine(ap *AutoPipeliner, client *Client) *fdEngine {
 	mb := ap.config.MaxBatchSize
@@ -436,15 +452,16 @@ func newFDEngine(ap *AutoPipeliner, client *Client) *fdEngine {
 		chCap = 4096
 	}
 	return &fdEngine{
-		ap:       ap,
-		client:   client,
-		pool:     client.getPipelinePool(),
-		ch:       make(chan fdReq, chCap),
-		maxBatch: mb,
-		window:   w,
-		idle:     idle,
-		maxHold:  maxHold,
-		retrySem: make(chan struct{}, w),
+		ap:         ap,
+		client:     client,
+		pool:       client.getPipelinePool(),
+		ch:         make(chan fdReq, chCap),
+		maxBatch:   mb,
+		window:     w,
+		idle:       idle,
+		maxHold:    maxHold,
+		retrySem:   make(chan struct{}, w),
+		fastSubmit: ap.config.FullDuplexFastSubmit,
 	}
 }
 
@@ -494,6 +511,26 @@ func (fd *fdEngine) submit(ctx context.Context, cmd Cmder) *apBatch {
 		// was started) so processAsync surfaces the error from raw Process(ctx,cmd),
 		// matching every other submit-time-rejection path.
 		return completedBatch
+	}
+	// Fast path (opt-in via FullDuplexFastSubmit): while the submit queue is
+	// shallow, a non-blocking send skips the blocking three-arm selectgo that
+	// dominates submit CPU at high producer counts. Admission is IDENTICAL to the
+	// blocking case below (same gate held, same host start, same return); only the
+	// wait is skipped. The queue-depth gate keeps this off once the channel bursts
+	// deep, so contended traffic takes the fair blocking select and the p99 tail is
+	// preserved. On a miss (or a full channel) it falls through to that select.
+	if fd.fastSubmit && len(fd.ch)*100 < cap(fd.ch)*fdFastSubmitGatePct {
+		select {
+		case fd.ch <- req:
+			fd.fastSubmitTake.Add(1) // test observability; single atomic on the (already RLock'd) fast path
+			if hookDone != nil {
+				fd.hostWg.Add(1)
+				go fd.hostHook(ctx, cmd, b, hookDone)
+			}
+			fd.submitMu.RUnlock()
+			return b
+		default:
+		}
 	}
 	select {
 	case fd.ch <- req:

--- a/autopipeline_fullduplex_test.go
+++ b/autopipeline_fullduplex_test.go
@@ -1265,6 +1265,72 @@ func TestFullDuplexCloseWhileBackpressured(t *testing.T) {
 	}
 }
 
+// TestFullDuplexFastSubmitCloseRace exercises the FullDuplexFastSubmit fast path
+// under a concurrent Close. The non-blocking fast send runs under the SAME submit
+// RLock as the blocking send, so a send can never win the race with the shutdown
+// drain (WLock + closed + drain), and the pooled blocking batch is recycled on
+// every reject path. Every caller must settle (no hang, no panic) with either a
+// served result or a shutdown/ctx error. Run under -race to catch any data race
+// on the fast path.
+func TestFullDuplexFastSubmitCloseRace(t *testing.T) {
+	ctx := context.Background()
+	c := fdTestClient(":6379")
+	defer c.Close()
+	if err := c.Ping(ctx).Err(); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
+	// Window 4096 -> chCap 4096 -> gate fires while len(ch) < 410. With G blocking
+	// submitters (each at most one outstanding) len(ch) <= G << 410, so the fast
+	// path is live for the whole run and genuinely races Close.
+	ap, err := c.AutoPipelineWithOptions(&AutoPipelineOptions{
+		FullDuplex: true, FullDuplexFastSubmit: true, FullDuplexWindow: 4096, MaxBatchSize: 8,
+	})
+	if err != nil {
+		t.Fatalf("AutoPipelineWithOptions: %v", err)
+	}
+	if ap.fd == nil || !ap.fd.fastSubmit {
+		t.Fatal("fast-submit full-duplex engine not active")
+	}
+
+	const G, K = 16, 2000
+	var settled int64
+	var wg sync.WaitGroup
+	for g := 0; g < G; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for k := 0; k < K; k++ {
+				// nil (served) or a shutdown/ctx error are both fine; the point is
+				// that EVERY call RETURNS — none hangs on a req stranded in the
+				// channel past the drain, and none panics.
+				_ = ap.Set(ctx, fmt.Sprintf("fsc:%d:%d", g, k), "v", 0).Err()
+				atomic.AddInt64(&settled, 1)
+			}
+		}(g)
+	}
+	// Close while submitters are mid-flight so the fast send interleaves with the
+	// shutdown drain.
+	time.Sleep(20 * time.Millisecond)
+	if err := ap.Close(); err != nil {
+		t.Fatalf("Close during fast-submit: %v", err)
+	}
+	doneCh := make(chan struct{})
+	go func() { wg.Wait(); close(doneCh) }()
+	select {
+	case <-doneCh:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("callers hung after Close: settled %d/%d", atomic.LoadInt64(&settled), G*K)
+	}
+	if got := atomic.LoadInt64(&settled); got != int64(G*K) {
+		t.Fatalf("not all callers settled: %d/%d", got, G*K)
+	}
+	// Prove the fast path was actually exercised — otherwise this test would pass
+	// on the pre-existing blocking path alone and cover nothing.
+	if took := ap.fd.fastSubmitTake.Load(); took == 0 {
+		t.Fatal("fast-submit path was never taken — config did not exercise it")
+	}
+}
+
 // TestFullDuplexBlockingCmdDetection proves the divert predicate catches blocking
 // commands — in particular a RAW XREAD whose BLOCK token is a []byte (the form a
 // plain string type switch would miss, letting it ride the shared pipe). Pure.


### PR DESCRIPTION
## What

Adds `AutoPipelineOptions.FullDuplexFastSubmit` (opt-in): a queue-depth-gated
non-blocking fast path in the full-duplex `submit()` hot path, before the
blocking three-arm select. `selectgo` is ~40% of submit CPU at high producer
counts; the fast send skips it while the submit queue is shallow.

## Tail safety

The fast path is gated on submit-queue depth (`< 10%` of channel cap). Past
saturation the channel backs up and blocked senders form; an ungated
non-blocking send would let producers that find room jump ahead of them,
starving the waiters and inflating p99. The gate closes exactly as that backup
starts, so contended traffic uses the fair blocking select. The send runs under
the same submit RLock as the blocking path, so it cannot race the shutdown
drain; the pooled blocking batch is recycled on every reject path.

## Numbers (FD blocking face, latproxy, median)

| RTT | w | off | fast-submit | tail |
|--|--|--|--|--|
| 1ms | 2048 | 2.42M | 2.91M (+20%) | p99 3.8ms -> 3.5ms |
| 1ms | 4096 | 2.18M / p99 38.5ms | 2.89M (+33%) | p99 6.4ms |
| 5ms | 4096 | 2.10M / p99 9.6ms | 2.48M (+18%) | p99 6.2ms |

No-op on high-RTT (WAN) links (RTT-bound) and at low concurrency; off by
default. Pinned by `TestFullDuplexFastSubmitCloseRace` (race).

Stacked on #3970 (base `ndyakov/fd-alloc-opt`); retarget after that merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the concurrent full-duplex submit/close hot path (channel send under the same RLock as the blocking path). Opt-in and gated, but a gate or race bug could starve waiters or hang callers on Close.
> 
> **Overview**
> Adds opt-in `FullDuplexFastSubmit` so full-duplex `submit()` can skip the blocking three-arm select while the submit queue is shallow, reducing `selectgo` cost at high producer counts on low-RTT links.
> 
> The fast path is a non-blocking send that only runs when the channel is under ~10% full (`fdFastSubmitGatePct`). Once the queue bursts, traffic falls back to the fair blocking select so waiters are not starved and p99 stays equal-or-better. Admission, hook-host start, and the submit RLock are unchanged from the blocking path.
> 
> Off by default; a no-op on high-RTT or low-concurrency workloads. `TestFullDuplexFastSubmitCloseRace` races the fast send against Close and asserts every caller settles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f737dbeb2b2b192548ecb4c44e326f6ee60550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->