### PR TITLE
fix(cluster): slotClosestNode can return a failing node while a healthy one is available

### DIFF
--- a/osscluster.go
+++ b/osscluster.go
@@ -995,14 +995,27 @@ func (c *clusterState) slotClosestNode(slot int) (*clusterNode, error) {
 	// setting the max possible duration as zerovalue for minlatency
 	minLatency = time.Duration(math.MaxInt64)
 
+	minNonFailingLatency := time.Duration(math.MaxInt64)
+
 	for _, n := range nodes {
-		if closestNode == nil || n.Latency() < minLatency {
+		// Sampled once: Latency() reads an atomic the background probe writes, so two
+		// reads in one iteration can disagree.
+		latency := n.Latency()
+
+		if closestNode == nil || latency < minLatency {
 			closestNode = n
-			minLatency = n.Latency()
-			if !n.Failing() {
-				closestNonFailingNode = n
-				allNodesFailing = false
-			}
+			minLatency = latency
+		}
+
+		// Tracked independently of the minimum above. Nesting this inside that branch
+		// meant a healthy node was only ever considered when it was also the outright
+		// fastest - so a failing node with lower latency (a refused connection fails
+		// fast, and often has the lowest measured latency of the slot) hid every
+		// healthy node behind it, and the slot fell through to the all-failing path.
+		if !n.Failing() && (closestNonFailingNode == nil || latency < minNonFailingLatency) {
+			closestNonFailingNode = n
+			minNonFailingLatency = latency
+			allNodesFailing = false
 		}
 	}
 

--- a/osscluster_closest_node_test.go
+++ b/osscluster_closest_node_test.go
@@ -1,0 +1,83 @@
+package redis
+
+import (
+	"testing"
+	"time"
+)
+
+func closestNodeTestNode(t *testing.T, latency time.Duration, failing bool) *clusterNode {
+	t.Helper()
+
+	n := &clusterNode{Client: NewClient(&Options{Addr: "127.0.0.1:0"})}
+	t.Cleanup(func() { _ = n.Client.Close() })
+
+	n.loaded.Store(1)
+	n.latency.Store(uint32(latency / time.Microsecond))
+	if failing {
+		n.MarkAsFailing()
+	}
+
+	return n
+}
+
+// A failing node with the lowest latency used to hide every healthy node behind it: the
+// healthy check sat inside the "new minimum" branch, so a healthy node that was not also
+// the outright fastest never became closestNonFailingNode. The slot then fell through to
+// the all-failing path and served the read from the failing node.
+//
+// This is not a rare shape - a refused connection fails fast, so a failing node often has
+// the lowest measured latency in its slot.
+func TestSlotClosestNodePrefersHealthyBehindFasterFailingNode(t *testing.T) {
+	failingFast := closestNodeTestNode(t, 10*time.Millisecond, true)
+	healthySlow := closestNodeTestNode(t, 20*time.Millisecond, false)
+
+	state := &clusterState{slots: []*clusterSlot{{start: 0, end: 16383, nodes: []*clusterNode{failingFast, healthySlow}}}}
+
+	got, err := state.slotClosestNode(0)
+	if err != nil {
+		t.Fatalf("slotClosestNode: %v", err)
+	}
+	if got == failingFast {
+		t.Fatal("returned the failing node while a healthy one was available")
+	}
+	if got != healthySlow {
+		t.Fatalf("expected the healthy node, got %v", got)
+	}
+}
+
+// The healthy node must be the fastest healthy one, not merely the last seen.
+func TestSlotClosestNodePicksFastestHealthyNode(t *testing.T) {
+	failingFast := closestNodeTestNode(t, 1*time.Millisecond, true)
+	healthyFast := closestNodeTestNode(t, 5*time.Millisecond, false)
+	healthySlow := closestNodeTestNode(t, 50*time.Millisecond, false)
+
+	// healthySlow last, so a "last healthy wins" implementation would return it.
+	state := &clusterState{slots: []*clusterSlot{{start: 0, end: 16383, nodes: []*clusterNode{failingFast, healthyFast, healthySlow}}}}
+
+	for i := 0; i < 10; i++ {
+		got, err := state.slotClosestNode(0)
+		if err != nil {
+			t.Fatalf("slotClosestNode: %v", err)
+		}
+		if got != healthyFast {
+			t.Fatalf("iteration %d: expected the fastest healthy node", i)
+		}
+	}
+}
+
+// With every node failing the original behaviour still applies: the least-slow one is
+// served rather than failing the read.
+func TestSlotClosestNodeAllFailingPicksLeastSlow(t *testing.T) {
+	slow := closestNodeTestNode(t, 30*time.Millisecond, true)
+	fast := closestNodeTestNode(t, 3*time.Millisecond, true)
+
+	state := &clusterState{slots: []*clusterSlot{{start: 0, end: 16383, nodes: []*clusterNode{slow, fast}}}}
+
+	got, err := state.slotClosestNode(0)
+	if err != nil {
+		t.Fatalf("slotClosestNode: %v", err)
+	}
+	if got != fast {
+		t.Fatal("expected the least-slow failing node")
+	}
+}


### PR DESCRIPTION
`slotClosestNode` can return a **failing** node while a healthy one is available, and log `all nodes are marked as failed` when they are not.

Spotted while working on #3973 (now merged) and raised separately as agreed with @ndyakov, since it is pre-existing and independent of that change.

## The bug

`closestNonFailingNode` is only updated **inside** the "new minimum" branch:

```go
for _, n := range nodes {
    if closestNode == nil || n.Latency() < minLatency {
        closestNode = n
        minLatency = n.Latency()
        if !n.Failing() {          // <- only reached when n is the new minimum
            closestNonFailingNode = n
            allNodesFailing = false
        }
    }
}
```

So a healthy node is considered only when it is *also* the outright fastest in the slot. Any healthy node sitting behind a faster failing one is never examined.

## Failure

Slot with two nodes — `A` failing at 10ms, `B` healthy at 20ms:

| iteration | outcome |
|---|---|
| `A` | `closestNode == nil` → enters. `closestNode = A`, `minLatency = 10ms`. `A.Failing()` → inner block skipped. |
| `B` | `20ms < 10ms` is false → **the whole branch is skipped**. `B` is never looked at. |

Result: `closestNonFailingNode == nil`, `allNodesFailing == true`. The healthy check fails, and the next branch (`minLatency < maximumNodeLatency`) returns **`A`, the failing node**, after logging that all nodes are failing.

This is not a rare shape. A refused connection fails fast, so a failing node frequently has the *lowest* measured latency in its slot — which is precisely the case that triggers it.

## Fix

Track the closest healthy node against its own minimum, independently of the overall minimum:

```go
if closestNode == nil || latency < minLatency {
    closestNode = n
    minLatency = latency
}

if !n.Failing() && (closestNonFailingNode == nil || latency < minNonFailingLatency) {
    closestNonFailingNode = n
    minNonFailingLatency = latency
    allNodesFailing = false
}
```

`Latency()` is also sampled once per iteration now. It reads an atomic that the background probe writes, so the two reads in the old condition could disagree — the same hazard fixed in #3973.

Behaviour is otherwise unchanged: an all-failing slot still serves the least-slow node rather than failing the read.

## Tests

Three, in `osscluster_closest_node_test.go`:

- `TestSlotClosestNodePrefersHealthyBehindFasterFailingNode` — the case above.
- `TestSlotClosestNodePicksFastestHealthyNode` — the *fastest* healthy node wins, not merely the last one seen (the slow healthy node is placed last, so a "last healthy wins" implementation would fail it).
- `TestSlotClosestNodeAllFailingPicksLeastSlow` — the all-failing path is preserved.

The first two **fail against the current implementation** and pass with the fix. `go vet` clean, and `go test -race` clean across the closest-node and latency-tolerance tests.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster read routing for RouteByLatency clients; the fix corrects node selection but any regression would misroute read-only traffic at slot pick time.
> 
> **Overview**
> Fixes **`slotClosestNode`** so **`RouteByLatency`** no longer picks a **failing** replica when a healthier-but-slower one exists in the same slot.
> 
> The loop now tracks the **lowest-latency healthy node** separately from the overall minimum (previously the healthy check only ran when a node was also the outright fastest, so a fast-failing node could hide every healthy replica and trigger the all-failing fallback). **`Latency()`** is read once per iteration to avoid inconsistent atomic samples.
> 
> Adds **`osscluster_closest_node_test.go`** with cases for healthy-behind-faster-failing, fastest-among-multiple-healthy, and unchanged all-failing least-slow fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0b3f007eb6172bd0ccdd642e3d477415a73c78b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
