### PR TITLE
feat(otel): MultiDB metrics in redisotel-native

### DIFF
--- a/extra/redisotel-native/attributes.go
+++ b/extra/redisotel-native/attributes.go
@@ -47,6 +47,16 @@ const (
 
 	// Notification attributes
 	AttrRedisClientConnectionNotification = "redis.client.connection.notification"
+
+	// MultiDB (Active-Active failover) attributes. Databases are identified
+	// by the host-only FQDN the client reports for a member.
+	AttrRedisClientMultiDBDatabase           = "redis.client.multidb.database"
+	AttrRedisClientMultiDBFromDatabase       = "redis.client.multidb.from_database"
+	AttrRedisClientMultiDBToDatabase         = "redis.client.multidb.to_database"
+	AttrRedisClientMultiDBFailoverReason     = "redis.client.multidb.failover.reason"
+	AttrRedisClientMultiDBCircuitFromState   = "redis.client.multidb.circuit_breaker.from_state"
+	AttrRedisClientMultiDBCircuitToState     = "redis.client.multidb.circuit_breaker.to_state"
+	AttrRedisClientMultiDBHealthCheckSuccess = "redis.client.multidb.health_check.success"
 )
 
 // Connection state values

--- a/extra/redisotel-native/config.go
+++ b/extra/redisotel-native/config.go
@@ -15,6 +15,7 @@ const (
 	MetricGroupConnectionAdvanced MetricGroup = "connection-advanced"
 	MetricGroupPubSub             MetricGroup = "pubsub"
 	MetricGroupStream             MetricGroup = "stream"
+	MetricGroupMultiDB            MetricGroup = "multidb"
 )
 
 type HistogramAggregation string
@@ -105,6 +106,10 @@ const (
 	MetricGroupFlagConnectionAdvanced MetricGroupFlags = 1 << 3
 	MetricGroupFlagPubSub             MetricGroupFlags = 1 << 4
 	MetricGroupFlagStream             MetricGroupFlags = 1 << 5
+	// MetricGroupFlagMultiDB enables the MultiDB (Active-Active failover)
+	// metrics: failovers, active database changes, member circuit breaker
+	// transitions and health checks.
+	MetricGroupFlagMultiDB MetricGroupFlags = 1 << 6
 
 	// MetricGroupAll enables all metric groups
 	MetricGroupAll MetricGroupFlags = MetricGroupFlagCommand |
@@ -112,7 +117,8 @@ const (
 		MetricGroupFlagResiliency |
 		MetricGroupFlagConnectionAdvanced |
 		MetricGroupFlagPubSub |
-		MetricGroupFlagStream
+		MetricGroupFlagStream |
+		MetricGroupFlagMultiDB
 )
 
 // Use NewConfig() to create a new instance with defaults, then chain
@@ -156,7 +162,7 @@ type Config struct {
 // NewConfig creates a new Config with default values.
 // Default configuration:
 // - Enabled: false (must explicitly enable)
-// - MetricGroups: all metric groups (command, connection, resiliency, pubsub, stream)
+// - MetricGroups: all metric groups (command, connection, resiliency, pubsub, stream, multidb)
 // - HistogramAggregation: explicit bucket
 // - Buckets: 0.1ms to 10s (suitable for Redis operations)
 //

--- a/extra/redisotel-native/metrics.go
+++ b/extra/redisotel-native/metrics.go
@@ -55,6 +55,14 @@ type metricsRecorder struct {
 
 	streamLag metric.Float64Histogram
 
+	// MultiDB (Active-Active failover); see metrics_multidb.go
+	multiDBFailovers             metric.Int64Counter
+	multiDBFailoverDuration      metric.Float64Histogram
+	multiDBActiveDatabaseChanges metric.Int64Counter
+	multiDBCircuitStateChanges   metric.Int64Counter
+	multiDBHealthChecks          metric.Int64Counter
+	multiDBHealthCheckDuration   metric.Float64Histogram
+
 	// Configuration
 	cfg *config
 }

--- a/extra/redisotel-native/metrics_multidb.go
+++ b/extra/redisotel-native/metrics_multidb.go
@@ -1,0 +1,97 @@
+package redisotel
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// MultiDB (Active-Active failover) metrics.
+//
+// The MultiDB client reports its events through an optional capability
+// interface on the recorder (go-redis #3954): a recorder without these
+// methods receives none of them. Database FQDNs are the host-only names the
+// client reports for its members. There is one per member, so they are
+// recorded as attributes without a cardinality switch.
+
+func multiDBBaseAttrs() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String(AttrDBSystemName, DBSystemRedis),
+		getLibraryVersionAttr(),
+	}
+}
+
+// RecordMultiDBFailover records a failover from one member database to
+// another. reason is "automatic" or "manual"; duration is the wall time of
+// the failover.
+func (r *metricsRecorder) RecordMultiDBFailover(
+	ctx context.Context,
+	fromFQDN, toFQDN, reason string,
+	duration time.Duration,
+) {
+	if r.multiDBFailovers == nil && r.multiDBFailoverDuration == nil {
+		return
+	}
+	attrs := append(
+		multiDBBaseAttrs(),
+		attribute.String(AttrRedisClientMultiDBFromDatabase, fromFQDN),
+		attribute.String(AttrRedisClientMultiDBToDatabase, toFQDN),
+		attribute.String(AttrRedisClientMultiDBFailoverReason, reason),
+	)
+	if r.multiDBFailovers != nil {
+		r.multiDBFailovers.Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+	if r.multiDBFailoverDuration != nil {
+		r.multiDBFailoverDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(attrs...))
+	}
+}
+
+// RecordMultiDBActiveDatabaseChange records a change of the active member
+// database (failover, fallback or manual selection).
+func (r *metricsRecorder) RecordMultiDBActiveDatabaseChange(ctx context.Context, fromFQDN, toFQDN string) {
+	if r.multiDBActiveDatabaseChanges == nil {
+		return
+	}
+	attrs := append(
+		multiDBBaseAttrs(),
+		attribute.String(AttrRedisClientMultiDBFromDatabase, fromFQDN),
+		attribute.String(AttrRedisClientMultiDBToDatabase, toFQDN),
+	)
+	r.multiDBActiveDatabaseChanges.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// RecordMultiDBCircuitStateChange records a member circuit breaker state
+// transition ("closed", "open", "half-open").
+func (r *metricsRecorder) RecordMultiDBCircuitStateChange(ctx context.Context, dbFQDN, fromState, toState string) {
+	if r.multiDBCircuitStateChanges == nil {
+		return
+	}
+	attrs := append(
+		multiDBBaseAttrs(),
+		attribute.String(AttrRedisClientMultiDBDatabase, dbFQDN),
+		attribute.String(AttrRedisClientMultiDBCircuitFromState, fromState),
+		attribute.String(AttrRedisClientMultiDBCircuitToState, toState),
+	)
+	r.multiDBCircuitStateChanges.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// RecordMultiDBHealthCheck records the outcome and wall time of one member
+// health check.
+func (r *metricsRecorder) RecordMultiDBHealthCheck(ctx context.Context, dbFQDN string, success bool, duration time.Duration) {
+	if r.multiDBHealthChecks == nil && r.multiDBHealthCheckDuration == nil {
+		return
+	}
+	attrs := append(
+		multiDBBaseAttrs(),
+		attribute.String(AttrRedisClientMultiDBDatabase, dbFQDN),
+		attribute.Bool(AttrRedisClientMultiDBHealthCheckSuccess, success),
+	)
+	if r.multiDBHealthChecks != nil {
+		r.multiDBHealthChecks.Add(ctx, 1, metric.WithAttributes(attrs...))
+	}
+	if r.multiDBHealthCheckDuration != nil {
+		r.multiDBHealthCheckDuration.Record(ctx, duration.Seconds(), metric.WithAttributes(attrs...))
+	}
+}

--- a/extra/redisotel-native/metrics_multidb_test.go
+++ b/extra/redisotel-native/metrics_multidb_test.go
@@ -1,0 +1,176 @@
+package redisotel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// multiDBRecorder mirrors redis.OTelMultiDBRecorder, the capability interface
+// the MultiDB client asserts for on the recorder (go-redis #3954). Pinning
+// the method set here keeps the signatures in step until that interface is
+// on master; then this can become a direct assertion against it.
+type multiDBRecorder interface {
+	RecordMultiDBFailover(ctx context.Context, fromFQDN, toFQDN, reason string, duration time.Duration)
+	RecordMultiDBActiveDatabaseChange(ctx context.Context, fromFQDN, toFQDN string)
+	RecordMultiDBCircuitStateChange(ctx context.Context, dbFQDN, fromState, toState string)
+	RecordMultiDBHealthCheck(ctx context.Context, dbFQDN string, success bool, duration time.Duration)
+}
+
+var _ multiDBRecorder = (*metricsRecorder)(nil)
+
+// newTestRecorder builds a recorder for the given metric groups on a manual
+// reader, without touching the global observability instance.
+func newTestRecorder(t *testing.T, groups MetricGroupFlags) (*metricsRecorder, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(context.Background()) })
+	o := &ObservabilityInstance{}
+	cfg := NewConfig().WithEnabled(true).WithMeterProvider(mp).WithMetricGroups(groups)
+	rec, err := o.createRecorder(mp.Meter("test"), o.configToInternal(cfg))
+	if err != nil {
+		t.Fatalf("createRecorder: %v", err)
+	}
+	return rec, reader
+}
+
+func collectMetrics(t *testing.T, reader *sdkmetric.ManualReader) map[string]metricdata.Metrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	out := map[string]metricdata.Metrics{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			out[m.Name] = m
+		}
+	}
+	return out
+}
+
+func attrString(t *testing.T, set attribute.Set, key string) string {
+	t.Helper()
+	v, ok := set.Value(attribute.Key(key))
+	if !ok {
+		t.Fatalf("attribute %q missing from %v", key, set.ToSlice())
+	}
+	return v.AsString()
+}
+
+func TestMultiDBMetricNames(t *testing.T) {
+	for name, want := range map[string]string{
+		MetricMultiDBFailovers:             "redis.client.multidb.failovers",
+		MetricMultiDBFailoverDuration:      "redis.client.multidb.failover.duration",
+		MetricMultiDBActiveDatabaseChanges: "redis.client.multidb.active_database.changes",
+		MetricMultiDBCircuitStateChanges:   "redis.client.multidb.circuit_breaker.state_changes",
+		MetricMultiDBHealthChecks:          "redis.client.multidb.health_checks",
+		MetricMultiDBHealthCheckDuration:   "redis.client.multidb.health_check.duration",
+	} {
+		if name != want {
+			t.Errorf("metric name %q, want %q", name, want)
+		}
+	}
+}
+
+func TestMultiDBMetricsRecorded(t *testing.T) {
+	ctx := context.Background()
+	rec, reader := newTestRecorder(t, MetricGroupFlagMultiDB)
+
+	rec.RecordMultiDBFailover(ctx, "a.example.com", "b.example.com", "automatic", 250*time.Millisecond)
+	rec.RecordMultiDBActiveDatabaseChange(ctx, "a.example.com", "b.example.com")
+	rec.RecordMultiDBCircuitStateChange(ctx, "a.example.com", "closed", "open")
+	rec.RecordMultiDBHealthCheck(ctx, "b.example.com", true, 10*time.Millisecond)
+	rec.RecordMultiDBHealthCheck(ctx, "a.example.com", false, 3*time.Second)
+
+	got := collectMetrics(t, reader)
+
+	failovers, ok := got[MetricMultiDBFailovers].Data.(metricdata.Sum[int64])
+	if !ok || len(failovers.DataPoints) != 1 || failovers.DataPoints[0].Value != 1 {
+		t.Fatalf("%s: want one data point with value 1, got %+v", MetricMultiDBFailovers, got[MetricMultiDBFailovers].Data)
+	}
+	fa := failovers.DataPoints[0].Attributes
+	if attrString(t, fa, AttrRedisClientMultiDBFromDatabase) != "a.example.com" ||
+		attrString(t, fa, AttrRedisClientMultiDBToDatabase) != "b.example.com" ||
+		attrString(t, fa, AttrRedisClientMultiDBFailoverReason) != "automatic" {
+		t.Fatalf("%s attributes = %v", MetricMultiDBFailovers, fa.ToSlice())
+	}
+	failoverDur, ok := got[MetricMultiDBFailoverDuration].Data.(metricdata.Histogram[float64])
+	if !ok || len(failoverDur.DataPoints) != 1 || failoverDur.DataPoints[0].Count != 1 || failoverDur.DataPoints[0].Sum != 0.25 {
+		t.Fatalf("%s: want one point, count 1, sum 0.25s, got %+v", MetricMultiDBFailoverDuration, got[MetricMultiDBFailoverDuration].Data)
+	}
+
+	changes, ok := got[MetricMultiDBActiveDatabaseChanges].Data.(metricdata.Sum[int64])
+	if !ok || len(changes.DataPoints) != 1 || changes.DataPoints[0].Value != 1 {
+		t.Fatalf("%s: want one data point with value 1, got %+v", MetricMultiDBActiveDatabaseChanges, got[MetricMultiDBActiveDatabaseChanges].Data)
+	}
+
+	cb, ok := got[MetricMultiDBCircuitStateChanges].Data.(metricdata.Sum[int64])
+	if !ok || len(cb.DataPoints) != 1 {
+		t.Fatalf("%s: want one data point, got %+v", MetricMultiDBCircuitStateChanges, got[MetricMultiDBCircuitStateChanges].Data)
+	}
+	ca := cb.DataPoints[0].Attributes
+	if attrString(t, ca, AttrRedisClientMultiDBDatabase) != "a.example.com" ||
+		attrString(t, ca, AttrRedisClientMultiDBCircuitFromState) != "closed" ||
+		attrString(t, ca, AttrRedisClientMultiDBCircuitToState) != "open" {
+		t.Fatalf("%s attributes = %v", MetricMultiDBCircuitStateChanges, ca.ToSlice())
+	}
+
+	// Health checks: one series per (database, success).
+	hc, ok := got[MetricMultiDBHealthChecks].Data.(metricdata.Sum[int64])
+	if !ok || len(hc.DataPoints) != 2 {
+		t.Fatalf("%s: want two data points (one per database/outcome), got %+v", MetricMultiDBHealthChecks, got[MetricMultiDBHealthChecks].Data)
+	}
+	for _, dp := range hc.DataPoints {
+		success, ok := dp.Attributes.Value(attribute.Key(AttrRedisClientMultiDBHealthCheckSuccess))
+		if !ok {
+			t.Fatalf("%s: success attribute missing: %v", MetricMultiDBHealthChecks, dp.Attributes.ToSlice())
+		}
+		db := attrString(t, dp.Attributes, AttrRedisClientMultiDBDatabase)
+		if (db == "b.example.com") != success.AsBool() {
+			t.Fatalf("%s: database %s recorded with success=%v", MetricMultiDBHealthChecks, db, success.AsBool())
+		}
+	}
+	hcDur, ok := got[MetricMultiDBHealthCheckDuration].Data.(metricdata.Histogram[float64])
+	if !ok || len(hcDur.DataPoints) != 2 {
+		t.Fatalf("%s: want two data points, got %+v", MetricMultiDBHealthCheckDuration, got[MetricMultiDBHealthCheckDuration].Data)
+	}
+}
+
+// With the group disabled the instruments are nil and the methods are no-ops.
+func TestMultiDBMetricsDisabledGroup(t *testing.T) {
+	ctx := context.Background()
+	rec, reader := newTestRecorder(t, MetricGroupFlagCommand)
+
+	rec.RecordMultiDBFailover(ctx, "a", "b", "manual", time.Second)
+	rec.RecordMultiDBActiveDatabaseChange(ctx, "a", "b")
+	rec.RecordMultiDBCircuitStateChange(ctx, "a", "open", "half-open")
+	rec.RecordMultiDBHealthCheck(ctx, "a", true, time.Millisecond)
+
+	got := collectMetrics(t, reader)
+	for _, name := range []string{
+		MetricMultiDBFailovers, MetricMultiDBFailoverDuration, MetricMultiDBActiveDatabaseChanges,
+		MetricMultiDBCircuitStateChanges, MetricMultiDBHealthChecks, MetricMultiDBHealthCheckDuration,
+	} {
+		if _, present := got[name]; present {
+			t.Errorf("%s recorded although the multidb metric group is disabled", name)
+		}
+	}
+}
+
+// MetricGroupAll includes the MultiDB group.
+func TestMultiDBGroupInAll(t *testing.T) {
+	if MetricGroupAll&MetricGroupFlagMultiDB == 0 {
+		t.Fatal("MetricGroupAll does not include MetricGroupFlagMultiDB")
+	}
+	o := &ObservabilityInstance{}
+	internal := o.configToInternal(NewConfig())
+	if !internal.isMetricGroupEnabled(MetricGroupMultiDB) {
+		t.Fatal("default config does not enable the multidb metric group")
+	}
+}

--- a/extra/redisotel-native/redisotel.go
+++ b/extra/redisotel-native/redisotel.go
@@ -37,6 +37,14 @@ const (
 	// Stream metrics
 	MetricStreamLag = "redis.client.stream.lag"
 
+	// MultiDB (Active-Active failover) metrics
+	MetricMultiDBFailovers             = "redis.client.multidb.failovers"
+	MetricMultiDBFailoverDuration      = "redis.client.multidb.failover.duration"
+	MetricMultiDBActiveDatabaseChanges = "redis.client.multidb.active_database.changes"
+	MetricMultiDBCircuitStateChanges   = "redis.client.multidb.circuit_breaker.state_changes"
+	MetricMultiDBHealthChecks          = "redis.client.multidb.health_checks"
+	MetricMultiDBHealthCheckDuration   = "redis.client.multidb.health_check.duration"
+
 	// Special pool names
 	PoolNameMain   = "main"
 	PoolNamePubSub = "pubsub"
@@ -158,6 +166,9 @@ func (o *ObservabilityInstance) configToInternal(cfg *Config) config {
 	}
 	if cfg.MetricGroups&MetricGroupFlagStream != 0 {
 		enabledGroups[MetricGroupStream] = true
+	}
+	if cfg.MetricGroups&MetricGroupFlagMultiDB != 0 {
+		enabledGroups[MetricGroupMultiDB] = true
 	}
 
 	return config{
@@ -337,6 +348,72 @@ func (o *ObservabilityInstance) createRecorder(meter metric.Meter, cfg config) (
 		}
 	}
 
+	// MultiDB (Active-Active failover). The durations share the operation
+	// duration buckets: a failover or a health check spans the same range
+	// (sub-millisecond to seconds) as a command.
+	var multiDBFailovers, multiDBActiveDatabaseChanges, multiDBCircuitStateChanges, multiDBHealthChecks metric.Int64Counter
+	var multiDBFailoverDuration, multiDBHealthCheckDuration metric.Float64Histogram
+	if cfg.isMetricGroupEnabled(MetricGroupMultiDB) {
+		var durationOpts []metric.Float64HistogramOption
+		if cfg.histAggregation == HistogramAggregationExplicitBucket {
+			durationOpts = append(durationOpts,
+				metric.WithExplicitBucketBoundaries(cfg.bucketsOperationDuration...),
+			)
+		}
+		multiDBFailovers, err = meter.Int64Counter(
+			MetricMultiDBFailovers,
+			metric.WithDescription("Number of MultiDB failovers from one member database to another"),
+			metric.WithUnit("{failover}"),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create multidb failovers metric: %w", err)
+		}
+		multiDBFailoverDuration, err = meter.Float64Histogram(
+			MetricMultiDBFailoverDuration,
+			append(durationOpts,
+				metric.WithDescription("Wall time of a MultiDB failover"),
+				metric.WithUnit("s"),
+			)...,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create multidb failover duration histogram: %w", err)
+		}
+		multiDBActiveDatabaseChanges, err = meter.Int64Counter(
+			MetricMultiDBActiveDatabaseChanges,
+			metric.WithDescription("Number of MultiDB active database changes (failover, fallback or manual selection)"),
+			metric.WithUnit("{change}"),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create multidb active database changes metric: %w", err)
+		}
+		multiDBCircuitStateChanges, err = meter.Int64Counter(
+			MetricMultiDBCircuitStateChanges,
+			metric.WithDescription("Number of MultiDB member circuit breaker state transitions"),
+			metric.WithUnit("{transition}"),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create multidb circuit breaker state changes metric: %w", err)
+		}
+		multiDBHealthChecks, err = meter.Int64Counter(
+			MetricMultiDBHealthChecks,
+			metric.WithDescription("Number of MultiDB member health checks, by outcome"),
+			metric.WithUnit("{check}"),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create multidb health checks metric: %w", err)
+		}
+		multiDBHealthCheckDuration, err = meter.Float64Histogram(
+			MetricMultiDBHealthCheckDuration,
+			append(durationOpts,
+				metric.WithDescription("Wall time of a MultiDB member health check"),
+				metric.WithUnit("s"),
+			)...,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create multidb health check duration histogram: %w", err)
+		}
+	}
+
 	// Create recorder
 	recorder := &metricsRecorder{
 		operationDuration:        operationDuration,
@@ -351,7 +428,15 @@ func (o *ObservabilityInstance) createRecorder(meter metric.Meter, cfg config) (
 		connectionPendingReqs:    connectionPendingReqs,
 		pubsubMessages:           pubsubMessages,
 		streamLag:                streamLag,
-		cfg:                      &cfg,
+
+		multiDBFailovers:             multiDBFailovers,
+		multiDBFailoverDuration:      multiDBFailoverDuration,
+		multiDBActiveDatabaseChanges: multiDBActiveDatabaseChanges,
+		multiDBCircuitStateChanges:   multiDBCircuitStateChanges,
+		multiDBHealthChecks:          multiDBHealthChecks,
+		multiDBHealthCheckDuration:   multiDBHealthCheckDuration,
+
+		cfg: &cfg,
 	}
 
 	return recorder, nil


### PR DESCRIPTION
## What

Implements the MultiDB (Active-Active failover) metrics in `extra/redisotel-native`. The MultiDB client in #3954 reports its events through an optional capability interface on the OTel recorder (`OTelMultiDBRecorder`: failover, active database change, circuit breaker state change, health check). The native recorder did not implement it, so applications using the repository's standard instrumentation received none of those events.

## Metrics

New metric group `multidb` (`MetricGroupFlagMultiDB`, included in `MetricGroupAll`), six instruments in the module's `redis.client.*` naming:

| Metric | Instrument | Unit | Attributes |
|---|---|---|---|
| `redis.client.multidb.failovers` | counter | `{failover}` | from_database, to_database, failover.reason |
| `redis.client.multidb.failover.duration` | histogram | `s` | from_database, to_database, failover.reason |
| `redis.client.multidb.active_database.changes` | counter | `{change}` | from_database, to_database |
| `redis.client.multidb.circuit_breaker.state_changes` | counter | `{transition}` | database, circuit_breaker.from_state, circuit_breaker.to_state |
| `redis.client.multidb.health_checks` | counter | `{check}` | database, health_check.success |
| `redis.client.multidb.health_check.duration` | histogram | `s` | database, health_check.success |

All attributes are under `redis.client.multidb.*`, plus the usual `db.system.name` and `redis.client.library`. Durations share the operation duration buckets. Databases are identified by the host-only FQDN the client reports for a member; there is one per member, so it is an attribute without a cardinality switch.

## Relation to #3954

The capability interface lives in #3954 and is not on master yet. The recorder methods here match its signatures exactly; the tests pin the method set through a local mirror of the interface (`multiDBRecorder`). Once #3954 merges, that mirror can become a direct `var _ redis.OTelMultiDBRecorder = (*metricsRecorder)(nil)`. Until then the methods are inert: nothing on master calls them, and nothing on master breaks.

## Testing

- `TestMultiDBMetricsRecorded`: records each event against a manual reader and checks instrument names, data point counts, values and attributes.
- `TestMultiDBMetricsDisabledGroup`: with the group disabled the instruments are nil and the methods are no-ops.
- `TestMultiDBGroupInAll`: the default config enables the group.
- `TestMultiDBMetricNames`: pins the metric names.
- Module `go test -race`, `go vet` and `golangci-lint` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive metrics and recorder methods following existing redisotel-native patterns; no runtime behavior change until the MultiDB client calls the new APIs.
> 
> **Overview**
> Adds **MultiDB (Active-Active failover)** observability to `extra/redisotel-native` so the native OTel recorder can emit the events the MultiDB client will report via an optional capability interface (go-redis #3954).
> 
> A new **`multidb` metric group** (`MetricGroupFlagMultiDB`, included in `MetricGroupAll`) registers six `redis.client.multidb.*` instruments: failover count/duration, active database changes, circuit breaker state transitions, and health check count/duration. Member databases are labeled with host-only FQDN attributes; duration histograms reuse operation-duration buckets.
> 
> `metricsRecorder` gains `RecordMultiDB*` methods that no-op when the group is disabled (nil instruments). Tests cover recording, disabled group behavior, default config inclusion, and metric name constants; a local interface mirror keeps signatures aligned until `redis.OTelMultiDBRecorder` lands on master.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb4b58117cf12ab38277212c65df75d24da6352c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->