### PR TITLE
fix(cluster): reload topology on connection refused

### DIFF
--- a/error.go
+++ b/error.go
@@ -179,17 +179,18 @@ func isDialError(err error) bool {
 }
 
 // isNodeGoneError reports errors that mean the routed cluster node is
-// unreachable: a dial failure or context deadline. ReadTimeout i/o errors
-// are excluded so a slow or paused shard does not reload topology.
-// Caller cancellation is excluded so canceled requests do not either.
+// unreachable: a dial failure, or a network timeout that is not the
+// caller's context. Caller cancel and caller deadline are excluded so
+// request timeouts do not mark a healthy node failing.
 func isNodeGoneError(err error) bool {
-	if err == nil || errors.Is(err, context.Canceled) {
+	if err == nil || isContextError(err) {
 		return false
 	}
 	if isDialError(err) {
 		return true
 	}
-	return errors.Is(err, context.DeadlineExceeded)
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 func isRedisError(err error) bool {

--- a/error.go
+++ b/error.go
@@ -179,8 +179,9 @@ func isDialError(err error) bool {
 }
 
 // isNodeGoneError reports errors that mean the routed cluster node is
-// unreachable: a dial failure, I/O timeout, or context deadline. Caller
-// cancellation is excluded so canceled requests do not trigger topology reloads.
+// unreachable: a dial failure or context deadline. ReadTimeout i/o errors
+// are excluded so a slow or paused shard does not reload topology.
+// Caller cancellation is excluded so canceled requests do not either.
 func isNodeGoneError(err error) bool {
 	if err == nil || errors.Is(err, context.Canceled) {
 		return false
@@ -188,13 +189,7 @@ func isNodeGoneError(err error) bool {
 	if isDialError(err) {
 		return true
 	}
-	if errors.Is(err, context.DeadlineExceeded) {
-		return true
-	}
-	if isTimeout, timedOut := isTimeoutError(err); isTimeout && timedOut {
-		return true
-	}
-	return false
+	return errors.Is(err, context.DeadlineExceeded)
 }
 
 func isRedisError(err error) bool {

--- a/error.go
+++ b/error.go
@@ -179,18 +179,15 @@ func isDialError(err error) bool {
 }
 
 // isNodeGoneError reports errors that mean the routed cluster node is
-// unreachable: a dial failure, or a network timeout that is not the
-// caller's context. Caller cancel and caller deadline are excluded so
-// request timeouts do not mark a healthy node failing.
+// unreachable: a dial failure, including a dial timeout that is not the
+// caller's context. Caller cancel, caller deadline, and client Read/Write
+// timeouts are excluded. Those fire against a connection that already
+// succeeded, so they are not evidence the node is gone.
 func isNodeGoneError(err error) bool {
 	if err == nil || isContextError(err) {
 		return false
 	}
-	if isDialError(err) {
-		return true
-	}
-	var netErr net.Error
-	return errors.As(err, &netErr) && netErr.Timeout()
+	return isDialError(err)
 }
 
 func isRedisError(err error) bool {

--- a/error.go
+++ b/error.go
@@ -94,8 +94,7 @@ func shouldRetry(err error, retryTimeout bool) bool {
 	// Dial errors mean TCP connection was never established — safe to retry even
 	// when wrapped inside context.DeadlineExceeded (from DialTimeout context).
 	// Must be checked before the context error check below.
-	var opErr *net.OpError
-	if errors.As(err, &opErr) && opErr.Op == "dial" {
+	if isDialError(err) {
 		return true
 	}
 
@@ -172,6 +171,11 @@ func shouldRetry(err error, retryTimeout bool) bool {
 	// -SEARCH_TIMEOUT (search-on-timeout fail): retrying would just repeat the
 	// same expensive query.
 	return false
+}
+
+func isDialError(err error) bool {
+	var opErr *net.OpError
+	return errors.As(err, &opErr) && opErr.Op == "dial"
 }
 
 func isRedisError(err error) bool {

--- a/error.go
+++ b/error.go
@@ -178,6 +178,25 @@ func isDialError(err error) bool {
 	return errors.As(err, &opErr) && opErr.Op == "dial"
 }
 
+// isNodeGoneError reports errors that mean the routed cluster node is
+// unreachable: a dial failure, I/O timeout, or context deadline. Caller
+// cancellation is excluded so canceled requests do not trigger topology reloads.
+func isNodeGoneError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if isDialError(err) {
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if isTimeout, timedOut := isTimeoutError(err); isTimeout && timedOut {
+		return true
+	}
+	return false
+}
+
 func isRedisError(err error) bool {
 	// Check if error implements the Error interface (works with wrapped errors)
 	var redisErr Error

--- a/osscluster.go
+++ b/osscluster.go
@@ -1381,10 +1381,10 @@ func (c *ClusterClient) process(ctx context.Context, cmd Cmder) error {
 		}
 
 		if isNodeGoneError(lastErr) {
-			// Same as MOVED: the routed node is gone or unresponsive after
-			// failover (connection refused or a network timeout).
-			// LazyReload coalesces concurrent CLUSTER SLOTS refreshes
-			// instead of blocking this goroutine on a sync Reload.
+			// Same as MOVED: the routed node is gone after failover
+			// (connection refused or a dial timeout). LazyReload coalesces
+			// concurrent CLUSTER SLOTS refreshes instead of blocking this
+			// goroutine on a sync Reload.
 			c.state.LazyReload()
 			node.MarkAsFailing()
 			node = nil

--- a/osscluster.go
+++ b/osscluster.go
@@ -1382,7 +1382,7 @@ func (c *ClusterClient) process(ctx context.Context, cmd Cmder) error {
 
 		if isNodeGoneError(lastErr) {
 			// Same as MOVED: the routed node is gone or unresponsive after
-			// failover (connection refused or context deadline).
+			// failover (connection refused or a network timeout).
 			// LazyReload coalesces concurrent CLUSTER SLOTS refreshes
 			// instead of blocking this goroutine on a sync Reload.
 			c.state.LazyReload()

--- a/osscluster.go
+++ b/osscluster.go
@@ -1381,6 +1381,17 @@ func (c *ClusterClient) process(ctx context.Context, cmd Cmder) error {
 		}
 
 		if shouldRetry(lastErr, cmd.readTimeout() == nil) && !cmd.NoRetry() {
+			if isDialError(lastErr) {
+				// The routed node is gone (connection refused after failover).
+				// Reload topology before the next pick; LazyReload is async and
+				// Get() would still return the stale slot map.
+				if _, err := c.state.Reload(ctx); err != nil {
+					c.state.LazyReload()
+				}
+				node.MarkAsFailing()
+				node = nil
+				continue
+			}
 			// First retry the same node.
 			if attempt == 0 {
 				continue

--- a/osscluster.go
+++ b/osscluster.go
@@ -1380,16 +1380,21 @@ func (c *ClusterClient) process(ctx context.Context, cmd Cmder) error {
 			continue
 		}
 
-		if shouldRetry(lastErr, cmd.readTimeout() == nil) && !cmd.NoRetry() {
-			if isDialError(lastErr) {
-				// Same as MOVED: the routed node is gone after failover.
-				// LazyReload coalesces concurrent CLUSTER SLOTS refreshes
-				// instead of blocking this goroutine on a sync Reload.
-				c.state.LazyReload()
-				node.MarkAsFailing()
-				node = nil
+		if isNodeGoneError(lastErr) {
+			// Same as MOVED: the routed node is gone or unresponsive after
+			// failover (connection refused, I/O timeout, context deadline).
+			// LazyReload coalesces concurrent CLUSTER SLOTS refreshes
+			// instead of blocking this goroutine on a sync Reload.
+			c.state.LazyReload()
+			node.MarkAsFailing()
+			node = nil
+			if shouldRetry(lastErr, cmd.readTimeout() == nil) && !cmd.NoRetry() {
 				continue
 			}
+			return lastErr
+		}
+
+		if shouldRetry(lastErr, cmd.readTimeout() == nil) && !cmd.NoRetry() {
 			// First retry the same node.
 			if attempt == 0 {
 				continue

--- a/osscluster.go
+++ b/osscluster.go
@@ -1382,12 +1382,10 @@ func (c *ClusterClient) process(ctx context.Context, cmd Cmder) error {
 
 		if shouldRetry(lastErr, cmd.readTimeout() == nil) && !cmd.NoRetry() {
 			if isDialError(lastErr) {
-				// The routed node is gone (connection refused after failover).
-				// Reload topology before the next pick; LazyReload is async and
-				// Get() would still return the stale slot map.
-				if _, err := c.state.Reload(ctx); err != nil {
-					c.state.LazyReload()
-				}
+				// Same as MOVED: the routed node is gone after failover.
+				// LazyReload coalesces concurrent CLUSTER SLOTS refreshes
+				// instead of blocking this goroutine on a sync Reload.
+				c.state.LazyReload()
 				node.MarkAsFailing()
 				node = nil
 				continue

--- a/osscluster.go
+++ b/osscluster.go
@@ -1382,7 +1382,7 @@ func (c *ClusterClient) process(ctx context.Context, cmd Cmder) error {
 
 		if isNodeGoneError(lastErr) {
 			// Same as MOVED: the routed node is gone or unresponsive after
-			// failover (connection refused, I/O timeout, context deadline).
+			// failover (connection refused or context deadline).
 			// LazyReload coalesces concurrent CLUSTER SLOTS refreshes
 			// instead of blocking this goroutine on a sync Reload.
 			c.state.LazyReload()

--- a/osscluster_dial_reload_test.go
+++ b/osscluster_dial_reload_test.go
@@ -136,12 +136,12 @@ func TestIsNodeGoneError(t *testing.T) {
 		{name: "canceled", err: context.Canceled, want: false},
 		{name: "wrapped canceled", err: fmt.Errorf("op: %w", context.Canceled), want: false},
 		{name: "dial canceled", err: dialCanceled, want: false},
-		{name: "deadline", err: context.DeadlineExceeded, want: true},
-		{name: "wrapped deadline", err: fmt.Errorf("op: %w", context.DeadlineExceeded), want: true},
+		{name: "deadline", err: context.DeadlineExceeded, want: false},
+		{name: "wrapped deadline", err: fmt.Errorf("op: %w", context.DeadlineExceeded), want: false},
 		{name: "dial refused", err: dialRefused, want: true},
-		{name: "dial deadline", err: dialDeadline, want: true},
-		{name: "i/o timeout", err: ioTimeout, want: false},
-		{name: "wrapped i/o timeout", err: fmt.Errorf("read: %w", ioTimeout), want: false},
+		{name: "dial deadline", err: dialDeadline, want: false},
+		{name: "i/o timeout", err: ioTimeout, want: true},
+		{name: "wrapped i/o timeout", err: fmt.Errorf("read: %w", ioTimeout), want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -181,8 +181,32 @@ func TestClusterClientReloadsStateOnConnectionRefused(t *testing.T) {
 	waitForClusterPing(t, client, ctx)
 }
 
-func TestClusterClientDoesNotReloadOnReadTimeout(t *testing.T) {
+func TestClusterClientReloadsStateOnNetworkTimeout(t *testing.T) {
 	hung := startHungServer(t)
+	live := startMockPONGServer(t)
+	defer live.Close()
+	liveAddr := live.Addr().String()
+
+	var currentAddr atomic.Value
+	currentAddr.Store(hung.Addr().String())
+
+	ctx := context.Background()
+	client := newSlotSwapClusterClient(t, &currentAddr, func(opt *ClusterOptions) {
+		opt.ReadTimeout = 50 * time.Millisecond
+		opt.WriteTimeout = 50 * time.Millisecond
+	})
+
+	if err := client.Ping(ctx).Err(); err == nil {
+		t.Fatal("expected ping against the hung listener to fail")
+	}
+
+	currentAddr.Store(liveAddr)
+	waitForClusterPing(t, client, ctx)
+}
+
+func TestClusterClientDoesNotReloadOnDeadlineExceeded(t *testing.T) {
+	live := startMockPONGServer(t)
+	defer live.Close()
 
 	var loads atomic.Int32
 	client := NewClusterClient(&ClusterOptions{
@@ -191,59 +215,28 @@ func TestClusterClientDoesNotReloadOnReadTimeout(t *testing.T) {
 			return []ClusterSlot{{
 				Start: 0,
 				End:   16383,
-				Nodes: []ClusterNode{{Addr: hung.Addr().String()}},
+				Nodes: []ClusterNode{{Addr: live.Addr().String()}},
 			}}, nil
 		},
 		ClusterStateReloadInterval: time.Hour,
-		ReadTimeout:                50 * time.Millisecond,
-		WriteTimeout:               50 * time.Millisecond,
 		MinRetryBackoff:            -1,
 		MaxRetryBackoff:            -1,
-		MaxRedirects:               0,
+		Dialer: func(context.Context, string, string) (net.Conn, error) {
+			return nil, context.DeadlineExceeded
+		},
 	})
 	defer client.Close()
 
 	if err := client.Ping(context.Background()).Err(); err == nil {
-		t.Fatal("expected ping against the hung listener to fail")
+		t.Fatal("expected ping to fail with deadline")
 	}
 	before := loads.Load()
 
 	// LazyReload's goroutine would call ClusterSlots after the 200ms cooldown.
 	time.Sleep(350 * time.Millisecond)
 	if got := loads.Load(); got != before {
-		t.Fatalf("read timeout triggered topology reload: loads %d -> %d", before, got)
+		t.Fatalf("caller deadline triggered topology reload: loads %d -> %d", before, got)
 	}
-}
-
-func TestClusterClientReloadsStateOnDeadlineExceeded(t *testing.T) {
-	live := startMockPONGServer(t)
-	defer live.Close()
-	liveAddr := live.Addr().String()
-
-	var currentAddr atomic.Value
-	currentAddr.Store("127.0.0.1:1")
-
-	var gone atomic.Bool
-	gone.Store(true)
-
-	ctx := context.Background()
-	client := newSlotSwapClusterClient(t, &currentAddr, func(opt *ClusterOptions) {
-		opt.Dialer = func(ctx context.Context, network, addr string) (net.Conn, error) {
-			if gone.Load() {
-				return nil, context.DeadlineExceeded
-			}
-			var d net.Dialer
-			return d.DialContext(ctx, network, addr)
-		}
-	})
-
-	if err := client.Ping(ctx).Err(); err == nil {
-		t.Fatal("expected ping to fail with deadline")
-	}
-
-	currentAddr.Store(liveAddr)
-	gone.Store(false)
-	waitForClusterPing(t, client, ctx)
 }
 
 func TestClusterClientDoesNotReloadOnCanceledContext(t *testing.T) {

--- a/osscluster_dial_reload_test.go
+++ b/osscluster_dial_reload_test.go
@@ -90,7 +90,16 @@ func TestClusterClientReloadsStateOnConnectionRefused(t *testing.T) {
 
 	currentAddr.Store(liveAddr)
 
-	if err := client.Ping(ctx).Err(); err != nil {
-		t.Fatalf("ping after topology change: %v", err)
+	// LazyReload is async and has a 200ms cooldown, so the next Get may
+	// still see the previous slot map. Wait until the refresh lands.
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		lastErr = client.Ping(ctx).Err()
+		if lastErr == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
+	t.Fatalf("ping after topology change: %v", lastErr)
 }

--- a/osscluster_dial_reload_test.go
+++ b/osscluster_dial_reload_test.go
@@ -140,8 +140,8 @@ func TestIsNodeGoneError(t *testing.T) {
 		{name: "wrapped deadline", err: fmt.Errorf("op: %w", context.DeadlineExceeded), want: true},
 		{name: "dial refused", err: dialRefused, want: true},
 		{name: "dial deadline", err: dialDeadline, want: true},
-		{name: "i/o timeout", err: ioTimeout, want: true},
-		{name: "wrapped i/o timeout", err: fmt.Errorf("read: %w", ioTimeout), want: true},
+		{name: "i/o timeout", err: ioTimeout, want: false},
+		{name: "wrapped i/o timeout", err: fmt.Errorf("read: %w", ioTimeout), want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -181,26 +181,38 @@ func TestClusterClientReloadsStateOnConnectionRefused(t *testing.T) {
 	waitForClusterPing(t, client, ctx)
 }
 
-func TestClusterClientReloadsStateOnIOTimeout(t *testing.T) {
-	live := startMockPONGServer(t)
-	defer live.Close()
+func TestClusterClientDoesNotReloadOnReadTimeout(t *testing.T) {
 	hung := startHungServer(t)
 
-	var currentAddr atomic.Value
-	currentAddr.Store(hung.Addr().String())
-
-	ctx := context.Background()
-	client := newSlotSwapClusterClient(t, &currentAddr, func(opt *ClusterOptions) {
-		opt.ReadTimeout = 50 * time.Millisecond
-		opt.WriteTimeout = 50 * time.Millisecond
+	var loads atomic.Int32
+	client := NewClusterClient(&ClusterOptions{
+		ClusterSlots: func(context.Context) ([]ClusterSlot, error) {
+			loads.Add(1)
+			return []ClusterSlot{{
+				Start: 0,
+				End:   16383,
+				Nodes: []ClusterNode{{Addr: hung.Addr().String()}},
+			}}, nil
+		},
+		ClusterStateReloadInterval: time.Hour,
+		ReadTimeout:                50 * time.Millisecond,
+		WriteTimeout:               50 * time.Millisecond,
+		MinRetryBackoff:            -1,
+		MaxRetryBackoff:            -1,
+		MaxRedirects:               0,
 	})
+	defer client.Close()
 
-	if err := client.Ping(ctx).Err(); err == nil {
+	if err := client.Ping(context.Background()).Err(); err == nil {
 		t.Fatal("expected ping against the hung listener to fail")
 	}
+	before := loads.Load()
 
-	currentAddr.Store(live.Addr().String())
-	waitForClusterPing(t, client, ctx)
+	// LazyReload's goroutine would call ClusterSlots after the 200ms cooldown.
+	time.Sleep(350 * time.Millisecond)
+	if got := loads.Load(); got != before {
+		t.Fatalf("read timeout triggered topology reload: loads %d -> %d", before, got)
+	}
 }
 
 func TestClusterClientReloadsStateOnDeadlineExceeded(t *testing.T) {

--- a/osscluster_dial_reload_test.go
+++ b/osscluster_dial_reload_test.go
@@ -125,6 +125,7 @@ func TestIsNodeGoneError(t *testing.T) {
 	dialRefused := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
 	dialDeadline := &net.OpError{Op: "dial", Net: "tcp", Err: context.DeadlineExceeded}
 	dialCanceled := &net.OpError{Op: "dial", Net: "tcp", Err: context.Canceled}
+	dialIOTimeout := &net.OpError{Op: "dial", Net: "tcp", Err: os.ErrDeadlineExceeded}
 	ioTimeout := &net.OpError{Op: "read", Net: "tcp", Err: os.ErrDeadlineExceeded}
 
 	tests := []struct {
@@ -140,8 +141,9 @@ func TestIsNodeGoneError(t *testing.T) {
 		{name: "wrapped deadline", err: fmt.Errorf("op: %w", context.DeadlineExceeded), want: false},
 		{name: "dial refused", err: dialRefused, want: true},
 		{name: "dial deadline", err: dialDeadline, want: false},
-		{name: "i/o timeout", err: ioTimeout, want: true},
-		{name: "wrapped i/o timeout", err: fmt.Errorf("read: %w", ioTimeout), want: true},
+		{name: "dial i/o timeout", err: dialIOTimeout, want: true},
+		{name: "i/o timeout", err: ioTimeout, want: false},
+		{name: "wrapped i/o timeout", err: fmt.Errorf("read: %w", ioTimeout), want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -181,27 +183,37 @@ func TestClusterClientReloadsStateOnConnectionRefused(t *testing.T) {
 	waitForClusterPing(t, client, ctx)
 }
 
-func TestClusterClientReloadsStateOnNetworkTimeout(t *testing.T) {
+func TestClusterClientDoesNotReloadOnReadTimeout(t *testing.T) {
 	hung := startHungServer(t)
-	live := startMockPONGServer(t)
-	defer live.Close()
-	liveAddr := live.Addr().String()
 
-	var currentAddr atomic.Value
-	currentAddr.Store(hung.Addr().String())
-
-	ctx := context.Background()
-	client := newSlotSwapClusterClient(t, &currentAddr, func(opt *ClusterOptions) {
-		opt.ReadTimeout = 50 * time.Millisecond
-		opt.WriteTimeout = 50 * time.Millisecond
+	var loads atomic.Int32
+	client := NewClusterClient(&ClusterOptions{
+		ClusterSlots: func(context.Context) ([]ClusterSlot, error) {
+			loads.Add(1)
+			return []ClusterSlot{{
+				Start: 0,
+				End:   16383,
+				Nodes: []ClusterNode{{Addr: hung.Addr().String()}},
+			}}, nil
+		},
+		ClusterStateReloadInterval: time.Hour,
+		ReadTimeout:                50 * time.Millisecond,
+		WriteTimeout:               50 * time.Millisecond,
+		MinRetryBackoff:            -1,
+		MaxRetryBackoff:            -1,
 	})
+	defer client.Close()
 
-	if err := client.Ping(ctx).Err(); err == nil {
+	if err := client.Ping(context.Background()).Err(); err == nil {
 		t.Fatal("expected ping against the hung listener to fail")
 	}
+	before := loads.Load()
 
-	currentAddr.Store(liveAddr)
-	waitForClusterPing(t, client, ctx)
+	// LazyReload's goroutine would call ClusterSlots after the 200ms cooldown.
+	time.Sleep(350 * time.Millisecond)
+	if got := loads.Load(); got != before {
+		t.Fatalf("read timeout triggered topology reload: loads %d -> %d", before, got)
+	}
 }
 
 func TestClusterClientDoesNotReloadOnDeadlineExceeded(t *testing.T) {

--- a/osscluster_dial_reload_test.go
+++ b/osscluster_dial_reload_test.go
@@ -1,0 +1,96 @@
+package redis
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// startMockPONGServer speaks enough RESP for Ping() against a ClusterClient
+// that uses ClusterSlots (no CLUSTER SLOTS command on the wire).
+func startMockPONGServer(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				r := bufio.NewReader(c)
+				for {
+					args, err := readRESPCommand(r)
+					if err != nil {
+						return
+					}
+					if len(args) == 0 {
+						continue
+					}
+					switch strings.ToUpper(args[0]) {
+					case "HELLO":
+						_, _ = c.Write([]byte("-ERR unknown command 'hello'\r\n"))
+					case "PING":
+						_, _ = c.Write([]byte("+PONG\r\n"))
+					default:
+						_, _ = c.Write([]byte("+OK\r\n"))
+					}
+				}
+			}(conn)
+		}
+	}()
+	return ln
+}
+
+func TestClusterClientReloadsStateOnConnectionRefused(t *testing.T) {
+	live := startMockPONGServer(t)
+	defer live.Close()
+	liveAddr := live.Addr().String()
+
+	dead, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen dead: %v", err)
+	}
+	deadAddr := dead.Addr().String()
+	_ = dead.Close()
+
+	var currentAddr atomic.Value
+	currentAddr.Store(deadAddr)
+
+	ctx := context.Background()
+	client := NewClusterClient(&ClusterOptions{
+		ClusterSlots: func(context.Context) ([]ClusterSlot, error) {
+			return []ClusterSlot{{
+				Start: 0,
+				End:   16383,
+				Nodes: []ClusterNode{{Addr: currentAddr.Load().(string)}},
+			}}, nil
+		},
+		MaxRedirects:               3,
+		ClusterStateReloadInterval: time.Hour,
+		DialTimeout:                200 * time.Millisecond,
+		DialerRetries:              1,
+		DialerRetryTimeout:         time.Millisecond,
+		MinRetryBackoff:            -1,
+		MaxRetryBackoff:            -1,
+	})
+	defer client.Close()
+
+	if err := client.Ping(ctx).Err(); err == nil {
+		t.Fatal("expected ping against the closed listener to fail")
+	}
+
+	currentAddr.Store(liveAddr)
+
+	if err := client.Ping(ctx).Err(); err != nil {
+		t.Fatalf("ping after topology change: %v", err)
+	}
+}

--- a/osscluster_dial_reload_test.go
+++ b/osscluster_dial_reload_test.go
@@ -109,7 +109,7 @@ func newSlotSwapClusterClient(t *testing.T, currentAddr *atomic.Value, extra fun
 
 func waitForClusterPing(t *testing.T, client *ClusterClient, ctx context.Context) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(4 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {
 		lastErr = client.Ping(ctx).Err()
@@ -218,26 +218,32 @@ func TestClusterClientDoesNotReloadOnReadTimeout(t *testing.T) {
 func TestClusterClientReloadsStateOnDeadlineExceeded(t *testing.T) {
 	live := startMockPONGServer(t)
 	defer live.Close()
-	hung := startHungServer(t)
+	liveAddr := live.Addr().String()
 
 	var currentAddr atomic.Value
-	currentAddr.Store(hung.Addr().String())
+	currentAddr.Store("127.0.0.1:1")
 
+	var gone atomic.Bool
+	gone.Store(true)
+
+	ctx := context.Background()
 	client := newSlotSwapClusterClient(t, &currentAddr, func(opt *ClusterOptions) {
-		opt.ContextTimeoutEnabled = true
-		opt.ReadTimeout = time.Second
-		opt.WriteTimeout = time.Second
+		opt.Dialer = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if gone.Load() {
+				return nil, context.DeadlineExceeded
+			}
+			var d net.Dialer
+			return d.DialContext(ctx, network, addr)
+		}
 	})
 
-	deadCtx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
-	if err := client.Ping(deadCtx).Err(); err == nil {
-		cancel()
-		t.Fatal("expected ping against the hung listener to fail")
+	if err := client.Ping(ctx).Err(); err == nil {
+		t.Fatal("expected ping to fail with deadline")
 	}
-	cancel()
 
-	currentAddr.Store(live.Addr().String())
-	waitForClusterPing(t, client, context.Background())
+	currentAddr.Store(liveAddr)
+	gone.Store(false)
+	waitForClusterPing(t, client, ctx)
 }
 
 func TestClusterClientDoesNotReloadOnCanceledContext(t *testing.T) {

--- a/osscluster_dial_reload_test.go
+++ b/osscluster_dial_reload_test.go
@@ -3,7 +3,10 @@ package redis
 import (
 	"bufio"
 	"context"
+	"errors"
+	"fmt"
 	"net"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -50,6 +53,105 @@ func startMockPONGServer(t *testing.T) net.Listener {
 	return ln
 }
 
+// startHungServer accepts TCP connections but never replies, so reads hit
+// the socket deadline (i/o timeout) instead of connection refused.
+func startHungServer(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		close(done)
+		_ = ln.Close()
+	})
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				<-done
+			}(conn)
+		}
+	}()
+	return ln
+}
+
+func newSlotSwapClusterClient(t *testing.T, currentAddr *atomic.Value, extra func(*ClusterOptions)) *ClusterClient {
+	t.Helper()
+	opt := &ClusterOptions{
+		ClusterSlots: func(context.Context) ([]ClusterSlot, error) {
+			return []ClusterSlot{{
+				Start: 0,
+				End:   16383,
+				Nodes: []ClusterNode{{Addr: currentAddr.Load().(string)}},
+			}}, nil
+		},
+		MaxRedirects:               3,
+		ClusterStateReloadInterval: time.Hour,
+		DialTimeout:                200 * time.Millisecond,
+		DialerRetries:              1,
+		DialerRetryTimeout:         time.Millisecond,
+		MinRetryBackoff:            -1,
+		MaxRetryBackoff:            -1,
+	}
+	if extra != nil {
+		extra(opt)
+	}
+	client := NewClusterClient(opt)
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func waitForClusterPing(t *testing.T, client *ClusterClient, ctx context.Context) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		lastErr = client.Ping(ctx).Err()
+		if lastErr == nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("ping after topology change: %v", lastErr)
+}
+
+func TestIsNodeGoneError(t *testing.T) {
+	dialRefused := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+	dialDeadline := &net.OpError{Op: "dial", Net: "tcp", Err: context.DeadlineExceeded}
+	dialCanceled := &net.OpError{Op: "dial", Net: "tcp", Err: context.Canceled}
+	ioTimeout := &net.OpError{Op: "read", Net: "tcp", Err: os.ErrDeadlineExceeded}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "canceled", err: context.Canceled, want: false},
+		{name: "wrapped canceled", err: fmt.Errorf("op: %w", context.Canceled), want: false},
+		{name: "dial canceled", err: dialCanceled, want: false},
+		{name: "deadline", err: context.DeadlineExceeded, want: true},
+		{name: "wrapped deadline", err: fmt.Errorf("op: %w", context.DeadlineExceeded), want: true},
+		{name: "dial refused", err: dialRefused, want: true},
+		{name: "dial deadline", err: dialDeadline, want: true},
+		{name: "i/o timeout", err: ioTimeout, want: true},
+		{name: "wrapped i/o timeout", err: fmt.Errorf("read: %w", ioTimeout), want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNodeGoneError(tt.err); got != tt.want {
+				t.Fatalf("isNodeGoneError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClusterClientReloadsStateOnConnectionRefused(t *testing.T) {
 	live := startMockPONGServer(t)
 	defer live.Close()
@@ -66,23 +168,7 @@ func TestClusterClientReloadsStateOnConnectionRefused(t *testing.T) {
 	currentAddr.Store(deadAddr)
 
 	ctx := context.Background()
-	client := NewClusterClient(&ClusterOptions{
-		ClusterSlots: func(context.Context) ([]ClusterSlot, error) {
-			return []ClusterSlot{{
-				Start: 0,
-				End:   16383,
-				Nodes: []ClusterNode{{Addr: currentAddr.Load().(string)}},
-			}}, nil
-		},
-		MaxRedirects:               3,
-		ClusterStateReloadInterval: time.Hour,
-		DialTimeout:                200 * time.Millisecond,
-		DialerRetries:              1,
-		DialerRetryTimeout:         time.Millisecond,
-		MinRetryBackoff:            -1,
-		MaxRetryBackoff:            -1,
-	})
-	defer client.Close()
+	client := newSlotSwapClusterClient(t, &currentAddr, nil)
 
 	if err := client.Ping(ctx).Err(); err == nil {
 		t.Fatal("expected ping against the closed listener to fail")
@@ -92,14 +178,88 @@ func TestClusterClientReloadsStateOnConnectionRefused(t *testing.T) {
 
 	// LazyReload is async and has a 200ms cooldown, so the next Get may
 	// still see the previous slot map. Wait until the refresh lands.
-	deadline := time.Now().Add(2 * time.Second)
-	var lastErr error
-	for time.Now().Before(deadline) {
-		lastErr = client.Ping(ctx).Err()
-		if lastErr == nil {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
+	waitForClusterPing(t, client, ctx)
+}
+
+func TestClusterClientReloadsStateOnIOTimeout(t *testing.T) {
+	live := startMockPONGServer(t)
+	defer live.Close()
+	hung := startHungServer(t)
+
+	var currentAddr atomic.Value
+	currentAddr.Store(hung.Addr().String())
+
+	ctx := context.Background()
+	client := newSlotSwapClusterClient(t, &currentAddr, func(opt *ClusterOptions) {
+		opt.ReadTimeout = 50 * time.Millisecond
+		opt.WriteTimeout = 50 * time.Millisecond
+	})
+
+	if err := client.Ping(ctx).Err(); err == nil {
+		t.Fatal("expected ping against the hung listener to fail")
 	}
-	t.Fatalf("ping after topology change: %v", lastErr)
+
+	currentAddr.Store(live.Addr().String())
+	waitForClusterPing(t, client, ctx)
+}
+
+func TestClusterClientReloadsStateOnDeadlineExceeded(t *testing.T) {
+	live := startMockPONGServer(t)
+	defer live.Close()
+	hung := startHungServer(t)
+
+	var currentAddr atomic.Value
+	currentAddr.Store(hung.Addr().String())
+
+	client := newSlotSwapClusterClient(t, &currentAddr, func(opt *ClusterOptions) {
+		opt.ContextTimeoutEnabled = true
+		opt.ReadTimeout = time.Second
+		opt.WriteTimeout = time.Second
+	})
+
+	deadCtx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+	if err := client.Ping(deadCtx).Err(); err == nil {
+		cancel()
+		t.Fatal("expected ping against the hung listener to fail")
+	}
+	cancel()
+
+	currentAddr.Store(live.Addr().String())
+	waitForClusterPing(t, client, context.Background())
+}
+
+func TestClusterClientDoesNotReloadOnCanceledContext(t *testing.T) {
+	live := startMockPONGServer(t)
+	defer live.Close()
+
+	var loads atomic.Int32
+	client := NewClusterClient(&ClusterOptions{
+		ClusterSlots: func(context.Context) ([]ClusterSlot, error) {
+			loads.Add(1)
+			return []ClusterSlot{{
+				Start: 0,
+				End:   16383,
+				Nodes: []ClusterNode{{Addr: live.Addr().String()}},
+			}}, nil
+		},
+		ClusterStateReloadInterval: time.Hour,
+		MinRetryBackoff:            -1,
+		MaxRetryBackoff:            -1,
+	})
+	defer client.Close()
+
+	if err := client.Ping(context.Background()).Err(); err != nil {
+		t.Fatalf("warmup ping: %v", err)
+	}
+	before := loads.Load()
+
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = client.Ping(canceled).Err()
+
+	// LazyReload's goroutine would call ClusterSlots after the 200ms cooldown.
+	time.Sleep(350 * time.Millisecond)
+	if got := loads.Load(); got != before {
+		t.Fatalf("canceled context triggered topology reload: loads %d -> %d", before, got)
+	}
 }


### PR DESCRIPTION
Fixes #3979

`process` retries dial errors (connection refused) against the cached slot map. MOVED/ASK and READONLY already reload topology. Dial failures did not, so after a failover the client kept hitting the old master until `ClusterStateReloadInterval` (60s).

On a dial error, including a dial timeout that is not the request context, mark the node as failing and trigger `LazyReload`, matching the MOVED path. Caller cancel, caller deadline, and client Read/Write timeouts do not: those fire after the connection already succeeded. A synchronous `Reload` would block the command on `CLUSTER SLOTS` and is unguarded, so concurrent failovers can stampede. `LazyReload` coalesces those refreshes. The next `Get` may still see the previous map until the async reload lands; waiting on that reload is left for a follow-up if we want it.

## Test

`TestClusterClientReloadsStateOnConnectionRefused` fails against the closed listener, then swaps in a live mock Redis and waits for ping to succeed after the async reload.

```
go test -count=1 -run TestClusterClientReloadsStateOnConnectionRefused
```