### PR TITLE
chore(tests): fast TCP probe before Ping in Redis-availability skips

### DIFF
--- a/autopipeline_internal_test.go
+++ b/autopipeline_internal_test.go
@@ -42,6 +42,9 @@ func TestAutoPipelineLoneCallerFlushesImmediately(t *testing.T) {
 	client := NewClient(&Options{Addr: internalTestRedisAddr()})
 	defer client.Close()
 
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -97,6 +100,9 @@ func TestAutoPipelineExplicitDelayWaitsFullWindow(t *testing.T) {
 	client := NewClient(&Options{Addr: internalTestRedisAddr()})
 	defer client.Close()
 
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -192,6 +198,9 @@ func TestAutoPipelineWaveCoalesces(t *testing.T) {
 	client := NewClient(&Options{Addr: internalTestRedisAddr()})
 	defer client.Close()
 
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -322,6 +331,9 @@ func TestDoBypassesPipeline(t *testing.T) {
 	client := NewClient(&Options{Addr: internalTestRedisAddr(), PipelineReadBufferSize: 64 << 10, PipelineWriteBufferSize: 64 << 10})
 	defer client.Close()
 
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -564,6 +576,9 @@ func TestDispatchChunkedAbortsAfterFailedPrefix(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(&Options{Addr: internalTestRedisAddr(), MaxRetries: -1})
 	defer client.Close()
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -764,6 +779,9 @@ func TestCloseWaitsForDivertedCommand(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(&Options{Addr: internalTestRedisAddr()})
 	defer client.Close()
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -794,6 +812,9 @@ func TestCloseWaitsForDivertedCommand(t *testing.T) {
 // opposite in its doc).
 func TestSharedClosedRejectsEveryEntryPoint(t *testing.T) {
 	ctx := context.Background()
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	parent := NewClient(&Options{Addr: internalTestRedisAddr()})
 	defer parent.Close()
 	if err := parent.Ping(ctx).Err(); err != nil {
@@ -863,6 +884,9 @@ func TestDivertRegistrationRacesClose(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(&Options{Addr: internalTestRedisAddr()})
 	defer client.Close()
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -933,6 +957,9 @@ func TestOtelMetricsDoNotAwaitOnAsyncFace(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(&Options{Addr: internalTestRedisAddr()})
 	defer client.Close()
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -1036,6 +1063,9 @@ func TestEvalDoesNotAwaitOnAsyncFace(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(&Options{Addr: internalTestRedisAddr()})
 	defer client.Close()
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -1191,6 +1221,9 @@ func TestNoRetryOrderObservedEndToEnd(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(&Options{Addr: internalTestRedisAddr()})
 	defer client.Close()
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -1227,6 +1260,9 @@ func TestNoRetrySplitExecutesEveryCommand(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(&Options{Addr: internalTestRedisAddr()})
 	defer client.Close()
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -1308,6 +1344,9 @@ func TestSuccessfulHookShortCircuitIsHonored(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(&Options{Addr: internalTestRedisAddr()})
 	defer client.Close()
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -1370,6 +1409,9 @@ func TestMustDivertKeepsCommandOffTheBatchPath(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(&Options{Addr: internalTestRedisAddr()})
 	defer client.Close()
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -1418,6 +1460,9 @@ func TestRetryRunsStopAfterFailedPrefix(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(&Options{Addr: internalTestRedisAddr(), MaxRetries: -1})
 	defer client.Close()
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -1459,6 +1504,9 @@ func TestAsyncProcessReportsSubmitRejection(t *testing.T) {
 	ctx := context.Background()
 	client := NewClient(&Options{Addr: internalTestRedisAddr()})
 	defer client.Close()
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -1507,6 +1555,9 @@ func TestAutopipelineSoloRoutingGate(t *testing.T) {
 	}
 
 	// CSC client: needs a live RESP3 server for CLIENT TRACKING to attach.
+	if err := probeRedis(internalTestRedisAddr()); err != nil {
+		t.Skipf("no redis for the CSC half: %v", err)
+	}
 	if err := NewClient(&Options{Addr: internalTestRedisAddr(), Protocol: 3}).Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis for the CSC half: %v", err)
 	}

--- a/csc_e2e_test.go
+++ b/csc_e2e_test.go
@@ -321,6 +321,9 @@ func TestCSCNonZeroDBRejected(t *testing.T) {
 	t.Cleanup(func() { _ = c.Close() })
 
 	ctx := context.Background()
+	if err := probeRedis(cscNativeAddr()); err != nil {
+		t.Skipf("redis not available at %s: %v", cscNativeAddr(), err)
+	}
 	if err := c.Ping(ctx).Err(); err != nil {
 		t.Skipf("redis not available at %s: %v", cscNativeAddr(), err)
 	}
@@ -371,6 +374,9 @@ func TestCSCReadYourWrites(t *testing.T) {
 	t.Cleanup(func() { _ = mutator.Close() })
 
 	ctx := context.Background()
+	if err := probeRedis(cscNativeAddr()); err != nil {
+		t.Skipf("redis not available at %s: %v", cscNativeAddr(), err)
+	}
 	if err := c.Ping(ctx).Err(); err != nil {
 		t.Skipf("redis not available at %s: %v", cscNativeAddr(), err)
 	}

--- a/digest_test.go
+++ b/digest_test.go
@@ -30,6 +30,9 @@ func TestDigestBasic(t *testing.T) {
 	skipIfRedisBelow84(t)
 
 	ctx := context.Background()
+	if err := probeRedis("localhost:6379"); err != nil {
+		t.Skipf("Redis not available: %v", err)
+	}
 	client := redis.NewClient(&redis.Options{
 		Addr: "localhost:6379",
 	})
@@ -74,6 +77,9 @@ func TestSetIFDEQWithDigest(t *testing.T) {
 	skipIfRedisBelow84(t)
 
 	ctx := context.Background()
+	if err := probeRedis("localhost:6379"); err != nil {
+		t.Skipf("Redis not available: %v", err)
+	}
 	client := redis.NewClient(&redis.Options{
 		Addr: "localhost:6379",
 	})
@@ -138,6 +144,9 @@ func TestSetIFDNEWithDigest(t *testing.T) {
 	skipIfRedisBelow84(t)
 
 	ctx := context.Background()
+	if err := probeRedis("localhost:6379"); err != nil {
+		t.Skipf("Redis not available: %v", err)
+	}
 	client := redis.NewClient(&redis.Options{
 		Addr: "localhost:6379",
 	})
@@ -202,6 +211,9 @@ func TestDelExArgsWithDigest(t *testing.T) {
 	skipIfRedisBelow84(t)
 
 	ctx := context.Background()
+	if err := probeRedis("localhost:6379"); err != nil {
+		t.Skipf("Redis not available: %v", err)
+	}
 	client := redis.NewClient(&redis.Options{
 		Addr: "localhost:6379",
 	})
@@ -267,6 +279,9 @@ func TestDigestHelperMatchesRedis(t *testing.T) {
 	skipIfRedisBelow84(t)
 
 	ctx := context.Background()
+	if err := probeRedis("localhost:6379"); err != nil {
+		t.Skipf("Redis not available: %v", err)
+	}
 	client := redis.NewClient(&redis.Options{
 		Addr: "localhost:6379",
 	})
@@ -326,6 +341,9 @@ func TestDigestBytesHelperMatchesRedis(t *testing.T) {
 	skipIfRedisBelow84(t)
 
 	ctx := context.Background()
+	if err := probeRedis("localhost:6379"); err != nil {
+		t.Skipf("Redis not available: %v", err)
+	}
 	client := redis.NewClient(&redis.Options{
 		Addr: "localhost:6379",
 	})
@@ -382,6 +400,9 @@ func TestDigestHelperWithSetIFDEQ(t *testing.T) {
 	skipIfRedisBelow84(t)
 
 	ctx := context.Background()
+	if err := probeRedis("localhost:6379"); err != nil {
+		t.Skipf("Redis not available: %v", err)
+	}
 	client := redis.NewClient(&redis.Options{
 		Addr: "localhost:6379",
 	})
@@ -439,6 +460,9 @@ func TestDigestHelperWithDelExArgs(t *testing.T) {
 	skipIfRedisBelow84(t)
 
 	ctx := context.Background()
+	if err := probeRedis("localhost:6379"); err != nil {
+		t.Skipf("Redis not available: %v", err)
+	}
 	client := redis.NewClient(&redis.Options{
 		Addr: "localhost:6379",
 	})

--- a/languages_test.go
+++ b/languages_test.go
@@ -11,6 +11,9 @@ import (
 
 func newLanguagesTestClient(t *testing.T) *redis.Client {
 	t.Helper()
+	if err := probeRedis("localhost:6379"); err != nil {
+		t.Skipf("Redis not available: %v", err)
+	}
 	client := redis.NewClient(&redis.Options{
 		Addr: "localhost:6379",
 	})

--- a/pipeline_pool_gate_test.go
+++ b/pipeline_pool_gate_test.go
@@ -194,6 +194,9 @@ func TestPipelinePoolSpillsToMainPool(t *testing.T) {
 		PoolTimeout:      100 * time.Millisecond, // spill latency bound
 	})
 	defer c.Close()
+	if err := probeRedis(gateTestAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := c.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}
@@ -265,6 +268,9 @@ func TestPipelineConnsSkipClientTracking(t *testing.T) {
 		ClientSideCacheConfig: &ClientSideCacheConfig{},
 	})
 	defer c.Close()
+	if err := probeRedis(gateTestAddr()); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := c.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}

--- a/pipeline_spill_test.go
+++ b/pipeline_spill_test.go
@@ -29,6 +29,9 @@ func TestWithPipelineConnSpillAccountsLimiterOnce(t *testing.T) {
 	lim := &spillCountingLimiter{}
 	c := NewClient(&Options{Addr: ":6379", PipelinePoolSize: 1, Limiter: lim})
 	defer c.Close()
+	if err := probeRedis(":6379"); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
 	if err := c.Ping(ctx).Err(); err != nil {
 		t.Skipf("no redis: %v", err)
 	}

--- a/probe_internal_test.go
+++ b/probe_internal_test.go
@@ -1,0 +1,18 @@
+package redis
+
+import (
+	"net"
+	"time"
+)
+
+// probeRedis is the package redis copy of the redis_test helper of the same
+// name (the internal tests cannot import the external test package). See
+// probe_test.go for the rationale: a fast TCP probe avoids the ~1.7s
+// dial-retry + command-retry cost a Ping pays when nothing is listening.
+func probeRedis(addr string) error {
+	c, err := net.DialTimeout("tcp", addr, 300*time.Millisecond)
+	if err != nil {
+		return err
+	}
+	return c.Close()
+}

--- a/probe_test.go
+++ b/probe_test.go
@@ -1,0 +1,27 @@
+package redis_test
+
+import (
+	"net"
+	"time"
+)
+
+// probeRedis reports whether a TCP listener answers at addr within a short
+// timeout. Tests that skip when Redis is absent call this before building a
+// client and Ping-ing it: a Ping to an addr with nothing listening does not
+// return immediately, it pays go-redis's dial-retry (DialerRetries, 5 by
+// default) plus command-retry (MaxRetries) budget first — ~1.7s per call. In an
+// environment without a local Redis (for example the RE nightly, whose real
+// endpoint is remote), hundreds of such skips add up to minutes of wasted wall
+// time. A single short-timeout TCP dial fails in microseconds on
+// connection-refused instead.
+//
+// A nil return only means something is listening; callers keep their Ping so a
+// reachable-but-unusable server (auth required, a different service on the port)
+// still skips rather than proceeds.
+func probeRedis(addr string) error {
+	c, err := net.DialTimeout("tcp", addr, 300*time.Millisecond)
+	if err != nil {
+		return err
+	}
+	return c.Close()
+}

--- a/search_collect_integration_test.go
+++ b/search_collect_integration_test.go
@@ -41,6 +41,9 @@ func TestFTAggregateCollect_Integration(t *testing.T) {
 	// REDIS_VERSION env variable (whose float form cannot tell 8.10 from 8.1
 	// and defaults when unset).
 	probeCtx := context.Background()
+	if err := probeRedis(collectTestAddr()); err != nil {
+		t.Skipf("redis not reachable at %s: %v", collectTestAddr(), err)
+	}
 	probe := redis.NewClient(&redis.Options{Addr: collectTestAddr()})
 	t.Cleanup(func() { _ = probe.Close() })
 	if err := probe.Ping(probeCtx).Err(); err != nil {

--- a/search_resp_test.go
+++ b/search_resp_test.go
@@ -28,6 +28,9 @@ func TestSearchCommandsRESP2AndRESP3Equivalence(t *testing.T) {
 	defer client3.Close()
 
 	// Check connection
+	if err := probeRedis("localhost:6379"); err != nil {
+		t.Skipf("Redis not available: %v", err)
+	}
 	if err := client2.Ping(ctx).Err(); err != nil {
 		t.Skipf("Redis not available: %v", err)
 	}


### PR DESCRIPTION
## What

Adds a short-timeout TCP probe before the client `Ping` in the test
helpers/sites that skip when Redis is unavailable. When something is
listening the existing `Ping` still runs (so a reachable-but-unusable
server — auth required, wrong service on the port — still skips rather
than proceeds).

## Why

A `Ping` to an address with nothing listening does **not** return
immediately: it pays go-redis's dial-retry (`DialerRetries`, default 5,
100ms backoff) plus command-retry (`MaxRetries`) budget first — ~1.7s per
call. Tests that gate on that Ping then skip. This removes that fixed
wasted retry time in any environment without a local Redis, making
absent-Redis skips instant.

Measured on a recent RE integration-nightly log: 68 such skips at ~1.4s
avg ≈ 1.6 min. A single short-timeout TCP dial fails in microseconds on
connection-refused. Verified locally: the affected skips drop from
~1.72s to ~0.00s; the happy path (Redis present) is unchanged.

## Scope / non-goals

This is a wall-time cleanup, **not** the nightly-timeout fix. The nightly
timed out because it runs `go test . -v` (all plain tests, including
latency-bound AutoPipeline tests against the remote endpoint) rather than
`-run TestGinkgoSuite` like this repo's own Makefile — that belongs in
the cae-client-testing workflow, not here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only harness change with no library API or runtime behavior impact; skip semantics are preserved via the follow-up Ping.
> 
> **Overview**
> Adds **`probeRedis`**, a 300ms TCP dial check, in both `redis_test` (`probe_test.go`) and internal `redis` tests (`probe_internal_test.go`), and calls it **before** existing `Ping`-based skip logic across integration tests (autopipeline, CSC, digest, languages, pipeline pool/spill, search, etc.).
> 
> When nothing is listening, **`Ping` no longer runs first**, avoiding go-redis dial/command retry budgets (~1.7s per skip). Tests still **`Ping` after a successful probe** so a open port with wrong auth or a non-Redis service continues to skip correctly.
> 
> **No production client behavior changes**—only faster skips in CI and local runs without Redis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e77580405dde2f522e88e118cb44a4307d8b554. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->