### PR TITLE
feat(multidb): identify members by stable id

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -131,25 +131,25 @@ func (c *sentinelFailover) ReplicaAddrs(ctx context.Context) ([]string, error) {
 	return c.replicaAddrs(ctx, false)
 }
 
-// TestBreakerRecordFailure records one failure on the indexed member's
-// circuit breaker. Exported for testing breaker-gate interactions.
-func (c *MultiDBClient) TestBreakerRecordFailure(index int) {
-	c.core.dbAt(index).cb.RecordFailure()
+// TestBreakerRecordFailure records one failure on the given member's circuit
+// breaker. Exported for testing breaker-gate interactions.
+func (c *MultiDBClient) TestBreakerRecordFailure(id int) {
+	c.core.dbByID(id).cb.RecordFailure()
 }
 
-// TestBreakerReserveHalfOpen runs the indexed member's breaker admission
-// check, reserving one half-open probe slot when the breaker is half-open.
-// Exported for testing breaker-gate interactions.
-func (c *MultiDBClient) TestBreakerReserveHalfOpen(index int) bool {
-	return c.core.dbAt(index).cb.IsAllowed()
+// TestBreakerReserveHalfOpen runs the given member's breaker admission check,
+// reserving one half-open probe slot when the breaker is half-open. Exported
+// for testing breaker-gate interactions.
+func (c *MultiDBClient) TestBreakerReserveHalfOpen(id int) bool {
+	return c.core.dbByID(id).cb.IsAllowed()
 }
 
 // TestProbeRacingRemoval reproduces the background health-check loop racing a
 // concurrent RemoveDatabase: the member is snapshotted (as the loop does),
 // removed, and then probed through the stale snapshot.
-func (c *MultiDBClient) TestProbeRacingRemoval(index int) {
-	db := c.core.dbAt(index)
-	if err := c.core.removeDatabase(context.Background(), index); err != nil {
+func (c *MultiDBClient) TestProbeRacingRemoval(id int) {
+	db := c.core.dbByID(id)
+	if err := c.core.removeDatabase(context.Background(), id); err != nil {
 		panic(err)
 	}
 	db.probe(context.Background(), c.core.opts.HealthCheckTimeout)
@@ -168,9 +168,9 @@ func (c *MultiDBClient) TestTryFallback() {
 // TestStaleRecordAfterRemoval simulates a probe that passed its removed-check
 // just before the member was removed: the breaker outcome lands after the
 // removal completed.
-func (c *MultiDBClient) TestStaleRecordAfterRemoval(index int) {
-	db := c.core.dbAt(index)
-	if err := c.core.removeDatabase(context.Background(), index); err != nil {
+func (c *MultiDBClient) TestStaleRecordAfterRemoval(id int) {
+	db := c.core.dbByID(id)
+	if err := c.core.removeDatabase(context.Background(), id); err != nil {
 		panic(err)
 	}
 	db.cb.RecordFailure()

--- a/multidb.go
+++ b/multidb.go
@@ -39,10 +39,14 @@ var (
 	// ErrInsufficientHealthyDatabases is returned by NewMultiDBClient when the
 	// InitialDBState policy is not satisfied.
 	ErrInsufficientHealthyDatabases = errors.New("redis: multidb: insufficient healthy databases on initialization")
-	// ErrTargetUnhealthy is returned by SetActiveIndex when the requested
-	// target database fails its health probe. Use ForceActiveIndex to switch
+	// ErrTargetUnhealthy is returned by SetActiveDatabase when the requested
+	// target database fails its health probe. Use ForceActiveDatabase to switch
 	// unconditionally.
 	ErrTargetUnhealthy = errors.New("redis: multidb: target database is unhealthy")
+	// ErrDatabaseNotFound is returned by the control API when no member has the
+	// given id (never added, or already removed). Member ids are stable and
+	// never reused, so a removed member's id stays invalid forever.
+	ErrDatabaseNotFound = errors.New("redis: multidb: no database with the given id")
 )
 
 // MultiDBFailureDetector aggregates command outcomes and decides when the
@@ -69,13 +73,16 @@ type MultiDBHealthCheckPolicy interface {
 // MultiDBDatabaseState is a snapshot of one database handed to a failover
 // strategy.
 type MultiDBDatabaseState struct {
-	Index   int
+	// ID is the database's stable member id (the value AddDatabase returned and
+	// ActiveDatabaseID reports), not a position. It is what Select must return.
+	ID      int
 	Weight  float64
 	Allowed bool // circuit breaker allows traffic
 }
 
 // MultiDBFailoverStrategy selects the failover target from candidate
-// databases. Return the chosen index, or -1 when no candidate is acceptable.
+// databases. Return the chosen database's id (MultiDBDatabaseState.ID), or -1
+// when no candidate is acceptable.
 type MultiDBFailoverStrategy interface {
 	Select(candidates []MultiDBDatabaseState) int
 }
@@ -92,7 +99,7 @@ func (WeightBasedFailoverStrategy) Select(candidates []MultiDBDatabaseState) int
 			continue
 		}
 		if best == -1 || c.Weight > bestWeight {
-			best = c.Index
+			best = c.ID
 			bestWeight = c.Weight
 		}
 	}
@@ -210,19 +217,22 @@ type MultiDBOptions struct {
 	ProbeTargetBeforeFailover bool
 
 	// OnFailover is called after an automatic or manual failover switched the
-	// active database from `from` to `to`. Delivered asynchronously (FIFO); do
-	// not rely on it running synchronously with the failover. The ctx keeps
-	// the triggering operation's trace/values but not its cancellation.
+	// active database from `from` to `to`, both stable member ids (see
+	// AddDatabase). Delivered asynchronously (FIFO); do not rely on it running
+	// synchronously with the failover. The ids stay valid even if a concurrent
+	// RemoveDatabase drops another member. The ctx keeps the triggering
+	// operation's trace/values but not its cancellation.
 	OnFailover func(ctx context.Context, from, to int)
 	// OnActiveDatabaseChanged is called on every active-database change,
-	// including auto-fallback. Delivered asynchronously (FIFO); do not rely on
-	// it running synchronously with the change.
+	// including auto-fallback. `from` and `to` are stable member ids. Delivered
+	// asynchronously (FIFO); do not rely on it running synchronously with the
+	// change.
 	OnActiveDatabaseChanged func(from, to int)
 	// OnCircuitStateChanged is called when any database's circuit breaker
-	// changes state ("closed", "open", "half-open"). Delivered asynchronously
-	// (FIFO per database); do not rely on it running synchronously with the
-	// transition.
-	OnCircuitStateChanged func(dbIndex int, from, to string)
+	// changes state ("closed", "open", "half-open"). dbID is the database's
+	// stable member id. Delivered asynchronously (FIFO per database); do not
+	// rely on it running synchronously with the transition.
+	OnCircuitStateChanged func(dbID int, from, to string)
 }
 
 // CommandRetriesNone disables command retries.
@@ -341,23 +351,32 @@ func (cfg *MultiDBClientConfig) fqdn() string {
 // MultiDBCtrl is the operational control surface of MultiDBClient: active
 // database selection, runtime membership changes and health management. It is
 // implemented by *MultiDBClient.
+//
+// Databases are addressed by a stable id: AddDatabase returns one, and it keeps
+// naming the same database until that database is removed. Ids are never
+// reused, so a handle held by the caller (or delivered to a callback) never
+// silently points at a different member. An id that names no current member
+// yields ErrDatabaseNotFound.
 type MultiDBCtrl interface {
-	// ActiveIndex returns the index of the currently active database.
-	ActiveIndex() int
-	// SetActiveIndex switches to the database at index after a fresh health
-	// probe of the target; it refuses with ErrTargetUnhealthy when the probe
-	// fails.
-	SetActiveIndex(ctx context.Context, index int) error
-	// ForceActiveIndex switches to the database at index unconditionally
-	// (operator override; only the index range is validated).
-	ForceActiveIndex(ctx context.Context, index int) error
-	// AddDatabase adds a member database at runtime and returns its index.
+	// ActiveDatabaseID returns the stable id of the currently active database,
+	// or -1 when none is selected.
+	ActiveDatabaseID() int
+	// SetActiveDatabase switches to the database with the given id after a fresh
+	// health probe of the target; it refuses with ErrTargetUnhealthy when the
+	// probe fails, or ErrDatabaseNotFound for an unknown id.
+	SetActiveDatabase(ctx context.Context, id int) error
+	// ForceActiveDatabase switches to the database with the given id
+	// unconditionally (operator override); it returns ErrDatabaseNotFound for an
+	// unknown id.
+	ForceActiveDatabase(ctx context.Context, id int) error
+	// AddDatabase adds a member database at runtime and returns its stable id.
 	AddDatabase(ctx context.Context, cfg MultiDBClientConfig) (int, error)
-	// RemoveDatabase removes the database at index. The active database
-	// cannot be removed.
-	RemoveDatabase(ctx context.Context, index int) error
-	// SetWeight changes the weight of the database at index.
-	SetWeight(index int, weight float64) error
+	// RemoveDatabase removes the database with the given id. The active database
+	// cannot be removed. Returns ErrDatabaseNotFound for an unknown id.
+	RemoveDatabase(ctx context.Context, id int) error
+	// SetWeight changes the weight of the database with the given id. Returns
+	// ErrDatabaseNotFound for an unknown id.
+	SetWeight(id int, weight float64) error
 	// SetAutoFallback enables or disables automatic fallback at runtime.
 	SetAutoFallback(enabled bool)
 }
@@ -422,8 +441,7 @@ func NewMultiDBClient(ctx context.Context, opts *MultiDBOptions) (*MultiDBClient
 			_ = core.closeAll()
 			return nil, err
 		}
-		db.idx.Store(int32(len(core.dbs)))
-		core.dbs = append(core.dbs, db)
+		core.dbs[db.id] = db
 	}
 
 	if err := core.initialize(ctx); err != nil {
@@ -449,17 +467,17 @@ func (c *MultiDBClient) Close() error {
 	return c.core.close()
 }
 
-// ActiveIndex implements MultiDBCtrl.
-func (c *MultiDBClient) ActiveIndex() int { return c.core.activeIndex() }
+// ActiveDatabaseID implements MultiDBCtrl.
+func (c *MultiDBClient) ActiveDatabaseID() int { return c.core.activeDatabaseID() }
 
-// SetActiveIndex implements MultiDBCtrl.
-func (c *MultiDBClient) SetActiveIndex(ctx context.Context, index int) error {
-	return c.core.setActiveIndex(ctx, index, true)
+// SetActiveDatabase implements MultiDBCtrl.
+func (c *MultiDBClient) SetActiveDatabase(ctx context.Context, id int) error {
+	return c.core.setActiveDatabase(ctx, id, true)
 }
 
-// ForceActiveIndex implements MultiDBCtrl.
-func (c *MultiDBClient) ForceActiveIndex(ctx context.Context, index int) error {
-	return c.core.setActiveIndex(ctx, index, false)
+// ForceActiveDatabase implements MultiDBCtrl.
+func (c *MultiDBClient) ForceActiveDatabase(ctx context.Context, id int) error {
+	return c.core.setActiveDatabase(ctx, id, false)
 }
 
 // AddDatabase implements MultiDBCtrl.
@@ -468,13 +486,13 @@ func (c *MultiDBClient) AddDatabase(ctx context.Context, cfg MultiDBClientConfig
 }
 
 // RemoveDatabase implements MultiDBCtrl.
-func (c *MultiDBClient) RemoveDatabase(ctx context.Context, index int) error {
-	return c.core.removeDatabase(ctx, index)
+func (c *MultiDBClient) RemoveDatabase(ctx context.Context, id int) error {
+	return c.core.removeDatabase(ctx, id)
 }
 
 // SetWeight implements MultiDBCtrl.
-func (c *MultiDBClient) SetWeight(index int, weight float64) error {
-	return c.core.setWeight(index, weight)
+func (c *MultiDBClient) SetWeight(id int, weight float64) error {
+	return c.core.setWeight(id, weight)
 }
 
 // SetAutoFallback implements MultiDBCtrl.
@@ -482,10 +500,10 @@ func (c *MultiDBClient) SetAutoFallback(enabled bool) {
 	c.core.setAutoFallback(enabled)
 }
 
-// AddDatabaseHook installs a hook on the underlying client of the database at
-// index. It is mainly useful for testing and instrumentation.
-func (c *MultiDBClient) AddDatabaseHook(index int, hook Hook) error {
-	return c.core.addDatabaseHook(index, hook)
+// AddDatabaseHook installs a hook on the underlying client of the database with
+// the given id. It is mainly useful for testing and instrumentation.
+func (c *MultiDBClient) AddDatabaseHook(id int, hook Hook) error {
+	return c.core.addDatabaseHook(id, hook)
 }
 
 // Subscribe creates a PubSub subscription that follows the active database:

--- a/multidb_core.go
+++ b/multidb_core.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -31,11 +32,11 @@ type multidbDatabase struct {
 	cb     *imultidb.CircuitBreaker
 	weight float64 // guarded by core.dbMu
 	fqdn   string
-	// idx is the database's current position in core.dbs, maintained under
-	// core.dbMu on every membership change. Callbacks read it lock-free to
-	// avoid recursive dbMu read-locking (which can deadlock with a queued
-	// writer).
-	idx atomic.Int32
+	// id is the database's stable identifier and its key in core.dbs. Assigned
+	// once at membership time (before the initial probe), immutable, and never
+	// reused, so callbacks and the public API can name a member with an int
+	// that a RemoveDatabase never invalidates or renumbers. Read lock-free.
+	id int
 
 	checks []MultiDBHealthCheck
 	policy MultiDBHealthCheckPolicy
@@ -240,9 +241,19 @@ type multidbCore struct {
 	opts *MultiDBOptions
 
 	dbMu sync.RWMutex
-	dbs  []*multidbDatabase
+	// dbs is keyed by stable member id (multidbDatabase.id), not by position:
+	// membership changes never renumber survivors, so a caller's handle and a
+	// queued callback stay valid across a RemoveDatabase.
+	dbs map[int]*multidbDatabase
 
-	active atomic.Int32
+	// active is the id of the active member, or -1 when none is selected. An id,
+	// not a position, so removing another member never shifts it.
+	active atomic.Int64
+
+	// nextID hands out member ids: monotonic, never decremented, never reset
+	// (not even in closeAll). Reuse would let a stale handle or a queued
+	// callback resurrect as a different member, so ids are permanent.
+	nextID atomic.Int64
 
 	detector MultiDBFailureDetector
 	strategy MultiDBFailoverStrategy
@@ -285,6 +296,7 @@ func newMultidbCore(opts *MultiDBOptions) *multidbCore {
 		opts:     opts,
 		detector: opts.FailureDetector,
 		strategy: opts.FailoverStrategy,
+		dbs:      make(map[int]*multidbDatabase),
 		pubsubs:  make(map[*PubSub]struct{}),
 		stopCh:   make(chan struct{}),
 	}
@@ -309,6 +321,10 @@ func newMultidbCore(opts *MultiDBOptions) *multidbCore {
 // resolved health checks for one member database.
 func (c *multidbCore) buildDatabase(cfg *MultiDBClientConfig) (*multidbDatabase, error) {
 	db := &multidbDatabase{
+		// Stable id assigned here, before the circuit-breaker callback below
+		// captures the member: a probe-fired state change then reports the real
+		// id. Monotonic and never reused; a failed build just leaves a gap.
+		id:     int(c.nextID.Add(1) - 1),
 		weight: cfg.Weight,
 		fqdn:   cfg.fqdn(),
 	}
@@ -377,19 +393,17 @@ func (c *multidbCore) buildDatabase(cfg *MultiDBClientConfig) (*multidbDatabase,
 		if stateCallback != nil && !dbRef.removed.Load() {
 			// Deliver asynchronously (FIFO per database): state changes fire
 			// under internal locks, and a callback that calls a control API
-			// would otherwise self-deadlock. The removed flag and the index
-			// are (re-)read at DELIVERY time: a removal that lands while the
-			// callback is queued would otherwise surface a stale index that
-			// now points at a different member. A removal racing the final
-			// reads keeps an unavoidable instant-wide window — carrying the
-			// member identity (fqdn) in the callback is the follow-up API
-			// that closes it entirely.
+			// would otherwise self-deadlock. The member id is stable and
+			// immutable, so it is captured here and stays correct however
+			// membership changes; the removed flag is re-read at DELIVERY time
+			// so a member removed while the callback was queued fires nothing.
 			from, to := oldState.String(), newState.String()
+			id := dbRef.id
 			dbRef.cbq.Dispatch(func() {
 				if dbRef.removed.Load() {
 					return
 				}
-				stateCallback(int(dbRef.idx.Load()), from, to)
+				stateCallback(id, from, to)
 			})
 		}
 	})
@@ -405,18 +419,18 @@ func (c *multidbCore) initialize(ctx context.Context) error {
 	required := c.requiredAvailableCount()
 	_, hasDeadline := ctx.Deadline()
 
-	probeHealthy := make([]bool, len(c.dbs))
+	probeHealthy := make(map[int]bool, len(c.dbs))
 	for {
 		healthy := 0
-		for i, db := range c.dbs {
+		for id, db := range c.dbs {
 			// Stop probing as soon as the constructor's context ends, rather
 			// than finishing the whole pass: a check that ignores ctx would
 			// otherwise keep the constructor running past cancellation.
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-			probeHealthy[i] = db.probe(ctx, c.opts.HealthCheckTimeout)
-			if probeHealthy[i] {
+			probeHealthy[id] = db.probe(ctx, c.opts.HealthCheckTimeout)
+			if probeHealthy[id] {
 				healthy++
 			}
 		}
@@ -450,8 +464,8 @@ func (c *multidbCore) initialize(ctx context.Context) error {
 	// The context check above guarantees the loop only breaks with a live
 	// context, so every probe verdict here is real (a canceled pass returns
 	// before this reconciliation).
-	for i, db := range c.dbs {
-		if probeHealthy[i] {
+	for id, db := range c.dbs {
+		if probeHealthy[id] {
 			if db.cb.CheckState() != imultidb.CircuitClosed {
 				db.cb.Reset()
 			}
@@ -467,19 +481,27 @@ func (c *multidbCore) initialize(ctx context.Context) error {
 	// FailureThreshold a database that failed its only startup probe would
 	// otherwise still look selectable.
 	cands := make([]MultiDBDatabaseState, 0, len(c.dbs))
-	for i, db := range c.dbs {
+	for id, db := range c.dbs {
 		cands = append(cands, MultiDBDatabaseState{
-			Index:   i,
+			ID:      id,
 			Weight:  db.weight,
-			Allowed: probeHealthy[i],
+			Allowed: probeHealthy[id],
 		})
 	}
+	sortCandidatesByID(cands)
 	best := c.selectCandidate(cands)
 	if best < 0 {
 		return fmt.Errorf("%w: no selectable database", ErrInsufficientHealthyDatabases)
 	}
-	c.active.Store(int32(best))
+	c.active.Store(int64(best))
 	return nil
+}
+
+// sortCandidatesByID orders candidates by ascending stable id so map iteration
+// order never leaks into failover: the strategy sees a deterministic list, and
+// equal-weight ties resolve by id instead of arbitrary map order.
+func sortCandidatesByID(cands []MultiDBDatabaseState) {
+	sort.Slice(cands, func(i, j int) bool { return cands[i].ID < cands[j].ID })
 }
 
 func (c *multidbCore) requiredAvailableCount() int {
@@ -494,22 +516,24 @@ func (c *multidbCore) requiredAvailableCount() int {
 	}
 }
 
-// candidates snapshots every database except `exclude` for the failover
-// strategy.
-func (c *multidbCore) candidates(exclude int) []MultiDBDatabaseState {
+// candidates snapshots every database except the one with id excludeID (the
+// active) for the failover strategy, ordered by id so selection is
+// deterministic despite map iteration order.
+func (c *multidbCore) candidates(excludeID int) []MultiDBDatabaseState {
 	c.dbMu.RLock()
 	defer c.dbMu.RUnlock()
 	out := make([]MultiDBDatabaseState, 0, len(c.dbs))
-	for i, db := range c.dbs {
-		if i == exclude {
+	for id, db := range c.dbs {
+		if id == excludeID {
 			continue
 		}
 		out = append(out, MultiDBDatabaseState{
-			Index:   i,
+			ID:      id,
 			Weight:  db.weight,
 			Allowed: db.selectable(),
 		})
 	}
+	sortCandidatesByID(out)
 	return out
 }
 
@@ -541,7 +565,7 @@ func (c *multidbCore) selectCandidate(cands []MultiDBDatabaseState) (best int) {
 	// the candidates offered. An out-of-range or non-candidate index would
 	// otherwise be stored as the active and later index a wrong/absent member.
 	for _, cand := range cands {
-		if cand.Index == idx {
+		if cand.ID == idx {
 			return idx
 		}
 	}
@@ -561,7 +585,15 @@ func (c *multidbCore) resetDetectorSafely() {
 	c.detector.Reset()
 }
 
-func (c *multidbCore) activeIndex() int { return int(c.active.Load()) }
+// activeDatabaseID returns the stable id of the active database, or -1 when none is
+// selected.
+func (c *multidbCore) activeDatabaseID() int {
+	db, id := c.activeSnapshot()
+	if db == nil {
+		return -1
+	}
+	return id
+}
 
 // memberCount returns the current number of member databases.
 func (c *multidbCore) memberCount() int {
@@ -570,27 +602,27 @@ func (c *multidbCore) memberCount() int {
 	return len(c.dbs)
 }
 
-// activeSnapshot returns the active database, or nil when none is selected or
-// the index is stale after a removal. The index is loaded under dbMu so it is
-// coherent with the slice: RemoveDatabase shifts both under the write lock,
-// and reading the index first could otherwise resolve to a shifted neighbor.
+// activeSnapshot returns the active database and its id, or (nil, id) when none
+// is selected or the active id is absent. The id and the map read happen under
+// dbMu so they are coherent with a concurrent RemoveDatabase.
 func (c *multidbCore) activeSnapshot() (*multidbDatabase, int) {
 	c.dbMu.RLock()
 	defer c.dbMu.RUnlock()
-	idx := int(c.active.Load())
-	if idx < 0 || idx >= len(c.dbs) {
-		return nil, idx
+	id := int(c.active.Load())
+	if id < 0 {
+		// -1 sentinel: no active selected. A non-negative active is always a
+		// live key — removeDatabase refuses to remove the active — so the map
+		// lookup below cannot resolve a stale id to a reused member.
+		return nil, id
 	}
-	return c.dbs[idx], idx
+	return c.dbs[id], id
 }
 
-func (c *multidbCore) dbAt(index int) *multidbDatabase {
+// dbByID returns the member with the given stable id, or nil if none.
+func (c *multidbCore) dbByID(id int) *multidbDatabase {
 	c.dbMu.RLock()
 	defer c.dbMu.RUnlock()
-	if index < 0 || index >= len(c.dbs) {
-		return nil
-	}
-	return c.dbs[index]
+	return c.dbs[id]
 }
 
 // process is the command hot path: an attempt loop bounded by CommandRetries
@@ -887,7 +919,7 @@ func (c *multidbCore) tryFailover(ctx context.Context, from int) error {
 			return c.recordFailedFailoverLocked()
 		}
 		if c.opts.ProbeTargetBeforeFailover {
-			if db := c.dbAt(best); db != nil && !db.probe(ctx, c.opts.HealthCheckTimeout) {
+			if db := c.dbByID(best); db != nil && !db.probe(ctx, c.opts.HealthCheckTimeout) {
 				if err := ctx.Err(); err != nil {
 					// The caller's context ended mid-probe: the candidate was
 					// never proven unhealthy. Surface the context error
@@ -908,7 +940,7 @@ func (c *multidbCore) tryFailover(ctx context.Context, from int) error {
 			}
 		}
 		if c.closed.Load() {
-			// Same close-during-probe race as setActiveIndex: close() takes no
+			// Same close-during-probe race as setActiveDatabase: close() takes no
 			// lock, so a ProbeTargetBeforeFailover probe can outlast it. Do not
 			// switch the active state on an already-closed client.
 			return ErrClosed
@@ -930,7 +962,7 @@ func (c *multidbCore) tryFailover(ctx context.Context, from int) error {
 func removeCandidate(cands []MultiDBDatabaseState, index int) []MultiDBDatabaseState {
 	out := cands[:0]
 	for _, cand := range cands {
-		if cand.Index != index {
+		if cand.ID != index {
 			out = append(out, cand)
 		}
 	}
@@ -976,16 +1008,20 @@ func (c *multidbCore) recordFailedFailoverLocked() error {
 // non-nil announce closure when the switch happened; callers MUST invoke it
 // AFTER releasing failoverMu. Metrics and the PubSub nudge run synchronously;
 // the user callbacks go through cbq.
+// from and to are stable member ids. Because ids are immutable, the ids
+// captured here stay correct in the async callbacks however membership changes,
+// and the CAS now fails only on a genuine concurrent switch (a RemoveDatabase of
+// another member no longer moves `active`).
 func (c *multidbCore) switchActive(ctx context.Context, from, to int, reason string, took time.Duration) (announce func()) {
-	if !c.active.CompareAndSwap(int32(from), int32(to)) {
+	if !c.active.CompareAndSwap(int64(from), int64(to)) {
 		return nil
 	}
 
 	fromFQDN, toFQDN := "", ""
-	if db := c.dbAt(from); db != nil {
+	if db := c.dbByID(from); db != nil {
 		fromFQDN = db.fqdn
 	}
-	if db := c.dbAt(to); db != nil {
+	if db := c.dbByID(to); db != nil {
 		toFQDN = db.fqdn
 	}
 
@@ -999,13 +1035,13 @@ func (c *multidbCore) switchActive(ctx context.Context, from, to int, reason str
 	// and ping-ponging a flaky higher-weight primary. Manual selection and
 	// fallback itself (which does not gate on this) are unaffected.
 	if reason == failoverReasonAutomatic {
-		if fromDB := c.dbAt(from); fromDB != nil {
+		if fromDB := c.dbByID(from); fromDB != nil {
 			fromDB.noFallbackBefore.Store(time.Now().Add(c.fallbackInterval).UnixNano())
 		}
 	}
 
 	// Callbacks run later on cbq, so detach from the caller ctx (a manual
-	// SetActiveIndex ctx dies on return). Keep trace/values, drop cancel.
+	// SetActiveDatabase ctx dies on return). Keep trace/values, drop cancel.
 	cbCtx := context.WithoutCancel(ctx)
 
 	// Enqueue the user callbacks HERE, under failoverMu (every caller holds it
@@ -1047,10 +1083,10 @@ func (c *multidbCore) switchActive(ctx context.Context, from, to int, reason str
 	}
 }
 
-// setActiveIndex implements manual failover. With probe=true it is the safe
-// probe-then-switch path (SetActiveIndex); with probe=false it is the
-// unconditional operator override (ForceActiveIndex).
-func (c *multidbCore) setActiveIndex(ctx context.Context, index int, probe bool) error {
+// setActiveDatabase implements manual failover. With probe=true it is the safe
+// probe-then-switch path (SetActiveDatabase); with probe=false it is the
+// unconditional operator override (ForceActiveDatabase).
+func (c *multidbCore) setActiveDatabase(ctx context.Context, index int, probe bool) error {
 	if c.closed.Load() {
 		// Consistent with the command paths: the drained membership would
 		// otherwise surface as a misleading out-of-range error.
@@ -1085,9 +1121,9 @@ func (c *multidbCore) setActiveIndex(ctx context.Context, index int, probe bool)
 		return err
 	}
 
-	db := c.dbAt(index)
+	db := c.dbByID(index)
 	if db == nil {
-		return fmt.Errorf("redis: multidb: database index %d out of range", index)
+		return fmt.Errorf("%w: %d", ErrDatabaseNotFound, index)
 	}
 	start := time.Now()
 	if probe {
@@ -1135,7 +1171,7 @@ func (c *multidbCore) setActiveIndex(ctx context.Context, index int, probe bool)
 		return ErrClosed
 	}
 	// The operator explicitly selected this database — either a fresh probe
-	// just passed, or ForceActiveIndex is an unconditional override. Reset
+	// just passed, or ForceActiveDatabase is an unconditional override. Reset
 	// its breaker in both cases so a still-open circuit does not immediately
 	// fail the switch away; a genuinely dead forced target re-opens it
 	// organically on the next failures.
@@ -1187,11 +1223,6 @@ func (c *multidbCore) addDatabase(ctx context.Context, cfg MultiDBClientConfig) 
 		return -1, err
 	}
 
-	c.dbMu.RLock()
-	idx := len(c.dbs)
-	c.dbMu.RUnlock()
-	db.idx.Store(int32(idx))
-
 	// The initial probe result never blocks membership; it only seeds the
 	// circuit breaker (and is skipped entirely with SkipInitialHealthCheck).
 	// A failed probe opens the breaker outright — one recorded failure would
@@ -1203,7 +1234,7 @@ func (c *multidbCore) addDatabase(ctx context.Context, cfg MultiDBClientConfig) 
 			// The caller's context ended while the probe ran (whatever the
 			// verdict): a canceled control operation must not mutate the
 			// membership. Mark it removed first: the probe may already have
-			// queued circuit callbacks for an index that was never added.
+			// queued circuit callbacks for a member that was never added.
 			db.removed.Store(true)
 			_ = db.closeClient()
 			return -1, err
@@ -1218,29 +1249,29 @@ func (c *multidbCore) addDatabase(ctx context.Context, cfg MultiDBClientConfig) 
 	c.dbMu.Lock()
 	if c.closed.Load() {
 		// Close ran while the member was being prepared: closeAll has
-		// already drained c.dbs, so appending here would leak the client
+		// already drained c.dbs, so inserting here would leak the client
 		// (nothing would ever close it).
 		c.dbMu.Unlock()
 		db.removed.Store(true)
 		_ = db.closeClient()
 		return -1, ErrClosed
 	}
-	c.dbs = append(c.dbs, db)
+	c.dbs[db.id] = db
 	c.dbMu.Unlock()
-	return idx, nil
+	return db.id, nil
 }
 
-func (c *multidbCore) removeDatabase(ctx context.Context, index int) error {
+func (c *multidbCore) removeDatabase(ctx context.Context, id int) error {
 	if c.closed.Load() {
 		// Consistent with the other control paths: the drained membership
-		// would otherwise surface as a misleading out-of-range error.
+		// would otherwise surface as a misleading not-found error.
 		return ErrClosed
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	// Hold failoverMu so the active-index adjustment below cannot race a
-	// concurrent switchActive (all active transitions happen under it).
+	// Hold failoverMu so the active-id check below cannot race a concurrent
+	// switchActive (all active transitions happen under it).
 	c.failoverMu.Lock()
 	defer c.failoverMu.Unlock()
 	// Re-check after the lock wait: a client closed or an operator request
@@ -1252,45 +1283,40 @@ func (c *multidbCore) removeDatabase(ctx context.Context, index int) error {
 		return err
 	}
 	c.dbMu.Lock()
-	if index < 0 || index >= len(c.dbs) {
+	db, ok := c.dbs[id]
+	if !ok {
 		c.dbMu.Unlock()
-		return fmt.Errorf("redis: multidb: database index %d out of range", index)
+		return fmt.Errorf("%w: %d", ErrDatabaseNotFound, id)
 	}
-	if int(c.active.Load()) == index {
+	if int(c.active.Load()) == id {
 		c.dbMu.Unlock()
 		return errors.New("redis: multidb: cannot remove the active database")
 	}
-	db := c.dbs[index]
 	// Mark before the client is closed: a background probe holding a stale
 	// snapshot must stop recording outcomes for this member.
 	db.removed.Store(true)
-	c.dbs = append(c.dbs[:index], c.dbs[index+1:]...)
-	for i := index; i < len(c.dbs); i++ {
-		c.dbs[i].idx.Store(int32(i))
-	}
-	// Keep the active index pointing at the same database after the slice
-	// shifted.
-	if active := int(c.active.Load()); active > index {
-		c.active.Store(int32(active - 1))
-	}
+	// Ids are stable and `active` is an id, so removing a non-active member
+	// renumbers nothing and never shifts the active — just drop the key.
+	delete(c.dbs, id)
 	c.dbMu.Unlock()
 
 	return db.closeClient()
 }
 
-func (c *multidbCore) setWeight(index int, weight float64) error {
+func (c *multidbCore) setWeight(id int, weight float64) error {
 	if c.closed.Load() {
-		// After Close drains the membership the index would surface as a
-		// misleading out-of-range error; report the terminal state instead,
+		// After Close drains the membership the id would surface as a
+		// misleading not-found error; report the terminal state instead,
 		// consistent with the other control APIs.
 		return ErrClosed
 	}
 	c.dbMu.Lock()
 	defer c.dbMu.Unlock()
-	if index < 0 || index >= len(c.dbs) {
-		return fmt.Errorf("redis: multidb: database index %d out of range", index)
+	db, ok := c.dbs[id]
+	if !ok {
+		return fmt.Errorf("%w: %d", ErrDatabaseNotFound, id)
 	}
-	c.dbs[index].weight = weight
+	db.weight = weight
 	return nil
 }
 
@@ -1298,10 +1324,10 @@ func (c *multidbCore) setAutoFallback(enabled bool) {
 	c.autoFallbackDisabled.Store(!enabled)
 }
 
-func (c *multidbCore) addDatabaseHook(index int, hook Hook) error {
-	db := c.dbAt(index)
+func (c *multidbCore) addDatabaseHook(id int, hook Hook) error {
+	db := c.dbByID(id)
 	if db == nil {
-		return fmt.Errorf("redis: multidb: database index %d out of range", index)
+		return fmt.Errorf("%w: %d", ErrDatabaseNotFound, id)
 	}
 	if db.cc != nil {
 		db.cc.AddHook(hook)
@@ -1367,8 +1393,10 @@ func (c *multidbCore) startBackgroundLoop() {
 
 func (c *multidbCore) runHealthChecksOnce(ctx context.Context) {
 	c.dbMu.RLock()
-	dbs := make([]*multidbDatabase, len(c.dbs))
-	copy(dbs, c.dbs)
+	dbs := make([]*multidbDatabase, 0, len(c.dbs))
+	for _, db := range c.dbs {
+		dbs = append(dbs, db)
+	}
 	c.dbMu.RUnlock()
 
 	for _, db := range dbs {
@@ -1418,15 +1446,15 @@ func (c *multidbCore) tryFallbackToPrimary(ctx context.Context) {
 	// post-failover suppression window. Weights are captured under the lock
 	// (SetWeight mutates them under dbMu); the probes below run off-lock.
 	type fbCand struct {
-		pos    int
+		id     int
 		weight float64
 		db     *multidbDatabase
 	}
 	c.dbMu.RLock()
 	activeWeight := active.weight
 	var cands []fbCand
-	for i, db := range c.dbs {
-		if i == idx {
+	for id, db := range c.dbs {
+		if id == idx {
 			continue
 		}
 		// Skip a member still in its post-failover fallback-suppression window:
@@ -1436,7 +1464,7 @@ func (c *multidbCore) tryFallbackToPrimary(ctx context.Context) {
 			continue
 		}
 		if db.weight > activeWeight && db.cb.CheckState() == imultidb.CircuitClosed {
-			cands = append(cands, fbCand{i, db.weight, db})
+			cands = append(cands, fbCand{id, db.weight, db})
 		}
 	}
 	c.dbMu.RUnlock()
@@ -1452,14 +1480,17 @@ func (c *multidbCore) tryFallbackToPrimary(ctx context.Context) {
 	for len(cands) > 0 {
 		top := 0
 		for j := 1; j < len(cands); j++ {
-			if cands[j].weight > cands[top].weight {
+			// Highest weight wins; ties break by lowest id so map iteration
+			// order never decides which member fallback picks.
+			if cands[j].weight > cands[top].weight ||
+				(cands[j].weight == cands[top].weight && cands[j].id < cands[top].id) {
 				top = j
 			}
 		}
 		cand := cands[top]
 		cands = append(cands[:top], cands[top+1:]...)
 		if cand.db.checkHealthyNoRecord(ctx, c.opts.HealthCheckTimeout, cand.db.checks) {
-			best = cand.pos
+			best = cand.id
 			break
 		}
 	}

--- a/multidb_test.go
+++ b/multidb_test.go
@@ -193,8 +193,8 @@ func TestMultiDBActiveIsHighestWeight(t *testing.T) {
 	db3 := newTestDB("db3", "127.0.0.1:3", 1.0, true)
 	mdb := newTestMultiDB(t, baseOptions(), db1, db2, db3)
 
-	if got := mdb.ActiveIndex(); got != 1 {
-		t.Fatalf("active index = %d, want 1 (highest weight)", got)
+	if got := mdb.ActiveDatabaseID(); got != 1 {
+		t.Fatalf("active id = %d, want 1 (highest weight)", got)
 	}
 }
 
@@ -243,8 +243,8 @@ func TestMultiDBFailoverOnCommandFailures(t *testing.T) {
 	if err := mdb.Set(ctx, "k", "v", 0).Err(); err != nil {
 		t.Fatalf("Set after active failure: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 1 {
-		t.Fatalf("active index after failover = %d, want 1", got)
+	if got := mdb.ActiveDatabaseID(); got != 1 {
+		t.Fatalf("active id after failover = %d, want 1", got)
 	}
 	if db2.hook.commands.Load() == 0 {
 		t.Error("db2 did not receive the retried command")
@@ -259,12 +259,12 @@ func TestMultiDBFailoverOnCommandFailures(t *testing.T) {
 	}
 }
 
-// TestMultiDBSetActiveIndexUnhealthyTargetOpensBreaker covers fix C: a failed
+// TestMultiDBSetActiveDatabaseUnhealthyTargetOpensBreaker covers fix C: a failed
 // manual selection of a DIFFERENT member must open its breaker (like init and
 // AddDatabase), so a known-down target is not left selectable for the next
 // automatic failover. FailureThreshold=3, so the probe's single failure is not
 // enough on its own.
-func TestMultiDBSetActiveIndexUnhealthyTargetOpensBreaker(t *testing.T) {
+func TestMultiDBSetActiveDatabaseUnhealthyTargetOpensBreaker(t *testing.T) {
 	dbA := newTestDB("a", "127.0.0.1:1", 2, true) // active
 	dbB := newTestDB("b", "127.0.0.1:2", 1, true) // healthy at init, sick later
 	opts := baseOptions()
@@ -278,15 +278,15 @@ func TestMultiDBSetActiveIndexUnhealthyTargetOpensBreaker(t *testing.T) {
 
 	dbB.check.healthy.Store(false) // dbB now fails its probe
 
-	if err := mdb.SetActiveIndex(ctx, 1); !errors.Is(err, redis.ErrTargetUnhealthy) {
-		t.Fatalf("SetActiveIndex(1) = %v, want ErrTargetUnhealthy", err)
+	if err := mdb.SetActiveDatabase(ctx, 1); !errors.Is(err, redis.ErrTargetUnhealthy) {
+		t.Fatalf("SetActiveDatabase(1) = %v, want ErrTargetUnhealthy", err)
 	}
 	// The failed target's breaker must be open (not merely +1 failure).
 	if mdb.TestBreakerReserveHalfOpen(1) {
-		t.Error("dbB's breaker still admits after a failed SetActiveIndex; want opened")
+		t.Error("dbB's breaker still admits after a failed SetActiveDatabase; want opened")
 	}
 	// The active is unchanged.
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Errorf("active = %d, want 0 (unchanged by the failed selection)", got)
 	}
 }
@@ -304,11 +304,11 @@ func TestMultiDBFallbackDeclinesLaggyTarget(t *testing.T) {
 	ctx := context.Background()
 
 	// Move the active to the lower-weight dbA so dbB is a fallback target.
-	// ForceActiveIndex is manual, so it does not arm dbB's fallback-suppression.
-	if err := mdb.ForceActiveIndex(ctx, 0); err != nil {
-		t.Fatalf("ForceActiveIndex(0): %v", err)
+	// ForceActiveDatabase is manual, so it does not arm dbB's fallback-suppression.
+	if err := mdb.ForceActiveDatabase(ctx, 0); err != nil {
+		t.Fatalf("ForceActiveDatabase(0): %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Fatalf("active = %d, want 0 after force", got)
 	}
 
@@ -316,7 +316,7 @@ func TestMultiDBFallbackDeclinesLaggyTarget(t *testing.T) {
 	fbB.healthy.Store(false)
 	mdb.TestTryFallback()
 
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Errorf("fallback returned to the laggy higher-weight dbB (active=%d), want 0", got)
 	}
 	// The non-recording gate must not have evicted dbB.
@@ -340,16 +340,186 @@ func TestMultiDBFallbackSkipsLaggyToNextCandidate(t *testing.T) {
 	mdb := newTestMultiDB(t, baseOptions(), dbA, dbB, dbC)
 	ctx := context.Background()
 
-	// Init active = dbB (highest weight, idx 1); force down to dbA.
-	if err := mdb.ForceActiveIndex(ctx, 0); err != nil {
-		t.Fatalf("ForceActiveIndex(0): %v", err)
+	// Init active = dbB (highest weight, id 1); force down to dbA.
+	if err := mdb.ForceActiveDatabase(ctx, 0); err != nil {
+		t.Fatalf("ForceActiveDatabase(0): %v", err)
 	}
 
 	fbB.healthy.Store(false) // top-weight candidate is laggy now
 	mdb.TestTryFallback()
 
-	if got := mdb.ActiveIndex(); got != 2 {
+	if got := mdb.ActiveDatabaseID(); got != 2 {
 		t.Errorf("fallback active = %d, want 2 (healthy middle dbC, skipping laggy dbB)", got)
+	}
+}
+
+// TestMultiDBFailoverCallbackCarriesStableID: a failover callback identifies the
+// target by a stable id, so a concurrent RemoveDatabase of another member does
+// not make the delivered id name a different database.
+func TestMultiDBFailoverCallbackCarriesStableID(t *testing.T) {
+	db0 := newTestDB("db0", "127.0.0.1:1", 3.0, true) // id 0, initial active
+	db1 := newTestDB("db1", "127.0.0.1:2", 1.0, true) // id 1, removed below target
+	db2 := newTestDB("db2", "127.0.0.1:3", 2.0, true) // id 2, failover target
+
+	opts := baseOptions()
+	opts.CommandRetries = 3
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1, SuccessThreshold: 1, GracePeriod: time.Hour,
+	}
+	var failoverTo atomic.Int32
+	failoverTo.Store(-99)
+	var gotCallback atomic.Bool
+	opts.OnFailover = func(ctx context.Context, from, to int) {
+		failoverTo.Store(int32(to))
+		gotCallback.Store(true)
+	}
+	mdb := newTestMultiDB(t, opts, db0, db1, db2)
+	ctx := context.Background()
+	if got := mdb.ActiveDatabaseID(); got != 0 {
+		t.Fatalf("initial active = %d, want 0", got)
+	}
+	db0.hook.fail.Store(true)
+	if err := mdb.Set(ctx, "k", "v", 0).Err(); err != nil {
+		t.Fatalf("Set after active failure: %v", err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && !gotCallback.Load() {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !gotCallback.Load() {
+		t.Fatal("OnFailover not delivered")
+	}
+	to := int(failoverTo.Load())
+	if err := mdb.RemoveDatabase(ctx, 1); err != nil { // remove a non-active member
+		t.Fatalf("RemoveDatabase(1): %v", err)
+	}
+	if got := mdb.ActiveDatabaseID(); got != to {
+		t.Errorf("OnFailover delivered to=%d but ActiveDatabaseID()=%d after removal; handle went stale", to, got)
+	}
+}
+
+// TestMultiDBStableIDSurvivesRemoval: an id keeps naming the same database
+// across a RemoveDatabase, a removed id stays invalid, and new members draw
+// fresh ids without reusing freed ones.
+func TestMultiDBStableIDSurvivesRemoval(t *testing.T) {
+	db0 := newTestDB("db0", "127.0.0.1:1", 3.0, true) // id 0, active
+	db1 := newTestDB("db1", "127.0.0.1:2", 1.0, true) // id 1
+	db2 := newTestDB("db2", "127.0.0.1:3", 2.0, true) // id 2
+	mdb := newTestMultiDB(t, baseOptions(), db0, db1, db2)
+	ctx := context.Background()
+	if got := mdb.ActiveDatabaseID(); got != 0 {
+		t.Fatalf("initial active id = %d, want 0", got)
+	}
+	if err := mdb.RemoveDatabase(ctx, 1); err != nil {
+		t.Fatalf("RemoveDatabase(1): %v", err)
+	}
+	if got := mdb.ActiveDatabaseID(); got != 0 {
+		t.Errorf("active id after removal = %d, want 0 (stable)", got)
+	}
+	if err := mdb.SetWeight(2, 5.0); err != nil {
+		t.Errorf("SetWeight(2) after removal = %v, want nil (id 2 still valid)", err)
+	}
+	if err := mdb.RemoveDatabase(ctx, 1); !errors.Is(err, redis.ErrDatabaseNotFound) {
+		t.Errorf("RemoveDatabase(1) again = %v, want ErrDatabaseNotFound", err)
+	}
+	if err := mdb.SetWeight(1, 1.0); !errors.Is(err, redis.ErrDatabaseNotFound) {
+		t.Errorf("SetWeight(1) after removal = %v, want ErrDatabaseNotFound", err)
+	}
+	db3 := newTestDB("db3", "127.0.0.1:4", 1.0, true)
+	newID, err := mdb.AddDatabase(ctx, db3.cfg)
+	if err != nil {
+		t.Fatalf("AddDatabase: %v", err)
+	}
+	if newID != 3 {
+		t.Errorf("new member id = %d, want 3 (monotonic, no reuse of freed id 1)", newID)
+	}
+}
+
+type recordingStrategy struct {
+	mu   sync.Mutex
+	seen [][]int
+}
+
+func (s *recordingStrategy) Select(cands []redis.MultiDBDatabaseState) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ids := make([]int, 0, len(cands))
+	best, bestWeight := -1, 0.0
+	for _, c := range cands {
+		ids = append(ids, c.ID)
+		if c.Allowed && (best == -1 || c.Weight > bestWeight) {
+			best, bestWeight = c.ID, c.Weight
+		}
+	}
+	s.seen = append(s.seen, ids)
+	return best
+}
+
+func (s *recordingStrategy) lastSeen() []int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.seen) == 0 {
+		return nil
+	}
+	return s.seen[len(s.seen)-1]
+}
+
+// TestMultiDBStrategySeesStableID: the failover strategy is offered stable ids
+// in MultiDBDatabaseState.ID, not renumbered positions.
+func TestMultiDBStrategySeesStableID(t *testing.T) {
+	db0 := newTestDB("db0", "127.0.0.1:1", 3.0, true) // id 0, active
+	db1 := newTestDB("db1", "127.0.0.1:2", 1.0, true) // id 1, removed
+	db2 := newTestDB("db2", "127.0.0.1:3", 2.0, true) // id 2, failover target
+	strat := &recordingStrategy{}
+	opts := baseOptions()
+	opts.FailoverStrategy = strat
+	opts.CommandRetries = 3
+	opts.CircuitBreakerConfig = &redis.MultiDBCircuitBreakerConfig{
+		FailureThreshold: 1, SuccessThreshold: 1, GracePeriod: time.Hour,
+	}
+	mdb := newTestMultiDB(t, opts, db0, db1, db2)
+	ctx := context.Background()
+	if err := mdb.RemoveDatabase(ctx, 1); err != nil {
+		t.Fatalf("RemoveDatabase(1): %v", err)
+	}
+	strat.mu.Lock()
+	strat.seen = nil
+	strat.mu.Unlock()
+	db0.hook.fail.Store(true)
+	if err := mdb.Set(ctx, "k", "v", 0).Err(); err != nil {
+		t.Fatalf("Set after active failure: %v", err)
+	}
+	if got := mdb.ActiveDatabaseID(); got != 2 {
+		t.Fatalf("active id after failover = %d, want 2 (db2)", got)
+	}
+	// After removing id 1 and excluding the active (id 0), the only candidate is
+	// db2 — and it must be offered by its stable id 2, not a renumbered position.
+	offered := strat.lastSeen()
+	if len(offered) != 1 || offered[0] != 2 {
+		t.Errorf("strategy offered candidate ids %v, want exactly [2] (db2 by stable id)", offered)
+	}
+}
+
+// TestMultiDBOutOfRangeIDNotTruncated pins the int-width contract: an id outside
+// the int32 range must resolve to no member, never alias one. With a map[int]
+// store this is inherent; the test guards against a regression to narrow keys.
+func TestMultiDBOutOfRangeIDNotTruncated(t *testing.T) {
+	if ^uint(0)>>32 == 0 {
+		t.Skip("int is 32-bit: high-bit truncation cannot occur")
+	}
+	db0 := newTestDB("db0", "127.0.0.1:1", 1, true)
+	db1 := newTestDB("db1", "127.0.0.1:2", 2, true) // active
+	mdb := newTestMultiDB(t, baseOptions(), db0, db1)
+	ctx := context.Background()
+	aliasID := int(int64(1) << 32) // int32(aliasID) == 0 would alias member 0
+	if err := mdb.SetActiveDatabase(ctx, aliasID); !errors.Is(err, redis.ErrDatabaseNotFound) {
+		t.Errorf("SetActiveDatabase(1<<32) = %v, want ErrDatabaseNotFound", err)
+	}
+	if err := mdb.RemoveDatabase(ctx, aliasID); !errors.Is(err, redis.ErrDatabaseNotFound) {
+		t.Errorf("RemoveDatabase(1<<32) = %v, want ErrDatabaseNotFound", err)
+	}
+	if got := mdb.ActiveDatabaseID(); got != 1 {
+		t.Errorf("active id = %d, want 1 (unchanged by out-of-range ops)", got)
 	}
 }
 
@@ -400,7 +570,7 @@ func TestMultiDBEscalation(t *testing.T) {
 	}
 }
 
-// After an operator reset (ForceActiveIndex), a fresh outage must escalate
+// After an operator reset (ForceActiveDatabase), a fresh outage must escalate
 // from zero. If the reset clears failoverAttempts but not lastFailoverAttempt,
 // the FailoverAttemptDelay gate treats the new chain's first failure as part of
 // the old burst and never escalates — permanently stuck on temporary here,
@@ -440,8 +610,8 @@ func TestMultiDBEscalationResetsTimestampOnOperatorSelection(t *testing.T) {
 	escalateToPermanent("first outage")
 
 	// Operator forces back to db1: resets the escalation chain.
-	if err := mdb.ForceActiveIndex(ctx, 0); err != nil {
-		t.Fatalf("ForceActiveIndex: %v", err)
+	if err := mdb.ForceActiveDatabase(ctx, 0); err != nil {
+		t.Fatalf("ForceActiveDatabase: %v", err)
 	}
 
 	// A distinct outage within FailoverAttemptDelay must escalate from zero
@@ -458,37 +628,37 @@ func TestMultiDBManualFailover(t *testing.T) {
 	mdb := newTestMultiDB(t, opts, db1, db2)
 	ctx := context.Background()
 
-	// SetActiveIndex probes the target and must refuse the unhealthy one.
-	if err := mdb.SetActiveIndex(ctx, 1); !errors.Is(err, redis.ErrTargetUnhealthy) {
-		t.Fatalf("SetActiveIndex to unhealthy target: err = %v, want ErrTargetUnhealthy", err)
+	// SetActiveDatabase probes the target and must refuse the unhealthy one.
+	if err := mdb.SetActiveDatabase(ctx, 1); !errors.Is(err, redis.ErrTargetUnhealthy) {
+		t.Fatalf("SetActiveDatabase to unhealthy target: err = %v, want ErrTargetUnhealthy", err)
 	}
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Fatalf("active changed to %d after refused switch", got)
 	}
 
-	// ForceActiveIndex switches unconditionally.
-	if err := mdb.ForceActiveIndex(ctx, 1); err != nil {
-		t.Fatalf("ForceActiveIndex: %v", err)
+	// ForceActiveDatabase switches unconditionally.
+	if err := mdb.ForceActiveDatabase(ctx, 1); err != nil {
+		t.Fatalf("ForceActiveDatabase: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 1 {
-		t.Fatalf("active index = %d after force, want 1", got)
+	if got := mdb.ActiveDatabaseID(); got != 1 {
+		t.Fatalf("active id = %d after force, want 1", got)
 	}
 
-	// Once the target is healthy, SetActiveIndex succeeds.
+	// Once the target is healthy, SetActiveDatabase succeeds.
 	db1.check.healthy.Store(true)
-	if err := mdb.SetActiveIndex(ctx, 0); err != nil {
-		t.Fatalf("SetActiveIndex to healthy target: %v", err)
+	if err := mdb.SetActiveDatabase(ctx, 0); err != nil {
+		t.Fatalf("SetActiveDatabase to healthy target: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 0 {
-		t.Fatalf("active index = %d, want 0", got)
+	if got := mdb.ActiveDatabaseID(); got != 0 {
+		t.Fatalf("active id = %d, want 0", got)
 	}
 
-	// Out-of-range index errors on both methods.
-	if err := mdb.SetActiveIndex(ctx, 9); err == nil {
-		t.Error("SetActiveIndex(9) should fail")
+	// An unknown id errors on both methods.
+	if err := mdb.SetActiveDatabase(ctx, 9); err == nil {
+		t.Error("SetActiveDatabase(9) should fail")
 	}
-	if err := mdb.ForceActiveIndex(ctx, -1); err == nil {
-		t.Error("ForceActiveIndex(-1) should fail")
+	if err := mdb.ForceActiveDatabase(ctx, -1); err == nil {
+		t.Error("ForceActiveDatabase(-1) should fail")
 	}
 }
 
@@ -500,15 +670,15 @@ func TestMultiDBRuntimeMembership(t *testing.T) {
 
 	db3 := newTestDB("db3", "127.0.0.1:3", 3.0, true)
 	db3.cfg.SkipInitialHealthCheck = true
-	idx, err := mdb.AddDatabase(ctx, db3.cfg)
+	id, err := mdb.AddDatabase(ctx, db3.cfg)
 	if err != nil {
 		t.Fatalf("AddDatabase: %v", err)
 	}
-	if idx != 2 {
-		t.Fatalf("AddDatabase index = %d, want 2", idx)
+	if id != 2 {
+		t.Fatalf("AddDatabase id = %d, want 2", id)
 	}
 
-	if err := mdb.SetWeight(idx, 5.0); err != nil {
+	if err := mdb.SetWeight(id, 5.0); err != nil {
 		t.Fatalf("SetWeight: %v", err)
 	}
 	if err := mdb.SetWeight(42, 1.0); err == nil {
@@ -516,7 +686,7 @@ func TestMultiDBRuntimeMembership(t *testing.T) {
 	}
 
 	// Cannot remove the active database.
-	if err := mdb.RemoveDatabase(ctx, mdb.ActiveIndex()); err == nil {
+	if err := mdb.RemoveDatabase(ctx, mdb.ActiveDatabaseID()); err == nil {
 		t.Error("RemoveDatabase(active) should fail")
 	}
 	if err := mdb.RemoveDatabase(ctx, 1); err != nil {
@@ -571,17 +741,17 @@ func TestMultiDBBackgroundFailover(t *testing.T) {
 	mdb := newTestMultiDB(t, opts, db1, db2)
 
 	// No command traffic at all: the background loop alone must move the
-	// active index when the active database's health checks start failing.
+	// active id when the active database's health checks start failing.
 	db1.check.healthy.Store(false)
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if mdb.ActiveIndex() == 1 {
+		if mdb.ActiveDatabaseID() == 1 {
 			return // success
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("background loop never failed over; active = %d", mdb.ActiveIndex())
+	t.Fatalf("background loop never failed over; active = %d", mdb.ActiveDatabaseID())
 }
 
 func TestMultiDBAutoFallback(t *testing.T) {
@@ -605,21 +775,21 @@ func TestMultiDBAutoFallback(t *testing.T) {
 	// Fail db1 → background failover to db2.
 	db1.check.healthy.Store(false)
 	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) && mdb.ActiveIndex() != 1 {
+	for time.Now().Before(deadline) && mdb.ActiveDatabaseID() != 1 {
 		time.Sleep(10 * time.Millisecond)
 	}
-	if mdb.ActiveIndex() != 1 {
+	if mdb.ActiveDatabaseID() != 1 {
 		t.Fatal("setup: background failover to db2 never happened")
 	}
 
 	// Recover db1 (higher weight) → auto-fallback should switch back.
 	db1.check.healthy.Store(true)
 	deadline = time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) && mdb.ActiveIndex() != 0 {
+	for time.Now().Before(deadline) && mdb.ActiveDatabaseID() != 0 {
 		time.Sleep(10 * time.Millisecond)
 	}
-	if mdb.ActiveIndex() != 0 {
-		t.Fatalf("auto-fallback never returned to db1; active = %d", mdb.ActiveIndex())
+	if mdb.ActiveDatabaseID() != 0 {
+		t.Fatalf("auto-fallback never returned to db1; active = %d", mdb.ActiveDatabaseID())
 	}
 	// OnActiveDatabaseChanged is delivered asynchronously; give the queue a
 	// beat to drain the second change before asserting the count.
@@ -643,7 +813,7 @@ func TestMultiDBInitSelectsProbeHealthyDatabase(t *testing.T) {
 	opts.InitialDBState = redis.InitialDBStateOneAvailable
 	mdb := newTestMultiDB(t, opts, db1, db2)
 
-	if got := mdb.ActiveIndex(); got != 1 {
+	if got := mdb.ActiveDatabaseID(); got != 1 {
 		t.Fatalf("initial active = %d, want 1 (the probe-healthy member)", got)
 	}
 }
@@ -741,8 +911,8 @@ func TestMultiDBCallerCanceledDialStaysNeutral(t *testing.T) {
 	if !mdb.TestBreakerReserveHalfOpen(0) {
 		t.Error("caller-canceled dial opened db1 breaker; the outcome must be neutral")
 	}
-	if got := mdb.ActiveIndex(); got != 0 {
-		t.Errorf("active index = %d, want 0 (no failover on caller cancel)", got)
+	if got := mdb.ActiveDatabaseID(); got != 0 {
+		t.Errorf("active id = %d, want 0 (no failover on caller cancel)", got)
 	}
 }
 
@@ -803,10 +973,10 @@ func (h *gatedHealthCheck) CheckClusterHealth(context.Context, *redis.ClusterCli
 	return true, nil
 }
 
-// setActiveIndex must not mutate state or report success when the client is
+// setActiveDatabaseID must not mutate state or report success when the client is
 // closed DURING its probe: close() takes no lock, so it can drain the
 // membership while the probe (bounded by HealthCheckTimeout) is still running.
-func TestMultiDBSetActiveIndexLosesToConcurrentClose(t *testing.T) {
+func TestMultiDBSetActiveDatabaseLosesToConcurrentClose(t *testing.T) {
 	db1 := newTestDB("db1", "127.0.0.1:1", 2.0, true) // active (higher weight)
 	db2 := newTestDB("db2", "127.0.0.1:2", 1.0, true)
 
@@ -828,19 +998,21 @@ func TestMultiDBSetActiveIndexLosesToConcurrentClose(t *testing.T) {
 	gate.armed.Store(true) // construction done; the next probe blocks
 
 	errCh := make(chan error, 1)
-	go func() { errCh <- mdb.SetActiveIndex(context.Background(), 1) }()
+	go func() { errCh <- mdb.SetActiveDatabase(context.Background(), 1) }()
 
-	<-gate.started // SetActiveIndex is now inside db2's probe, holding failoverMu
+	<-gate.started // SetActiveDatabase is now inside db2's probe, holding failoverMu
 	if err := mdb.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	close(gate.release) // let the probe finish; setActiveIndex resumes post-probe
+	close(gate.release) // let the probe finish; setActiveDatabaseID resumes post-probe
 
 	if err := <-errCh; !errors.Is(err, redis.ErrClosed) {
-		t.Fatalf("SetActiveIndex racing Close = %v, want ErrClosed", err)
+		t.Fatalf("SetActiveDatabase racing Close = %v, want ErrClosed", err)
 	}
-	if got := mdb.ActiveIndex(); got != 0 {
-		t.Errorf("active index = %d, want 0 (no switch on a closed client)", got)
+	// The ErrClosed return proves the switch was skipped; Close then drains the
+	// membership, so the active id reports -1 rather than a stale value.
+	if got := mdb.ActiveDatabaseID(); got != -1 {
+		t.Errorf("active id = %d, want -1 (membership drained on a closed client)", got)
 	}
 }
 
@@ -864,7 +1036,7 @@ func TestMultiDBClientSideErrorsDoNotFailOver(t *testing.T) {
 	if err := mdb.Set(cctx, "k", "v", 0).Err(); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Set with canceled ctx: err = %v, want context.Canceled", err)
 	}
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Fatalf("client-side error caused failover; active = %d", got)
 	}
 	// The database is still healthy and serving.
@@ -893,7 +1065,7 @@ func TestMultiDBLocalRedisErrorIsNeutral(t *testing.T) {
 	if err := mdb.Get(ctx, "k").Err(); !errors.Is(err, redis.ErrCrossSlot) {
 		t.Fatalf("Get: err = %v, want ErrCrossSlot", err)
 	}
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Fatalf("local error caused failover; active = %d", got)
 	}
 	if got := db1.hook.commands.Load(); got != 1 {
@@ -947,24 +1119,24 @@ func TestMultiDBManualFailoverResetsBreaker(t *testing.T) {
 
 	// Open db2's breaker: force it active while failing, let a command fail.
 	db2.hook.fail.Store(true)
-	if err := mdb.ForceActiveIndex(ctx, 1); err != nil {
-		t.Fatalf("ForceActiveIndex: %v", err)
+	if err := mdb.ForceActiveDatabase(ctx, 1); err != nil {
+		t.Fatalf("ForceActiveDatabase: %v", err)
 	}
 	_ = mdb.Set(ctx, "k", "v", 0).Err() // opens db2's breaker, fails over back to db1
 
 	// db2 recovers before the grace period; the manual probe passes and must
 	// reset the still-open breaker, or the switch would immediately fail away.
 	db2.hook.fail.Store(false)
-	if err := mdb.SetActiveIndex(ctx, 1); err != nil {
-		t.Fatalf("SetActiveIndex after recovery: %v", err)
+	if err := mdb.SetActiveDatabase(ctx, 1); err != nil {
+		t.Fatalf("SetActiveDatabase after recovery: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 1 {
+	if got := mdb.ActiveDatabaseID(); got != 1 {
 		t.Fatalf("active = %d, want 1", got)
 	}
 	if err := mdb.Set(ctx, "k", "v", 0).Err(); err != nil {
 		t.Fatalf("Set on manually selected member: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 1 {
+	if got := mdb.ActiveDatabaseID(); got != 1 {
 		t.Fatalf("switch did not stick; active = %d", got)
 	}
 }
@@ -1022,7 +1194,7 @@ func TestMultiDBFailoverSkipsStartupUnhealthyMember(t *testing.T) {
 	}
 }
 
-func TestMultiDBForceActiveIndexThroughOpenBreaker(t *testing.T) {
+func TestMultiDBForceActiveDatabaseThroughOpenBreaker(t *testing.T) {
 	db1 := newTestDB("db1", "127.0.0.1:1", 2.0, true)
 	db2 := newTestDB("db2", "127.0.0.1:2", 1.0, true)
 
@@ -1038,19 +1210,19 @@ func TestMultiDBForceActiveIndexThroughOpenBreaker(t *testing.T) {
 
 	// Open db2's breaker organically.
 	db2.hook.fail.Store(true)
-	_ = mdb.ForceActiveIndex(ctx, 1)
+	_ = mdb.ForceActiveDatabase(ctx, 1)
 	_ = mdb.Set(ctx, "k", "v", 0).Err() // fails on db2, opens breaker, fails over back
 
 	// db2 recovers; the forced override must reset the open breaker so the
 	// switch sticks instead of failing away on the next command.
 	db2.hook.fail.Store(false)
-	if err := mdb.ForceActiveIndex(ctx, 1); err != nil {
-		t.Fatalf("ForceActiveIndex: %v", err)
+	if err := mdb.ForceActiveDatabase(ctx, 1); err != nil {
+		t.Fatalf("ForceActiveDatabase: %v", err)
 	}
 	if err := mdb.Set(ctx, "k", "v", 0).Err(); err != nil {
 		t.Fatalf("Set on forced member: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 1 {
+	if got := mdb.ActiveDatabaseID(); got != 1 {
 		t.Fatalf("forced switch did not stick; active = %d", got)
 	}
 }
@@ -1110,8 +1282,8 @@ func TestMultiDBConcurrentProcess(t *testing.T) {
 	}
 	wg.Wait()
 
-	if got := mdb.ActiveIndex(); got != 1 {
-		t.Fatalf("active index = %d after concurrent failover, want 1", got)
+	if got := mdb.ActiveDatabaseID(); got != 1 {
+		t.Fatalf("active id = %d after concurrent failover, want 1", got)
 	}
 }
 
@@ -1213,40 +1385,40 @@ func TestMultiDBRecoveredActiveClearsTrippedDetector(t *testing.T) {
 	}
 }
 
-func TestMultiDBAddDatabaseCallbackSeesNewIndex(t *testing.T) {
+func TestMultiDBAddDatabaseCallbackSeesNewID(t *testing.T) {
 	dbA := newTestDB("a", "db-a:6379", 2, true)
 
 	var mu sync.Mutex
-	var indexes []int
+	var ids []int
 	opts := baseOptions()
-	opts.OnCircuitStateChanged = func(dbIndex int, from, to string) {
+	opts.OnCircuitStateChanged = func(dbID int, from, to string) {
 		mu.Lock()
-		indexes = append(indexes, dbIndex)
+		ids = append(ids, dbID)
 		mu.Unlock()
 	}
 	mdb := newTestMultiDB(t, opts, dbA)
 
 	// Adding an unhealthy member opens its breaker during the initial probe;
-	// the state-change callback must report the member's real index, not the
-	// zero default.
+	// the state-change callback must report the member's real id, not the zero
+	// default.
 	dbB := newTestDB("b", "db-b:6379", 1, false)
-	idx, err := mdb.AddDatabase(context.Background(), dbB.cfg)
+	id, err := mdb.AddDatabase(context.Background(), dbB.cfg)
 	if err != nil {
 		t.Fatalf("AddDatabase: %v", err)
 	}
-	if idx != 1 {
-		t.Fatalf("AddDatabase index = %d, want 1", idx)
+	if id != 1 {
+		t.Fatalf("AddDatabase id = %d, want 1", id)
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		mu.Lock()
-		got := append([]int(nil), indexes...)
+		got := append([]int(nil), ids...)
 		mu.Unlock()
 		if len(got) > 0 {
 			for _, i := range got {
 				if i != 1 {
-					t.Fatalf("circuit state callback reported index %d, want 1 (all: %v)", i, got)
+					t.Fatalf("circuit state callback reported id %d, want 1 (all: %v)", i, got)
 				}
 			}
 			return
@@ -1268,7 +1440,7 @@ func TestMultiDBCircuitCallbackMayCallControlAPIs(t *testing.T) {
 		FailureThreshold: 1,
 		SuccessThreshold: 1,
 	}
-	opts.OnCircuitStateChanged = func(dbIndex int, from, to string) {
+	opts.OnCircuitStateChanged = func(dbID int, from, to string) {
 		if mdb := mdbRef.Load(); mdb != nil {
 			// Any control API that serializes on the failover lock.
 			_ = mdb.RemoveDatabase(context.Background(), 99)
@@ -1286,14 +1458,14 @@ func TestMultiDBCircuitCallbackMayCallControlAPIs(t *testing.T) {
 	// reset, firing the state callback. A callback that re-enters a control
 	// API must not deadlock the switch.
 	done := make(chan error, 1)
-	go func() { done <- mdb.SetActiveIndex(context.Background(), 0) }()
+	go func() { done <- mdb.SetActiveDatabase(context.Background(), 0) }()
 	select {
 	case err := <-done:
 		if err != nil {
-			t.Fatalf("SetActiveIndex: %v", err)
+			t.Fatalf("SetActiveDatabase: %v", err)
 		}
 	case <-time.After(3 * time.Second):
-		t.Fatal("SetActiveIndex deadlocked with a re-entrant circuit state callback")
+		t.Fatal("SetActiveDatabase deadlocked with a re-entrant circuit state callback")
 	}
 }
 
@@ -1488,7 +1660,7 @@ func TestMultiDBAutoFallbackDoesNotUndoDetectorFailover(t *testing.T) {
 		GracePeriod:      time.Hour,
 	}
 	mdb := newTestMultiDB(t, opts, dbA, dbB)
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Fatalf("setup: active=%d, want 0", got)
 	}
 
@@ -1496,7 +1668,7 @@ func TestMultiDBAutoFallbackDoesNotUndoDetectorFailover(t *testing.T) {
 	// breaker (threshold 100).
 	det.tripped.Store(true)
 	_ = mdb.Set(context.Background(), "k", "v", 0).Err()
-	if got := mdb.ActiveIndex(); got != 1 {
+	if got := mdb.ActiveDatabaseID(); got != 1 {
 		t.Fatalf("detector failover: active=%d, want 1", got)
 	}
 	if !mdb.TestBreakerReserveHalfOpen(0) {
@@ -1508,7 +1680,7 @@ func TestMultiDBAutoFallbackDoesNotUndoDetectorFailover(t *testing.T) {
 	// keep the client on B.
 	det.tripped.Store(false)
 	mdb.TestTryFallback()
-	if got := mdb.ActiveIndex(); got != 1 {
+	if got := mdb.ActiveDatabaseID(); got != 1 {
 		t.Errorf("auto-fallback bounced to A (active=%d); it must not undo the detector failover", got)
 	}
 }
@@ -1563,35 +1735,35 @@ func TestMultiDBSurfacedRedirectTriggersFailover(t *testing.T) {
 	if err := mdb.Get(context.Background(), "k").Err(); err != nil {
 		t.Fatalf("Get should have failed over to B and succeeded: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 1 {
-		t.Errorf("active index = %d, want 1 (surfaced MOVED must trigger failover)", got)
+	if got := mdb.ActiveDatabaseID(); got != 1 {
+		t.Errorf("active id = %d, want 1 (surfaced MOVED must trigger failover)", got)
 	}
 }
 
-// badStrategy always returns a fixed index, used to test that an out-of-range
+// badStrategy always returns a fixed id, used to test that an unknown-id
 // selection is rejected rather than stored as the active.
-type badStrategy struct{ idx int }
+type badStrategy struct{ id int }
 
-func (s badStrategy) Select([]redis.MultiDBDatabaseState) int { return s.idx }
+func (s badStrategy) Select([]redis.MultiDBDatabaseState) int { return s.id }
 
-func TestMultiDBInvalidStrategyIndexRejected(t *testing.T) {
+func TestMultiDBInvalidStrategyIDRejected(t *testing.T) {
 	db1 := newTestDB("db1", "127.0.0.1:1", 2, true)
 	db2 := newTestDB("db2", "127.0.0.1:2", 1, true)
 	opts := baseOptions()
-	opts.FailoverStrategy = badStrategy{idx: 99} // out of range
+	opts.FailoverStrategy = badStrategy{id: 99} // no such member
 	opts.Clients = append(opts.Clients, db1.cfg, db2.cfg)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	// Both members are healthy, so the only reason selection can fail is the
-	// strategy returning an out-of-range index. It must be rejected (not stored
-	// as the active or used to index a nil member) and surface as a clean error
-	// rather than a panic.
+	// strategy returning an id that names no candidate. It must be rejected
+	// (not stored as the active or used to resolve a nil member) and surface as
+	// a clean error rather than a panic.
 	mdb, err := redis.NewMultiDBClient(ctx, opts)
 	if mdb != nil {
 		_ = mdb.Close()
 	}
 	if !errors.Is(err, redis.ErrInsufficientHealthyDatabases) {
-		t.Fatalf("bad strategy index: err = %v, want ErrInsufficientHealthyDatabases", err)
+		t.Fatalf("bad strategy id: err = %v, want ErrInsufficientHealthyDatabases", err)
 	}
 }
 
@@ -1650,7 +1822,7 @@ type switchThenFailHook struct {
 func (*switchThenFailHook) DialHook(next redis.DialHook) redis.DialHook { return next }
 func (h *switchThenFailHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
 	return func(ctx context.Context, cmd redis.Cmder) error {
-		h.once.Do(func() { _ = h.mdb.ForceActiveIndex(context.Background(), h.to) })
+		h.once.Do(func() { _ = h.mdb.ForceActiveDatabase(context.Background(), h.to) })
 		cmd.SetErr(io.EOF)
 		return io.EOF
 	}
@@ -1716,7 +1888,7 @@ func TestMultiDBFallbackResetsDetector(t *testing.T) {
 	// Fail A over to B.
 	dbA.hook.fail.Store(true)
 	_ = mdb.Get(ctx, "k").Err()
-	if got := mdb.ActiveIndex(); got != 1 {
+	if got := mdb.ActiveDatabaseID(); got != 1 {
 		t.Fatalf("active = %d, want 1 after failover", got)
 	}
 
@@ -1727,7 +1899,7 @@ func TestMultiDBFallbackResetsDetector(t *testing.T) {
 	dbA.hook.fail.Store(false)
 	det.tripped.Store(true)
 	deadline := time.Now().Add(3 * time.Second)
-	for mdb.ActiveIndex() != 0 {
+	for mdb.ActiveDatabaseID() != 0 {
 		if time.Now().After(deadline) {
 			t.Fatal("auto-fallback to member 0 never happened")
 		}
@@ -1737,7 +1909,7 @@ func TestMultiDBFallbackResetsDetector(t *testing.T) {
 	if err := mdb.Get(ctx, "k").Err(); err != nil {
 		t.Fatalf("Get after fallback: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Errorf("tripped detector failed away from the just-recovered primary: active = %d", got)
 	}
 }
@@ -1753,17 +1925,17 @@ func TestMultiDBNoCallbacksForRemovedMember(t *testing.T) {
 		FailureThreshold: 1,
 		SuccessThreshold: 1,
 	}
-	opts.OnCircuitStateChanged = func(dbIndex int, from, to string) {
+	opts.OnCircuitStateChanged = func(dbID int, from, to string) {
 		mu.Lock()
-		events = append(events, dbIndex)
+		events = append(events, dbID)
 		mu.Unlock()
 	}
 	mdb := newTestMultiDB(t, opts, dbA, dbB)
 
 	// Reproduce the background-loop race deterministically: snapshot B like
 	// runHealthChecksOnce does, remove it, then run the stale probe. The
-	// removed member's breaker transition must not fire a user callback —
-	// its recorded index is stale after the slice shift.
+	// removed member's breaker transition must not fire a user callback — its
+	// `removed` flag, set on removal, suppresses delivery.
 	dbB.check.healthy.Store(false)
 	mdb.TestProbeRacingRemoval(1)
 
@@ -1772,7 +1944,7 @@ func TestMultiDBNoCallbacksForRemovedMember(t *testing.T) {
 	got := append([]int(nil), events...)
 	mu.Unlock()
 	if len(got) != 0 {
-		t.Errorf("stale probe of a removed member fired callbacks: indexes %v", got)
+		t.Errorf("stale probe of a removed member fired callbacks: ids %v", got)
 	}
 }
 
@@ -1929,8 +2101,8 @@ func TestMultiDBFailbackOnlyCheckDoesNotEvictActive(t *testing.T) {
 
 	// The ACTIVE member must not be evicted by the lag verdict: its breaker
 	// stays closed and traffic keeps flowing.
-	if got := mdb.ActiveIndex(); got != 0 {
-		t.Fatalf("active index = %d, want 0 (lag must not evict the active)", got)
+	if got := mdb.ActiveDatabaseID(); got != 0 {
+		t.Fatalf("active id = %d, want 0 (lag must not evict the active)", got)
 	}
 	if err := mdb.Ping(context.Background()).Err(); err != nil {
 		t.Errorf("Ping after health pass: %v (active breaker must stay closed)", err)
@@ -1945,9 +2117,9 @@ func TestMultiDBFailbackOnlyCheckDoesNotEvictActive(t *testing.T) {
 }
 
 // Re-selecting the current active must not be gated by a fail-back-only check:
-// SetActiveIndex(activeIndex) with a failing lag check must succeed and must
-// not record a failure on the active's breaker.
-func TestMultiDBSetActiveIndexReselectIgnoresFailbackOnly(t *testing.T) {
+// SetActiveDatabase on the current active with a failing lag check must succeed
+// and must not record a failure on the active's breaker.
+func TestMultiDBSetActiveDatabaseReselectIgnoresFailbackOnly(t *testing.T) {
 	dbA := newTestDB("a", "127.0.0.1:1", 2, true) // active (higher weight)
 	dbB := newTestDB("b", "127.0.0.1:2", 1, true)
 	fbA := newFailbackOnlyCheck(true)
@@ -1960,16 +2132,16 @@ func TestMultiDBSetActiveIndexReselectIgnoresFailbackOnly(t *testing.T) {
 		GracePeriod:      time.Hour,
 	}
 	mdb := newTestMultiDB(t, opts, dbA, dbB)
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Fatalf("setup: active=%d, want 0", got)
 	}
 
 	fbA.healthy.Store(false) // lag breach on the active
-	if err := mdb.SetActiveIndex(context.Background(), 0); err != nil {
-		t.Fatalf("SetActiveIndex(current active) with a failing fail-back-only check = %v, want nil", err)
+	if err := mdb.SetActiveDatabase(context.Background(), 0); err != nil {
+		t.Fatalf("SetActiveDatabase(current active) with a failing fail-back-only check = %v, want nil", err)
 	}
-	if got := mdb.ActiveIndex(); got != 0 {
-		t.Errorf("active index = %d, want 0", got)
+	if got := mdb.ActiveDatabaseID(); got != 0 {
+		t.Errorf("active id = %d, want 0", got)
 	}
 	if !mdb.TestBreakerReserveHalfOpen(0) {
 		t.Error("re-selecting the active recorded a fail-back-only failure on its breaker")
@@ -1978,7 +2150,7 @@ func TestMultiDBSetActiveIndexReselectIgnoresFailbackOnly(t *testing.T) {
 
 // Under concurrency, OnActiveDatabaseChanged deliveries must form a contiguous
 // chain (each `to` == the next `from`). Switches are serialized by failoverMu
-// and each does current->index, so the chain only holds if the callbacks are
+// and each does current->id, so the chain only holds if the callbacks are
 // enqueued in switch order — the bug being that enqueuing in the announce
 // closure (after failoverMu is released) lets two switches reorder.
 func TestMultiDBActiveChangeCallbackOrderUnderConcurrency(t *testing.T) {
@@ -2003,7 +2175,7 @@ func TestMultiDBActiveChangeCallbackOrderUnderConcurrency(t *testing.T) {
 		go func(g int) {
 			defer wg.Done()
 			for i := 0; i < 300; i++ {
-				_ = mdb.ForceActiveIndex(ctx, (g+i)%3)
+				_ = mdb.ForceActiveDatabase(ctx, (g+i)%3)
 			}
 		}(g)
 	}
@@ -2198,7 +2370,7 @@ func TestMultiDBPanickyCircuitCallbackDoesNotStallQueue(t *testing.T) {
 		FailureThreshold: 1,
 		SuccessThreshold: 1,
 	}
-	opts.OnCircuitStateChanged = func(dbIndex int, from, to string) {
+	opts.OnCircuitStateChanged = func(dbID int, from, to string) {
 		if panicked.CompareAndSwap(false, true) {
 			panic("panicky circuit callback")
 		}
@@ -2211,8 +2383,8 @@ func TestMultiDBPanickyCircuitCallbackDoesNotStallQueue(t *testing.T) {
 	// which must neither crash the process nor wedge the queue — the next
 	// transition's callback must still be delivered.
 	mdb.TestBreakerRecordFailure(0) // closed -> open: first callback panics
-	if err := mdb.ForceActiveIndex(context.Background(), 0); err != nil {
-		t.Fatalf("ForceActiveIndex: %v", err) // resets the breaker: open -> closed
+	if err := mdb.ForceActiveDatabase(context.Background(), 0); err != nil {
+		t.Fatalf("ForceActiveDatabase: %v", err) // resets the breaker: open -> closed
 	}
 
 	deadline := time.Now().Add(2 * time.Second)
@@ -2266,11 +2438,11 @@ func TestMultiDBCanceledHealthyProbeDoesNotSwitch(t *testing.T) {
 
 	// The probe reports healthy, but the caller's context died while it ran:
 	// a canceled control operation must not mutate the active state.
-	if err := mdb.SetActiveIndex(parent, 1); !errors.Is(err, context.Canceled) {
-		t.Fatalf("SetActiveIndex = %v, want context.Canceled", err)
+	if err := mdb.SetActiveDatabase(parent, 1); !errors.Is(err, context.Canceled) {
+		t.Fatalf("SetActiveDatabase = %v, want context.Canceled", err)
 	}
-	if got := mdb.ActiveIndex(); got != 0 {
-		t.Errorf("canceled SetActiveIndex switched the active database to %d", got)
+	if got := mdb.ActiveDatabaseID(); got != 0 {
+		t.Errorf("canceled SetActiveDatabase switched the active database to %d", got)
 	}
 }
 
@@ -2307,7 +2479,7 @@ func TestMultiDBCanceledHealthyPreFailoverProbeDoesNotSwitch(t *testing.T) {
 	if err := mdb.Get(parent, "k").Err(); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Get = %v, want context.Canceled", err)
 	}
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Errorf("canceled attempt switched the active database to %d", got)
 	}
 }
@@ -2349,7 +2521,7 @@ func TestMultiDBAllHalfOpenFullReturnsUnavailable(t *testing.T) {
 	// Every member half-open with its probe budget exhausted: the gate
 	// rejects each candidate, and failover keeps finding "selectable"
 	// half-open members. This must surface ErrTemporarilyNotAvailable, not
-	// ping-pong the active index in a busy loop until the context dies.
+	// ping-pong the active id in a busy loop until the context dies.
 	mdb.TestBreakerRecordFailure(0)
 	mdb.TestBreakerRecordFailure(1)
 	time.Sleep(50 * time.Millisecond)
@@ -2377,16 +2549,16 @@ func TestMultiDBStaleBreakerRecordAfterRemovalFiresNoCallback(t *testing.T) {
 		FailureThreshold: 1,
 		SuccessThreshold: 1,
 	}
-	opts.OnCircuitStateChanged = func(dbIndex int, from, to string) {
+	opts.OnCircuitStateChanged = func(dbID int, from, to string) {
 		mu.Lock()
-		events = append(events, dbIndex)
+		events = append(events, dbID)
 		mu.Unlock()
 	}
 	mdb := newTestMultiDB(t, opts, dbA, dbB)
 
 	// A breaker outcome that lands AFTER the member was removed (the probe
 	// passed its removed-check just before the removal) must not surface a
-	// user callback: the recorded index is stale after the slice shift.
+	// user callback: the member is gone and its `removed` flag suppresses it.
 	mdb.TestStaleRecordAfterRemoval(1)
 
 	time.Sleep(300 * time.Millisecond) // callbacks are delivered asynchronously
@@ -2394,7 +2566,7 @@ func TestMultiDBStaleBreakerRecordAfterRemovalFiresNoCallback(t *testing.T) {
 	got := append([]int(nil), events...)
 	mu.Unlock()
 	if len(got) != 0 {
-		t.Errorf("stale breaker record on a removed member fired callbacks: indexes %v", got)
+		t.Errorf("stale breaker record on a removed member fired callbacks: ids %v", got)
 	}
 }
 
@@ -2436,12 +2608,12 @@ func TestMultiDBMembershipOpsCanceledWhileWaitingForLock(t *testing.T) {
 	mdb := newTestMultiDB(t, opts, dbA, dbB)
 	check.armed.Store(true)
 
-	// Hold failoverMu: SetActiveIndex probes B, and B's blocking check stalls
+	// Hold failoverMu: SetActiveDatabase probes B, and B's blocking check stalls
 	// with the lock held.
 	holderDone := make(chan struct{})
 	go func() {
 		defer close(holderDone)
-		_ = mdb.SetActiveIndex(context.Background(), 1)
+		_ = mdb.SetActiveDatabase(context.Background(), 1)
 	}()
 	time.Sleep(100 * time.Millisecond) // let the holder acquire the lock
 
@@ -2490,12 +2662,12 @@ func TestMultiDBManualSelectionAfterClose(t *testing.T) {
 	}
 
 	// Consistent with the command paths: after Close, control APIs report
-	// ErrClosed rather than an out-of-range error from the drained slice.
-	if err := mdb.SetActiveIndex(context.Background(), 0); !errors.Is(err, redis.ErrClosed) {
-		t.Errorf("SetActiveIndex after Close: err = %v, want ErrClosed", err)
+	// ErrClosed rather than a not-found error from the drained membership.
+	if err := mdb.SetActiveDatabase(context.Background(), 0); !errors.Is(err, redis.ErrClosed) {
+		t.Errorf("SetActiveDatabase after Close: err = %v, want ErrClosed", err)
 	}
-	if err := mdb.ForceActiveIndex(context.Background(), 0); !errors.Is(err, redis.ErrClosed) {
-		t.Errorf("ForceActiveIndex after Close: err = %v, want ErrClosed", err)
+	if err := mdb.ForceActiveDatabase(context.Background(), 0); !errors.Is(err, redis.ErrClosed) {
+		t.Errorf("ForceActiveDatabase after Close: err = %v, want ErrClosed", err)
 	}
 	if err := mdb.RemoveDatabase(context.Background(), 0); !errors.Is(err, redis.ErrClosed) {
 		t.Errorf("RemoveDatabase after Close: err = %v, want ErrClosed", err)
@@ -2549,7 +2721,7 @@ func TestMultiDBPanickyFailoverCallbacksDoNotCrash(t *testing.T) {
 	if err := mdb.Get(context.Background(), "k").Err(); err != nil {
 		t.Fatalf("Get across failover: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 1 {
+	if got := mdb.ActiveDatabaseID(); got != 1 {
 		t.Fatalf("active = %d, want 1", got)
 	}
 	// Let the announce queue drain so the panicking callbacks actually run
@@ -2613,7 +2785,7 @@ func TestMultiDBClusterOverridesAfterClose(t *testing.T) {
 	}
 }
 
-func TestMultiDBSameIndexManualSelectionResetsEscalation(t *testing.T) {
+func TestMultiDBSameActiveManualSelectionResetsEscalation(t *testing.T) {
 	dbA := newTestDB("a", "127.0.0.1:1", 1, true)
 	opts := baseOptions()
 	opts.CommandRetries = 1
@@ -2635,10 +2807,10 @@ func TestMultiDBSameIndexManualSelectionResetsEscalation(t *testing.T) {
 
 	// Operator forces the already-active member (its breaker resets): an
 	// explicit healthy selection ends the failed-failover chain even when
-	// no index change happens.
+	// the active id does not change.
 	dbA.hook.fail.Store(false)
-	if err := mdb.ForceActiveIndex(ctx, 0); err != nil {
-		t.Fatalf("ForceActiveIndex: %v", err)
+	if err := mdb.ForceActiveDatabase(ctx, 0); err != nil {
+		t.Fatalf("ForceActiveDatabase: %v", err)
 	}
 
 	// A fresh outage must escalate from a clean slate.
@@ -2669,16 +2841,16 @@ func TestMultiDBControlOpsClosedWhileWaitingForLock(t *testing.T) {
 	holderDone := make(chan struct{})
 	go func() {
 		defer close(holderDone)
-		_ = mdb.SetActiveIndex(context.Background(), 1)
+		_ = mdb.SetActiveDatabase(context.Background(), 1)
 	}()
 	time.Sleep(100 * time.Millisecond)
 
 	// Queue control operations with LIVE contexts, then Close: once they
 	// finally acquire the lock the client is closed — they must report
-	// ErrClosed, not mutate the drained membership or report bogus indexes.
+	// ErrClosed, not mutate the drained membership or report bogus ids.
 	setDone := make(chan error, 1)
 	removeDone := make(chan error, 1)
-	go func() { setDone <- mdb.ForceActiveIndex(context.Background(), 1) }()
+	go func() { setDone <- mdb.ForceActiveDatabase(context.Background(), 1) }()
 	go func() { removeDone <- mdb.RemoveDatabase(context.Background(), 1) }()
 	time.Sleep(100 * time.Millisecond)
 
@@ -2689,7 +2861,7 @@ func TestMultiDBControlOpsClosedWhileWaitingForLock(t *testing.T) {
 	close(check.gate) // release the lock holder
 
 	if err := <-setDone; !errors.Is(err, redis.ErrClosed) {
-		t.Errorf("ForceActiveIndex after Close during lock wait: err = %v, want ErrClosed", err)
+		t.Errorf("ForceActiveDatabase after Close during lock wait: err = %v, want ErrClosed", err)
 	}
 	if err := <-removeDone; !errors.Is(err, redis.ErrClosed) {
 		t.Errorf("RemoveDatabase after Close during lock wait: err = %v, want ErrClosed", err)
@@ -2788,8 +2960,8 @@ func TestMultiDBCanceledHealthyProbeDoesNotTouchBreaker(t *testing.T) {
 	mdb.TestBreakerRecordFailure(1)
 	time.Sleep(50 * time.Millisecond)
 	check.armed.Store(true)
-	if err := mdb.SetActiveIndex(parent, 1); !errors.Is(err, context.Canceled) {
-		t.Fatalf("SetActiveIndex = %v, want context.Canceled", err)
+	if err := mdb.SetActiveDatabase(parent, 1); !errors.Is(err, context.Canceled) {
+		t.Fatalf("SetActiveDatabase = %v, want context.Canceled", err)
 	}
 
 	if !mdb.TestBreakerReserveHalfOpen(1) {
@@ -2862,7 +3034,7 @@ func TestMultiDBDefaultPolicySurvivesPanickyCheck(t *testing.T) {
 	// A panicking custom check under the default policy must mark the member
 	// unhealthy, not crash initialization or the background loop.
 	mdb := newTestMultiDB(t, opts, dbA, dbB)
-	if got := mdb.ActiveIndex(); got != 0 {
+	if got := mdb.ActiveDatabaseID(); got != 0 {
 		t.Fatalf("active = %d, want 0 (the member with the panicking check is unhealthy)", got)
 	}
 }
@@ -2889,8 +3061,8 @@ func TestMultiDBCanceledProbeDoesNotDamageBreaker(t *testing.T) {
 	canceled, cancel := context.WithCancel(context.Background())
 	cancel()
 	for i := 0; i < 3; i++ {
-		if err := mdb.SetActiveIndex(canceled, 1); !errors.Is(err, context.Canceled) {
-			t.Fatalf("SetActiveIndex with canceled ctx: err = %v, want context.Canceled", err)
+		if err := mdb.SetActiveDatabase(canceled, 1); !errors.Is(err, context.Canceled) {
+			t.Fatalf("SetActiveDatabase with canceled ctx: err = %v, want context.Canceled", err)
 		}
 	}
 
@@ -2899,7 +3071,7 @@ func TestMultiDBCanceledProbeDoesNotDamageBreaker(t *testing.T) {
 	if err := mdb.Set(context.Background(), "k", "v", 0).Err(); err != nil {
 		t.Fatalf("command after failover: %v", err)
 	}
-	if got := mdb.ActiveIndex(); got != 1 {
+	if got := mdb.ActiveDatabaseID(); got != 1 {
 		t.Errorf("active = %d, want 1", got)
 	}
 }


### PR DESCRIPTION
Members are addressed by an immutable, never-reused **stable id** instead of a
slice position, stored in a `map[int]*db` keyed by that id.

- `RemoveDatabase` is a map delete: survivors are never renumbered and the
  active member's id never shifts, so an operator handle and a queued callback
  stay valid across it. No reindex loop, no active-position adjustment.
- The active database is tracked by id (`-1` = none); a non-negative active is
  always a live key (removing the active is refused).
- Failover callbacks (`OnFailover`, `OnActiveDatabaseChanged`,
  `OnCircuitStateChanged`) carry stable ids — a concurrent `RemoveDatabase` can
  never make a delivered handle name a different member.
- Strategy candidates (`MultiDBDatabaseState`) are sorted by id, so selection is
  deterministic despite map iteration order.

## API (unreleased — renamed for clarity, no positional "index")
- `ActiveIndex` → `ActiveDatabaseID`
- `SetActiveIndex` → `SetActiveDatabase`
- `ForceActiveIndex` → `ForceActiveDatabase`
- `MultiDBDatabaseState.Index` → `.ID`
- `AddDatabase` returns the id; `RemoveDatabase` / `SetWeight` /
  `AddDatabaseHook` take it; an unknown id yields the new `ErrDatabaseNotFound`.

## Notes
- **Supersedes** the earlier slice + id↔position-translation approach and its
  int32-narrowing fix (commit `f3791731`): narrowing is structurally impossible
  with an int-keyed map, so that resolved thread's SHA is no longer on the
  branch.
- Stacked on #3950 (`feature/multidb/client`).

Tests: stable id survives removal; failover callback carries a stable id;
strategy sees ids (exact candidate set); a large/out-of-range id resolves to no
member; full multidb suite green with `-race`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a breaking API rename plus a core change to how active membership and removal interact with failover; incorrect id handling could mis-route traffic or deliver stale handles in callbacks.
> 
> **Overview**
> **MultiDB members are now addressed by immutable stable ids** instead of slice positions. Membership lives in a `map[int]*multidbDatabase` with monotonic, never-reused ids from `AddDatabase`; removing a non-active member is a map delete with no reindexing and no adjustment of the active handle.
> 
> The **control and callback surface is renamed and re-typed** for ids: `ActiveDatabaseID`, `SetActiveDatabase`, `ForceActiveDatabase`, `MultiDBDatabaseState.ID`, and failover callbacks (`OnFailover`, `OnActiveDatabaseChanged`, `OnCircuitStateChanged`) all use stable member ids. Unknown ids return **`ErrDatabaseNotFound`** instead of out-of-range index errors.
> 
> **Failover and fallback selection** pass sorted candidate lists (by id) so map iteration order and equal-weight ties do not change behavior. Tests cover id stability across removal, callback handles, strategy input, and large/out-of-range ids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b87a7b448c2d630b9c266ba975f359d150807072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->