### PR TITLE
fix(msetex): first key index handling

### DIFF
--- a/command.go
+++ b/command.go
@@ -330,12 +330,11 @@ func cmdFirstKeyPosWithInfo(cmd Cmder, info *CommandInfo) int {
 		if cmd.stringArg(1) == "usage" {
 			return 2
 		}
-	// CommandInfo (if available) gives the correct answer
-	// otherwise the hardcoded fallback applies.
-
 	case "msetex":
+		// MSetEX's constructor already sets this via SetFirstKeyPos; this
+		// fallback only covers raw Do("msetex", ...) calls, which aren't
+		// guaranteed to route correctly and aren't the recommended usage.
 		return 2
-
 	}
 
 	// Use CommandInfo cache when warm (in-memory only, no extra round-trips).

--- a/command.go
+++ b/command.go
@@ -330,8 +330,12 @@ func cmdFirstKeyPosWithInfo(cmd Cmder, info *CommandInfo) int {
 		if cmd.stringArg(1) == "usage" {
 			return 2
 		}
-		// CommandInfo (if available) gives the correct answer
-		// otherwise the hardcoded fallback applies.
+	// CommandInfo (if available) gives the correct answer
+	// otherwise the hardcoded fallback applies.
+
+	case "msetex":
+		return 2
+
 	}
 
 	// Use CommandInfo cache when warm (in-memory only, no extra round-trips).

--- a/string_commands.go
+++ b/string_commands.go
@@ -464,6 +464,7 @@ func (c cmdable) MSetEX(ctx context.Context, args MSetEXArgs, values ...interfac
 	}
 
 	cmd := NewIntCmd(ctx, cmdArgs...)
+	cmd.SetFirstKeyPos(2)
 	_ = c(ctx, cmd)
 	return cmd
 }

--- a/unit_test.go
+++ b/unit_test.go
@@ -106,3 +106,26 @@ func TestCmdFirstKeyPosWithInfo_PolicyTableKeyless(t *testing.T) {
 		t.Errorf("unregistered module cmd: got %d, want 1", got)
 	}
 }
+
+// TestCmdFirstKeyPosWithInfo_MsetEx checks that msetex's first key is
+// resolved to position 2 (after the command name and the numkeys arg),
+// unlike mset/msetnx where the first key sits at position 1 immediately
+// after the command name.
+func TestCmdFirstKeyPosWithInfo_MsetEx(t *testing.T) {
+	ctx := context.Background()
+
+	msetex := NewCmd(ctx, "msetex", 2, "key1", "val1", "key2", "val2", "ex", 10)
+	if got := cmdFirstKeyPosWithInfo(msetex, nil); got != 2 {
+		t.Errorf("msetex cold cache: got %d, want 2", got)
+	}
+
+	mset := NewCmd(ctx, "mset", "key1", "val1", "key2", "val2")
+	if got := cmdFirstKeyPosWithInfo(mset, nil); got != 1 {
+		t.Errorf("mset cold cache: got %d, want 1", got)
+	}
+
+	msetnx := NewCmd(ctx, "msetnx", "key1", "val1", "key2", "val2")
+	if got := cmdFirstKeyPosWithInfo(msetnx, nil); got != 1 {
+		t.Errorf("msetnx cold cache: got %d, want 1", got)
+	}
+}


### PR DESCRIPTION
fixes #3986

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches cluster key-position routing for MSETEX; a wrong first-key index would send writes to the wrong shard. The change is small and covered by unit tests.
> 
> **Overview**
> Fixes cluster slot hashing for `MSETEX` so the first key is taken at arg position 2 (after the command name and `numkeys`), not position 1 like `MSET`/`MSETNX`.
> 
> `MSetEX` now calls `SetFirstKeyPos(2)` on the constructed command. `cmdFirstKeyPosWithInfo` also hardcodes that fallback for raw `Do("msetex", ...)` when the command-info cache is cold. Tests cover the cold-cache path versus `mset`/`msetnx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e5968f6f9b5bf8ed269318195eeae8f4cdc909e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->