### PR TITLE
test(command): skip CLIENT INFO tracking-flag assert on RE

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -417,7 +417,12 @@ var _ = Describe("Commands", func() {
 
 			info, err := conn.ClientInfo(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(info.Flags & redis.ClientTracking).NotTo(BeZero())
+			// Redis Enterprise's proxy does not surface the client-tracking flag in
+			// CLIENT INFO, so assert it only against a direct server. Tracking still
+			// works on RE (the command returns OK and CSC operates).
+			if !RECluster {
+				Expect(info.Flags & redis.ClientTracking).NotTo(BeZero())
+			}
 
 			status, err = conn.ClientTrackingOff(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
@@ -444,8 +449,13 @@ var _ = Describe("Commands", func() {
 
 			info, err := conn.ClientInfo(ctx).Result()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(info.Flags & redis.ClientTracking).NotTo(BeZero())
-			Expect(info.Flags & redis.ClientTrackingBCAST).NotTo(BeZero())
+			// Redis Enterprise's proxy does not surface tracking flags in CLIENT
+			// INFO, so assert them only against a direct server (tracking still
+			// works on RE).
+			if !RECluster {
+				Expect(info.Flags & redis.ClientTracking).NotTo(BeZero())
+				Expect(info.Flags & redis.ClientTrackingBCAST).NotTo(BeZero())
+			}
 			// Redis does not expose the NOLOOP flag in CLIENT INFO; it is only
 			// observable via CLIENT TRACKINGINFO.
 


### PR DESCRIPTION
The Redis Enterprise integration run's only remaining failures are the two
`CLIENT TRACKING` specs:

```
[FAIL] Commands server should ClientTracking ON/OFF (commands_test.go:420)
[FAIL] Commands server should ClientTracking with BCAST and NOLOOP (commands_test.go:447)
  Expected <redis.ClientFlags>: 0 not to be zero-valued
```

Against an RE database the proxy does not surface the client-tracking flags in
`CLIENT INFO`, so `info.Flags & ClientTracking` (and `ClientTrackingBCAST`) read
back zero — even though `CLIENT TRACKING ON` returns OK and client-side caching
works (the CSC specs pass on RE).

Assert those `CLIENT INFO` flags only against a direct server (`!RECluster`). The
rest of each spec still runs everywhere: the command returning OK, and the flag
clearing after `TRACKING OFF`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only skip of CLIENT INFO flag assertions on Redis Enterprise; no production code or behavior changes.
> 
> **Overview**
> Relaxes two `CLIENT TRACKING` specs so they no longer fail against Redis Enterprise.
> 
> `CLIENT TRACKING ON` still must return OK everywhere, but assertions that `CLIENT INFO` flags include `ClientTracking` / `ClientTrackingBCAST` now run only when `!RECluster`. RE’s proxy does not surface those flags even though tracking and CSC still work. The post-`TRACKING OFF` zero-flag check is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d3a8d54276150cf71d17d9da45a619c03d57ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->