### PR TITLE
fix(client): don't leak pools on NewClient panic

### DIFF
--- a/newclient_panic_cleanup_test.go
+++ b/newclient_panic_cleanup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -36,13 +37,25 @@ func (fakeAddr) String() string  { return "fake" }
 // panics — modelling a custom processor that rejects handler registration. With
 // MaintNotificationsConfig in ModeEnabled, NewClient registers maintenance
 // handlers (after the pools are created) and this panic propagates out.
-type panicOnRegisterProcessor struct{}
+//
+// RegisterHandler first waits for dialed, which the test's dialer closes on its
+// first call. The min-idle dial runs in a pool goroutine; without this wait the
+// deferred Close in NewClient can win the race, the pool's dialConn sees the
+// closed pool and never calls the dialer, and the test observes opened=0 — a
+// legal outcome for the client, but not the leak scenario this test pins.
+type panicOnRegisterProcessor struct{ dialed <-chan struct{} }
 
 func (panicOnRegisterProcessor) GetHandler(string) push.NotificationHandler { return nil }
 func (panicOnRegisterProcessor) ProcessPendingNotifications(context.Context, push.NotificationHandlerContext, *proto.Reader) error {
 	return nil
 }
-func (panicOnRegisterProcessor) RegisterHandler(string, push.NotificationHandler, bool) error {
+
+func (p panicOnRegisterProcessor) RegisterHandler(string, push.NotificationHandler, bool) error {
+	select {
+	case <-p.dialed:
+	case <-time.After(5 * time.Second):
+		// Fall through and panic anyway; the caller's poll reports opened=0.
+	}
 	panic("push processor rejects handler registration")
 }
 func (panicOnRegisterProcessor) UnregisterHandler(string) error { return nil }
@@ -53,8 +66,11 @@ func (panicOnRegisterProcessor) UnregisterHandler(string) error { return nil }
 // panic still propagates to the caller; here it is recovered.
 func TestNewClientPanicClosesPartialClient(t *testing.T) {
 	var opened, closed int64
+	var dialedOnce sync.Once
+	dialed := make(chan struct{})
 	dialer := func(context.Context, string, string) (net.Conn, error) {
 		atomic.AddInt64(&opened, 1)
+		dialedOnce.Do(func() { close(dialed) })
 		return &fakeConn{closed: &closed}, nil
 	}
 
@@ -71,12 +87,14 @@ func TestNewClientPanicClosesPartialClient(t *testing.T) {
 			MinIdleConns:              1,
 			Dialer:                    dialer,
 			MaintNotificationsConfig:  &maintnotifications.Config{Mode: maintnotifications.ModeEnabled},
-			PushNotificationProcessor: panicOnRegisterProcessor{},
+			PushNotificationProcessor: panicOnRegisterProcessor{dialed: dialed},
 		})
 	}()
 
-	// The min-idle dial runs in a pool goroutine, so poll: the pool must have
-	// dialed at least once and every dialed connection must end up closed.
+	// The dialer has run at least once by the time the panic fires (see
+	// panicOnRegisterProcessor). The dialed connection is closed either by the
+	// pool's Close (if it was registered in time) or by addIdleConn when it
+	// finds the pool already closed, so poll until every dialed conn is closed.
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		o := atomic.LoadInt64(&opened)

--- a/newclient_panic_cleanup_test.go
+++ b/newclient_panic_cleanup_test.go
@@ -3,7 +3,9 @@ package redis
 import (
 	"context"
 	"io"
+	"math"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -105,5 +107,27 @@ func TestNewClientPanicClosesPartialClient(t *testing.T) {
 			t.Fatalf("partial client leaked its pool after NewClient panicked: opened=%d closed=%d", o, atomic.LoadInt64(&closed))
 		}
 		time.Sleep(time.Millisecond)
+	}
+}
+
+// TestNewClientPanicCleanupSurvivesNilPool pins that the panic-cleanup defer
+// does not itself panic when a pool constructor fails. newConnPool returns a
+// nil pool plus an error for an out-of-range PoolSize; the pool field must stay
+// nil (not a typed-nil pool.Pooler) so closeResources skips it and the ORIGINAL
+// construction error surfaces to the caller, not a nil-deref from the cleanup.
+func TestNewClientPanicCleanupSurvivesNilPool(t *testing.T) {
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		// PoolSize overflows int32 -> newConnPool returns (nil, err) -> NewClient
+		// panics at pool creation, before the field is assigned.
+		NewClient(&Options{PoolSize: math.MaxInt32 + 1})
+	}()
+	if recovered == nil {
+		t.Fatal("expected NewClient to panic on an out-of-range PoolSize")
+	}
+	err, ok := recovered.(error)
+	if !ok || !strings.Contains(err.Error(), "failed to create connection pool") {
+		t.Fatalf("cleanup replaced the construction panic (typed-nil pool nil-deref?): recovered=%v (%T)", recovered, recovered)
 	}
 }

--- a/newclient_panic_cleanup_test.go
+++ b/newclient_panic_cleanup_test.go
@@ -1,0 +1,91 @@
+package redis
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9/internal/proto"
+	"github.com/redis/go-redis/v9/maintnotifications"
+	"github.com/redis/go-redis/v9/push"
+)
+
+// fakeConn is a no-I/O net.Conn: the min-idle connection is created in the pool
+// but never initialized (initConn is deferred to first checkout), so its
+// Read/Write are never exercised. Close bumps a counter.
+type fakeConn struct{ closed *int64 }
+
+func (f *fakeConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (f *fakeConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (f *fakeConn) Close() error                     { atomic.AddInt64(f.closed, 1); return nil }
+func (f *fakeConn) LocalAddr() net.Addr              { return fakeAddr{} }
+func (f *fakeConn) RemoteAddr() net.Addr             { return fakeAddr{} }
+func (f *fakeConn) SetDeadline(time.Time) error      { return nil }
+func (f *fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (f *fakeConn) SetWriteDeadline(time.Time) error { return nil }
+
+type fakeAddr struct{}
+
+func (fakeAddr) Network() string { return "fake" }
+func (fakeAddr) String() string  { return "fake" }
+
+// panicOnRegisterProcessor is a push.NotificationProcessor whose RegisterHandler
+// panics — modelling a custom processor that rejects handler registration. With
+// MaintNotificationsConfig in ModeEnabled, NewClient registers maintenance
+// handlers (after the pools are created) and this panic propagates out.
+type panicOnRegisterProcessor struct{}
+
+func (panicOnRegisterProcessor) GetHandler(string) push.NotificationHandler { return nil }
+func (panicOnRegisterProcessor) ProcessPendingNotifications(context.Context, push.NotificationHandlerContext, *proto.Reader) error {
+	return nil
+}
+func (panicOnRegisterProcessor) RegisterHandler(string, push.NotificationHandler, bool) error {
+	panic("push processor rejects handler registration")
+}
+func (panicOnRegisterProcessor) UnregisterHandler(string) error { return nil }
+
+// TestNewClientPanicClosesPartialClient pins that when a NewClient construction
+// step panics AFTER the connection pools are created, the partial client is
+// closed on the way out so the pools (and their connections) do not leak. The
+// panic still propagates to the caller; here it is recovered.
+func TestNewClientPanicClosesPartialClient(t *testing.T) {
+	var opened, closed int64
+	dialer := func(context.Context, string, string) (net.Conn, error) {
+		atomic.AddInt64(&opened, 1)
+		return &fakeConn{closed: &closed}, nil
+	}
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("NewClient did not panic; the trigger no longer fires")
+			}
+		}()
+		NewClient(&Options{
+			Addr:                      "localhost:6379", // never contacted (fake dialer)
+			Protocol:                  3,
+			PoolSize:                  1,
+			MinIdleConns:              1,
+			Dialer:                    dialer,
+			MaintNotificationsConfig:  &maintnotifications.Config{Mode: maintnotifications.ModeEnabled},
+			PushNotificationProcessor: panicOnRegisterProcessor{},
+		})
+	}()
+
+	// The min-idle dial runs in a pool goroutine, so poll: the pool must have
+	// dialed at least once and every dialed connection must end up closed.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		o := atomic.LoadInt64(&opened)
+		if o >= 1 && atomic.LoadInt64(&closed) == o {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("partial client leaked its pool after NewClient panicked: opened=%d closed=%d", o, atomic.LoadInt64(&closed))
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/redis.go
+++ b/redis.go
@@ -2125,16 +2125,23 @@ func NewClient(opt *Options) *Client {
 	mainPoolName := opt.Addr + "_" + uniqueID
 	pubsubPoolName := opt.Addr + "_" + uniqueID + "_pubsub"
 
-	// Create connection pools
-	var err error
-	c.connPool, err = newConnPool(opt, c.dialHook, mainPoolName)
+	// Create connection pools. Assign the fields only AFTER the error check:
+	// newConnPool/newPubSubPool return a nil *pool on error, and assigning that
+	// straight to the pool.Pooler field would leave a typed-nil interface that
+	// closeResources treats as present (its != nil check passes), so the
+	// panic-cleanup defer above would nil-deref inside ConnPool.Close instead of
+	// surfacing the original construction error. A local var keeps the field nil
+	// on failure. The pipeline pool below already follows this pattern.
+	connPool, err := newConnPool(opt, c.dialHook, mainPoolName)
 	if err != nil {
 		panic(fmt.Errorf("redis: failed to create connection pool: %w", err))
 	}
-	c.pubSubPool, err = newPubSubPool(opt, c.dialHook, pubsubPoolName)
+	c.connPool = connPool
+	pubSubPool, err := newPubSubPool(opt, c.dialHook, pubsubPoolName)
 	if err != nil {
 		panic(fmt.Errorf("redis: failed to create pubsub pool: %w", err))
 	}
+	c.pubSubPool = pubSubPool
 
 	// Create the dedicated pipeline pool unconditionally, like pubSubPool: it
 	// is pure burst capacity (no pre-dialing, small cap, larger buffers — see

--- a/redis.go
+++ b/redis.go
@@ -2098,6 +2098,22 @@ func NewClient(opt *Options) *Client {
 	}
 	c.init()
 
+	// Close a partially-built client if a construction step below panics before
+	// NewClient returns. The pools (and their background goroutines) are created
+	// below, but several later steps can panic — maintnotifications in
+	// ModeEnabled failing, or a custom push processor rejecting handler
+	// registration. The panic propagates to the caller (some callers, e.g.
+	// MultiDB AddDatabase, recover it), yet &c is never returned, so without this
+	// those pools would leak with no reference left to Close them. closeResources
+	// is nil-safe for a partially-built client, and the panic still propagates:
+	// this defer runs during unwind and does not recover.
+	built := false
+	defer func() {
+		if !built {
+			_ = c.Close()
+		}
+	}()
+
 	// Initialize push notification processor using shared helper
 	// Use void processor for RESP2 connections (push notifications not available)
 	c.pushProcessor = initializePushProcessor(opt)
@@ -2186,6 +2202,7 @@ func NewClient(opt *Options) *Client {
 	// This allows async gauge metrics to pull stats from pools periodically
 	otel.RegisterPools(c.connPool, c.pubSubPool, c.getPipelinePool(), opt.Addr)
 
+	built = true
 	return &c
 }
 


### PR DESCRIPTION
## What

`NewClient` creates the connection pools and then runs later construction steps that can panic — maintnotifications in `ModeEnabled` failing, or a custom push processor rejecting handler registration. The panic propagates to the caller (some callers, e.g. MultiDB `AddDatabase`, recover it), but the `*Client` is never returned, so the already-created pools and their pooled connections leak with no reference left to close them.

This adds a deferred cleanup in `NewClient` that closes the partially-built client if a construction step panics before it returns. `baseClient.closeResources` is already nil-safe for a partially-built client, and the defer does not `recover()`, so the panic still propagates unchanged.

## Cost / behavior

Every `NewClient` now carries a deferred closure that no-ops on the normal path (a `built` flag is set right before `return &c`). Behavior changes only when a construction step panics after the pools exist.

## Scope

- Covers `NewClient`. `NewClusterClient`, `NewFailoverClient`, and `NewRing` have the same shape (pools created, later steps can panic) and are **not** addressed here — a follow-up can apply the same recipe if wanted.
- The defer is placed after `c.init()`, so panics before any pool exists (nil options, `opt.init()`) are intentionally not covered — there is nothing to clean up there.

## Test

`TestNewClientPanicClosesPartialClient` triggers a post-pool panic via a custom push processor whose `RegisterHandler` panics (with `MaintNotificationsConfig` in `ModeEnabled`), then asserts every dialed connection is closed. It fails without the fix (the min-idle connection leaks on a never-closed pool).

## Provenance

Found by the review bot on the MultiDB stack (#3950, `multidb_core.go:358`, P2). The leak's root cause is in core `NewClient`, so it is fixed here against master rather than inside that PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `NewClient` construction and shutdown on failure paths; behavior change is limited to panic/error cases, but incorrect cleanup could affect pool lifecycle or error reporting.
> 
> **Overview**
> **Fixes connection pool leaks when `NewClient` panics after pools are created** (e.g. maint notifications in `ModeEnabled`, or a custom push processor that panics on `RegisterHandler`). A deferred cleanup calls `Close()` on the partial client if construction never sets `built`; the panic still propagates because the defer does not recover.
> 
> **Hardens pool creation assignment** so failed `newConnPool` / `newPubSubPool` do not store a typed-nil `pool.Pooler` on the client. That keeps the new cleanup path from nil-dereferencing in `closeResources` and preserves the original construction error.
> 
> **Adds tests** that simulate a post-pool panic and assert dialed connections are closed, and that an invalid `PoolSize` still surfaces the pool-creation panic without cleanup masking it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90aa448e5d447dbb77e849186888de00c9bb1b9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->