### PR TITLE
fix(command): guard zero-length entry arrays in reply parsers

### DIFF
--- a/command.go
+++ b/command.go
@@ -2615,6 +2615,9 @@ func (cmd *MapStringSliceInterfaceCmd) readReply(rd *proto.Reader) (err error) {
 			if err != nil {
 				return err
 			}
+			if itemLen < 1 {
+				return fmt.Errorf("redis: got %d elements in map-string-slice-interface entry, expected at least 1", itemLen)
+			}
 
 			key, err := rd.ReadString()
 			if err != nil {

--- a/command_entry_len_test.go
+++ b/command_entry_len_test.go
@@ -1,0 +1,55 @@
+package redis
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/redis/go-redis/v9/internal/proto"
+)
+
+// A per-entry array whose declared length is zero must be rejected before the
+// parser uses itemLen-1 as a slice size. Without the guard, itemLen-1 == -1
+// panics the make (len/cap out of range) and the mandatory first field is read
+// out of the empty entry, consuming a frame from the next reply and desyncing
+// the pooled connection.
+func TestZeroLengthEntryRejected(t *testing.T) {
+	t.Run("TSTimestampValueSliceCmd", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader("*1\r\n*0\r\n:123\r\n"))
+		cmd := newTSTimestampValueSliceCmd(context.Background())
+		if err := cmd.readReply(rd); err == nil {
+			t.Fatalf("zero-length sample accepted; readReply returned nil (val=%+v)", cmd.val)
+		}
+	})
+	t.Run("MapStringSliceInterfaceCmd", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader("*1\r\n*0\r\n$1\r\nk\r\n"))
+		cmd := NewMapStringSliceInterfaceCmd(context.Background())
+		if err := cmd.readReply(rd); err == nil {
+			t.Fatalf("zero-length entry accepted; readReply returned nil (val=%+v)", cmd.val)
+		}
+	})
+}
+
+// Valid replies must still parse after the guard.
+func TestEntryLenValidStillParses(t *testing.T) {
+	t.Run("TSTimestampValueSliceCmd", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader("*1\r\n*2\r\n:123\r\n$3\r\n1.5\r\n"))
+		cmd := newTSTimestampValueSliceCmd(context.Background())
+		if err := cmd.readReply(rd); err != nil {
+			t.Fatalf("valid sample: %v", err)
+		}
+		if len(cmd.val) != 1 || cmd.val[0].Timestamp != 123 || cmd.val[0].Value != 1.5 {
+			t.Fatalf("unexpected val: %+v", cmd.val)
+		}
+	})
+	t.Run("MapStringSliceInterfaceCmd", func(t *testing.T) {
+		rd := proto.NewReader(strings.NewReader("*1\r\n*2\r\n$1\r\nk\r\n$3\r\n1.5\r\n"))
+		cmd := NewMapStringSliceInterfaceCmd(context.Background())
+		if err := cmd.readReply(rd); err != nil {
+			t.Fatalf("valid entry: %v", err)
+		}
+		if got := cmd.val["k"]; len(got) != 1 {
+			t.Fatalf("unexpected val: %+v", cmd.val)
+		}
+	})
+}

--- a/timeseries_commands.go
+++ b/timeseries_commands.go
@@ -985,6 +985,9 @@ func (cmd *TSTimestampValueSliceCmd) readReply(rd *proto.Reader) (err error) {
 		if err != nil {
 			return err
 		}
+		if itemLen < 1 {
+			return fmt.Errorf("redis: got %d elements in timeseries sample, expected at least 1", itemLen)
+		}
 
 		timestamp, err := rd.ReadInt()
 		if err != nil {


### PR DESCRIPTION
1. TSTimestampValueSliceCmd.readReply (TS.RANGE/TS.REVRANGE) and the RESP2 branch of MapStringSliceInterfaceCmd.readReply (TS.MRANGE/TS.MGET) read a per-entry array length with ReadArrayLen and use it as make([]float64, itemLen-1) / make([]interface{}, 0, itemLen-1) with no lower bound on itemLen.
2. a server that declares a zero-length entry makes itemLen-1 == -1, so the make panics (makeslice len/cap out of range); before that the mandatory timestamp/key is read out of the empty entry, taking a frame from the next reply and desyncing the pooled connection.

Reject itemLen < 1 in both parsers so a malformed entry returns a parse error and the bad connection is dropped. Test feeds a zero-length entry (panics before, errors after) and keeps a valid reply passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive validation on malformed server replies; normal responses unchanged and covered by new tests.
> 
> **Overview**
> Malformed TimeSeries RESP replies that declare a **zero-length** inner array could crash the client or corrupt pooled connections. Parsers for **TS.RANGE/TS.REVRANGE** samples and the RESP2 path of **TS.MRANGE/TS.MGET** (`MapStringSliceInterfaceCmd`) now reject `itemLen < 1` with a parse error instead of using `itemLen-1` in `make`, which previously panicked or read past the entry and desynced the reader.
> 
> New unit tests feed a `*0` entry (must error) and valid `*2` replies (must still parse) for both command types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f500b5e7917ef01c02c3f517ad74e21092efc7dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->