### PR TITLE
fix(log): guard global Logger and LogLevel with atomics

### DIFF
--- a/internal/log.go
+++ b/internal/log.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"sync/atomic"
 )
 
 // TODO (ned): Revisit logging
@@ -28,11 +29,62 @@ func NewDefaultLogger() Logging {
 	}
 }
 
+// atomicLogger holds the active Logging behind an atomic pointer so
+// redis.SetLogger, logging.Enable and logging.Disable can swap it while pool
+// and background goroutines read it through Printf. The interface is stored via
+// a pointer rather than atomic.Value, whose single-concrete-type rule the
+// swappable implementations (DefaultLogger, VoidLogger, custom loggers) break.
+type atomicLogger struct {
+	v atomic.Pointer[Logging]
+}
+
+func (a *atomicLogger) Store(l Logging) { a.v.Store(&l) }
+
+func (a *atomicLogger) Load() Logging {
+	if p := a.v.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+func (a *atomicLogger) Printf(ctx context.Context, format string, v ...interface{}) {
+	if l := a.Load(); l != nil {
+		l.Printf(ctx, format, v...)
+	}
+}
+
+func newAtomicLogger(l Logging) *atomicLogger {
+	a := &atomicLogger{}
+	a.Store(l)
+	return a
+}
+
 // Logger calls Output to print to the stderr.
 // Arguments are handled in the manner of fmt.Print.
-var Logger Logging = NewDefaultLogger()
+// Swap it with redis.SetLogger; read it through Logger.Printf.
+var Logger = newAtomicLogger(NewDefaultLogger())
 
-var LogLevel LogLevelT = LogLevelError
+// atomicLogLevel stores the active level as an int32 so redis.SetLogLevel can
+// change it while the level guards (isHealthyConn on the Get path, the
+// maintnotifications loggers) read it through the *OrAbove helpers.
+type atomicLogLevel struct {
+	v atomic.Int32
+}
+
+func (a *atomicLogLevel) Store(l LogLevelT) { a.v.Store(int32(l)) }
+func (a *atomicLogLevel) Load() LogLevelT   { return LogLevelT(a.v.Load()) }
+
+func (a *atomicLogLevel) WarnOrAbove() bool  { return a.Load().WarnOrAbove() }
+func (a *atomicLogLevel) InfoOrAbove() bool  { return a.Load().InfoOrAbove() }
+func (a *atomicLogLevel) DebugOrAbove() bool { return a.Load().DebugOrAbove() }
+
+func newAtomicLogLevel(l LogLevelT) *atomicLogLevel {
+	a := &atomicLogLevel{}
+	a.Store(l)
+	return a
+}
+
+var LogLevel = newAtomicLogLevel(LogLevelError)
 
 // LogLevelT represents the logging level
 type LogLevelT int

--- a/internal/log.go
+++ b/internal/log.go
@@ -16,16 +16,22 @@ type Logging interface {
 }
 
 type DefaultLogger struct {
-	log *log.Logger
+	log       *log.Logger
+	calldepth int
 }
 
 func (l *DefaultLogger) Printf(ctx context.Context, format string, v ...interface{}) {
-	_ = l.log.Output(2, fmt.Sprintf(format, v...))
+	_ = l.log.Output(l.calldepth, fmt.Sprintf(format, v...))
 }
 
-func NewDefaultLogger() Logging {
+// NewDefaultLogger returns a stderr logger that attributes each line to the
+// frame calldepth levels up the stack. Reads through Logger.Printf add one
+// forwarding frame (atomicLogger.Printf), so the plain logger uses 3; wrappers
+// that add another Printf frame (e.g. logging's filterLogger) need 4.
+func NewDefaultLogger(calldepth int) Logging {
 	return &DefaultLogger{
-		log: log.New(os.Stderr, "redis: ", log.LstdFlags|log.Lshortfile),
+		log:       log.New(os.Stderr, "redis: ", log.LstdFlags|log.Lshortfile),
+		calldepth: calldepth,
 	}
 }
 
@@ -62,7 +68,7 @@ func newAtomicLogger(l Logging) *atomicLogger {
 // Logger calls Output to print to the stderr.
 // Arguments are handled in the manner of fmt.Print.
 // Swap it with redis.SetLogger; read it through Logger.Printf.
-var Logger = newAtomicLogger(NewDefaultLogger())
+var Logger = newAtomicLogger(NewDefaultLogger(3))
 
 // atomicLogLevel stores the active level as an int32 so redis.SetLogLevel can
 // change it while the level guards (isHealthyConn on the Get path, the

--- a/internal/log.go
+++ b/internal/log.go
@@ -24,10 +24,17 @@ func (l *DefaultLogger) Printf(ctx context.Context, format string, v ...interfac
 	_ = l.log.Output(l.calldepth, fmt.Sprintf(format, v...))
 }
 
+// Calldepth values for NewDefaultLogger. Reads through Logger.Printf add one
+// forwarding frame (atomicLogger.Printf), so the plain default logger uses
+// DefaultLoggerCalldepth; wrappers that add another Printf frame (e.g.
+// logging's filterLogger) use FilterLoggerCalldepth.
+const (
+	DefaultLoggerCalldepth = 3
+	FilterLoggerCalldepth  = 4
+)
+
 // NewDefaultLogger returns a stderr logger that attributes each line to the
-// frame calldepth levels up the stack. Reads through Logger.Printf add one
-// forwarding frame (atomicLogger.Printf), so the plain logger uses 3; wrappers
-// that add another Printf frame (e.g. logging's filterLogger) need 4.
+// frame calldepth levels up the stack.
 func NewDefaultLogger(calldepth int) Logging {
 	return &DefaultLogger{
 		log:       log.New(os.Stderr, "redis: ", log.LstdFlags|log.Lshortfile),
@@ -68,7 +75,7 @@ func newAtomicLogger(l Logging) *atomicLogger {
 // Logger calls Output to print to the stderr.
 // Arguments are handled in the manner of fmt.Print.
 // Swap it with redis.SetLogger; read it through Logger.Printf.
-var Logger = newAtomicLogger(NewDefaultLogger(3))
+var Logger = newAtomicLogger(NewDefaultLogger(DefaultLoggerCalldepth))
 
 // atomicLogLevel stores the active level as an int32 so redis.SetLogLevel can
 // change it while the level guards (isHealthyConn on the Get path, the

--- a/log_global_race_test.go
+++ b/log_global_race_test.go
@@ -1,0 +1,74 @@
+package redis
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9/internal"
+	"github.com/redis/go-redis/v9/logging"
+)
+
+type raceTestLogger struct{}
+
+func (raceTestLogger) Printf(ctx context.Context, format string, v ...interface{}) {}
+
+// internal.Logger and internal.LogLevel are process-wide logging config that
+// SetLogger/SetLogLevel and logging.Enable/Disable swap while command and pool
+// goroutines read them: internal.Logger through Printf (e.g. the sub-millisecond
+// duration warning in formatSec) and internal.LogLevel through the *OrAbove
+// guards (isHealthyConn on the Get path). Run with -race: the writers below race
+// the reads unless both are accessed atomically.
+func TestSetLoggerLogLevelConcurrentWithReads(t *testing.T) {
+	origLogger := internal.Logger.Load()
+	origLevel := internal.LogLevel.Load()
+	defer func() {
+		internal.Logger.Store(origLogger)
+		internal.LogLevel.Store(origLevel)
+	}()
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writers: swap the logger and level through the public setters.
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					SetLogger(raceTestLogger{})
+					SetLogLevel(internal.LogLevelDebug)
+					logging.Disable()
+					SetLogLevel(internal.LogLevelError)
+				}
+			}
+		}()
+	}
+
+	// Readers: the exact patterns the library uses from its goroutines.
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					internal.Logger.Printf(ctx, "probe %d", 1)
+					_ = internal.LogLevel.DebugOrAbove()
+				}
+			}
+		}()
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -31,22 +31,21 @@ func (v *VoidLogger) Printf(_ context.Context, _ string, _ ...interface{}) {
 // This can be used to speed up the library if logging is not needed.
 // It will override any custom logger that was set before and set the VoidLogger.
 func Disable() {
-	internal.Logger = &VoidLogger{}
+	internal.Logger.Store(&VoidLogger{})
 }
 
 // Enable enables logging by setting the internal logger to the default logger.
 // This is the default behavior.
 // You can use redis.SetLogger to set a custom logger.
 //
-// NOTE: This function is not thread-safe.
 // It will override any custom logger that was set before and set the DefaultLogger.
 func Enable() {
-	internal.Logger = internal.NewDefaultLogger()
+	internal.Logger.Store(internal.NewDefaultLogger())
 }
 
 // SetLogLevel sets the log level for the library.
 func SetLogLevel(logLevel LogLevelT) {
-	internal.LogLevel = logLevel
+	internal.LogLevel.Store(logLevel)
 }
 
 // NewBlacklistLogger returns a new logger that filters out messages containing any of the substrings.

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -40,7 +40,7 @@ func Disable() {
 //
 // It will override any custom logger that was set before and set the DefaultLogger.
 func Enable() {
-	internal.Logger.Store(internal.NewDefaultLogger())
+	internal.Logger.Store(internal.NewDefaultLogger(3))
 }
 
 // SetLogLevel sets the log level for the library.
@@ -51,14 +51,18 @@ func SetLogLevel(logLevel LogLevelT) {
 // NewBlacklistLogger returns a new logger that filters out messages containing any of the substrings.
 // This can be used to filter out messages containing sensitive information.
 func NewBlacklistLogger(substr []string) internal.Logging {
-	l := internal.NewDefaultLogger()
+	// calldepth 4: filterLogger.Printf adds a frame on top of the
+	// atomicLogger.Printf forwarding frame.
+	l := internal.NewDefaultLogger(4)
 	return &filterLogger{logger: l, substr: substr, blacklist: true}
 }
 
 // NewWhitelistLogger returns a new logger that only logs messages containing any of the substrings.
 // This can be used to only log messages related to specific commands or patterns.
 func NewWhitelistLogger(substr []string) internal.Logging {
-	l := internal.NewDefaultLogger()
+	// calldepth 4: filterLogger.Printf adds a frame on top of the
+	// atomicLogger.Printf forwarding frame.
+	l := internal.NewDefaultLogger(4)
 	return &filterLogger{logger: l, substr: substr, blacklist: false}
 }
 

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -40,7 +40,7 @@ func Disable() {
 //
 // It will override any custom logger that was set before and set the DefaultLogger.
 func Enable() {
-	internal.Logger.Store(internal.NewDefaultLogger(3))
+	internal.Logger.Store(internal.NewDefaultLogger(internal.DefaultLoggerCalldepth))
 }
 
 // SetLogLevel sets the log level for the library.
@@ -51,18 +51,18 @@ func SetLogLevel(logLevel LogLevelT) {
 // NewBlacklistLogger returns a new logger that filters out messages containing any of the substrings.
 // This can be used to filter out messages containing sensitive information.
 func NewBlacklistLogger(substr []string) internal.Logging {
-	// calldepth 4: filterLogger.Printf adds a frame on top of the
-	// atomicLogger.Printf forwarding frame.
-	l := internal.NewDefaultLogger(4)
+	// filterLogger.Printf adds a frame on top of the atomicLogger.Printf
+	// forwarding frame.
+	l := internal.NewDefaultLogger(internal.FilterLoggerCalldepth)
 	return &filterLogger{logger: l, substr: substr, blacklist: true}
 }
 
 // NewWhitelistLogger returns a new logger that only logs messages containing any of the substrings.
 // This can be used to only log messages related to specific commands or patterns.
 func NewWhitelistLogger(substr []string) internal.Logging {
-	// calldepth 4: filterLogger.Printf adds a frame on top of the
-	// atomicLogger.Printf forwarding frame.
-	l := internal.NewDefaultLogger(4)
+	// filterLogger.Printf adds a frame on top of the atomicLogger.Printf
+	// forwarding frame.
+	l := internal.NewDefaultLogger(internal.FilterLoggerCalldepth)
 	return &filterLogger{logger: l, substr: substr, blacklist: false}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -607,8 +607,8 @@ func TestNewClientSkipsEndpointDetectWhenMaintDisabled(t *testing.T) {
 }
 
 func TestClientSideCacheRESP2Warning(t *testing.T) {
-	origLogger := internal.Logger
-	defer func() { internal.Logger = origLogger }()
+	origLogger := internal.Logger.Load()
+	defer func() { internal.Logger.Store(origLogger) }()
 
 	cases := []struct {
 		name     string
@@ -640,7 +640,7 @@ func TestClientSideCacheRESP2Warning(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			logger := &capturingLogger{}
-			internal.Logger = logger
+			internal.Logger.Store(logger)
 
 			tc.opt.init()
 

--- a/redis.go
+++ b/redis.go
@@ -42,12 +42,12 @@ func SetLogger(logger internal.Logging) {
 	if logger == nil {
 		return
 	}
-	internal.Logger = logger
+	internal.Logger.Store(logger)
 }
 
 // SetLogLevel sets the log level for the library.
 func SetLogLevel(logLevel internal.LogLevelT) {
-	internal.LogLevel = logLevel
+	internal.LogLevel.Store(logLevel)
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
`go test -race`:

    WARNING: DATA RACE
    Read at 0x... by goroutine 23:
      github.com/redis/go-redis/v9.formatSec()   commands.go:43
    Previous write at 0x... by goroutine 22:
      github.com/redis/go-redis/v9.SetLogger()   redis.go:45

`internal.Logger` and `internal.LogLevel` are plain package vars. `SetLogger`/`SetLogLevel` and `logging.Enable`/`Disable` write them while command and pool goroutines read them lock-free: `Logger.Printf` at every call site (the sub-millisecond warning in `formatSec`, the background dial goroutine at `pool.go:762`) and `LogLevel.*OrAbove` at the level guards (`isHealthyConn` on the Get path). Any `SetLogLevel`/`SetLogger` during live client traffic races.

Wrap both behind small atomic holders (`atomic.Pointer[Logging]` for the logger, `atomic.Int32` for the level) that keep the existing read syntax (`Logger.Printf`, `LogLevel.DebugOrAbove`), so only the five setter sites change and the read sites stay untouched. The regression test drives the public setters against the reads and is clean under `-race`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized concurrency fix for process-wide logging globals; behavior is unchanged aside from thread-safe swaps and slightly adjusted default log file/line attribution.
> 
> **Overview**
> Fixes data races when `SetLogger`, `SetLogLevel`, and `logging.Enable`/`Disable` run while pool and command goroutines call `internal.Logger.Printf` or read `internal.LogLevel` via the `*OrAbove` helpers.
> 
> **`internal.Logger` and `internal.LogLevel`** are no longer plain package variables. They sit behind small atomic holders (`atomic.Pointer[Logging]` and `atomic.Int32`) with `Store`/`Load` and unchanged hot-path usage (`Logger.Printf`, `LogLevel.DebugOrAbove()`). Setters in `redis.go` and `logging/logging.go` now call `Store`.
> 
> **`NewDefaultLogger`** takes an explicit **calldepth** so stderr line attribution stays correct through the extra `atomicLogger.Printf` frame and through `filterLogger` wrappers (`DefaultLoggerCalldepth` vs `FilterLoggerCalldepth`).
> 
> Adds **`TestSetLoggerLogLevelConcurrentWithReads`** (intended for `go test -race`) and updates tests that swap the global logger to use `Load`/`Store`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9106f51fee3eeed6ae74848a49dbfe81de958f29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->