### PR TITLE
fix(internal): drain pooled semaphore timer unconditionally

### DIFF
--- a/internal/semaphore.go
+++ b/internal/semaphore.go
@@ -14,24 +14,26 @@ var semTimers = sync.Pool{
 	},
 }
 
-// putSemTimer stops a pooled timer and drains a stale fire before reuse,
-// portably across both timer-channel semantics (the drain must never block):
+// putSemTimer returns a timer to the pool, draining any pending fire first so a
+// later Reset-and-reuse cannot deliver a stale timeout.
 //
-//   - main module on go >= 1.23 (synchronous channels): Stop returns TRUE for
-//     an expired-but-undelivered fire — the delivery is aborted — and false
-//     only once the value was actually received. With the sole receiver
-//     being Acquire's own select, the drain branch is unreachable; the
-//     select-with-default is a safety net so a future semantics shift cannot
-//     turn it into a blocking receive (reviewed on #3942).
-//   - GODEBUG=asynctimerchan=1 (consumer main module on go < 1.23, old
-//     buffered channels): Stop returns false and the fired value sits in the
-//     buffer; the drain consumes it so the timer is clean for Reset-reuse.
+// The drain is UNCONDITIONAL. Stop's return value cannot decide whether a fire
+// is pending: it reports false for an already-expired timer, but a fire can also
+// settle into the channel while Stop runs, and Stop can report true in that
+// window. The earlier code gated the drain on `!t.Stop()` and skipped it when
+// Stop returned true, so a timer holding an undelivered fire went back to the
+// pool dirty; the next Acquire's select then read that stale value as an instant
+// timeout. Observed in CI on Go 1.24 (oldstable, GODEBUG unset) as a spurious
+// timeout in TestFIFOSemaphoreNoStaleTimerFire (semaphore_test.go).
+//
+// The non-blocking select/default is safe under both timer-channel semantics and
+// never hangs: after Stop the timer is disarmed, so at most one fire can be
+// pending; if none is pending the default branch runs.
 func putSemTimer(t *time.Timer) {
-	if !t.Stop() {
-		select {
-		case <-t.C:
-		default:
-		}
+	t.Stop()
+	select {
+	case <-t.C:
+	default:
 	}
 	semTimers.Put(t)
 }

--- a/internal/semaphore_test.go
+++ b/internal/semaphore_test.go
@@ -12,15 +12,12 @@ var errSemTestTimeout = errors.New("sem test timeout")
 
 // hammerAcquireReleaseRace races Release against timeout expiry so the
 // Acquire select's token case regularly commits around the moment the pooled
-// timer fires, pinning the `if !timer.Stop() { <-timer.C }` drain against
-// BOTH timer-channel semantics (reviewed on #3942 as a suspected Go 1.23+
-// hang, refuted empirically):
+// timer fires, exercising putSemTimer's unconditional drain against BOTH
+// timer-channel semantics. It must never hang (the drain is non-blocking).
 //
-//   - go.mod >= 1.23 (synchronous channels): Stop returns TRUE for an
-//     expired-but-undelivered fire — it aborts the delivery — and returns
-//     false only once the value was actually received. With the receiving
-//     select on the SAME goroutine, a taken token means the fire was never
-//     received, so the drain branch is unreachable and cannot block.
+//   - go.mod >= 1.23 (synchronous channels): a fire can settle into the channel
+//     while the select takes the token case; Stop cannot be trusted to report or
+//     abort it, so the drain runs unconditionally to keep the pooled timer clean.
 //   - GODEBUG=asynctimerchan=1 (old buffered channels, e.g. a consumer main
 //     module on go < 1.23): Stop returns false and the fired value sits
 //     buffered; the drain consumes it so the pooled timer is clean for
@@ -55,8 +52,8 @@ func hammerAcquireReleaseRace(t *testing.T, tryAcquire func() bool, acquire func
 	select {
 	case <-done:
 	case <-time.After(60 * time.Second):
-		t.Fatal("Acquire hung: timer drained with a blocking receive after Stop returned false " +
-			"(Go 1.23+ synchronous timer channels discard undelivered fires)")
+		t.Fatal("Acquire hung: a pooled-timer drain blocked on receive instead of " +
+			"using a non-blocking select/default")
 	}
 }
 


### PR DESCRIPTION
putSemTimer gated its stale-fire drain on `!t.Stop()` and skipped it when Stop
returned true. Stop's return cannot decide whether a fire is pending: it reports
false for an already-expired timer, but a fire can settle into the channel while
Stop runs, and Stop can report true in that window. A timer holding an
undelivered fire then went back to the pool dirty, and the next Acquire's
Reset-and-select read the stale value as an instant timeout.

Drain unconditionally with a non-blocking select/default after Stop. It is safe
under both timer-channel semantics and never hangs: after Stop the timer is
disarmed, so at most one fire can be pending; the default branch runs when none
is.

Observed in CI on Go 1.24 (oldstable, GODEBUG unset) as a spurious timeout in
TestFIFOSemaphoreNoStaleTimerFire. Not reproduced locally on go1.24.13 or
go1.25.3 across tens of thousands of iterations; the fix holds by construction,
since Stop's return cannot detect a pending fire.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared timer-pool hygiene on all semaphore acquire timeouts; incorrect draining could cause hangs or false timeouts, though the change is narrowly scoped and justified by Go timer semantics.
> 
> **Overview**
> Fixes **spurious acquire timeouts** when semaphores reuse pooled `time.Timer` values after an acquire wins on the token path instead of the timer.
> 
> **`putSemTimer`** now always calls `Stop()` and then runs a **non-blocking** drain on `timer.C`. The previous logic only drained when `Stop()` returned false, but on Go 1.24+ a fire can land in the channel while `Stop()` runs and still get `true`—so dirty timers re-entered the pool and the next `Acquire` could treat a stale fire as an immediate timeout (seen in CI for `TestFIFOSemaphoreNoStaleTimerFire`).
> 
> Test comments and the race-hammer hang message were updated to describe the unconditional drain and that it must not block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 138ccd5678fa3708798a6708aaa8e062403b6a23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->