### PR TITLE
fix(pipeline): remove duplicate getPipelinePool

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -10046,6 +10046,14 @@ var _ = Describe("Commands", func() {
 		})
 
 		It("returns the number of slow queries", Label("NonRedisEnterprise"), func() {
+			// Warm the autopipeline face's dedicated pipeline pool before lowering
+			// the slowlog threshold. That pool dials lazily on the first flush, so
+			// its HELLO + CLIENT SETINFO handshake would otherwise be recorded as
+			// slow queries once slowlog-log-slower-than is 0 and inflate the count.
+			// Read the result so the dial has completed before we reset. Harmless
+			// on the default (non-autopipeline) subject.
+			Expect(client.Set(ctx, "test", "true", 0).Err()).NotTo(HaveOccurred())
+
 			// Reset slowlog
 			err := rawClient.SlowLogReset(ctx).Err()
 			Expect(err).NotTo(HaveOccurred())

--- a/pipeline_pool_getter_test.go
+++ b/pipeline_pool_getter_test.go
@@ -22,7 +22,7 @@ func TestAutoPipelineCapturesPipelinePool(t *testing.T) {
 	if c.getPipelinePool() == nil {
 		t.Fatal("getPipelinePool() returned nil for a client configured with a pipeline pool")
 	}
-	if c.getPipelinePool() != c.pipelinePool {
+	if c.getPipelinePool() != c.pipelinePool.pool {
 		t.Fatal("getPipelinePool() did not return the client's pipeline pool")
 	}
 
@@ -46,8 +46,11 @@ func TestAutoPipelineCapturesPipelinePool(t *testing.T) {
 // TestAutoPipelineNilPipelinePoolConservative verifies the safe fallback: a
 // client with no pipeline pool captures nil and the gate stays conservative
 // (pipelineHasFreeConn() == false → the original long hold is kept).
+//
+// The pipeline pool is now always-on (PipelinePoolSize >= 0), so the nil path
+// is reached via the explicit opt-out, PipelinePoolSize: -1.
 func TestAutoPipelineNilPipelinePoolConservative(t *testing.T) {
-	c := NewClient(&Options{Addr: ":6379"}) // no pipeline buffers => no pipeline pool
+	c := NewClient(&Options{Addr: ":6379", PipelinePoolSize: -1}) // opt out => no pipeline pool
 	defer c.Close()
 
 	if c.getPipelinePool() != nil {

--- a/redis.go
+++ b/redis.go
@@ -1205,15 +1205,6 @@ func (c *baseClient) withConn(
 	return fnErr
 }
 
-// getPipelinePool returns the dedicated pipeline connection pool as a
-// pool.Pooler, or nil when the client has none. AutoPipeliner reads it (via an
-// in-package interface assertion on its underlying client) so the straggler
-// hold can gate on live pipeline-pool occupancy; without this accessor that
-// assertion fails and the gate silently degrades to the conservative long hold.
-func (c *baseClient) getPipelinePool() pool.Pooler {
-	return c.pipelinePool
-}
-
 // withPipelineConn executes fn with a connection from the pipeline pool when
 // one is configured (PipelineReadBufferSize/PipelineWriteBufferSize set),
 // otherwise it falls back to the regular pool via withConn.


### PR DESCRIPTION
PR #3959 branched before sibling #3962 merged; the merge kept both copies of getPipelinePool, and #3962's copy returns *pipelinePoolRef, which no longer satisfies pool.Pooler after #3959's field refactor.

Drop the stale duplicate and adapt #3962's getter test: compare against pipelinePool.pool, and reach the nil path via the new always-on opt-out (PipelinePoolSize: -1).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and duplicate-method cleanup only; production getter behavior is unchanged aside from dropping a broken merge leftover.
> 
> **Overview**
> Removes a leftover `getPipelinePool` that survived a merge of two pipeline-pool PRs. After `pipelinePool` became a `*pipelinePoolRef`, that copy no longer implemented `pool.Pooler`, so AutoPipeliner’s in-package assertion would fail and the straggler-hold gate would silently fall back to a long hold.
> 
> The remaining getter (unwraps `ref.pool`) is the one callers already use. Tests now compare against `pipelinePool.pool` and reach the nil-pool path via `PipelinePoolSize: -1`. A SlowLog test warms the autopipeline pool so lazy HELLO/SETINFO handshakes are not counted as slow queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f3ba824d99ff82964348fa288f1db61c365a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->