### PR TITLE
fix(pool): run conn teardown even when already CLOSED

### DIFF
--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -61,6 +61,13 @@ type atomicNetConn struct {
 	conn net.Conn
 }
 
+// closedNetConn is the sentinel Close swaps into netConnAtomic to take ownership
+// of the current transport. atomic.Value panics on nil and on mismatched
+// concrete types, so the sentinel keeps the *atomicNetConn type while its nil
+// conn makes getNetConn report "no transport". Sharing one immutable value
+// avoids a per-close allocation.
+var closedNetConn = &atomicNetConn{}
+
 // generateConnID generates a fast unique identifier for a connection with zero allocations
 func generateConnID() uint64 {
 	return connIDCounter.Add(1)
@@ -160,19 +167,6 @@ type Conn struct {
 	// them. Atomic for the same init-vs-Close race as onClose: it is also
 	// installed by initConn and read and cleared by Close.
 	onCscClose atomic.Pointer[func() error]
-
-	// transportClosed claims the net.Conn teardown so it happens exactly once.
-	// Close CAS-claims it and only then calls net.Conn.Close, so repeated or
-	// concurrent Close calls (and the initConn-failure path where the pool
-	// closes a connection already marked CLOSED) do not double-close the socket
-	// or surface a spurious "use of closed network connection" error to callers
-	// that collect it (e.g. ConnPool.closeConnsIf).
-	//
-	// Invariant: the claim is never stale. The socket is only replaced by
-	// SetNetConnAndInitConn, which gates on non-CLOSED states, so no socket
-	// replacement can follow a Close (Close transitions to CLOSED). A given
-	// Conn therefore only ever closes the transport it was claimed on.
-	transportClosed atomic.Bool
 
 	// onCscReinit runs after the connection is claimed for reinitialization but
 	// before its socket is replaced. CSC uses it to invalidate entries whose
@@ -1171,12 +1165,24 @@ func (cn *Conn) Close() error {
 		_ = (*fn)()
 	}
 
-	// Lock-free netConn access for better performance. transportClosed claims
-	// the teardown with a CAS so the socket is closed exactly once; repeated or
-	// concurrent Close calls return nil rather than a double-close error.
-	if netConn := cn.getNetConn(); netConn != nil {
-		if cn.transportClosed.CompareAndSwap(false, true) {
-			return netConn.Close()
+	// Atomically take ownership of the current transport and close it. Swapping
+	// (rather than a sticky "closed" flag) closes exactly the socket installed
+	// when this Close ran: every value stored in netConnAtomic is closed by the
+	// one caller that swaps it out, and a socket a concurrent handoff installs
+	// afterwards is a fresh generation closed by the next Close. This keeps the
+	// close exactly-once (repeat/concurrent closes swap out the sentinel and
+	// return nil, avoiding a spurious "use of closed network connection" to
+	// callers such as ConnPool.closeConnsIf) without leaking a replacement
+	// socket when a Close races SetNetConnAndInitConn and init resurrects the
+	// conn to IDLE.
+	//
+	// A handoff may also close the pre-handoff socket directly
+	// (handoff_worker.go captures oldConn and closes it); if that races this
+	// swap the socket is closed twice, which is harmless — the second close is
+	// discarded.
+	if v := cn.netConnAtomic.Swap(closedNetConn); v != nil {
+		if wrapper, ok := v.(*atomicNetConn); ok && wrapper.conn != nil {
+			return wrapper.conn.Close()
 		}
 	}
 	return nil

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -161,6 +161,19 @@ type Conn struct {
 	// installed by initConn and read and cleared by Close.
 	onCscClose atomic.Pointer[func() error]
 
+	// transportClosed claims the net.Conn teardown so it happens exactly once.
+	// Close CAS-claims it and only then calls net.Conn.Close, so repeated or
+	// concurrent Close calls (and the initConn-failure path where the pool
+	// closes a connection already marked CLOSED) do not double-close the socket
+	// or surface a spurious "use of closed network connection" error to callers
+	// that collect it (e.g. ConnPool.closeConnsIf).
+	//
+	// Invariant: the claim is never stale. The socket is only replaced by
+	// SetNetConnAndInitConn, which gates on non-CLOSED states, so no socket
+	// replacement can follow a Close (Close transitions to CLOSED). A given
+	// Conn therefore only ever closes the transport it was claimed on.
+	transportClosed atomic.Bool
+
 	// onCscReinit runs after the connection is claimed for reinitialization but
 	// before its socket is replaced. CSC uses it to invalidate entries whose
 	// server-side tracking coverage belongs to the old socket.
@@ -1158,10 +1171,13 @@ func (cn *Conn) Close() error {
 		_ = (*fn)()
 	}
 
-	// Lock-free netConn access for better performance. net.Conn.Close is safe
-	// to call more than once, so no extra guard is needed here.
+	// Lock-free netConn access for better performance. transportClosed claims
+	// the teardown with a CAS so the socket is closed exactly once; repeated or
+	// concurrent Close calls return nil rather than a double-close error.
 	if netConn := cn.getNetConn(); netConn != nil {
-		return netConn.Close()
+		if cn.transportClosed.CompareAndSwap(false, true) {
+			return netConn.Close()
+		}
 	}
 	return nil
 }

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -1125,10 +1125,17 @@ func (cn *Conn) IsClosed() bool {
 }
 
 func (cn *Conn) Close() error {
+	// Transition to CLOSED. When the connection is already CLOSED, fall through
+	// to the cleanup below rather than returning early: a rejected initConn
+	// marks the connection CLOSED to report failure *before* any teardown runs
+	// (see redis.go initConn failure paths), so the pool's subsequent Close must
+	// still release the transport and run the close callbacks. Returning early
+	// on StateClosed leaked the socket and skipped the streaming-credentials
+	// unsubscribe / CSC close callbacks (issue #3982).
 	for {
 		state := cn.stateMachine.GetState()
 		if state == StateClosed {
-			return nil
+			break
 		}
 		if cn.stateMachine.TryTransitionFast(state, StateClosed) {
 			// TryTransitionFast deliberately skips waiter notification; Close
@@ -1138,6 +1145,10 @@ func (cn *Conn) Close() error {
 		}
 	}
 
+	// Callbacks are cleared with an atomic swap so each runs at most once even
+	// across concurrent or repeated Close calls, and independently of the state
+	// machine — the CLOSED state may have been set by a failed initialization
+	// rather than here.
 	if fn := cn.onClose.Swap(nil); fn != nil {
 		// ignore error
 		_ = (*fn)()
@@ -1147,7 +1158,8 @@ func (cn *Conn) Close() error {
 		_ = (*fn)()
 	}
 
-	// Lock-free netConn access for better performance
+	// Lock-free netConn access for better performance. net.Conn.Close is safe
+	// to call more than once, so no extra guard is needed here.
 	if netConn := cn.getNetConn(); netConn != nil {
 		return netConn.Close()
 	}

--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -56,17 +56,20 @@ type HandoffState struct {
 	SeqID         int64  // Sequence ID from MOVING notification
 }
 
-// atomicNetConn is a wrapper to ensure consistent typing in atomic.Value
+// atomicNetConn is a wrapper to ensure consistent typing in atomic.Value.
+// It is always stored and accessed by pointer, so the embedded atomic.Bool is
+// never copied.
 type atomicNetConn struct {
 	conn net.Conn
+	// closed claims teardown of this specific transport generation. Close
+	// CAS-claims it before calling conn.Close, so a given socket is closed
+	// exactly once. A handoff installs a fresh wrapper (closed=false) via
+	// setNetConn, so a replacement socket is a new generation claimed by the
+	// next Close rather than skipped under a stale flag. The wrapper is left in
+	// place on Close (not swapped out) so getNetConn keeps returning the closed
+	// conn, preserving RemoteAddr/LocalAddr and the connCheck health path.
+	closed atomic.Bool
 }
-
-// closedNetConn is the sentinel Close swaps into netConnAtomic to take ownership
-// of the current transport. atomic.Value panics on nil and on mismatched
-// concrete types, so the sentinel keeps the *atomicNetConn type while its nil
-// conn makes getNetConn report "no transport". Sharing one immutable value
-// avoids a per-close allocation.
-var closedNetConn = &atomicNetConn{}
 
 // generateConnID generates a fast unique identifier for a connection with zero allocations
 func generateConnID() uint64 {
@@ -1165,24 +1168,30 @@ func (cn *Conn) Close() error {
 		_ = (*fn)()
 	}
 
-	// Atomically take ownership of the current transport and close it. Swapping
-	// (rather than a sticky "closed" flag) closes exactly the socket installed
-	// when this Close ran: every value stored in netConnAtomic is closed by the
-	// one caller that swaps it out, and a socket a concurrent handoff installs
-	// afterwards is a fresh generation closed by the next Close. This keeps the
-	// close exactly-once (repeat/concurrent closes swap out the sentinel and
-	// return nil, avoiding a spurious "use of closed network connection" to
-	// callers such as ConnPool.closeConnsIf) without leaking a replacement
-	// socket when a Close races SetNetConnAndInitConn and init resurrects the
-	// conn to IDLE.
+	// Close the current transport generation exactly once, claiming it via the
+	// wrapper's per-generation flag. The wrapper is left in netConnAtomic (not
+	// nil-ed or swapped out) so getNetConn keeps returning the closed conn,
+	// preserving the pre-fix contract that RemoteAddr/LocalAddr and the
+	// connCheck health path rely on.
 	//
-	// A handoff may also close the pre-handoff socket directly
-	// (handoff_worker.go captures oldConn and closes it); if that races this
-	// swap the socket is closed twice, which is harmless — the second close is
+	// Load-then-CAS is deliberately not a single atomic step: if a concurrent
+	// handoff installs a new wrapper between the Load and the CAS, this Close
+	// claims and closes the OLD generation (which still needs closing) while the
+	// replacement is a fresh wrapper (closed=false) claimed by the next Close.
+	// That is the correct outcome and is what makes teardown generation-bound
+	// rather than leaking a socket installed after a Close set a lifetime flag.
+	//
+	// Repeat/concurrent closes of the same generation lose the CAS and return
+	// nil, so no spurious "use of closed network connection" reaches callers
+	// such as ConnPool.closeConnsIf. A handoff may also close the pre-handoff
+	// socket directly (handoff_worker.go captures oldConn); if that races this
+	// path the socket is closed twice, which is harmless — the extra close is
 	// discarded.
-	if v := cn.netConnAtomic.Swap(closedNetConn); v != nil {
+	if v := cn.netConnAtomic.Load(); v != nil {
 		if wrapper, ok := v.(*atomicNetConn); ok && wrapper.conn != nil {
-			return wrapper.conn.Close()
+			if wrapper.closed.CompareAndSwap(false, true) {
+				return wrapper.conn.Close()
+			}
 		}
 	}
 	return nil

--- a/internal/pool/conn_close_hooks_test.go
+++ b/internal/pool/conn_close_hooks_test.go
@@ -247,13 +247,21 @@ func TestConn_CscReinitHookRunsBeforeSocketReplacement(t *testing.T) {
 
 // closeCountingConn wraps a net.Conn and records how many times Close is
 // called, so tests can assert the underlying socket is torn down exactly once.
+// The second and later closes return an error, mirroring real transports (a
+// *net.TCPConn returns "use of closed network connection") rather than the
+// silent net.Pipe behavior, so tests can verify Close does not surface a
+// double-close error to its caller.
 type closeCountingConn struct {
 	net.Conn
 	closes atomic.Int32
 }
 
+var errAlreadyClosedTransport = errors.New("use of closed network connection")
+
 func (c *closeCountingConn) Close() error {
-	c.closes.Add(1)
+	if c.closes.Add(1) > 1 {
+		return errAlreadyClosedTransport
+	}
 	return c.Conn.Close()
 }
 
@@ -304,12 +312,13 @@ func TestConn_CloseAfterStateClosedStillCleansUp(t *testing.T) {
 	}
 }
 
-// TestConn_DoubleCloseRunsCallbacksExactlyOnce asserts idempotence of the
-// callback teardown: closing a connection more than once must run each close
-// callback exactly once (they are cleared with an atomic swap) and must always
-// reach the transport close. net.Conn.Close is itself safe to call repeatedly,
-// so the socket is closed at least once — Close does not add its own guard.
-func TestConn_DoubleCloseRunsCallbacksExactlyOnce(t *testing.T) {
+// TestConn_DoubleCloseCleansUpExactlyOnce asserts teardown idempotence:
+// closing a connection more than once must run each close callback and the
+// transport close exactly once. The transport close is CAS-claimed, so only
+// the first Close closes the socket and returns its result; later closes must
+// return nil rather than a spurious double-close error (which ConnPool paths
+// such as closeConnsIf would otherwise propagate).
+func TestConn_DoubleCloseCleansUpExactlyOnce(t *testing.T) {
 	server, client := net.Pipe()
 	defer server.Close()
 
@@ -327,13 +336,17 @@ func TestConn_DoubleCloseRunsCallbacksExactlyOnce(t *testing.T) {
 	})
 
 	for i := 0; i < 3; i++ {
-		if err := cn.Close(); err != nil && i == 0 {
+		err := cn.Close()
+		if i == 0 && err != nil {
 			t.Fatalf("first Close: %v", err)
+		}
+		if i > 0 && err != nil {
+			t.Fatalf("repeat Close #%d returned %v, want nil (no double-close error)", i, err)
 		}
 	}
 
-	if got := rec.closes.Load(); got < 1 {
-		t.Fatalf("net.Conn.Close calls: got %d want >= 1 (transport must be closed)", got)
+	if got := rec.closes.Load(); got != 1 {
+		t.Fatalf("net.Conn.Close calls: got %d want 1 (transport must close exactly once)", got)
 	}
 	if got := onCloseCalls.Load(); got != 1 {
 		t.Fatalf("onClose calls: got %d want 1", got)

--- a/internal/pool/conn_close_hooks_test.go
+++ b/internal/pool/conn_close_hooks_test.go
@@ -314,10 +314,10 @@ func TestConn_CloseAfterStateClosedStillCleansUp(t *testing.T) {
 
 // TestConn_DoubleCloseCleansUpExactlyOnce asserts teardown idempotence:
 // closing a connection more than once must run each close callback and the
-// transport close exactly once. Close atomically swaps the transport out, so
-// only the first Close closes the socket and returns its result; later closes
-// swap out the sentinel and return nil rather than a spurious double-close
-// error (which ConnPool paths such as closeConnsIf would otherwise propagate).
+// transport close exactly once. Close claims the transport generation with a
+// CAS, so only the first Close closes the socket and returns its result; later
+// closes lose the CAS and return nil rather than a spurious double-close error
+// (which ConnPool paths such as closeConnsIf would otherwise propagate).
 func TestConn_DoubleCloseCleansUpExactlyOnce(t *testing.T) {
 	server, client := net.Pipe()
 	defer server.Close()
@@ -398,5 +398,29 @@ func TestConn_CloseThenSocketReplacedClosesNewTransport(t *testing.T) {
 	}
 	if got := recB.closes.Load(); got != 1 {
 		t.Fatalf("replacement transport close calls: got %d want 1 (socket leaked under stale claim)", got)
+	}
+}
+
+// TestConn_GetNetConnSurvivesClose guards the post-close contract that other
+// subsystems depend on: after Close the connection must still expose its
+// (now closed) transport via getNetConn, so RemoteAddr/LocalAddr keep working
+// and connCheck receives a non-nil conn. Sentinel's Filter closes an in-use
+// connection while leaving it in the pool and later calls cn.RemoteAddr(); the
+// pool health check calls connCheck(cn.getNetConn()). A Close that cleared the
+// transport would turn both into nil-pointer panics.
+func TestConn_GetNetConnSurvivesClose(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+
+	cn := NewConn(client)
+	if err := cn.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if cn.getNetConn() == nil {
+		t.Fatal("getNetConn returned nil after Close; RemoteAddr/connCheck callers would panic")
+	}
+	if cn.RemoteAddr() == nil {
+		t.Fatal("RemoteAddr returned nil after Close")
 	}
 }

--- a/internal/pool/conn_close_hooks_test.go
+++ b/internal/pool/conn_close_hooks_test.go
@@ -244,3 +244,101 @@ func TestConn_CscReinitHookRunsBeforeSocketReplacement(t *testing.T) {
 		t.Fatalf("SetNetConnAndInitConn: %v", err)
 	}
 }
+
+// closeCountingConn wraps a net.Conn and records how many times Close is
+// called, so tests can assert the underlying socket is torn down exactly once.
+type closeCountingConn struct {
+	net.Conn
+	closes atomic.Int32
+}
+
+func (c *closeCountingConn) Close() error {
+	c.closes.Add(1)
+	return c.Conn.Close()
+}
+
+// TestConn_CloseAfterStateClosedStillCleansUp is a regression test for #3982.
+// baseClient.initConn transitions a connection to CLOSED to report an
+// initialization/authentication failure *before* any teardown runs; the pool
+// then removes the rejected connection and calls Close. Close must not treat
+// the pre-existing CLOSED state as proof that cleanup already happened: it has
+// to close the transport and run the installed close callbacks exactly once,
+// otherwise repeated init failures leak sockets/file descriptors.
+func TestConn_CloseAfterStateClosedStillCleansUp(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+
+	rec := &closeCountingConn{Conn: client}
+	cn := NewConn(rec)
+
+	var onCloseCalls, onCscCloseCalls atomic.Int32
+	cn.SetOnClose(func() error {
+		onCloseCalls.Add(1)
+		return nil
+	})
+	cn.SetOnCscClose(func() error {
+		onCscCloseCalls.Add(1)
+		return nil
+	})
+
+	// Mirror the initConn failure path: mark the connection CLOSED without any
+	// resource teardown.
+	cn.GetStateMachine().Transition(StateClosed)
+
+	// The pool removal path then closes the rejected connection.
+	if err := cn.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if got := rec.closes.Load(); got != 1 {
+		t.Fatalf("net.Conn.Close calls: got %d want 1 (socket leaked after StateClosed)", got)
+	}
+	if got := onCloseCalls.Load(); got != 1 {
+		t.Fatalf("onClose calls: got %d want 1", got)
+	}
+	if got := onCscCloseCalls.Load(); got != 1 {
+		t.Fatalf("onCscClose calls: got %d want 1", got)
+	}
+	if cn.onClose.Load() != nil || cn.onCscClose.Load() != nil {
+		t.Fatal("Close must clear both close callbacks")
+	}
+}
+
+// TestConn_DoubleCloseRunsCallbacksExactlyOnce asserts idempotence of the
+// callback teardown: closing a connection more than once must run each close
+// callback exactly once (they are cleared with an atomic swap) and must always
+// reach the transport close. net.Conn.Close is itself safe to call repeatedly,
+// so the socket is closed at least once — Close does not add its own guard.
+func TestConn_DoubleCloseRunsCallbacksExactlyOnce(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+
+	rec := &closeCountingConn{Conn: client}
+	cn := NewConn(rec)
+
+	var onCloseCalls, onCscCloseCalls atomic.Int32
+	cn.SetOnClose(func() error {
+		onCloseCalls.Add(1)
+		return nil
+	})
+	cn.SetOnCscClose(func() error {
+		onCscCloseCalls.Add(1)
+		return nil
+	})
+
+	for i := 0; i < 3; i++ {
+		if err := cn.Close(); err != nil && i == 0 {
+			t.Fatalf("first Close: %v", err)
+		}
+	}
+
+	if got := rec.closes.Load(); got < 1 {
+		t.Fatalf("net.Conn.Close calls: got %d want >= 1 (transport must be closed)", got)
+	}
+	if got := onCloseCalls.Load(); got != 1 {
+		t.Fatalf("onClose calls: got %d want 1", got)
+	}
+	if got := onCscCloseCalls.Load(); got != 1 {
+		t.Fatalf("onCscClose calls: got %d want 1", got)
+	}
+}

--- a/internal/pool/conn_close_hooks_test.go
+++ b/internal/pool/conn_close_hooks_test.go
@@ -314,10 +314,10 @@ func TestConn_CloseAfterStateClosedStillCleansUp(t *testing.T) {
 
 // TestConn_DoubleCloseCleansUpExactlyOnce asserts teardown idempotence:
 // closing a connection more than once must run each close callback and the
-// transport close exactly once. The transport close is CAS-claimed, so only
-// the first Close closes the socket and returns its result; later closes must
-// return nil rather than a spurious double-close error (which ConnPool paths
-// such as closeConnsIf would otherwise propagate).
+// transport close exactly once. Close atomically swaps the transport out, so
+// only the first Close closes the socket and returns its result; later closes
+// swap out the sentinel and return nil rather than a spurious double-close
+// error (which ConnPool paths such as closeConnsIf would otherwise propagate).
 func TestConn_DoubleCloseCleansUpExactlyOnce(t *testing.T) {
 	server, client := net.Pipe()
 	defer server.Close()
@@ -353,5 +353,50 @@ func TestConn_DoubleCloseCleansUpExactlyOnce(t *testing.T) {
 	}
 	if got := onCscCloseCalls.Load(); got != 1 {
 		t.Fatalf("onCscClose calls: got %d want 1", got)
+	}
+}
+
+// TestConn_CloseThenSocketReplacedClosesNewTransport is a regression test for
+// the handoff race reported on #3985: a Close during SetNetConnAndInitConn's
+// INITIALIZING window closes the original socket, then init stores a
+// replacement socket and unconditionally transitions the conn back to IDLE
+// (Transition is a plain Store). A later Close must close that replacement
+// socket. A teardown flag retained for the Conn's lifetime would stay set and
+// leak the replacement; binding the close to the transport generation (Close
+// swaps the socket out) closes each generation exactly once.
+//
+// The interleaving is reproduced deterministically rather than with goroutines.
+func TestConn_CloseThenSocketReplacedClosesNewTransport(t *testing.T) {
+	serverA, clientA := net.Pipe()
+	defer serverA.Close()
+	serverB, clientB := net.Pipe()
+	defer serverB.Close()
+
+	recA := &closeCountingConn{Conn: clientA}
+	recB := &closeCountingConn{Conn: clientB}
+
+	cn := NewConn(recA)
+
+	// Enter the handoff/init window and close from it, mirroring a pool
+	// shutdown that races an in-flight reinitialization.
+	cn.GetStateMachine().Transition(StateInitializing)
+	if err := cn.Close(); err != nil {
+		t.Fatalf("Close in INITIALIZING: %v", err)
+	}
+	if got := recA.closes.Load(); got != 1 {
+		t.Fatalf("original transport close calls: got %d want 1", got)
+	}
+
+	// Init proceeds: it stores the replacement socket and resurrects the conn
+	// to IDLE (Transition overwrites the CLOSED state set above).
+	cn.SetNetConn(recB)
+	cn.GetStateMachine().Transition(StateIdle)
+
+	// The replacement socket must be closed by the next Close.
+	if err := cn.Close(); err != nil {
+		t.Fatalf("Close after socket replacement: %v", err)
+	}
+	if got := recB.closes.Load(); got != 1 {
+		t.Fatalf("replacement transport close calls: got %d want 1 (socket leaked under stale claim)", got)
 	}
 }


### PR DESCRIPTION
initConn marks a rejected connection CLOSED to report an init/auth failure before any teardown runs. Conn.Close early-returned on CLOSED, so the pool's subsequent close leaked the socket and skipped the streaming-credentials unsubscribe and CSC close callbacks. Repeated failures accumulated open file descriptors until GC.

Fall through to cleanup regardless of state: callbacks are cleared with an atomic swap (exactly once) and net.Conn.Close is double-close safe.

Closes #3982

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core pool `Conn.Close` lifecycle and concurrency with handoff/reinit; fixes FD leaks but affects hot-path teardown behavior relied on by streaming credentials and CSC hooks.
> 
> **Overview**
> Fixes **connection teardown leaks** when `initConn` has already moved a `Conn` to `CLOSED` before the pool calls `Close` (#3982). **`Close` no longer bails out on `StateClosed`**; it still runs `onClose` / `onCscClose` (atomic swap, once) and shuts down the socket.
> 
> Transport teardown is now **per socket generation**: `atomicNetConn` gets a `closed` flag claimed with CAS so each `net.Conn` is closed once, repeat `Close` returns `nil` (avoids double-close errors in pool paths), and a **replacement socket after handoff/init** (#3985) is closed on a later `Close` instead of being skipped by a lifetime flag. The wrapper stays in `netConnAtomic` after close so **`getNetConn` / `RemoteAddr` / health checks** keep working.
> 
> Adds regression tests for cleanup after pre-`CLOSED`, idempotent double-close, close-then-socket-replace, and post-close `getNetConn`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c04f39de5e2187fe243a0a67aa8cba3e5584b16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->