### PR TITLE
refactor: callback queue

### DIFF
--- a/internal/callbackqueue/callback_queue.go
+++ b/internal/callbackqueue/callback_queue.go
@@ -10,6 +10,8 @@ import (
 // CallbackQueue runs queued callbacks on a single goroutine, in FIFO order.
 // The drain goroutine is spawned on demand and exits when the queue empties,
 // so an idle queue holds no goroutine.
+//
+// Convention: name fields of this type `cbq` in every struct that holds one.
 type CallbackQueue struct {
 	mu       sync.Mutex
 	queue    []func()

--- a/internal/callbackqueue/callback_queue.go
+++ b/internal/callbackqueue/callback_queue.go
@@ -1,0 +1,56 @@
+package callbackqueue
+
+import (
+	"context"
+	"sync"
+
+	"github.com/redis/go-redis/v9/internal"
+)
+
+// CallbackQueue runs queued callbacks on a single goroutine, in FIFO order.
+// The drain goroutine is spawned on demand and exits when the queue empties,
+// so an idle queue holds no goroutine.
+type CallbackQueue struct {
+	mu       sync.Mutex
+	queue    []func()
+	draining bool
+}
+
+func (q *CallbackQueue) Dispatch(fn func()) {
+	q.mu.Lock()
+	q.queue = append(q.queue, fn)
+	if q.draining {
+		q.mu.Unlock()
+		return
+	}
+	q.draining = true
+	q.mu.Unlock()
+	go q.drain()
+}
+
+func (q *CallbackQueue) drain() {
+	for {
+		q.mu.Lock()
+		if len(q.queue) == 0 {
+			q.draining = false
+			q.mu.Unlock()
+			return
+		}
+		fn := q.queue[0]
+		q.queue = q.queue[1:]
+		q.mu.Unlock()
+		runCallbackSafely(fn)
+	}
+}
+
+// runCallbackSafely keeps a panicking callback from crashing the process
+// (callbacks run on a library-owned goroutine) and from wedging the queue in
+// the draining state.
+func runCallbackSafely(fn func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			internal.Logger.Printf(context.Background(), "callback queue error: the callback panicked: %v", r)
+		}
+	}()
+	fn()
+}

--- a/internal/callbackqueue/callback_queue.go
+++ b/internal/callbackqueue/callback_queue.go
@@ -39,14 +39,17 @@ func (q *CallbackQueue) drain() {
 		fn := q.queue[0]
 		q.queue = q.queue[1:]
 		q.mu.Unlock()
-		runCallbackSafely(fn)
+		RunSafely(fn)
 	}
 }
 
-// runCallbackSafely keeps a panicking callback from crashing the process
-// (callbacks run on a library-owned goroutine) and from wedging the queue in
-// the draining state.
-func runCallbackSafely(fn func()) {
+// RunSafely keeps a panicking callback from crashing the process (callbacks
+// run on a library-owned goroutine) and, when called from drain, from
+// wedging the queue in the draining state. Exported so callers that fan a
+// single dispatched item out to multiple independent callbacks (e.g. a
+// StateChangeCallback loop) can isolate each one without duplicating this
+// recovery logic.
+func RunSafely(fn func()) {
 	defer func() {
 		if r := recover(); r != nil {
 			internal.Logger.Printf(context.Background(), "callback queue error: the callback panicked: %v", r)

--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	cbq "github.com/redis/go-redis/v9/internal/callbackqueue"
 )
 
 // State represents the state of a circuit breaker.
@@ -84,7 +86,7 @@ func (c *Config) applyDefaults() {
 // StateChangeCallback is called when the circuit breaker state changes. stats
 // is a snapshot taken at the transition, so it reflects the counters that
 // triggered the change even though the callback runs asynchronously (see
-// notifyQueue): read it instead of calling Stats(), which by delivery time may
+// notify): read it instead of calling Stats(), which by delivery time may
 // show a later state.
 type StateChangeCallback func(oldState, newState State, stats Stats)
 
@@ -112,52 +114,7 @@ type CircuitBreaker struct {
 	// CAS order; the callbacks run OUTSIDE transitionMu, so two concurrent
 	// transitions cannot report out of order and a callback may safely re-enter
 	// the breaker (RecordFailure/CheckState/Reset) without deadlocking.
-	notify notifyQueue
-}
-
-// stateChange is one queued transition awaiting callback delivery, carrying
-// the Stats snapshot taken at the transition.
-type stateChange struct {
-	oldState, newState State
-	stats              Stats
-}
-
-// notifyQueue delivers state-change notifications on a single goroutine, in
-// FIFO order. It mirrors the enqueue/drain pattern used elsewhere: the drain
-// goroutine is spawned on demand and exits when the queue empties, so an idle
-// breaker holds no goroutine.
-type notifyQueue struct {
-	mu       sync.Mutex
-	queue    []stateChange
-	draining bool
-	fire     func(oldState, newState State, stats Stats)
-}
-
-func (q *notifyQueue) enqueue(oldState, newState State, stats Stats) {
-	q.mu.Lock()
-	q.queue = append(q.queue, stateChange{oldState, newState, stats})
-	if q.draining {
-		q.mu.Unlock()
-		return
-	}
-	q.draining = true
-	q.mu.Unlock()
-	go q.drain()
-}
-
-func (q *notifyQueue) drain() {
-	for {
-		q.mu.Lock()
-		if len(q.queue) == 0 {
-			q.draining = false
-			q.mu.Unlock()
-			return
-		}
-		sc := q.queue[0]
-		q.queue = q.queue[1:]
-		q.mu.Unlock()
-		q.fire(sc.oldState, sc.newState, sc.stats)
-	}
+	notify cbq.CallbackQueue
 }
 
 // New creates a new circuit breaker with the given configuration.
@@ -167,7 +124,6 @@ func New(config Config) *CircuitBreaker {
 		config: config,
 	}
 	cb.state.Store(int32(StateClosed))
-	cb.notify.fire = cb.notifyCallbacks
 	return cb
 }
 
@@ -210,7 +166,8 @@ func (cb *CircuitBreaker) CheckState() State {
 				if cb.state.CompareAndSwap(int32(StateOpen), int32(StateHalfOpen)) {
 					// Enqueue under the lock so callback order matches CAS order;
 					// the callback itself runs on the notify goroutine.
-					cb.notify.enqueue(StateOpen, StateHalfOpen, cb.Stats())
+					stats := cb.Stats()
+					cb.notify.Dispatch(func() { cb.notifyCallbacks(StateOpen, StateHalfOpen, stats) })
 					cb.transitionMu.Unlock()
 					return StateHalfOpen
 				}
@@ -318,7 +275,8 @@ func (cb *CircuitBreaker) recordSuccess(heldSlot bool) {
 				// Snapshot BEFORE clearing the half-open counters so the
 				// callback observes the success count that triggered the close;
 				// enqueue under the lock so delivery order matches CAS order.
-				cb.notify.enqueue(StateHalfOpen, StateClosed, cb.Stats())
+				stats := cb.Stats()
+				cb.notify.Dispatch(func() { cb.notifyCallbacks(StateHalfOpen, StateClosed, stats) })
 				cb.successes.Store(0)
 				cb.requests.Store(0)
 			}
@@ -366,7 +324,8 @@ func (cb *CircuitBreaker) RecordFailure() {
 					// Snapshot so observers see the failure count that triggered
 					// the transition; enqueue under the lock for CAS-ordered
 					// delivery, matching the half-open -> closed/open paths.
-					cb.notify.enqueue(StateClosed, StateOpen, cb.Stats())
+					stats := cb.Stats()
+					cb.notify.Dispatch(func() { cb.notifyCallbacks(StateClosed, StateOpen, stats) })
 					// successes and requests should already be 0 in Closed (they
 					// are only incremented while half-open, and every half-open
 					// exit zeroes them). Reset defensively so the invariant
@@ -388,7 +347,8 @@ func (cb *CircuitBreaker) RecordFailure() {
 				// Snapshot before resetting counters so observers see the counts
 				// that triggered the transition; enqueue under the lock for
 				// CAS-ordered delivery, matching the half-open -> closed path.
-				cb.notify.enqueue(StateHalfOpen, StateOpen, cb.Stats())
+				stats := cb.Stats()
+				cb.notify.Dispatch(func() { cb.notifyCallbacks(StateHalfOpen, StateOpen, stats) })
 				cb.successes.Store(0)
 				cb.requests.Store(0)
 				cb.transitionMu.Unlock()
@@ -445,7 +405,8 @@ func (cb *CircuitBreaker) Reset() {
 	cb.lastFailure.Store(0)
 	oldState := State(cb.state.Swap(int32(StateClosed)))
 	if oldState != StateClosed {
-		cb.notify.enqueue(oldState, StateClosed, cb.Stats())
+		stats := cb.Stats()
+		cb.notify.Dispatch(func() { cb.notifyCallbacks(oldState, StateClosed, stats) })
 	}
 	cb.transitionMu.Unlock()
 }

--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -384,7 +384,11 @@ func (cb *CircuitBreaker) notifyCallbacks(oldState, newState State, stats Stats)
 	cb.mu.RUnlock()
 
 	for _, callback := range callbacks {
-		callback(oldState, newState, stats)
+		// Recover per callback: the queue only recovers around this whole
+		// batch, so a panic here would otherwise unwind past the remaining
+		// callbacks and skip them for this transition (and every future one,
+		// since a deterministic panic recurs on the same callback each time).
+		cbq.RunSafely(func() { callback(oldState, newState, stats) })
 	}
 }
 

--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -86,7 +86,7 @@ func (c *Config) applyDefaults() {
 // StateChangeCallback is called when the circuit breaker state changes. stats
 // is a snapshot taken at the transition, so it reflects the counters that
 // triggered the change even though the callback runs asynchronously (see
-// notify): read it instead of calling Stats(), which by delivery time may
+// cbq): read it instead of calling Stats(), which by delivery time may
 // show a later state.
 type StateChangeCallback func(oldState, newState State, stats Stats)
 
@@ -109,12 +109,12 @@ type CircuitBreaker struct {
 	mu        sync.RWMutex
 	callbacks []StateChangeCallback
 
-	// notify delivers state-change callbacks on a single goroutine in FIFO
+	// cbq delivers state-change callbacks on a single goroutine in FIFO
 	// order. Enqueue happens under transitionMu, so the queue order matches the
 	// CAS order; the callbacks run OUTSIDE transitionMu, so two concurrent
 	// transitions cannot report out of order and a callback may safely re-enter
 	// the breaker (RecordFailure/CheckState/Reset) without deadlocking.
-	notify cbq.CallbackQueue
+	cbq cbq.CallbackQueue
 }
 
 // New creates a new circuit breaker with the given configuration.
@@ -165,9 +165,9 @@ func (cb *CircuitBreaker) CheckState() State {
 				// undo the reset.
 				if cb.state.CompareAndSwap(int32(StateOpen), int32(StateHalfOpen)) {
 					// Enqueue under the lock so callback order matches CAS order;
-					// the callback itself runs on the notify goroutine.
+					// the callback itself runs on the cbq goroutine.
 					stats := cb.Stats()
-					cb.notify.Dispatch(func() { cb.notifyCallbacks(StateOpen, StateHalfOpen, stats) })
+					cb.cbq.Dispatch(func() { cb.notifyCallbacks(StateOpen, StateHalfOpen, stats) })
 					cb.transitionMu.Unlock()
 					return StateHalfOpen
 				}
@@ -276,7 +276,7 @@ func (cb *CircuitBreaker) recordSuccess(heldSlot bool) {
 				// callback observes the success count that triggered the close;
 				// enqueue under the lock so delivery order matches CAS order.
 				stats := cb.Stats()
-				cb.notify.Dispatch(func() { cb.notifyCallbacks(StateHalfOpen, StateClosed, stats) })
+				cb.cbq.Dispatch(func() { cb.notifyCallbacks(StateHalfOpen, StateClosed, stats) })
 				cb.successes.Store(0)
 				cb.requests.Store(0)
 			}
@@ -325,7 +325,7 @@ func (cb *CircuitBreaker) RecordFailure() {
 					// the transition; enqueue under the lock for CAS-ordered
 					// delivery, matching the half-open -> closed/open paths.
 					stats := cb.Stats()
-					cb.notify.Dispatch(func() { cb.notifyCallbacks(StateClosed, StateOpen, stats) })
+					cb.cbq.Dispatch(func() { cb.notifyCallbacks(StateClosed, StateOpen, stats) })
 					// successes and requests should already be 0 in Closed (they
 					// are only incremented while half-open, and every half-open
 					// exit zeroes them). Reset defensively so the invariant
@@ -348,7 +348,7 @@ func (cb *CircuitBreaker) RecordFailure() {
 				// that triggered the transition; enqueue under the lock for
 				// CAS-ordered delivery, matching the half-open -> closed path.
 				stats := cb.Stats()
-				cb.notify.Dispatch(func() { cb.notifyCallbacks(StateHalfOpen, StateOpen, stats) })
+				cb.cbq.Dispatch(func() { cb.notifyCallbacks(StateHalfOpen, StateOpen, stats) })
 				cb.successes.Store(0)
 				cb.requests.Store(0)
 				cb.transitionMu.Unlock()
@@ -375,7 +375,7 @@ func (cb *CircuitBreaker) OnStateChange(callback StateChangeCallback) {
 }
 
 // notifyCallbacks notifies all registered callbacks of a state change. It runs
-// on the notify goroutine (never under transitionMu), so a callback may
+// on the cbq goroutine (never under transitionMu), so a callback may
 // re-enter the breaker without deadlocking.
 func (cb *CircuitBreaker) notifyCallbacks(oldState, newState State, stats Stats) {
 	cb.mu.RLock()
@@ -410,7 +410,7 @@ func (cb *CircuitBreaker) Reset() {
 	oldState := State(cb.state.Swap(int32(StateClosed)))
 	if oldState != StateClosed {
 		stats := cb.Stats()
-		cb.notify.Dispatch(func() { cb.notifyCallbacks(oldState, StateClosed, stats) })
+		cb.cbq.Dispatch(func() { cb.notifyCallbacks(oldState, StateClosed, stats) })
 	}
 	cb.transitionMu.Unlock()
 }

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -289,6 +289,41 @@ func TestCircuitBreaker_OnStateChange(t *testing.T) {
 	}
 }
 
+// TestCircuitBreaker_PanickingCallbackDoesNotStarveOthers pins that one
+// OnStateChange callback panicking must not stop callbacks registered after
+// it from being notified — neither for that transition nor for later ones,
+// since the panicking callback is never removed and panics again on every
+// subsequent delivery.
+func TestCircuitBreaker_PanickingCallbackDoesNotStarveOthers(t *testing.T) {
+	config := Config{
+		FailureThreshold: 1,
+		SuccessThreshold: 1,
+		OpenTimeout:      time.Hour,
+	}
+	cb := New(config)
+
+	var rec transitionRecorder
+	// Registered first and panics on every delivery.
+	cb.OnStateChange(func(oldState, newState State, stats Stats) {
+		panic("boom")
+	})
+	// Registered second: must still see every transition despite the earlier
+	// callback's panic.
+	cb.OnStateChange(rec.record)
+
+	cb.RecordFailure() // Closed -> Open
+	rec.waitFor(t, 1)
+	if got := rec.at(0); got.oldState != StateClosed || got.newState != StateOpen {
+		t.Errorf("expected Closed->Open, got %v->%v", got.oldState, got.newState)
+	}
+
+	cb.Reset() // Open -> Closed
+	rec.waitFor(t, 2)
+	if got := rec.at(1); got.oldState != StateOpen || got.newState != StateClosed {
+		t.Errorf("expected Open->Closed, got %v->%v", got.oldState, got.newState)
+	}
+}
+
 func TestCircuitBreaker_CallbackObservesSuccessCountOnClose(t *testing.T) {
 	config := Config{
 		FailureThreshold: 2,

--- a/multidb_core.go
+++ b/multidb_core.go
@@ -831,7 +831,7 @@ func (c *multidbCore) switchActive(ctx context.Context, from, to int, reason str
 			if c.opts.OnFailover != nil {
 				// Async via announceQ: running a callback inline here would
 				// deadlock if it called Close(). drain() wraps each in
-				// runCallbackSafely; skip if already closed.
+				// RunSafely; skip if already closed.
 				c.announceQ.Dispatch(func() {
 					if c.closed.Load() {
 						return

--- a/multidb_core.go
+++ b/multidb_core.go
@@ -190,12 +190,12 @@ type multidbCore struct {
 	wg     sync.WaitGroup
 	closed atomic.Bool
 
-	// announceQ runs the OnFailover / OnActiveDatabaseChanged callbacks on its
-	// own goroutine (FIFO). They fire from switchActive's announce closure,
-	// which runs on the background loop; running them inline there would
-	// deadlock if a callback called Close() (close() waits on that goroutine
-	// via wg.Wait). Like the per-db cbq, close() does not wait on this queue.
-	announceQ cbq.CallbackQueue
+	// cbq runs the OnFailover / OnActiveDatabaseChanged callbacks on its own
+	// goroutine (FIFO). They fire from switchActive's announce closure, which
+	// runs on the background loop; running them inline there would deadlock
+	// if a callback called Close() (close() waits on that goroutine via
+	// wg.Wait). Like the per-db cbq, close() does not wait on this queue.
+	cbq cbq.CallbackQueue
 }
 
 func newMultidbCore(opts *MultiDBOptions) *multidbCore {
@@ -804,7 +804,7 @@ func (c *multidbCore) recordFailedFailoverLocked() error {
 // callbacks, metrics and PubSub fire once per real change. It returns a
 // non-nil announce closure when the switch happened; callers MUST invoke it
 // AFTER releasing failoverMu. Metrics and the PubSub nudge run synchronously;
-// the user callbacks go through announceQ.
+// the user callbacks go through cbq.
 func (c *multidbCore) switchActive(ctx context.Context, from, to int, reason string, took time.Duration) (announce func()) {
 	if !c.active.CompareAndSwap(int32(from), int32(to)) {
 		return nil
@@ -821,7 +821,7 @@ func (c *multidbCore) switchActive(ctx context.Context, from, to int, reason str
 	internal.Logger.Printf(ctx, "multidb: active database changed %d (%s) -> %d (%s), reason=%s",
 		from, fromFQDN, to, toFQDN, reason)
 
-	// Callbacks run later on announceQ, so detach from the caller ctx (a manual
+	// Callbacks run later on cbq, so detach from the caller ctx (a manual
 	// SetActiveIndex ctx dies on return). Keep trace/values, drop cancel.
 	cbCtx := context.WithoutCancel(ctx)
 	return func() {
@@ -829,10 +829,10 @@ func (c *multidbCore) switchActive(ctx context.Context, from, to int, reason str
 		if reason == failoverReasonAutomatic || reason == failoverReasonManual {
 			otel.RecordMultiDBFailover(ctx, fromFQDN, toFQDN, reason, took)
 			if c.opts.OnFailover != nil {
-				// Async via announceQ: running a callback inline here would
+				// Async via cbq: running a callback inline here would
 				// deadlock if it called Close(). drain() wraps each in
 				// RunSafely; skip if already closed.
-				c.announceQ.Dispatch(func() {
+				c.cbq.Dispatch(func() {
 					if c.closed.Load() {
 						return
 					}
@@ -841,7 +841,7 @@ func (c *multidbCore) switchActive(ctx context.Context, from, to int, reason str
 			}
 		}
 		if c.opts.OnActiveDatabaseChanged != nil {
-			c.announceQ.Dispatch(func() {
+			c.cbq.Dispatch(func() {
 				if c.closed.Load() {
 					return
 				}

--- a/multidb_core.go
+++ b/multidb_core.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9/internal"
+	cbq "github.com/redis/go-redis/v9/internal/callbackqueue"
 	"github.com/redis/go-redis/v9/internal/failuredetector"
 	"github.com/redis/go-redis/v9/internal/otel"
 	"github.com/redis/go-redis/v9/internal/pool"
@@ -43,58 +44,12 @@ type multidbDatabase struct {
 	// firing callbacks for it.
 	removed atomic.Bool
 
-	// cbq delivers user circuit-state callbacks asynchronously (FIFO).
-	cbq callbackQueue
-}
-
-// callbackQueue runs user callbacks on their own goroutine, in FIFO order.
-// Breaker state changes fire deep inside locked sections (failoverMu is held
-// during manual selection, pre-failover probes and AddDatabase probes);
-// invoking a user callback there would self-deadlock the moment the callback
-// touches a control API that takes the same lock.
-type callbackQueue struct {
-	mu       sync.Mutex
-	queue    []func()
-	draining bool
-}
-
-func (q *callbackQueue) dispatch(fn func()) {
-	q.mu.Lock()
-	q.queue = append(q.queue, fn)
-	if q.draining {
-		q.mu.Unlock()
-		return
-	}
-	q.draining = true
-	q.mu.Unlock()
-	go q.drain()
-}
-
-func (q *callbackQueue) drain() {
-	for {
-		q.mu.Lock()
-		if len(q.queue) == 0 {
-			q.draining = false
-			q.mu.Unlock()
-			return
-		}
-		fn := q.queue[0]
-		q.queue = q.queue[1:]
-		q.mu.Unlock()
-		runCallbackSafely(fn)
-	}
-}
-
-// runCallbackSafely keeps a panicking user callback from crashing the process
-// (callbacks run on a library-owned goroutine) and from wedging the queue in
-// the draining state.
-func runCallbackSafely(fn func()) {
-	defer func() {
-		if r := recover(); r != nil {
-			internal.Logger.Printf(context.Background(), "multidb: circuit state callback panicked: %v", r)
-		}
-	}()
-	fn()
+	// cbq delivers user circuit-state callbacks asynchronously (FIFO). Breaker
+	// state changes fire deep inside locked sections (failoverMu is held
+	// during manual selection, pre-failover probes and AddDatabase probes);
+	// invoking a user callback there would self-deadlock the moment the
+	// callback touches a control API that takes the same lock.
+	cbq cbq.CallbackQueue
 }
 
 func (db *multidbDatabase) process(ctx context.Context, cmd Cmder) error {
@@ -240,7 +195,7 @@ type multidbCore struct {
 	// which runs on the background loop; running them inline there would
 	// deadlock if a callback called Close() (close() waits on that goroutine
 	// via wg.Wait). Like the per-db cbq, close() does not wait on this queue.
-	announceQ callbackQueue
+	announceQ cbq.CallbackQueue
 }
 
 func newMultidbCore(opts *MultiDBOptions) *multidbCore {
@@ -330,7 +285,7 @@ func (c *multidbCore) buildDatabase(cfg *MultiDBClientConfig) (*multidbDatabase,
 			// member identity (fqdn) in the callback is the follow-up API
 			// that closes it entirely.
 			from, to := oldState.String(), newState.String()
-			dbRef.cbq.dispatch(func() {
+			dbRef.cbq.Dispatch(func() {
 				if dbRef.removed.Load() {
 					return
 				}
@@ -877,7 +832,7 @@ func (c *multidbCore) switchActive(ctx context.Context, from, to int, reason str
 				// Async via announceQ: running a callback inline here would
 				// deadlock if it called Close(). drain() wraps each in
 				// runCallbackSafely; skip if already closed.
-				c.announceQ.dispatch(func() {
+				c.announceQ.Dispatch(func() {
 					if c.closed.Load() {
 						return
 					}
@@ -886,7 +841,7 @@ func (c *multidbCore) switchActive(ctx context.Context, from, to int, reason str
 			}
 		}
 		if c.opts.OnActiveDatabaseChanged != nil {
-			c.announceQ.dispatch(func() {
+			c.announceQ.Dispatch(func() {
 				if c.closed.Load() {
 					return
 				}


### PR DESCRIPTION
## refactor: callback queue

This extracts the two structurally-identical, hand-rolled FIFO dispatch queues `circuitbreaker` and `callbackQueue` in `multidb_core.go`  — into a single shared `internal/callbackqueue.CallbackQueue`, used by both.

**Why:** both types did the same thing (queue `func()`-like work under a mutex, spawn a drain goroutine on demand, recover panics), just with slightly different call signatures. Deduplicating removes ~110 lines of copy-pasted queue/drain/panic-recovery logic and gives circuit breaker's `notifyQueue` panic recovery for free — it previously had none, so a panicking `StateChangeCallback` would take down the goroutine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with behavior-preserving FIFO async delivery; the main functional change is safer panic isolation in circuit-breaker callbacks, covered by a new test.
> 
> **Overview**
> Introduces **`internal/callbackqueue.CallbackQueue`** — a reusable FIFO async dispatcher with on-demand drain goroutines and **`RunSafely`** panic recovery — and wires it into places that previously duplicated the same queue logic.
> 
> **Circuit breaker** drops its typed **`notifyQueue`** in favor of **`cbq.Dispatch`** closures that call **`notifyCallbacks`**. State-change delivery still runs off **`transitionMu`**, but panics are now contained at the queue level and **per registered callback** via **`RunSafely`**, so one bad **`OnStateChange`** handler cannot skip later listeners or stall the notifier.
> 
> **MultiDB** removes the local **`callbackQueue`** / **`runCallbackSafely`** helpers; per-database circuit callbacks and core **`OnFailover`** / **`OnActiveDatabaseChanged`** announcements both use the shared queue (**`announceQ`** renamed to **`cbq`**).
> 
> A new test asserts that a panicking **`OnStateChange`** callback does not starve subsequently registered callbacks across transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1265eace45667694261d71d8f2e60c656b4666b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->