### PR TITLE
fix(multidb): wait for autopipeliner drain on close

### DIFF
--- a/autopipeline.go
+++ b/autopipeline.go
@@ -1682,6 +1682,19 @@ func (ap *AutoPipeliner) WaitClosed() error {
 	return ap.closeErr
 }
 
+// drained reports whether the Close that claimed this autopipeliner's shutdown
+// has already finished its drain, without blocking. A wrapping client that
+// keeps closed instances around so it can wait for their drains uses this to
+// drop the ones that are already finished.
+func (ap *AutoPipeliner) drained() bool {
+	select {
+	case <-ap.closeDone:
+		return true
+	default:
+		return false
+	}
+}
+
 // drainAll runs Close's whole drain tail under a single bound and returns an
 // error naming every stage that was still outstanding when it expired. Split
 // out of Close so the bound is testable without a real stalled connection.

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -1305,3 +1305,46 @@ func TestCircuitBreaker_StaleReservationFailureIgnored(t *testing.T) {
 		t.Errorf("stale reservation failure re-opened the circuit: state=%v, want half-open", got)
 	}
 }
+
+// TestCircuitBreaker_HalfOpenSuccessFailureRaceNeverDropsOutcome pins that a
+// success closing the circuit and a failure re-opening it, arriving at the
+// same instant in half-open, can never race each other's CAS: both
+// recordSuccessHalfOpenLocked and recordFailureHalfOpenLocked run fully under
+// transitionMu, so exactly one of them completes first, and the other's own
+// state check (not a raw CompareAndSwap outside the lock) then classifies
+// correctly instead of silently discarding a completed outcome.
+func TestCircuitBreaker_HalfOpenSuccessFailureRaceNeverDropsOutcome(t *testing.T) {
+	config := Config{
+		FailureThreshold:    1,
+		SuccessThreshold:    1, // one success is enough to close from half-open
+		MaxHalfOpenRequests: 2,
+		OpenTimeout:         time.Nanosecond,
+	}
+	for i := 0; i < 2000; i++ {
+		cb := New(config)
+		cb.RecordFailure()
+		cb.CheckState() // -> HalfOpen
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); <-start; cb.RecordSuccess() }() // may close
+		go func() { defer wg.Done(); <-start; cb.RecordFailure() }() // may re-open
+		close(start)
+		wg.Wait()
+
+		state := State(cb.state.Load())
+		if state != StateClosed && state != StateOpen {
+			t.Fatalf("round %d: state=%v after a concurrent half-open success/failure, want Closed or Open (never stuck half-open)", i, state)
+		}
+		// Whichever outcome won, the loser's generation/state check must have
+		// left the counters clean for the new episode — a dropped-CAS bug would
+		// instead leave a stale non-zero successes/requests count behind.
+		if got := cb.Stats().Successes; got != 0 {
+			t.Fatalf("round %d: successes=%d after settling to %v, want 0", i, got, state)
+		}
+		if got := cb.Stats().Requests; got != 0 {
+			t.Fatalf("round %d: requests=%d after settling to %v, want 0", i, got, state)
+		}
+	}
+}

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -1333,18 +1333,73 @@ func TestCircuitBreaker_HalfOpenSuccessFailureRaceNeverDropsOutcome(t *testing.T
 		close(start)
 		wg.Wait()
 
+		// With FailureThreshold 1, EVERY correct serialization ends Open, so
+		// this is the assertion that actually detects a dropped failure.
+		// Failure first: half-open re-opens. Success first: the circuit closes,
+		// and the failure is then reclassified as a fresh closed-state failure
+		// (recordFailureHalfOpenLocked's StateClosed branch) which re-opens at
+		// the threshold of one. Accepting Closed here would pass exactly when
+		// the failure was discarded, which is the regression under test.
 		state := State(cb.state.Load())
-		if state != StateClosed && state != StateOpen {
-			t.Fatalf("round %d: state=%v after a concurrent half-open success/failure, want Closed or Open (never stuck half-open)", i, state)
+		if state != StateOpen {
+			t.Fatalf("round %d: state=%v after a concurrent half-open success/failure, want Open (the failure must survive either serialization)", i, state)
 		}
-		// Whichever outcome won, the loser's generation/state check must have
-		// left the counters clean for the new episode — a dropped-CAS bug would
-		// instead leave a stale non-zero successes/requests count behind.
+		// The failure must also be accounted for, not merely reflected in the
+		// state: a success that closed the circuit zeroes the failure count, so
+		// a dropped failure leaves this at zero.
+		if got := cb.Stats().Failures; got < 1 {
+			t.Fatalf("round %d: failures=%d after settling to Open, want at least 1 (the failure outcome was dropped)", i, got)
+		}
+		// Both transitions into Open clear the half-open counters, so a stale
+		// non-zero count would mean a botched transition.
 		if got := cb.Stats().Successes; got != 0 {
 			t.Fatalf("round %d: successes=%d after settling to %v, want 0", i, got, state)
 		}
 		if got := cb.Stats().Requests; got != 0 {
 			t.Fatalf("round %d: requests=%d after settling to %v, want 0", i, got, state)
 		}
+	}
+}
+
+// TestCircuitBreaker_FailureAfterSettlingSuccessIsReclassified pins the exact
+// interleaving the concurrent test above can only hit by luck: a failure reads
+// half-open, is descheduled, a success takes transitionMu first and closes the
+// circuit, and only then does the failure acquire the lock. The failure must
+// then be reclassified as a fresh closed-state failure and re-open the circuit,
+// not be discarded because the state it was recorded against is gone. Driving
+// the locked helpers directly makes the order deterministic instead of timing
+// dependent.
+func TestCircuitBreaker_FailureAfterSettlingSuccessIsReclassified(t *testing.T) {
+	cb := New(Config{
+		FailureThreshold:    1,
+		SuccessThreshold:    1,
+		MaxHalfOpenRequests: 2,
+		OpenTimeout:         time.Nanosecond,
+	})
+	cb.RecordFailure()
+	cb.CheckState() // -> HalfOpen
+	if got := State(cb.state.Load()); got != StateHalfOpen {
+		t.Fatalf("setup: state=%v, want half-open", got)
+	}
+
+	// The success wins transitionMu and closes the circuit.
+	cb.transitionMu.Lock()
+	cb.recordSuccessHalfOpenLocked(false)
+	cb.transitionMu.Unlock()
+	if got := State(cb.state.Load()); got != StateClosed {
+		t.Fatalf("after the settling success: state=%v, want closed", got)
+	}
+
+	// The failure that had already observed half-open now records. It must not
+	// be dropped just because the episode closed underneath it.
+	cb.transitionMu.Lock()
+	cb.recordFailureHalfOpenLocked()
+	cb.transitionMu.Unlock()
+
+	if got := State(cb.state.Load()); got != StateOpen {
+		t.Fatalf("state=%v, want open: the failure was discarded instead of reclassified as a closed-state failure", got)
+	}
+	if got := cb.Stats().Failures; got < 1 {
+		t.Fatalf("failures=%d, want at least 1: the failure outcome was not counted", got)
 	}
 }

--- a/maintnotifications/pool_hook_test.go
+++ b/maintnotifications/pool_hook_test.go
@@ -876,7 +876,6 @@ func TestConnectionHook(t *testing.T) {
 
 		ctx := context.Background()
 		shouldPool, shouldRemove, err := processor.OnPut(ctx, conn)
-
 		if err != nil {
 			t.Fatalf("OnPut failed: %v", err)
 		}
@@ -968,7 +967,11 @@ func TestConnectionHook(t *testing.T) {
 
 		// Set a dialer that will check the context timeout
 		var timeoutVerified atomic.Int32
-		var timeoutNotSetError string
+		// Atomic, like timeoutVerified above: the init func below runs on the
+		// handoff worker goroutine while the assertions run on the test
+		// goroutine, so a plain string would be a data race — and it would fire
+		// exactly on the failing path this diagnostic exists to capture.
+		var timeoutNotSetError atomic.Pointer[string]
 		conn.SetInitConnFunc(func(ctx context.Context, cn *pool.Conn) error {
 			// Check that the context has the expected timeout
 			deadline, ok := ctx.Deadline()
@@ -981,9 +984,10 @@ func TestConnectionHook(t *testing.T) {
 			expectedDeadline := time.Now().Add(customTimeout)
 			timeDiff := deadline.Sub(expectedDeadline)
 			if timeDiff < -500*time.Millisecond || timeDiff > 500*time.Millisecond {
-				timeoutNotSetError = fmt.Sprintf("Context deadline not as expected. Expected around %v, got %v (diff: %v)",
+				msg := fmt.Sprintf("Context deadline not as expected. Expected around %v, got %v (diff: %v)",
 					expectedDeadline, deadline, timeDiff)
-				t.Error(timeoutNotSetError)
+				timeoutNotSetError.Store(&msg)
+				t.Error(msg)
 			} else {
 				timeoutVerified.Store(1)
 			}
@@ -1007,7 +1011,16 @@ func TestConnectionHook(t *testing.T) {
 
 		if timeoutVerified.Load() == 0 {
 			t.Error("HandoffTimeout was not properly applied to context")
-			t.Error(timeoutNotSetError)
+			// Distinguish the two failures that look identical otherwise: the
+			// init func ran and saw a wrong deadline, or it never ran inside the
+			// fixed wait above. Printing an unset message reads like the former
+			// with no numbers, while on a loaded machine the latter is the more
+			// likely flake.
+			if msg := timeoutNotSetError.Load(); msg != nil {
+				t.Error(*msg)
+			} else {
+				t.Error("the init func never ran: the handoff did not reach it within the wait above")
+			}
 		}
 
 		t.Logf("HandoffTimeout configuration test completed successfully")

--- a/maintnotifications/pool_hook_test.go
+++ b/maintnotifications/pool_hook_test.go
@@ -968,6 +968,7 @@ func TestConnectionHook(t *testing.T) {
 
 		// Set a dialer that will check the context timeout
 		var timeoutVerified atomic.Int32
+		var timeoutNotSetError string
 		conn.SetInitConnFunc(func(ctx context.Context, cn *pool.Conn) error {
 			// Check that the context has the expected timeout
 			deadline, ok := ctx.Deadline()
@@ -980,8 +981,9 @@ func TestConnectionHook(t *testing.T) {
 			expectedDeadline := time.Now().Add(customTimeout)
 			timeDiff := deadline.Sub(expectedDeadline)
 			if timeDiff < -500*time.Millisecond || timeDiff > 500*time.Millisecond {
-				t.Errorf("Context deadline not as expected. Expected around %v, got %v (diff: %v)",
+				timeoutNotSetError = fmt.Sprintf("Context deadline not as expected. Expected around %v, got %v (diff: %v)",
 					expectedDeadline, deadline, timeDiff)
+				t.Error(timeoutNotSetError)
 			} else {
 				timeoutVerified.Store(1)
 			}
@@ -1005,6 +1007,7 @@ func TestConnectionHook(t *testing.T) {
 
 		if timeoutVerified.Load() == 0 {
 			t.Error("HandoffTimeout was not properly applied to context")
+			t.Error(timeoutNotSetError)
 		}
 
 		t.Logf("HandoffTimeout configuration test completed successfully")

--- a/multidb.go
+++ b/multidb.go
@@ -655,6 +655,12 @@ func (c *MultiDBClient) AddHook(hook Hook) {
 // locally and records no success for the circuit breaker or failure detector.
 // The effect is under-recording only — slower recovery of a half-open member,
 // failures not reset — never a phantom success or a replay.
+//
+// For a cluster member this installs the hook on the *ClusterClient's own
+// process and pipeline chains only. It does not reach the per-node *Client
+// instances the cluster dials internally, so a DialHook never runs for a
+// cluster member's connections. There is currently no MultiDB API to reach
+// those per-node clients.
 func (c *MultiDBClient) AddDatabaseHook(id int, hook Hook) error {
 	return c.core.addDatabaseHook(id, hook)
 }

--- a/multidb.go
+++ b/multidb.go
@@ -530,10 +530,18 @@ func (c *MultiDBClient) Close() error {
 		c.autopipelinerMu.Unlock()
 		var firstErr error
 		for _, p := range []*AutoPipeliner{ap, async} {
-			if p != nil {
-				if err := p.Close(); err != nil && firstErr == nil {
-					firstErr = err
-				}
+			if p == nil {
+				continue
+			}
+			// Close can return immediately without draining: it loses its
+			// internal CAS when something else (e.g. a batch hook calling Close
+			// on its own executor goroutine) already claimed the shutdown.
+			// WaitClosed blocks until that drain actually finishes and reports
+			// its real result either way, so core.close() below never tears
+			// down a member pool a drain is still writing to.
+			_ = p.Close()
+			if err := p.WaitClosed(); err != nil && firstErr == nil {
+				firstErr = err
 			}
 		}
 		if err := c.core.close(); err != nil && firstErr == nil {

--- a/multidb.go
+++ b/multidb.go
@@ -514,6 +514,21 @@ func (c *MultiDBClient) Process(ctx context.Context, cmd Cmder) error {
 
 // Close stops the autopipeliners, the background loop, and every underlying
 // client.
+//
+// Do not call Close from a goroutine this client owns. Close waits for the
+// background loop to exit and for any autopipeliner drain to finish, and
+// either one can be the goroutine that called Close:
+//
+//   - From a health check or a health-check policy, Close blocks forever: those
+//     run on the background loop, and Close waits for that loop to exit.
+//   - From a member hook invoked inside an autopipeliner batch, Close blocks
+//     until that drain reaches its internal backstop, then reports a timeout:
+//     the drain is waiting for the batch whose hook is calling Close.
+//
+// Calling Close from a member hook on an ordinary (not autopipelined) command
+// is fine, as is calling it from OnFailover, OnActiveDatabaseChanged or
+// OnCircuitStateChanged — those callbacks run on a queue Close does not wait
+// for.
 func (c *MultiDBClient) Close() error {
 	// Serialize concurrent Close calls. Without this a second caller can
 	// observe the autopipeliner pointers already cleared, skip the drain loop,
@@ -539,6 +554,14 @@ func (c *MultiDBClient) Close() error {
 			// WaitClosed blocks until that drain actually finishes and reports
 			// its real result either way, so core.close() below never tears
 			// down a member pool a drain is still writing to.
+			//
+			// The wait is unconditional on purpose. Skipping it when this
+			// Close lost the CAS is what caused the teardown-under-drain bug,
+			// and there is no way to tell "another goroutine is draining"
+			// (wait) from "the drain is waiting for my own goroutine" (do not
+			// wait) without goroutine identity. Bounding the wait does not
+			// help either: a legitimate drain may run to the backstop. The
+			// reentrant case is documented on Close instead.
 			_ = p.Close()
 			if err := p.WaitClosed(); err != nil && firstErr == nil {
 				firstErr = err

--- a/multidb.go
+++ b/multidb.go
@@ -424,6 +424,15 @@ type MultiDBClient struct {
 	autopipeliner       *AutoPipeliner
 	asyncAutopipeliner  *AutoPipeliner
 	autopipelinerClosed bool
+	// builtAutopipeliners holds every instance built for this client, including
+	// ones no longer cached. An instance leaves the cache as soon as its
+	// shutdown CAS is taken, which is before its drain finishes, so a caller
+	// that closes one and asks for another would otherwise leave the first
+	// draining with nothing left holding a reference — and Close must wait for
+	// that drain before core.close() tears down the member pools it writes to.
+	// Drained entries are dropped as new ones are added, so recreating in a
+	// loop does not accumulate. Guarded by autopipelinerMu.
+	builtAutopipeliners []*AutoPipeliner
 	// pendingClusterAdds counts cluster AddDatabase calls that passed the
 	// liveness check and released autopipelinerMu to run the member's initial
 	// health probe. The autopipeliner build funcs refuse to create an instance
@@ -539,12 +548,17 @@ func (c *MultiDBClient) Close() error {
 	// the same error.
 	c.closeOnce.Do(func() {
 		c.autopipelinerMu.Lock()
-		ap, async := c.autopipeliner, c.asyncAutopipeliner
+		// Every instance ever built, not just the two cached pointers: an
+		// instance is evicted from the cache as soon as its shutdown CAS is
+		// taken, so one closed by its own caller can still be draining with
+		// no cached reference left (see builtAutopipeliners).
+		aps := c.builtAutopipeliners
+		c.builtAutopipeliners = nil
 		c.autopipeliner, c.asyncAutopipeliner = nil, nil
 		c.autopipelinerClosed = true
 		c.autopipelinerMu.Unlock()
 		var firstErr error
-		for _, p := range []*AutoPipeliner{ap, async} {
+		for _, p := range aps {
 			if p == nil {
 				continue
 			}

--- a/multidb_pipeline.go
+++ b/multidb_pipeline.go
@@ -861,8 +861,27 @@ func (c *MultiDBClient) AutoPipelineWithOptions(config *AutoPipelineOptions) (*A
 			if c.core.hasClusterMember() || c.pendingClusterAdds > 0 {
 				return nil, errMultiDBAutoPipelineCluster
 			}
-			return newAutoPipeliner(c, cfg, true)
+			return c.trackAutopipelinerLocked(newAutoPipeliner(c, cfg, true))
 		})
+}
+
+// trackAutopipelinerLocked records a freshly built autopipeliner so Close can
+// wait for its drain even after it leaves the cache, and drops the entries
+// whose drains have already finished. It passes the build result through so a
+// build func can wrap its constructor call directly. autopipelinerMu MUST be
+// held: the build funcs run under it (see builtAutopipeliners).
+func (c *MultiDBClient) trackAutopipelinerLocked(ap *AutoPipeliner, err error) (*AutoPipeliner, error) {
+	if err != nil {
+		return nil, err
+	}
+	kept := c.builtAutopipeliners[:0]
+	for _, p := range c.builtAutopipeliners {
+		if p != nil && !p.drained() {
+			kept = append(kept, p)
+		}
+	}
+	c.builtAutopipeliners = append(kept, ap)
+	return ap, nil
 }
 
 // AsyncAutoPipeline returns the deferred autopipeliner for this MultiDB
@@ -883,6 +902,6 @@ func (c *MultiDBClient) AsyncAutoPipelineWithOptions(config *AutoPipelineOptions
 			if c.core.hasClusterMember() || c.pendingClusterAdds > 0 {
 				return nil, errMultiDBAutoPipelineCluster
 			}
-			return newAutoPipeliner(c, cfg, false)
+			return c.trackAutopipelinerLocked(newAutoPipeliner(c, cfg, false))
 		})
 }

--- a/multidb_pipeline_test.go
+++ b/multidb_pipeline_test.go
@@ -1663,3 +1663,117 @@ func TestMultiDBPipelineRetryExitPreservesPriorAttemptResults(t *testing.T) {
 		}
 	}
 }
+
+// blockingPipelineHook holds a batch dispatch open: it closes entered once the
+// hook is reached, then waits on release before returning. It never calls
+// next, so it must be the only hook on the member (installed without
+// installHooks, which would put a terminal hookedDB ahead of it in the FIFO
+// chain and make it unreachable).
+type blockingPipelineHook struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func newBlockingPipelineHook() *blockingPipelineHook {
+	return &blockingPipelineHook{entered: make(chan struct{}), release: make(chan struct{})}
+}
+
+func (h *blockingPipelineHook) DialHook(next redis.DialHook) redis.DialHook { return next }
+func (h *blockingPipelineHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return next
+}
+
+func (h *blockingPipelineHook) ProcessPipelineHook(redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		h.once.Do(func() { close(h.entered) })
+		<-h.release
+		return nil
+	}
+}
+
+// TestMultiDBCloseWaitsForAutopipelinerDrain pins the AutoPipeliner.Close /
+// WaitClosed contract at the MultiDBClient boundary. AutoPipeliner.Close
+// returns immediately, without draining, when something else already claimed
+// the shutdown (its own doc: a batch hook calling Close on its own executor
+// goroutine). If MultiDBClient.Close only called Close and not WaitClosed, it
+// would then tear down the member pool while that other drain was still
+// writing to it. Here a direct external Close call stands in for that other
+// claimant: it wins the CAS and blocks in the drain (a batch dispatch is held
+// open), so MultiDBClient.Close's own Close call loses the CAS and returns
+// nil immediately. MultiDBClient.Close must still block until the drain
+// finishes.
+func TestMultiDBCloseWaitsForAutopipelinerDrain(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 1, true)
+	opts := baseOptions()
+	opts.Clients = append(opts.Clients, db1.cfg)
+	mdb, err := redis.NewMultiDBClient(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	defer mdb.Close()
+
+	block := newBlockingPipelineHook()
+	if err := mdb.AddDatabaseHook(0, block); err != nil {
+		t.Fatalf("AddDatabaseHook: %v", err)
+	}
+
+	ap, err := mdb.AutoPipeline()
+	if err != nil {
+		t.Fatalf("AutoPipeline: %v", err)
+	}
+
+	// Hold a batch dispatch open in the hook.
+	setDone := make(chan struct{})
+	go func() {
+		_ = ap.Set(context.Background(), "k", "v", 0).Err()
+		close(setDone)
+	}()
+	select {
+	case <-block.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("batch dispatch never reached the blocking hook")
+	}
+
+	// Win the AutoPipeliner's shutdown CAS directly and block in its drain
+	// (the dispatch above is still stuck in the hook).
+	apCloseDone := make(chan error, 1)
+	go func() { apCloseDone <- ap.Close() }()
+	time.Sleep(50 * time.Millisecond) // let ap.Close() win the CAS before mdb.Close() tries
+
+	// MultiDBClient.Close's own Close call on this autopipeliner now loses the
+	// CAS and returns nil immediately; it must still wait for the winning
+	// drain via WaitClosed before tearing down the member pool.
+	mdbCloseDone := make(chan error, 1)
+	go func() { mdbCloseDone <- mdb.Close() }()
+
+	select {
+	case err := <-mdbCloseDone:
+		t.Fatalf("MultiDBClient.Close returned (err=%v) while the AutoPipeliner drain was still stuck — it did not wait for WaitClosed", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(block.release) // let the stuck dispatch, and both drains, finish
+
+	select {
+	case err := <-apCloseDone:
+		if err != nil {
+			t.Errorf("AutoPipeliner.Close: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("AutoPipeliner.Close never returned after the block was released")
+	}
+	select {
+	case err := <-mdbCloseDone:
+		if err != nil {
+			t.Errorf("MultiDBClient.Close: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("MultiDBClient.Close did not unblock after the AutoPipeliner drain finished")
+	}
+	select {
+	case <-setDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the blocked ap.Set call never returned")
+	}
+}

--- a/multidb_pipeline_test.go
+++ b/multidb_pipeline_test.go
@@ -1793,3 +1793,104 @@ func TestMultiDBCloseWaitsForAutopipelinerDrain(t *testing.T) {
 		t.Fatal("the blocked ap.Set call never returned")
 	}
 }
+
+// TestMultiDBCloseWaitsForReplacedAutopipelinerDrain covers the gap the cached
+// pointer leaves. An autopipeliner is swapped out of the cache as soon as its
+// shutdown CAS is taken, which is BEFORE its drain finishes, so a caller that
+// closes one and then asks for a new one leaves the first instance draining and
+// unreachable from the cache. Close must still wait for it: that drain is
+// flushing accepted commands into the member pools core.close() tears down,
+// which is the same failure the WaitClosed wiring exists to prevent.
+func TestMultiDBCloseWaitsForReplacedAutopipelinerDrain(t *testing.T) {
+	db1 := newTestDB("db1", "127.0.0.1:1", 1, true)
+	opts := baseOptions()
+	opts.Clients = append(opts.Clients, db1.cfg)
+	mdb, err := redis.NewMultiDBClient(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("NewMultiDBClient: %v", err)
+	}
+	defer mdb.Close()
+
+	block := newBlockingPipelineHook()
+	if err := mdb.AddDatabaseHook(0, block); err != nil {
+		t.Fatalf("AddDatabaseHook: %v", err)
+	}
+
+	first, err := mdb.AutoPipeline()
+	if err != nil {
+		t.Fatalf("AutoPipeline: %v", err)
+	}
+
+	// Hold a batch dispatch open on the first instance.
+	setDone := make(chan struct{})
+	go func() {
+		_ = first.Set(context.Background(), "k", "v", 0).Err()
+		close(setDone)
+	}()
+	select {
+	case <-block.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("batch dispatch never reached the blocking hook")
+	}
+
+	// Close the first instance directly. Its drain blocks on the held dispatch.
+	firstCloseDone := make(chan error, 1)
+	go func() { firstCloseDone <- first.Close() }()
+	claimed := false
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
+		if first.IsClosed() {
+			claimed = true
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if !claimed {
+		t.Fatal("the direct AutoPipeliner.Close never claimed the shutdown")
+	}
+
+	// Ask for an autopipeliner again. The first one is closed, so this builds a
+	// replacement and evicts the first from the cache while it is still
+	// draining.
+	second, err := mdb.AutoPipeline()
+	if err != nil {
+		t.Fatalf("AutoPipeline after closing the first: %v", err)
+	}
+	if second == first {
+		t.Fatal("expected a replacement instance, got the closed one back")
+	}
+
+	// Close must wait for the evicted instance's drain, not just the
+	// replacement's (the replacement has nothing in flight and settles at once).
+	mdbCloseDone := make(chan error, 1)
+	go func() { mdbCloseDone <- mdb.Close() }()
+
+	select {
+	case err := <-mdbCloseDone:
+		t.Fatalf("MultiDBClient.Close returned (err=%v) while the evicted AutoPipeliner was still draining — its drain is untracked", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(block.release) // let the stuck dispatch and the drain finish
+
+	select {
+	case err := <-firstCloseDone:
+		if err != nil {
+			t.Errorf("first AutoPipeliner.Close: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the first AutoPipeliner.Close never returned")
+	}
+	select {
+	case err := <-mdbCloseDone:
+		if err != nil {
+			t.Errorf("MultiDBClient.Close: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("MultiDBClient.Close did not unblock after the evicted drain finished")
+	}
+	select {
+	case <-setDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the blocked Set call never returned")
+	}
+}

--- a/multidb_pipeline_test.go
+++ b/multidb_pipeline_test.go
@@ -1739,7 +1739,23 @@ func TestMultiDBCloseWaitsForAutopipelinerDrain(t *testing.T) {
 	// (the dispatch above is still stuck in the hook).
 	apCloseDone := make(chan error, 1)
 	go func() { apCloseDone <- ap.Close() }()
-	time.Sleep(50 * time.Millisecond) // let ap.Close() win the CAS before mdb.Close() tries
+	// Wait for that Close to actually claim the shutdown, rather than assuming
+	// it gets scheduled inside a fixed window. IsClosed reports the flag the
+	// shutdown CAS sets, so once it is true, MultiDBClient.Close's own Close
+	// call is guaranteed to LOSE the CAS — which is the path under test. If
+	// MultiDBClient.Close won it instead, its p.Close() would block on its own
+	// drain and the test would pass even without the WaitClosed wiring.
+	claimed := false
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
+		if ap.IsClosed() {
+			claimed = true
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if !claimed {
+		t.Fatal("the direct AutoPipeliner.Close never claimed the shutdown")
+	}
 
 	// MultiDBClient.Close's own Close call on this autopipeliner now loses the
 	// CAS and returns nil immediately; it must still wait for the winning


### PR DESCRIPTION
## What

`AutoPipeliner.Close` returns immediately, without draining, when something else already claimed the shutdown CAS. Its own doc comment names the case: a batch hook calling `Close` on its own executor goroutine. `MultiDBClient.Close` called `Close` but not `WaitClosed`, so in that race it could reach `core.close()` and tear down a member's connection pool while the other caller's drain was still flushing a batch into it.

## Fix

`MultiDBClient.Close` now calls `WaitClosed` after `Close` for each autopipeliner, before `core.close()` runs. This is the contract `AutoPipeliner.WaitClosed`'s doc already describes for a wrapping client: Close, WaitClosed, then close the pools.

For the common case — `MultiDBClient.Close`'s own call wins the CAS — `Close` already blocks for the full drain and `WaitClosed` returns at once. No behavior change there.

## Testing

`TestMultiDBCloseWaitsForAutopipelinerDrain` reproduces the race deterministically: a blocking hook holds a batch dispatch open, a direct external `Close` call wins the CAS and blocks in the drain, then `MultiDBClient.Close` is started. Before this fix the test fails (`Close` returns while the drain is still stuck); after, it blocks until the drain finishes, then returns.

Discrimination-proven: reverting the fix turns the new test red. Full multidb suite (172 funcs) passes under `-race`.

## Context

Follow-up identified while preparing PR #3954's description, tracked there under Follow-ups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shutdown ordering for MultiDB autopipeliners and can block Close until drain completes (including reentrant cases documented as hazardous); incorrect wiring could still wedge or tear down pools under in-flight batches.
> 
> **Overview**
> **MultiDBClient.Close** no longer tears down member pools while an autopipeliner is still draining. When `AutoPipeliner.Close` loses the shutdown CAS (another caller is draining), it returns immediately; the client now always follows with **`WaitClosed`** before **`core.close()`**, matching the wrapping-client contract documented on `AutoPipeliner`.
> 
> To cover autopipeliners that leave the cache as soon as shutdown is claimed, MultiDB keeps a **`builtAutopipeliners`** registry (via **`trackAutopipelinerLocked`**), prunes finished drains with the new non-blocking **`drained()`** helper, and closes every tracked instance—not only the two cached pointers. **`Close`** docs warn against calling it from the background loop or from inside an autopipelined batch hook (deadlock / drain timeout).
> 
> **Tests:** `TestMultiDBCloseWaitsForAutopipelinerDrain` and `TestMultiDBCloseWaitsForReplacedAutopipelinerDrain` lock in the CAS-loser and replaced-instance cases.
> 
> **Also in this PR:** circuit breaker stress/deterministic tests for concurrent half-open success vs failure (outcomes must not be dropped; late failures reclassified after a close). Maintnotifications pool hook test hardening (race-safe deadline assertion, clearer flake messages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 327e3bfd03520deaf555dcd7be50af05db8ed614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->