### PR TITLE
fix(circuitbreaker): deliver state-change callbacks in transition order

### DIFF
--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -81,8 +81,12 @@ func (c *Config) applyDefaults() {
 	}
 }
 
-// StateChangeCallback is called when the circuit breaker state changes.
-type StateChangeCallback func(oldState, newState State)
+// StateChangeCallback is called when the circuit breaker state changes. stats
+// is a snapshot taken at the transition, so it reflects the counters that
+// triggered the change even though the callback runs asynchronously (see
+// notifyQueue): read it instead of calling Stats(), which by delivery time may
+// show a later state.
+type StateChangeCallback func(oldState, newState State, stats Stats)
 
 // CircuitBreaker implements the circuit breaker pattern.
 type CircuitBreaker struct {
@@ -94,12 +98,66 @@ type CircuitBreaker struct {
 	requests    atomic.Int32 // Request count in half-open state
 	lastFailure atomic.Int64 // Unix nano timestamp
 
-	// transitionMu serializes the open -> half-open transition so the
-	// half-open counters can be cleared before the new state is published.
+	// transitionMu serializes ALL state transitions and the enqueue of their
+	// notifications, so callbacks are delivered in transition (CAS) order. It
+	// is held across the counter-clear + CAS + enqueue only, never across the
+	// callback itself.
 	transitionMu sync.Mutex
 
 	mu        sync.RWMutex
 	callbacks []StateChangeCallback
+
+	// notify delivers state-change callbacks on a single goroutine in FIFO
+	// order. Enqueue happens under transitionMu, so the queue order matches the
+	// CAS order; the callbacks run OUTSIDE transitionMu, so two concurrent
+	// transitions cannot report out of order and a callback may safely re-enter
+	// the breaker (RecordFailure/CheckState/Reset) without deadlocking.
+	notify notifyQueue
+}
+
+// stateChange is one queued transition awaiting callback delivery, carrying
+// the Stats snapshot taken at the transition.
+type stateChange struct {
+	oldState, newState State
+	stats              Stats
+}
+
+// notifyQueue delivers state-change notifications on a single goroutine, in
+// FIFO order. It mirrors the enqueue/drain pattern used elsewhere: the drain
+// goroutine is spawned on demand and exits when the queue empties, so an idle
+// breaker holds no goroutine.
+type notifyQueue struct {
+	mu       sync.Mutex
+	queue    []stateChange
+	draining bool
+	fire     func(oldState, newState State, stats Stats)
+}
+
+func (q *notifyQueue) enqueue(oldState, newState State, stats Stats) {
+	q.mu.Lock()
+	q.queue = append(q.queue, stateChange{oldState, newState, stats})
+	if q.draining {
+		q.mu.Unlock()
+		return
+	}
+	q.draining = true
+	q.mu.Unlock()
+	go q.drain()
+}
+
+func (q *notifyQueue) drain() {
+	for {
+		q.mu.Lock()
+		if len(q.queue) == 0 {
+			q.draining = false
+			q.mu.Unlock()
+			return
+		}
+		sc := q.queue[0]
+		q.queue = q.queue[1:]
+		q.mu.Unlock()
+		q.fire(sc.oldState, sc.newState, sc.stats)
+	}
 }
 
 // New creates a new circuit breaker with the given configuration.
@@ -109,6 +167,7 @@ func New(config Config) *CircuitBreaker {
 		config: config,
 	}
 	cb.state.Store(int32(StateClosed))
+	cb.notify.fire = cb.notifyCallbacks
 	return cb
 }
 
@@ -149,8 +208,10 @@ func (cb *CircuitBreaker) CheckState() State {
 				// Closed, and overwriting it with HalfOpen would silently
 				// undo the reset.
 				if cb.state.CompareAndSwap(int32(StateOpen), int32(StateHalfOpen)) {
+					// Enqueue under the lock so callback order matches CAS order;
+					// the callback itself runs on the notify goroutine.
+					cb.notify.enqueue(StateOpen, StateHalfOpen, cb.Stats())
 					cb.transitionMu.Unlock()
-					cb.notifyCallbacks(StateOpen, StateHalfOpen)
 					return StateHalfOpen
 				}
 			}
@@ -247,18 +308,21 @@ func (cb *CircuitBreaker) recordSuccess(heldSlot bool) {
 			return
 		}
 		if int(successes) >= cb.config.SuccessThreshold {
+			cb.transitionMu.Lock()
 			// Clear the failure counter BEFORE Closed becomes visible: it
 			// still holds the count that opened the circuit, and a failure
 			// recorded between the state swap and a later reset would
 			// immediately re-open the circuit off that stale count.
 			cb.failures.Store(0)
 			if cb.state.CompareAndSwap(int32(StateHalfOpen), int32(StateClosed)) {
-				// Notify callbacks before resetting the half-open counters so
-				// they observe the success count that triggered the transition.
-				cb.notifyCallbacks(StateHalfOpen, StateClosed)
+				// Snapshot BEFORE clearing the half-open counters so the
+				// callback observes the success count that triggered the close;
+				// enqueue under the lock so delivery order matches CAS order.
+				cb.notify.enqueue(StateHalfOpen, StateClosed, cb.Stats())
 				cb.successes.Store(0)
 				cb.requests.Store(0)
 			}
+			cb.transitionMu.Unlock()
 			return
 		}
 		if heldSlot {
@@ -290,6 +354,7 @@ func (cb *CircuitBreaker) RecordFailure() {
 		case StateClosed:
 			failures := cb.failures.Add(1)
 			if int(failures) >= cb.config.FailureThreshold {
+				cb.transitionMu.Lock()
 				if cb.state.CompareAndSwap(int32(StateClosed), int32(StateOpen)) {
 					// A Reset that completed between the timestamp store above and
 					// this CAS wiped lastFailure; repair it (CAS so a concurrent
@@ -298,10 +363,10 @@ func (cb *CircuitBreaker) RecordFailure() {
 					// that wipes after this repair also publishes Closed after,
 					// so the circuit does not stay Open with a zero timestamp.
 					cb.lastFailure.CompareAndSwap(0, time.Now().UnixNano())
-					// Notify callbacks before clearing the half-open counters so
-					// observers see the failure count that triggered the
-					// transition, matching the half-open -> closed/open paths.
-					cb.notifyCallbacks(StateClosed, StateOpen)
+					// Snapshot so observers see the failure count that triggered
+					// the transition; enqueue under the lock for CAS-ordered
+					// delivery, matching the half-open -> closed/open paths.
+					cb.notify.enqueue(StateClosed, StateOpen, cb.Stats())
 					// successes and requests should already be 0 in Closed (they
 					// are only incremented while half-open, and every half-open
 					// exit zeroes them). Reset defensively so the invariant
@@ -311,21 +376,25 @@ func (cb *CircuitBreaker) RecordFailure() {
 					cb.successes.Store(0)
 					cb.requests.Store(0)
 				}
+				cb.transitionMu.Unlock()
 			}
 			return
 		case StateHalfOpen:
 			// Any failure in half-open state opens the circuit.
+			cb.transitionMu.Lock()
 			if cb.state.CompareAndSwap(int32(StateHalfOpen), int32(StateOpen)) {
 				// Same timestamp repair as the closed -> open transition above.
 				cb.lastFailure.CompareAndSwap(0, time.Now().UnixNano())
-				// Notify callbacks before resetting counters so they observe the
-				// counts that triggered the transition, matching the half-open ->
-				// closed path in RecordSuccess.
-				cb.notifyCallbacks(StateHalfOpen, StateOpen)
+				// Snapshot before resetting counters so observers see the counts
+				// that triggered the transition; enqueue under the lock for
+				// CAS-ordered delivery, matching the half-open -> closed path.
+				cb.notify.enqueue(StateHalfOpen, StateOpen, cb.Stats())
 				cb.successes.Store(0)
 				cb.requests.Store(0)
+				cb.transitionMu.Unlock()
 				return
 			}
+			cb.transitionMu.Unlock()
 			// Lost the transition race — typically to the closing success of
 			// another probe. Re-read and settle in the new state instead of
 			// dropping the failure.
@@ -345,15 +414,17 @@ func (cb *CircuitBreaker) OnStateChange(callback StateChangeCallback) {
 	cb.callbacks = append(cb.callbacks, callback)
 }
 
-// notifyCallbacks notifies all registered callbacks of a state change.
-func (cb *CircuitBreaker) notifyCallbacks(oldState, newState State) {
+// notifyCallbacks notifies all registered callbacks of a state change. It runs
+// on the notify goroutine (never under transitionMu), so a callback may
+// re-enter the breaker without deadlocking.
+func (cb *CircuitBreaker) notifyCallbacks(oldState, newState State, stats Stats) {
 	cb.mu.RLock()
 	callbacks := make([]StateChangeCallback, len(cb.callbacks))
 	copy(callbacks, cb.callbacks)
 	cb.mu.RUnlock()
 
 	for _, callback := range callbacks {
-		callback(oldState, newState)
+		callback(oldState, newState, stats)
 	}
 }
 
@@ -365,14 +436,18 @@ func (cb *CircuitBreaker) Reset() {
 	// stale one it could immediately re-open the circuit, and the
 	// lastFailure wipe below would then wedge it open past the
 	// zero-timestamp guard in CheckState.
+	// Hold transitionMu across the clear + swap + enqueue so Reset serializes
+	// with the other transitions and its notification keeps CAS order.
+	cb.transitionMu.Lock()
 	cb.failures.Store(0)
 	cb.successes.Store(0)
 	cb.requests.Store(0)
 	cb.lastFailure.Store(0)
 	oldState := State(cb.state.Swap(int32(StateClosed)))
 	if oldState != StateClosed {
-		cb.notifyCallbacks(oldState, StateClosed)
+		cb.notify.enqueue(oldState, StateClosed, cb.Stats())
 	}
+	cb.transitionMu.Unlock()
 }
 
 // Stats returns current statistics for monitoring.

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -211,6 +211,48 @@ func TestCircuitBreaker_ReleaseHalfOpen(t *testing.T) {
 	}
 }
 
+// transitionRecorder captures state-change callbacks (delivered asynchronously)
+// in a race-safe way and lets a test wait for a given count.
+type transitionRecorder struct {
+	mu    sync.Mutex
+	items []recordedTransition
+}
+
+type recordedTransition struct {
+	oldState, newState State
+	stats              Stats
+}
+
+func (r *transitionRecorder) record(oldState, newState State, stats Stats) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.items = append(r.items, recordedTransition{oldState, newState, stats})
+}
+
+func (r *transitionRecorder) len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.items)
+}
+
+func (r *transitionRecorder) at(i int) recordedTransition {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.items[i]
+}
+
+func (r *transitionRecorder) waitFor(t *testing.T, n int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if r.len() >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d transitions, got %d", n, r.len())
+}
+
 func TestCircuitBreaker_OnStateChange(t *testing.T) {
 	config := Config{
 		FailureThreshold: 2,
@@ -219,10 +261,8 @@ func TestCircuitBreaker_OnStateChange(t *testing.T) {
 	}
 	cb := New(config)
 
-	var transitions []struct{ old, new State }
-	cb.OnStateChange(func(oldState, newState State) {
-		transitions = append(transitions, struct{ old, new State }{oldState, newState})
-	})
+	var rec transitionRecorder
+	cb.OnStateChange(rec.record)
 
 	// Open the circuit
 	cb.RecordFailure()
@@ -235,23 +275,17 @@ func TestCircuitBreaker_OnStateChange(t *testing.T) {
 	// Close the circuit
 	cb.RecordSuccess()
 
-	if len(transitions) != 3 {
-		t.Fatalf("expected 3 transitions, got %d", len(transitions))
-	}
+	// Callbacks are delivered asynchronously in transition order.
+	rec.waitFor(t, 3)
 
-	// Closed -> Open
-	if transitions[0].old != StateClosed || transitions[0].new != StateOpen {
-		t.Errorf("expected Closed->Open, got %v->%v", transitions[0].old, transitions[0].new)
+	if got := rec.at(0); got.oldState != StateClosed || got.newState != StateOpen {
+		t.Errorf("expected Closed->Open, got %v->%v", got.oldState, got.newState)
 	}
-
-	// Open -> HalfOpen
-	if transitions[1].old != StateOpen || transitions[1].new != StateHalfOpen {
-		t.Errorf("expected Open->HalfOpen, got %v->%v", transitions[1].old, transitions[1].new)
+	if got := rec.at(1); got.oldState != StateOpen || got.newState != StateHalfOpen {
+		t.Errorf("expected Open->HalfOpen, got %v->%v", got.oldState, got.newState)
 	}
-
-	// HalfOpen -> Closed
-	if transitions[2].old != StateHalfOpen || transitions[2].new != StateClosed {
-		t.Errorf("expected HalfOpen->Closed, got %v->%v", transitions[2].old, transitions[2].new)
+	if got := rec.at(2); got.oldState != StateHalfOpen || got.newState != StateClosed {
+		t.Errorf("expected HalfOpen->Closed, got %v->%v", got.oldState, got.newState)
 	}
 }
 
@@ -263,12 +297,8 @@ func TestCircuitBreaker_CallbackObservesSuccessCountOnClose(t *testing.T) {
 	}
 	cb := New(config)
 
-	var closeSuccesses int32 = -1
-	cb.OnStateChange(func(oldState, newState State) {
-		if oldState == StateHalfOpen && newState == StateClosed {
-			closeSuccesses = cb.Stats().Successes
-		}
-	})
+	var rec transitionRecorder
+	cb.OnStateChange(rec.record)
 
 	// Open the circuit, wait for the timeout, then transition to half-open.
 	cb.RecordFailure()
@@ -283,8 +313,17 @@ func TestCircuitBreaker_CallbackObservesSuccessCountOnClose(t *testing.T) {
 	if cb.State() != StateClosed {
 		t.Fatalf("expected state to be Closed, got %v", cb.State())
 	}
-	// The callback must see the success count that triggered the close, not the
-	// post-reset value of 0.
+
+	// Find the HalfOpen->Closed transition; its carried snapshot must show the
+	// success count that triggered the close, not the post-reset value of 0 —
+	// the snapshot is taken at the transition, so async delivery cannot lose it.
+	rec.waitFor(t, 3) // Closed->Open, Open->HalfOpen, HalfOpen->Closed
+	var closeSuccesses int32 = -1
+	for i := 0; i < rec.len(); i++ {
+		if tr := rec.at(i); tr.oldState == StateHalfOpen && tr.newState == StateClosed {
+			closeSuccesses = tr.stats.Successes
+		}
+	}
 	if closeSuccesses != int32(config.SuccessThreshold) {
 		t.Errorf("expected callback to observe %d successes, got %d",
 			config.SuccessThreshold, closeSuccesses)
@@ -329,35 +368,29 @@ func TestCircuitBreaker_ResetNotifiesCallbacks(t *testing.T) {
 	}
 	cb := New(config)
 
-	var transitions []struct{ old, new State }
-	cb.OnStateChange(func(oldState, newState State) {
-		transitions = append(transitions, struct{ old, new State }{oldState, newState})
-	})
+	var rec transitionRecorder
+	cb.OnStateChange(rec.record)
 
 	// Open the circuit
 	cb.RecordFailure()
 	cb.RecordFailure()
-
-	if len(transitions) != 1 {
-		t.Fatalf("expected 1 transition (Closed->Open), got %d", len(transitions))
-	}
+	rec.waitFor(t, 1) // Closed->Open
 
 	// Reset should notify callback
 	cb.Reset()
-
-	if len(transitions) != 2 {
-		t.Fatalf("expected 2 transitions after reset, got %d", len(transitions))
-	}
+	rec.waitFor(t, 2)
 
 	// Verify Open -> Closed transition
-	if transitions[1].old != StateOpen || transitions[1].new != StateClosed {
-		t.Errorf("expected Open->Closed, got %v->%v", transitions[1].old, transitions[1].new)
+	if got := rec.at(1); got.oldState != StateOpen || got.newState != StateClosed {
+		t.Errorf("expected Open->Closed, got %v->%v", got.oldState, got.newState)
 	}
 
-	// Reset when already closed should NOT notify
+	// Reset when already closed should NOT notify. Give any stray delivery a
+	// beat to land, then confirm the count did not grow.
 	cb.Reset()
-	if len(transitions) != 2 {
-		t.Errorf("expected no callback when resetting already-closed circuit, got %d transitions", len(transitions))
+	time.Sleep(20 * time.Millisecond)
+	if got := rec.len(); got != 2 {
+		t.Errorf("expected no callback when resetting already-closed circuit, got %d transitions", got)
 	}
 }
 
@@ -478,9 +511,13 @@ func TestCircuitBreaker_FailureCounterClearedBeforeCloseIsPublished(t *testing.T
 	// Closed) must count against a fresh failure counter. If the counter
 	// still holds the count that opened the circuit, this single failure
 	// re-opens it immediately.
-	cb.OnStateChange(func(oldState, newState State) {
+	fired := make(chan struct{})
+	cb.OnStateChange(func(oldState, newState State, _ Stats) {
+		// A callback re-entering the breaker is supported: it runs on the notify
+		// goroutine, so RecordFailure here does not deadlock.
 		if oldState == StateHalfOpen && newState == StateClosed {
 			cb.RecordFailure()
+			close(fired)
 		}
 	})
 
@@ -488,10 +525,70 @@ func TestCircuitBreaker_FailureCounterClearedBeforeCloseIsPublished(t *testing.T
 	cb.RecordFailure() // -> Open, failures == FailureThreshold
 	time.Sleep(60 * time.Millisecond)
 	cb.CheckState()    // -> HalfOpen
-	cb.RecordSuccess() // -> Closed; callback records one failure
+	cb.RecordSuccess() // -> Closed; callback records one failure (async)
+
+	// Wait for the re-entrant failure to land before asserting.
+	select {
+	case <-fired:
+	case <-time.After(time.Second):
+		t.Fatal("HalfOpen->Closed callback never fired")
+	}
 
 	if got := cb.State(); got != StateClosed {
 		t.Errorf("one failure right after recovery re-opened the circuit: state = %v", got)
+	}
+}
+
+// Under concurrency, callbacks must be delivered in transition order. Winning
+// CAS transitions chain by construction (each new state is the next
+// transition's old state), so the delivered (old,new) pairs must form a
+// contiguous chain. A broken chain means two concurrent transitions reported
+// out of order — the bug this fix addresses.
+func TestCircuitBreaker_CallbackOrderUnderConcurrency(t *testing.T) {
+	config := Config{
+		FailureThreshold:    1,
+		SuccessThreshold:    1,
+		MaxHalfOpenRequests: 100,
+		OpenTimeout:         time.Nanosecond, // half-open is always reachable
+	}
+	cb := New(config)
+
+	var rec transitionRecorder
+	cb.OnStateChange(rec.record)
+
+	// Hammer the half-open edge: a closing success races an opening failure on
+	// the same transition, round after round.
+	const rounds = 3000
+	for r := 0; r < rounds; r++ {
+		cb.CheckState() // Open (1ns elapsed) -> HalfOpen
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); cb.RecordSuccess() }()
+		go func() { defer wg.Done(); cb.RecordFailure() }()
+		wg.Wait()
+	}
+
+	// Wait for the notify queue to drain (delivered count stops growing).
+	deadline := time.Now().Add(3 * time.Second)
+	last := -1
+	for time.Now().Before(deadline) {
+		if n := rec.len(); n == last {
+			break
+		} else {
+			last = n
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if rec.len() == 0 {
+		t.Fatal("no transitions recorded")
+	}
+	for i := 1; i < rec.len(); i++ {
+		prev, cur := rec.at(i-1), rec.at(i)
+		if cur.oldState != prev.newState {
+			t.Fatalf("out-of-order delivery at %d: ...->%v then %v->%v (chain broken)",
+				i, prev.newState, cur.oldState, cur.newState)
+		}
 	}
 }
 

--- a/internal/multidb/circuit_breaker.go
+++ b/internal/multidb/circuit_breaker.go
@@ -77,7 +77,7 @@ func NewCircuitBreaker(config CircuitBreakerConfig) *CircuitBreaker {
 
 // OnStateChange registers a callback to be called when the state changes.
 func (cb *CircuitBreaker) OnStateChange(callback CircuitBreakerCallback) {
-	cb.CircuitBreaker.OnStateChange(func(oldState, newState circuitbreaker.State) {
+	cb.CircuitBreaker.OnStateChange(func(oldState, newState circuitbreaker.State, _ circuitbreaker.Stats) {
 		callback(oldState, newState)
 	})
 }

--- a/internal/multidb/circuit_breaker_test.go
+++ b/internal/multidb/circuit_breaker_test.go
@@ -161,6 +161,18 @@ func TestCircuitBreaker_Callbacks(t *testing.T) {
 	// Close the circuit
 	cb.RecordSuccess()
 
+	// Callbacks are delivered asynchronously; wait for all three.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := len(transitions)
+		mu.Unlock()
+		if n >= 3 {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
 	mu.Lock()
 	defer mu.Unlock()
 

--- a/maintnotifications/circuit_breaker.go
+++ b/maintnotifications/circuit_breaker.go
@@ -59,11 +59,12 @@ func newCircuitBreaker(endpoint string, config *Config) *CircuitBreaker {
 	}
 
 	// Register logging callback for state changes
-	cb.inner.OnStateChange(func(oldState, newState circuitbreaker.State) {
+	cb.inner.OnStateChange(func(oldState, newState circuitbreaker.State, stats circuitbreaker.Stats) {
+		// stats is the transition snapshot; the callback runs asynchronously, so
+		// reading cb.inner.Stats() here could show a later state.
 		switch {
 		case oldState == circuitbreaker.StateClosed && newState == circuitbreaker.StateOpen:
 			if internal.LogLevel.WarnOrAbove() {
-				stats := cb.inner.Stats()
 				internal.Logger.Printf(context.Background(), logs.CircuitBreakerOpened(endpoint, int64(stats.Failures)))
 			}
 		case oldState == circuitbreaker.StateOpen && newState == circuitbreaker.StateHalfOpen:
@@ -72,7 +73,6 @@ func newCircuitBreaker(endpoint string, config *Config) *CircuitBreaker {
 			}
 		case oldState == circuitbreaker.StateHalfOpen && newState == circuitbreaker.StateClosed:
 			if internal.LogLevel.InfoOrAbove() {
-				stats := cb.inner.Stats()
 				internal.Logger.Printf(context.Background(), logs.CircuitBreakerClosed(endpoint, int64(stats.Successes)))
 			}
 		case oldState == circuitbreaker.StateHalfOpen && newState == circuitbreaker.StateOpen:


### PR DESCRIPTION
Fixes the circuit-breaker callback-ordering issue flagged on #3950 (cursor/codex review).

## Problem
State transitions use lock-free CAS and call `notifyCallbacks` after the CAS with **no lock spanning CAS→notify**. Two goroutines winning different transitions can interleave so the *later* transition's callback fires first. The per-database FIFO callback queue faithfully delivers the inverted order, so a consumer tracking the reported `to` state can believe the circuit is **Closed while it is actually Open** — sticky until the next transition. Reachable in default config via the `CheckState` Open→HalfOpen edge.

Shared by `internal/multidb` and `maintnotifications`.

## Fix
- Serialize every transition + the enqueue of its notification under one lock (`transitionMu`).
- Deliver callbacks on a single goroutine in FIFO (== CAS) order via a notify queue; callbacks run **outside** the lock, so a callback may re-enter the breaker without deadlocking (a supported, tested contract — a callback that records a failure).
- Delivery is now async, so a callback can't read the triggering counters via `Stats()`. The callback signature now carries a **`Stats` snapshot** taken at the transition: `StateChangeCallback = func(old, new State, stats Stats)`. `maintnotifications` logs from the snapshot; `multidb` ignores it. `internal/` isn't externally importable, so these are the only two callers.

## Tests
- New `TestCircuitBreaker_CallbackOrderUnderConcurrency`: hammers the half-open edge and asserts delivered transitions form a contiguous chain. **Verified red** against the pre-fix lock-free delivery (chain breaks every run); green after.
- Existing callback tests updated for async delivery (race-safe recorder + waits).
- `go test -race` green across `internal/circuitbreaker`, `internal/multidb`, `maintnotifications`, and the root multidb suite.

Targets `feature/multidb/client` (stacked on the MultiDB PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core circuit-breaker transition and notification semantics used by multidb and maintnotifications; behavior is correctness-critical but heavily tested including race and concurrency ordering cases.
> 
> **Overview**
> Fixes a concurrency bug where **state-change callbacks could fire out of order** relative to the actual CAS transitions. Under load, a consumer could briefly believe the circuit was **Closed while it was still Open**.
> 
> **Serialization:** All transitions (including `Reset`) now enqueue notifications under `transitionMu`, so queue order matches CAS order.
> 
> **Async delivery:** Callbacks run on a **single FIFO notify goroutine** outside the lock, so delivery stays ordered and callbacks can **re-enter** the breaker (`RecordFailure`, etc.) without deadlocking.
> 
> **API change:** `StateChangeCallback` is now `func(old, new State, stats Stats)` with a **stats snapshot at transition time** (async delivery makes `Stats()` at callback time unreliable). `maintnotifications` logs from the snapshot; `multidb` ignores the third argument.
> 
> Tests add `TestCircuitBreaker_CallbackOrderUnderConcurrency` and update existing callback tests for async delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 083ccb14d88c15e8bf33bdc315a41ceff73c2eb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->