### PR TITLE
register onClose hook in FailoverClusterClient

### DIFF
--- a/osscluster.go
+++ b/osscluster.go
@@ -1376,6 +1376,7 @@ type ClusterClient struct {
 	autopipeliner       *AutoPipeliner // blocking face (ClusterClient.AutoPipeline)
 	asyncAutopipeliner  *AutoPipeliner // deferred face (ClusterClient.AsyncAutoPipeline)
 	autopipelinerClosed bool           // set by Close: refuse to resurrect a pipeliner on a closed client
+	onClose             *onCloseHooks
 }
 
 // NewClusterClient returns a Redis Cluster client as described in
@@ -1392,6 +1393,7 @@ func NewClusterClient(opt *ClusterOptions) *ClusterClient {
 		nodes:           newClusterNodes(opt),
 		himport:         newHImportRegistry(),
 		autopipelinerMu: &sync.Mutex{},
+		onClose:         &onCloseHooks{},
 	}
 
 	// Every node client shares the cluster-wide fieldset registry, replicas
@@ -1472,6 +1474,9 @@ func (c *ClusterClient) Close() error {
 		}
 	}
 	if err := c.nodes.Close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	if err := c.onClose.run(); err != nil && firstErr == nil {
 		firstErr = err
 	}
 	return firstErr

--- a/sentinel.go
+++ b/sentinel.go
@@ -1321,6 +1321,8 @@ func NewFailoverClusterClient(failoverOpt *FailoverOptions) *ClusterClient {
 
 	c := NewClusterClient(opt)
 
+	c.onClose.register(onCloseHookIDSentinelFailover, failover.Close)
+
 	failover.mu.Lock()
 	failover.onUpdate = func(ctx context.Context) {
 		c.ReloadState(ctx)


### PR DESCRIPTION
Fixes #3999

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk lifecycle fix that mirrors existing FailoverClient close behavior; only affects ClusterClient shutdown ordering and Sentinel resource cleanup.
> 
> **Overview**
> **Fixes #3999** by ensuring Sentinel failover background resources are torn down when a failover cluster client is closed.
> 
> `ClusterClient` now owns an `onClose` hook registry (initialized in `NewClusterClient` and invoked from `Close()` after autopipeliners and node pools shut down). `NewFailoverClusterClient` registers `failover.Close` on that registry—the same hook `NewFailoverClient` already uses on standalone clients—so the Sentinel connection and `+switch-master` pub/sub goroutine stop when the cluster client is closed instead of leaking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a875ce0b865944735f04eb4f9eb33b8063ca316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->