### PR TITLE
feat(autopipeline): full-duplex on cluster clients

### DIFF
--- a/autopipeline.go
+++ b/autopipeline.go
@@ -79,10 +79,13 @@ type AutoPipelineOptions struct {
 	// nothing to overlap, and it still pays the held connection and goroutine
 	// overhead; the win needs MANY concurrent blocking callers, whose commands then
 	// overlap on the shared pipe exactly as on the async face (~1 RTT each instead
-	// of batch phase-locking). NOT supported on cluster clients: a ClusterClient
-	// silently falls back to half-duplex (the options type cannot see the client
-	// type, so Validate cannot catch it). Validate does reject the contradictory
-	// standalone combos (FullDuplex with Unordered or MaxConcurrentBatches>1).
+	// of batch phase-locking). On a ClusterClient it runs natively per node: the
+	// engine keeps one FD child per master (each on that node's node.Client, which
+	// has a pipeline pool by default) and routes each command to the child that
+	// owns its slot; MOVED/ASK redirects are followed through the redirect-aware
+	// cluster path (topology reload included). It falls back to half-duplex only
+	// when PipelinePoolSize<0 removes the node pipeline pools. Validate rejects the
+	// contradictory standalone combos (FullDuplex with Unordered or MaxConcurrentBatches>1).
 	//
 	// Ordering caveat: blocking and connection-hostile commands (BLPOP, WAIT,
 	// XREAD BLOCK, SUBSCRIBE, MULTI, ...) are diverted to a separate pooled
@@ -225,6 +228,22 @@ type AutoPipelineOptions struct {
 	// wiring from the NumShards ordering check in newAutoPipeliner. Never set
 	// by users (unexported).
 	contentSharded bool
+
+	// clusterReprocess is set internally by the cluster full-duplex router on each
+	// per-node child config. When non-nil, the child's full-duplex engine re-runs a
+	// command that came back with a retryable reply or a MOVED/ASK redirect through
+	// this function instead of the node client's standalone process path, so the
+	// redirect is followed on the redirect-aware ClusterClient (which routes to the
+	// target node, sends ASKING, and reloads topology). Never set by users
+	// (unexported). See clusterFDRouter and fdEngine.reprocess.
+	clusterReprocess func(ctx context.Context, cmd Cmder, startAttempt int, writtenAt time.Time) error
+
+	// clusterRetryBudget is set internally by the cluster full-duplex router to the
+	// ClusterClient's MaxRedirects. The child's full-duplex engine uses it as its
+	// connection-failure recovery budget (fdEngine.retryBudget) instead of the node
+	// client's MaxRetries, which cluster node clients normalize to -1 (cluster
+	// retries live in MaxRedirects). Never set by users (unexported).
+	clusterRetryBudget int
 
 	// NumShards is the number of independent queue+flusher shards the
 	// autopipeliner runs. 0 (the default) means auto: a single shard, which
@@ -807,6 +826,12 @@ type AutoPipeliner struct {
 	// submit() streams on one held connection instead of the sharded batch queue
 	// and no shard flusher is started. See autopipeline_fullduplex.go.
 	fd *fdEngine
+	// clusterFD, when non-nil, runs ordered full-duplex natively on a
+	// *ClusterClient by routing each command to a per-node FD child autopipeliner
+	// (one held connection per master). Mutually exclusive with fd and with the
+	// half-duplex shard flushers: when set, submit() routes to the owning node's
+	// child and no shard flusher is started. See autopipeline_cluster_fd.go.
+	clusterFD *clusterFDRouter
 	// pipelinePool is the connection pool that backs autopipelined batch
 	// dispatch (distinct from the client's main pool). Captured once at
 	// construction via an in-package assertion; nil when the underlying client
@@ -1167,6 +1192,55 @@ func newAutoPipeliner(pipeliner cmdableClient, config *AutoPipelineOptions, bloc
 	if nShards <= 0 {
 		nShards = 1
 	}
+	// Cluster full-duplex: a *ClusterClient cannot host an fdEngine (it has no
+	// pipeline pool of its own), but every master node's node.Client is a
+	// standalone *Client that gets one by default. When full-duplex is requested
+	// on the ordered single-face cluster autopipeliner, route each command to a
+	// per-node FD child (clusterFDRouter) instead of the half-duplex shard
+	// flushers. Gate on cc.opt.PipelinePoolSize >= 0 — the exact predicate that
+	// decides whether every node.Client gets a pipeline pool (osscluster.go passes
+	// it through, redis.go creates the pool on it) — so the check is synchronous
+	// and needs no topology load under the getter's mutex. Force a single
+	// flusherless shard, exactly like the fdOn path: no half-duplex flusher runs
+	// and enqueue's shard indexing stays safe (never a %0), even though submit
+	// routes past it.
+	var clusterFDCC *ClusterClient
+	clusterFDOn := false
+	if config.FullDuplex && !config.Unordered && config.MaxConcurrentBatches <= 1 {
+		// The router always routes to the slot's MASTER node child (slotMasterNode).
+		// A client configured for replica routing — ReadOnly, RouteByLatency, or
+		// RouteRandomly — would have those options silently ignored under cluster FD,
+		// pinning reads to masters. Fall back to the half-duplex shard flushers, which
+		// route through Process and honor the configured ShardPicker, and let
+		// Config().FullDuplex report false (honest: FD is not the effective mode).
+		// RouteByLatency/RouteRandomly auto-enable ReadOnly at option init (before this
+		// gate reads them), so !ReadOnly alone would cover all three; the explicit
+		// three document intent and are robust to any init reordering.
+		if cc, ok := pipeliner.(*ClusterClient); ok &&
+			cc.opt.PipelinePoolSize >= 0 &&
+			!cc.opt.ReadOnly && !cc.opt.RouteByLatency && !cc.opt.RouteRandomly {
+			clusterFDOn, clusterFDCC = true, cc
+			nShards = 1
+			// Report the actual shard count (1), not the cluster default, from Config().
+			config.NumShards = 1
+			// Resolve the FD tuning defaults on the PARENT config now, mirroring
+			// newFDEngine (which only writes them onto each child's config). Without
+			// this, Config() on a default-constructed cluster-FD autopipeliner would
+			// report zero for these while the children enforce nonzero defaults —
+			// breaking the effective-defaults contract the standalone FD path honors.
+			// config is the same pointer Config() reads; this runs at construction
+			// before ap escapes, so no Config() reader races these writes.
+			if config.FullDuplexWindow <= 0 {
+				config.FullDuplexWindow = fdDefaultWindow
+			}
+			if config.FullDuplexIdleTimeout <= 0 {
+				config.FullDuplexIdleTimeout = fdDefaultIdle
+			}
+			if config.FullDuplexMaxHold <= 0 {
+				config.FullDuplexMaxHold = fdDefaultMaxHold
+			}
+		}
+	}
 	// Split the concurrent-batch budget across shards so each shard has its own
 	// semaphore. A single shared semaphore became a contention point once the
 	// per-shard queue mutexes were no longer the bottleneck. Integer division
@@ -1193,12 +1267,15 @@ func newAutoPipeliner(pipeliner cmdableClient, config *AutoPipelineOptions, bloc
 			fdOn, fdClient = true, c
 		}
 	}
-	// Publish the EFFECTIVE full-duplex state, not the requested one: FullDuplex is a
-	// no-op on a *ClusterClient (or a client with no pipeline pool), where the engine
-	// falls back to the half-duplex shard flushers. Config() promises what the engine
-	// actually runs, so a requested-but-inactive FullDuplex must report false rather
-	// than claim a mode the instance is not in. Only Config() reads this after here.
-	ap.config.FullDuplex = fdOn
+	// Publish the EFFECTIVE full-duplex state, not the requested one: FullDuplex
+	// engages on a standalone *Client with a pipeline pool (fdOn) or on a
+	// *ClusterClient whose node clients have pipeline pools (clusterFDOn, via the
+	// per-node router). On a client with no pipeline pool it is a no-op and the
+	// engine falls back to the half-duplex shard flushers. Config() promises what
+	// the engine actually runs, so a requested-but-inactive FullDuplex must report
+	// false rather than claim a mode the instance is not in. Only Config() reads
+	// this after here.
+	ap.config.FullDuplex = fdOn || clusterFDOn
 
 	ap.shards = make([]*apShard, nShards)
 	for i := range ap.shards {
@@ -1222,20 +1299,22 @@ func newAutoPipeliner(pipeliner cmdableClient, config *AutoPipelineOptions, bloc
 			sem:     internal.NewFIFOSemaphore(int32(permits)),
 		}
 		for j := range s.stripes {
-			// In full-duplex mode submissions go straight to the FD engine (fd.ch);
-			// the shard queues are never enqueued to and no flusher drains them, so do
-			// NOT preallocate them to MaxBatchSize. Otherwise a large MaxBatchSize with
+			// In full-duplex mode submissions go straight to the FD engine (fd.ch),
+			// or — on a cluster — to a per-node FD child (clusterFD); the shard
+			// queues are never enqueued to and no flusher drains them, so do NOT
+			// preallocate them to MaxBatchSize. Otherwise a large MaxBatchSize with
 			// a small FullDuplexWindow would allocate MaxBatchSize slots per stripe
 			// (times apEnqueueStripes on the blocking face) up front — tens of MB or an
 			// OOM before any command is sent. A nil queue is safe: nothing appends to
-			// it while fdOn, and Len reads the atomic counter, not the slice.
-			if !fdOn {
+			// it while a full-duplex engine is active, and Len reads the atomic
+			// counter, not the slice.
+			if !fdOn && !clusterFDOn {
 				s.stripes[j].queue = getQueueSlice(config.MaxBatchSize)
 			}
 			s.stripes[j].curBatch = newAPBatch()
 		}
 		ap.shards[i] = s
-		if !fdOn {
+		if !fdOn && !clusterFDOn {
 			ap.wg.Add(1)
 			go s.flusher()
 		}
@@ -1245,6 +1324,9 @@ func newAutoPipeliner(pipeliner cmdableClient, config *AutoPipelineOptions, bloc
 		ap.fd = newFDEngine(ap, fdClient)
 		ap.wg.Add(1)
 		go ap.fd.run()
+	}
+	if clusterFDOn {
+		ap.clusterFD = newClusterFDRouter(ap, clusterFDCC, config, blocking)
 	}
 
 	return ap, nil
@@ -1731,7 +1813,9 @@ func (ap *AutoPipeliner) submit(ctx context.Context, cmd Cmder) AutoFuture {
 		// pipe can fail "no such fieldset". Divert it to the normal Process path,
 		// which injects the PREPARE (and updates the registry). The half-duplex
 		// sharded path injects inline (himportInjectedCmds) and stays on the pipeline.
-		(ap.fd != nil && isHImportCmd(cmd))
+		// Cluster full-duplex (clusterFD) routes to per-node FD children whose
+		// engines have the same limitation, so divert there too.
+		((ap.fd != nil || ap.clusterFD != nil) && isHImportCmd(cmd))
 	if !diverted && ap.preflight != nil {
 		if err := ap.preflight(ctx, cmd); err != nil {
 			cmd.SetErr(err)
@@ -1759,6 +1843,13 @@ func (ap *AutoPipeliner) submit(ctx context.Context, cmd Cmder) AutoFuture {
 	// No finish here: enqueue stamps ready under the stripe lock, before the
 	// command is visible to any drain (the error paths above still go through
 	// finish for uniform accessor behavior).
+	if ap.clusterFD != nil {
+		// Cluster full-duplex: route to the per-node FD child that owns this
+		// command's slot. The child is a standalone FD autopipeliner sharing this
+		// face's blocking flag, so its submit honors the same setReady/blocking
+		// contract — return its AutoFuture directly.
+		return ap.clusterFD.submit(ctx, cmd)
+	}
 	if ap.fd != nil {
 		// Ordered full-duplex: stream on one held connection. enqueue's async
 		// setReady is replicated here since we bypass it. ctx is threaded so a
@@ -1988,6 +2079,16 @@ func (ap *AutoPipeliner) Config() AutoPipelineOptions {
 	// round-robin shards, which really do flush concurrently and really do
 	// break submit order (review finding by codex on #3942).
 	cfg.contentSharded = false
+	// Same hazard for clusterReprocess: it holds a live ClusterClient.process
+	// closure set by the cluster FD router. Round-tripping this config into a
+	// STANDALONE *Client would carry that closure onto an unrelated client's FD
+	// engine (flipping redirectAware on and routing its retries through the wrong
+	// ClusterClient). Strip it.
+	cfg.clusterReprocess = nil
+	// clusterRetryBudget is internal cluster-FD wiring (the ClusterClient's
+	// MaxRedirects, used as the child engine's recovery budget); it has no meaning
+	// on a config a caller copies into a standalone client, so strip it too.
+	cfg.clusterRetryBudget = 0
 	return cfg
 }
 
@@ -2105,6 +2206,19 @@ func (ap *AutoPipeliner) drainBody() error {
 		s.wake()
 	}
 
+	// Cluster full-duplex: close the per-node FD children before the (empty) shard
+	// sweep and before clusterNodes closes the node clients, so each child flushes
+	// its accepted commands on the still-open node connection. Idempotent if a
+	// child was already reaped by its node client's close hook.
+	var clusterFDErr error
+	if ap.clusterFD != nil {
+		// Capture the child-drain error: a stalled/failed per-node child means
+		// accepted commands were not flushed, which the caller must be able to
+		// detect. Joined into closeErr below so it is not masked by the (empty)
+		// shard sweep's nil result.
+		clusterFDErr = ap.clusterFD.close()
+	}
+
 	// Pass through the divert gate once: by the time this runs the engine is
 	// already rejecting new work (Close set ap.closed before calling here; the
 	// shared-pool hook path has sharedClosed set before onClose runs), so any
@@ -2131,7 +2245,7 @@ func (ap *AutoPipeliner) drainBody() error {
 	// instead of blocking the caller: the engine is already closed to new work,
 	// and the leaked goroutines end when the server or the OS breaks the
 	// connection. See autoPipelineCloseBackstop for why the bound is generous.
-	ap.closeErr = ap.drainAll(autoPipelineCloseBackstop)
+	ap.closeErr = errors.Join(ap.drainAll(autoPipelineCloseBackstop), clusterFDErr)
 	return ap.closeErr
 }
 
@@ -3157,6 +3271,11 @@ func (ap *AutoPipeliner) Len() int {
 	// for monitoring or local backpressure lose the signal in FullDuplex mode.
 	if ap.fd != nil {
 		total += len(ap.fd.ch)
+	}
+	// Cluster full-duplex accepts commands onto per-node FD children, not the
+	// shard queues; include their backlog for the same monitoring reason.
+	if ap.clusterFD != nil {
+		total += ap.clusterFD.len()
 	}
 	return total
 }

--- a/autopipeline_cluster_fd.go
+++ b/autopipeline_cluster_fd.go
@@ -1,0 +1,279 @@
+package redis
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// clusterFDRouter runs the ordered full-duplex autopipeline natively on a
+// *ClusterClient.
+//
+// Full-duplex needs one held connection with a writer/reader goroutine pair
+// (fdEngine), which only a standalone *Client with a dedicated pipeline pool can
+// provide — a *ClusterClient has none of its own. But every master node's
+// node.Client IS a standalone *Client that gets a pipeline pool by default
+// (redis.go creates it whenever PipelinePoolSize >= 0, and osscluster.go passes
+// that option through to each node). So instead of the half-duplex shard
+// flushers, the router keeps one FD child autopipeliner per master node and
+// routes each command to the child that owns its slot. The parent AutoPipeliner
+// keeps diversion (blocking / fan-out / ReqSpecial) on the *ClusterClient, so
+// cluster-wide commands still fan out and aggregate correctly.
+//
+// Children are created lazily on first use for a node and cached on the
+// node.Client itself (via its AutoPipeline getters), so this router shares one
+// child instance per node with anything else that asks that node client for an
+// autopipeliner.
+//
+// Routing uses the live cluster state on every submit, so a stable topology
+// routes correctly. Redirects are handled too: a child's FD engine surfaces a
+// MOVED/ASK reply to the router's injected reprocess function (childCfg.
+// clusterReprocess), which re-runs the command through the redirect-aware
+// ClusterClient (cc.process) — MOVED is routed to the target node with a topology
+// reload; ASK is followed through cc.process's own redirect loop (which issues
+// ASKING). So a slot migration is followed rather than surfaced as an error.
+type clusterFDRouter struct {
+	parent   *AutoPipeliner
+	cc       *ClusterClient
+	blocking bool
+	// childCfg is the standalone FD config every node child is built with,
+	// derived once from the parent's config. Reused verbatim so the node
+	// client's "first getter call wins" cache always sees the same config.
+	childCfg *AutoPipelineOptions
+
+	mu       sync.RWMutex
+	closed   bool
+	children map[*Client]*AutoPipeliner
+}
+
+func newClusterFDRouter(parent *AutoPipeliner, cc *ClusterClient, cfg *AutoPipelineOptions, blocking bool) *clusterFDRouter {
+	// Derive the per-node child config from the parent's: force the ordered
+	// single-shard full-duplex combo the fdOn gate requires, carry the caller's
+	// sizing knobs (MaxBatchSize, FullDuplexWindow, MaxFlushDelay, ...) as-is, and
+	// strip contentSharded — a cluster-only bit that must not leak onto a
+	// standalone node child.
+	child := *cfg
+	child.FullDuplex = true
+	child.Unordered = false
+	child.MaxConcurrentBatches = 1
+	child.NumShards = 1
+	child.contentSharded = false
+	// Redirect handling: each child's FD engine re-runs a MOVED/ASK (or retryable)
+	// reply through the redirect-aware ClusterClient instead of its own node-local
+	// standalone path. cc.process is the cluster redirect loop (MOVED -> target node
+	// + LazyReload, ASK -> followed via its own loop with ASKING, bounded by
+	// MaxRedirects). One fn serves every node: the redirect target is resolved from
+	// the reply, not the source node. startAttempt/writtenAt are unused here —
+	// cc.process owns its own MaxRedirects budget.
+	child.clusterReprocess = func(ctx context.Context, cmd Cmder, _ int, _ time.Time) error {
+		return cc.process(ctx, cmd)
+	}
+	// Connection-failure recovery budget for each child engine. A node.Client
+	// normalizes MaxRetries to -1 (cluster retries live in MaxRedirects), which the
+	// FD carry-replay would read as "budget already spent" and fail every in-flight
+	// command on the first socket error. Give the child the cluster's MaxRedirects
+	// so a transient node blip replays the unacked tail on a fresh connection.
+	child.clusterRetryBudget = cc.opt.MaxRedirects
+	return &clusterFDRouter{
+		parent:   parent,
+		cc:       cc,
+		blocking: blocking,
+		childCfg: &child,
+		children: make(map[*Client]*AutoPipeliner),
+	}
+}
+
+// submit routes cmd to the FD child that owns its slot. It is called from
+// AutoPipeliner.submit AFTER diversion and preflight have been decided, so cmd
+// is a batchable single-node command. On any routing miss (keyless command,
+// unresolved slot, topology not loaded, or a node whose client turns out not to
+// be FD-capable) it falls back to the normal cluster Process path — correct,
+// just not pipelined.
+func (r *clusterFDRouter) submit(ctx context.Context, cmd Cmder) AutoFuture {
+	// Mirror enqueue's closed contract: reject once the parent is closing rather
+	// than route to a child that Close is tearing down.
+	if r.parent.isClosed() {
+		cmd.SetErr(ErrClosed)
+		if !r.blocking {
+			cmd.setReady(completedBatch)
+		}
+		return AutoFuture{cmd: cmd, batch: completedBatch}
+	}
+
+	child, closed := r.childFor(ctx, cmd)
+	if closed {
+		// close() ran between the parent.isClosed() check above and here (the router
+		// is tearing down). Mirror the closed contract rather than route to — or
+		// create — a child the drain has already swept; getOrCreateChild discards any
+		// child it built in this window so it cannot leak.
+		cmd.SetErr(ErrClosed)
+		if !r.blocking {
+			cmd.setReady(completedBatch)
+		}
+		return AutoFuture{cmd: cmd, batch: completedBatch}
+	}
+	if child == nil {
+		// runOutsidePipeline sets the command ready itself on the deferred face and
+		// returns a batch that completes when the command has executed — exactly
+		// the parent's own diverted path.
+		return AutoFuture{cmd: cmd, batch: r.parent.runOutsidePipeline(ctx, cmd)}
+	}
+	// Submit straight to the child's FD engine, skipping child.submit
+	// (AutoPipeliner.submit). The parent already decided this command is
+	// pipelineable — diversion (readTimeout/runsOutsidePipeline/isBlockingCmd/
+	// HIMPORT/mustDivert) and preflight ran above — so the child's submit would only
+	// re-run that same classification, hit its nil preflight, and build a finish
+	// closure: pure per-command CPU on the hot path (measured ~1/3 of submit cost is
+	// this second pass). child.fd is non-nil (getOrCreateChild screened it) and
+	// fd.submit still runs the child's own closed-check, so a racing child close is
+	// handled. Mirror the parent's fd branch: setReady on the async face (the child
+	// shares this face's blocking flag), return the batch.
+	b := child.fd.submit(ctx, cmd)
+	if !r.blocking {
+		cmd.setReady(b)
+	}
+	return AutoFuture{cmd: cmd, batch: b}
+}
+
+// childFor resolves the FD child for cmd's owning master node. It returns
+// (nil, false) when the command should divert to Process (keyless, unresolved
+// slot, topology not loaded, or a non-FD node), and (nil, true) when the router
+// is closing (submit must then reject with ErrClosed rather than divert).
+func (r *clusterFDRouter) childFor(ctx context.Context, cmd Cmder) (*AutoPipeliner, bool) {
+	slot := r.cc.cmdSlot(cmd, -1)
+	if slot < 0 {
+		// Keyless command: no single owning node. Let it run through Process, which
+		// applies the configured ShardPicker.
+		return nil, false
+	}
+	state, err := r.cc.state.Get(ctx)
+	if err != nil {
+		return nil, false
+	}
+	node, err := state.slotMasterNode(slot)
+	if err != nil || node == nil {
+		return nil, false
+	}
+	return r.getOrCreateChild(node.Client)
+}
+
+// getOrCreateChild returns the FD child autopipeliner for a node client,
+// creating it on first use. The second return value reports that the router is
+// closed. It returns (nil, false) when the node client is not FD-capable (its
+// child engine did not engage) so the caller diverts that node to Process, and
+// (nil, true) when the router has been closed (the caller must reject, not
+// divert — the drain has already swept the children).
+func (r *clusterFDRouter) getOrCreateChild(nc *Client) (*AutoPipeliner, bool) {
+	r.mu.RLock()
+	ch := r.children[nc]
+	closed := r.closed
+	r.mu.RUnlock()
+	if closed {
+		return nil, true
+	}
+	if ch != nil && !ch.IsClosed() {
+		return ch, false
+	}
+
+	// Build (or fetch the node client's cached) child WITHOUT holding the router
+	// lock: the node getter is idempotent (first call wins, cached on nc, and it
+	// rebuilds when its cached instance is closed — see getOrCreateAutoPipeliner),
+	// so a concurrent build just returns the same live instance. Keeping the
+	// getter off r.mu means a non-FD node (child.fd == nil) does not serialize
+	// every later submit on the write lock re-calling it.
+	var (
+		child *AutoPipeliner
+		err   error
+	)
+	if r.blocking {
+		child, err = nc.AutoPipelineWithOptions(r.childCfg)
+	} else {
+		child, err = nc.AsyncAutoPipelineWithOptions(r.childCfg)
+	}
+	// Honesty check: only treat this node as an FD node if the engine actually
+	// engaged, is live, AND is redirect-aware. A node client without a pipeline pool
+	// (PipelinePoolSize < 0) falls back to half-duplex (child.fd == nil); a
+	// just-closed instance must not be cached (fd is not nilled on close). The
+	// redirectAware requirement guards the first-call-wins node getter: application
+	// code may have already created a plain standalone autopipeliner on this
+	// node.Client (e.g. via ForEachMaster), and the getter would hand that instance
+	// back. It has no clusterReprocess, so a MOVED/ASK reply on it would be surfaced
+	// to the caller instead of routed through the cluster client. Divert all of
+	// these to Process rather than dispatch through an engine that cannot follow
+	// redirects.
+	if err != nil || child == nil || child.fd == nil || child.IsClosed() || !child.fd.redirectAware {
+		return nil, false
+	}
+
+	r.mu.Lock()
+	if r.closed {
+		// close() ran while we built this child outside the lock: it already
+		// snapshotted+cleared the map, so storing ours would leak a held FD conn and
+		// its writer/reader goroutines (nothing would ever close it). Discard it.
+		// Close AFTER releasing the lock so a concurrent close() draining the
+		// snapshot does not serialize behind this child's own drain (Close blocks on
+		// it). Close is idempotent, so double-closing a node-client-cached instance
+		// close() also holds is harmless.
+		r.mu.Unlock()
+		_ = child.Close()
+		return nil, true
+	}
+	// Prefer a live child another goroutine cached first; otherwise store ours.
+	if cached := r.children[nc]; cached != nil && !cached.IsClosed() {
+		child = cached
+	} else {
+		r.children[nc] = child
+	}
+	r.mu.Unlock()
+	return child, false
+}
+
+// len sums the pending backlog across all node children, for AutoPipeliner.Len.
+func (r *clusterFDRouter) len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	total := 0
+	for _, ch := range r.children {
+		total += ch.Len()
+	}
+	return total
+}
+
+// close closes every node child and waits for each drain to finish. Called from
+// the parent's drain before the parent's own (empty) shard sweep, and before
+// clusterNodes closes the node clients — so each child flushes its accepted
+// commands on the still-open node connection. A child may already have been
+// closed by its node client's shared-pool close hook; AutoPipeliner.Close is
+// idempotent, so the second close returns immediately.
+func (r *clusterFDRouter) close() error {
+	r.mu.Lock()
+	// Mark closed under the lock BEFORE snapshotting: a submit racing past the
+	// parent.isClosed() check that then builds a child outside the router lock will
+	// see r.closed when it takes the lock to store, and discard its orphan instead
+	// of leaking it (getOrCreateChild). Children created and stored before this
+	// point are in the snapshot below and get closed here.
+	r.closed = true
+	children := make([]*AutoPipeliner, 0, len(r.children))
+	for _, ch := range r.children {
+		children = append(children, ch)
+	}
+	r.children = make(map[*Client]*AutoPipeliner)
+	r.mu.Unlock()
+
+	var firstErr error
+	for _, ch := range children {
+		// WaitClosed is the authoritative drain result: Close returns the drain error
+		// only to the caller that WINS the close CAS, and returns nil to a loser. If
+		// application code already started Close on this node autopipeliner (exposed
+		// via ForEachMaster), our ch.Close() loses and returns nil while the real
+		// error surfaces here. So prefer WaitClosed's result and fall back to Close's.
+		cerr := ch.Close()
+		if werr := ch.WaitClosed(); werr != nil {
+			cerr = werr
+		}
+		if cerr != nil && firstErr == nil {
+			firstErr = cerr
+		}
+	}
+	return firstErr
+}

--- a/autopipeline_cluster_fd_internal_test.go
+++ b/autopipeline_cluster_fd_internal_test.go
@@ -1,0 +1,320 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// clusterFDTestAddrs is the local 3-master cluster the functional test targets.
+// Override with GOREDIS_CLUSTER_FD_ADDRS (comma-separated) to point at another
+// cluster (e.g. a real RE endpoint). The test self-skips when the cluster is not
+// reachable, so it is safe to run in any environment.
+var clusterFDTestAddrs = clusterFDTestAddrsFromEnv()
+
+func clusterFDTestAddrsFromEnv() []string {
+	if v := os.Getenv("GOREDIS_CLUSTER_FD_ADDRS"); v != "" {
+		return strings.Split(v, ",")
+	}
+	return []string{"127.0.0.1:16600", "127.0.0.1:16601", "127.0.0.1:16602"}
+}
+
+func dialClusterFDTest(t *testing.T) *ClusterClient {
+	t.Helper()
+	cc := NewClusterClient(&ClusterOptions{Addrs: clusterFDTestAddrs})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := cc.Ping(ctx).Err(); err != nil {
+		cc.Close()
+		t.Skipf("local cluster not reachable at %v: %v", clusterFDTestAddrs, err)
+	}
+	// Force a topology load so state.Masters is populated for the assertions.
+	if _, err := cc.state.ReloadOrGet(ctx); err != nil {
+		cc.Close()
+		t.Skipf("cluster state not loadable: %v", err)
+	}
+	return cc
+}
+
+// TestClusterFullDuplexEngagesPerNode is the correctness demo for native
+// full-duplex on a ClusterClient: FD is reported active, one FD child engine
+// runs per master, a mixed workload across all slots executes with zero errors,
+// diverted commands (fan-out, blocking) still work, and Close returns cleanly.
+func TestClusterFullDuplexEngagesPerNode(t *testing.T) {
+	cc := dialClusterFDTest(t)
+	defer cc.Close()
+
+	ctx := context.Background()
+
+	ap, err := cc.AsyncAutoPipelineWithOptions(&AutoPipelineOptions{FullDuplex: true})
+	if err != nil {
+		t.Fatalf("AsyncAutoPipelineWithOptions: %v", err)
+	}
+	defer ap.Close()
+
+	// (a) Config() reports FD active — the exact bit that was always false on a
+	// ClusterClient before this change.
+	if !ap.Config().FullDuplex {
+		t.Fatalf("Config().FullDuplex = false, want true (cluster FD should be active)")
+	}
+	if ap.clusterFD == nil {
+		t.Fatalf("ap.clusterFD is nil, want a router")
+	}
+	if got := ap.Config().NumShards; got != 1 {
+		t.Fatalf("Config().NumShards = %d, want 1 (cluster FD forces a single flusherless shard)", got)
+	}
+
+	// (c) Mixed GET/SET across many keys → keys spread over all three masters'
+	// slot ranges. Fire concurrently so the FD engines actually batch. Zero errors
+	// and correct read-back proves per-node routing lands each key on its owner.
+	const nKeys = 300
+	var wg sync.WaitGroup
+	errCh := make(chan error, nKeys)
+	for i := 0; i < nKeys; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := fmt.Sprintf("cfd:{%d}:k", i)
+			val := fmt.Sprintf("v%d", i)
+			if err := ap.Set(ctx, key, val, 0).Err(); err != nil {
+				errCh <- fmt.Errorf("SET %s: %w", key, err)
+				return
+			}
+			got, err := ap.Get(ctx, key).Result()
+			if err != nil {
+				errCh <- fmt.Errorf("GET %s: %w", key, err)
+				return
+			}
+			if got != val {
+				errCh <- fmt.Errorf("GET %s = %q, want %q", key, got, val)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("workload error: %v", err)
+	}
+
+	// (b) One FD child engine per master, and every child actually engaged FD.
+	state, err := cc.state.Get(ctx)
+	if err != nil {
+		t.Fatalf("state.Get: %v", err)
+	}
+	nMasters := len(state.Masters)
+	ap.clusterFD.mu.RLock()
+	nChildren := len(ap.clusterFD.children)
+	var notFD, badBudget int
+	for _, ch := range ap.clusterFD.children {
+		if ch.fd == nil {
+			notFD++
+			continue
+		}
+		// Recovery budget must be the cluster's MaxRedirects, not the node client's
+		// MaxRetries (-1) — otherwise carry-replay is disabled on this master.
+		if ch.fd.retryBudget() != cc.opt.MaxRedirects {
+			badBudget++
+		}
+	}
+	ap.clusterFD.mu.RUnlock()
+	if nChildren != nMasters {
+		t.Errorf("clusterFD has %d children, want %d (one per master)", nChildren, nMasters)
+	}
+	if notFD != 0 {
+		t.Errorf("%d/%d children did not engage FD (child.fd == nil)", notFD, nChildren)
+	}
+	if badBudget != 0 {
+		t.Errorf("%d/%d children have retryBudget != cc.MaxRedirects (%d) — carry-replay would be misbudgeted",
+			badBudget, nChildren, cc.opt.MaxRedirects)
+	}
+	t.Logf("cluster FD: %d masters, %d FD children engaged", nMasters, nChildren-notFD)
+
+	// (d) Diversion still works: a fan-out command (DBSIZE) and a blocking command
+	// (BLPOP with a short timeout) must not ride the FD pipe.
+	if err := cc.DBSize(ctx).Err(); err != nil {
+		t.Errorf("DBSize (fan-out) failed: %v", err)
+	}
+	blKey := "cfd:{bl}:list"
+	if _, err := ap.BLPop(ctx, 100*time.Millisecond, blKey).Result(); err != nil && err != Nil {
+		t.Errorf("BLPop (diverted) unexpected error: %v", err)
+	}
+
+	// (e) Close returns without hanging.
+	done := make(chan error, 1)
+	go func() { done <- ap.Close() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("ap.Close returned error: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatalf("ap.Close did not return within 10s")
+	}
+}
+
+// TestClusterFullDuplexReuseAfterClose covers the lifecycle the single-AP test
+// cannot: closing the cluster autopipeliner closes the per-node FD children,
+// which stay cached on each node.Client. A fresh autopipeliner on the SAME
+// (still-open) ClusterClient must NOT hand back a closed child and fail every
+// command with ErrClosed — the node getter rebuilds a live child and the router
+// re-engages FD.
+func TestClusterFullDuplexReuseAfterClose(t *testing.T) {
+	cc := dialClusterFDTest(t)
+	defer cc.Close()
+	ctx := context.Background()
+
+	ap1, err := cc.AsyncAutoPipelineWithOptions(&AutoPipelineOptions{FullDuplex: true})
+	if err != nil {
+		t.Fatalf("first AsyncAutoPipelineWithOptions: %v", err)
+	}
+	if err := ap1.Set(ctx, "cfd:{reuse}:k", "1", 0).Err(); err != nil {
+		t.Fatalf("first SET: %v", err)
+	}
+	if err := ap1.Close(); err != nil {
+		t.Fatalf("ap1.Close: %v", err)
+	}
+
+	// getOrCreateAutoPipeliner rebuilds on a closed cached instance, so this
+	// returns a NEW parent (the ClusterClient itself was never closed).
+	ap2, err := cc.AsyncAutoPipelineWithOptions(&AutoPipelineOptions{FullDuplex: true})
+	if err != nil {
+		t.Fatalf("second AsyncAutoPipelineWithOptions: %v", err)
+	}
+	defer ap2.Close()
+	if ap2 == ap1 {
+		t.Fatalf("expected a fresh autopipeliner after Close, got the closed one")
+	}
+	if !ap2.Config().FullDuplex {
+		t.Fatalf("reused AP Config().FullDuplex = false, want true")
+	}
+
+	// The command that would have failed ErrClosed if a closed child were cached.
+	got, err := func() (string, error) {
+		if err := ap2.Set(ctx, "cfd:{reuse}:k", "2", 0).Err(); err != nil {
+			return "", err
+		}
+		return ap2.Get(ctx, "cfd:{reuse}:k").Result()
+	}()
+	if err != nil {
+		t.Fatalf("SET/GET on reused AP: %v", err)
+	}
+	if got != "2" {
+		t.Fatalf("GET after reuse = %q, want %q", got, "2")
+	}
+
+	// FD re-engaged: a fresh live child, not the closed one.
+	ap2.clusterFD.mu.RLock()
+	var closedChildren int
+	for _, ch := range ap2.clusterFD.children {
+		if ch.fd == nil || ch.IsClosed() {
+			closedChildren++
+		}
+	}
+	nChildren := len(ap2.clusterFD.children)
+	ap2.clusterFD.mu.RUnlock()
+	if nChildren == 0 {
+		t.Fatalf("reused AP has no FD children after traffic")
+	}
+	if closedChildren != 0 {
+		t.Errorf("reused AP cached %d closed/non-FD children, want 0", closedChildren)
+	}
+}
+
+// TestClusterFullDuplexGatedOffForReplicaRouting asserts the construction gate:
+// a ClusterClient configured for replica routing (ReadOnly / RouteByLatency /
+// RouteRandomly) must NOT engage cluster FD, because the router only routes to
+// the slot master (slotMasterNode) and would silently ignore those options,
+// pinning reads to masters. It must fall back to the half-duplex flushers (which
+// honor the ShardPicker) and report Config().FullDuplex == false — the honest
+// effective state. Pure construction check: no live cluster required (the gate
+// reads cc.opt synchronously, and the half-duplex AP dials nothing until a
+// command is submitted).
+func TestClusterFullDuplexGatedOffForReplicaRouting(t *testing.T) {
+	addrs := []string{"127.0.0.1:16600"}
+	cases := []struct {
+		name string
+		opt  *ClusterOptions
+	}{
+		{"ReadOnly", &ClusterOptions{Addrs: addrs, ReadOnly: true}},
+		{"RouteByLatency", &ClusterOptions{Addrs: addrs, RouteByLatency: true}},
+		{"RouteRandomly", &ClusterOptions{Addrs: addrs, RouteRandomly: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cc := NewClusterClient(tc.opt)
+			defer cc.Close()
+			ap, err := cc.AsyncAutoPipelineWithOptions(&AutoPipelineOptions{FullDuplex: true})
+			if err != nil {
+				t.Fatalf("AsyncAutoPipelineWithOptions: %v", err)
+			}
+			defer ap.Close()
+			if ap.Config().FullDuplex {
+				t.Errorf("Config().FullDuplex = true, want false (replica routing must disable cluster FD)")
+			}
+			if ap.clusterFD != nil {
+				t.Errorf("ap.clusterFD is non-nil, want nil (cluster FD must not engage under replica routing)")
+			}
+		})
+	}
+}
+
+// TestClusterFullDuplexResolvesDefaultsOnParent asserts the effective-defaults
+// contract: a default-constructed cluster-FD autopipeliner must report the
+// resolved FD tuning defaults from Config(), not the raw zeros the user passed —
+// the same guarantee the standalone FD path gives. The per-node children resolve
+// these in newFDEngine; the parent must resolve them too so Config() is honest.
+// Pure construction check: cluster FD engages on PipelinePoolSize>=0 (the default)
+// without loading topology, so no live cluster is required.
+func TestClusterFullDuplexResolvesDefaultsOnParent(t *testing.T) {
+	cc := NewClusterClient(&ClusterOptions{Addrs: []string{"127.0.0.1:16600"}})
+	defer cc.Close()
+
+	ap, err := cc.AsyncAutoPipelineWithOptions(&AutoPipelineOptions{FullDuplex: true})
+	if err != nil {
+		t.Fatalf("AsyncAutoPipelineWithOptions: %v", err)
+	}
+	defer ap.Close()
+
+	cfg := ap.Config()
+	if !cfg.FullDuplex || ap.clusterFD == nil {
+		t.Fatalf("cluster FD did not engage (FullDuplex=%v, clusterFD==nil:%v); cannot check defaults",
+			cfg.FullDuplex, ap.clusterFD == nil)
+	}
+	if cfg.FullDuplexWindow != fdDefaultWindow {
+		t.Errorf("Config().FullDuplexWindow = %d, want %d (effective default)", cfg.FullDuplexWindow, fdDefaultWindow)
+	}
+	if cfg.FullDuplexIdleTimeout != fdDefaultIdle {
+		t.Errorf("Config().FullDuplexIdleTimeout = %v, want %v (effective default)", cfg.FullDuplexIdleTimeout, fdDefaultIdle)
+	}
+	if cfg.FullDuplexMaxHold != fdDefaultMaxHold {
+		t.Errorf("Config().FullDuplexMaxHold = %v, want %v (effective default)", cfg.FullDuplexMaxHold, fdDefaultMaxHold)
+	}
+}
+
+// TestClusterFullDuplexRecoveryBudgetFromMaxRedirects asserts the connection-
+// failure recovery budget wiring: a cluster node.Client normalizes MaxRetries to
+// -1 (cluster retries live in MaxRedirects), which the FD carry-replay would read
+// as "budget already spent" and fail every in-flight command on the first socket
+// error. The router must seed each child with the ClusterClient's MaxRedirects
+// instead. Pure construction check: the router is built at construction, so no
+// live cluster is needed to verify the plumbed budget.
+func TestClusterFullDuplexRecoveryBudgetFromMaxRedirects(t *testing.T) {
+	cc := NewClusterClient(&ClusterOptions{Addrs: []string{"127.0.0.1:16600"}, MaxRedirects: 5})
+	defer cc.Close()
+
+	ap, err := cc.AsyncAutoPipelineWithOptions(&AutoPipelineOptions{FullDuplex: true})
+	if err != nil {
+		t.Fatalf("AsyncAutoPipelineWithOptions: %v", err)
+	}
+	defer ap.Close()
+	if ap.clusterFD == nil {
+		t.Fatalf("cluster FD did not engage; cannot check the recovery budget")
+	}
+	if got := ap.clusterFD.childCfg.clusterRetryBudget; got != 5 {
+		t.Errorf("child clusterRetryBudget = %d, want 5 (cc.opt.MaxRedirects); the node client's MaxRetries=-1 would disable carry-replay", got)
+	}
+}

--- a/autopipeline_fullduplex.go
+++ b/autopipeline_fullduplex.go
@@ -534,6 +534,41 @@ type fdEngine struct {
 	// client.processPipelineRetries), so tests can drive flushReqs's chunk loop
 	// without a live server.
 	runPipeline func(ctx context.Context, cmds []Cmder, maxRetries int) error
+
+	// reprocess re-runs a command that came back with a retryable reply or a
+	// redirect on a NORMAL (non-FD) path. Defaults to client.processStartingAt (the
+	// standalone client, which cannot follow a redirect). The cluster full-duplex
+	// router overrides it (via AutoPipelineOptions.clusterReprocess) to route
+	// through the redirect-aware ClusterClient. Set once in newFDEngine before
+	// run() starts, so the reader goroutine reads it race-free.
+	reprocess func(ctx context.Context, cmd Cmder, startAttempt int, writtenAt time.Time) error
+	// redirectAware is true when reprocess follows MOVED/ASK (cluster mode). The
+	// reply path then diverts a redirect to reprocess instead of surfacing it
+	// inline. Standalone FD leaves this false: its normal path cannot follow a
+	// redirect, so diverting would waste a round trip and return the redirect anyway.
+	redirectAware bool
+	// clusterRetryBudget is the connection-failure recovery budget used ONLY in
+	// cluster mode (redirectAware): the ClusterClient's MaxRedirects, injected by the
+	// router. See retryBudget().
+	clusterRetryBudget int
+}
+
+// retryBudget bounds the engine's OWN connection-failure recovery: the lease retry
+// loop, the carried-tail replay (fdPartitionByBudget) and the Close-path flush.
+// Standalone FD uses the client's MaxRetries. Cluster node clients normalize
+// MaxRetries to -1 (cluster retries live in MaxRedirects), so a cluster child would
+// otherwise treat every carried command as budget-spent and fail all in-flight
+// commands on the first socket error instead of replaying them; the router injects
+// the ClusterClient's MaxRedirects (clusterRetryBudget) for that case. Reading the
+// client's option live (rather than caching a field) keeps test-constructed engines
+// working: they set client but not the cluster budget. The reply-side standalone
+// retryable divert still uses client.opt.MaxRetries directly (only reached when
+// !redirectAware).
+func (fd *fdEngine) retryBudget() int {
+	if fd.redirectAware {
+		return fd.clusterRetryBudget
+	}
+	return fd.client.opt.MaxRetries
 }
 
 // fdFastSubmitGatePct bounds fastSubmit to when the submit channel is below this
@@ -599,7 +634,7 @@ func newFDEngine(ap *AutoPipeliner, client *Client) *fdEngine {
 	if retryCap < 1 {
 		retryCap = 1
 	}
-	return &fdEngine{
+	fd := &fdEngine{
 		ap:         ap,
 		client:     client,
 		pool:       client.getPipelinePool(),
@@ -611,6 +646,23 @@ func newFDEngine(ap *AutoPipeliner, client *Client) *fdEngine {
 		retrySem:   make(chan struct{}, retryCap),
 		fastSubmit: ap.config.FullDuplexFastSubmit,
 	}
+	// Redirect/retry reprocess target. Default: the standalone client's own retry
+	// path (cannot follow a redirect). Cluster mode injects a redirect-aware
+	// ClusterClient path via config, which also flips redirectAware so the reply
+	// path diverts MOVED/ASK. Set before run() starts (below, in the caller), so
+	// the reader reads both fields without a race.
+	if ap.config.clusterReprocess != nil {
+		fd.reprocess = ap.config.clusterReprocess
+		fd.redirectAware = true
+		// Cluster node clients normalize MaxRetries to -1, which would make the
+		// carry-replay budget treat every command as spent. Use the cluster's
+		// MaxRedirects (where cluster retries live), injected by the router.
+		// retryBudget() reads this when redirectAware.
+		fd.clusterRetryBudget = ap.config.clusterRetryBudget
+	} else {
+		fd.reprocess = client.processStartingAt
+	}
+	return fd
 }
 
 // submit enqueues a command onto the ordered stream and returns its batch.
@@ -933,7 +985,7 @@ func (fd *fdEngine) retryOnNormalConn(req fdReq, startAttempt int) {
 		if req.ctx != nil {
 			rctx = context.WithoutCancel(req.ctx)
 		}
-		// processStartingAt, not pipeliner.process: fd.client IS the pipeliner
+		// reprocess (default client.processStartingAt): fd.client IS the pipeliner
 		// (fdClient is the *Client behind it), so this is the same raw exec, but it
 		// starts the retry loop at startAttempt — 1 for a retryable reply that already
 		// spent an attempt on the FD socket, 0 for a redirect that did not execute.
@@ -951,7 +1003,7 @@ func (fd *fdEngine) retryOnNormalConn(req fdReq, startAttempt int) {
 			if req.batch != nil {
 				defer req.batch.enterNodeDispatch()()
 			}
-			return fd.client.processStartingAt(rctx, req.cmd, startAttempt, req.writtenAt)
+			return fd.reprocess(rctx, req.cmd, startAttempt, req.writtenAt)
 		}()
 		req.cmd.SetErr(err)
 		req.complete()
@@ -1066,7 +1118,7 @@ func (fd *fdEngine) run() {
 				fd.shutdownFlush(bg, carry)
 				return
 			}
-			if shouldRetry(aerr, true) && leaseAttempts < fd.client.opt.MaxRetries {
+			if shouldRetry(aerr, true) && leaseAttempts < fd.retryBudget() {
 				leaseAttempts++
 				fd.sleepBackoff(leaseAttempts)
 				continue // carry unchanged; re-lease
@@ -1076,7 +1128,7 @@ func (fd *fdEngine) run() {
 			carry = nil
 			leaseAttempts++
 			fd.sleepBackoff(leaseAttempts)
-			if leaseAttempts >= fd.client.opt.MaxRetries {
+			if leaseAttempts >= fd.retryBudget() {
 				leaseAttempts = 0
 			}
 		default: // fdConnErr — a real connection error occurred
@@ -1116,11 +1168,11 @@ func (fd *fdEngine) run() {
 			eligible := unacked
 			if replayable && len(unacked) > 0 {
 				// unacked is PRE-BUMP here (a command sent A times carries attempts==A),
-				// so attempts > MaxRetries is exactly the spent-budget set. The Close-path
+				// so attempts > retryBudget is exactly the spent-budget set. The Close-path
 				// flush (flushCarryBudgeted) instead sees POST-BUMP carry, where the same
 				// command carries attempts==A+1 — do not unify the two thresholds.
 				var exhausted []fdReq
-				eligible, exhausted = fdPartitionByBudget(unacked, fd.client.opt.MaxRetries)
+				eligible, exhausted = fdPartitionByBudget(unacked, fd.retryBudget())
 				if len(exhausted) > 0 {
 					fd.failReqs(exhausted, aerr) // spent MaxRetries+1 attempts; fail with the real cause
 				}
@@ -1161,7 +1213,7 @@ func (fd *fdEngine) run() {
 			carry = nil
 			retryAttempts++
 			fd.sleepBackoff(retryAttempts)
-			if retryAttempts >= fd.client.opt.MaxRetries {
+			if retryAttempts >= fd.retryBudget() {
 				retryAttempts = 0 // reset so backoff restarts small once we're serving again
 			}
 		}
@@ -1413,38 +1465,71 @@ func (fd *fdEngine) session(bg context.Context, cn *pool.Conn, carry []fdReq) (u
 				// the standard retry/backoff. Done off the reader goroutine so it does not
 				// stall other in-flight replies, and counted in `done` so the reader
 				// advances past it now. Per-caller ordering is NOT promised across this
-				// divert (same exception as the blocking-command divert); NoRetry commands
-				// keep their error.
-				if e != nil && !fdNoRetrySafe(req.cmd) {
+				// divert (same exception as the blocking-command divert).
+				if e != nil {
 					moved, ask, _ := isMovedError(e)
-					// Do NOT divert a redirect. FD is enabled only for a standalone
-					// *Client, whose normal path cannot follow a MOVED/ASK — it neither
-					// re-routes to the target node nor sends ASKING, it just re-hits the
-					// same endpoint. Diverting would waste a round trip and return the
-					// redirect anyway, so surface it inline (below), exactly as a plain
-					// standalone command does. (A cluster-capable FD/CSC would route it
-					// here instead — follow-up.)
+					// Cluster full-duplex redirect: a MOVED/ASK is followable for EVERY
+					// command, including NoRetry ones (e.g. GetToBuffer, RawWriteTo). NoRetry
+					// guards against replaying a command whose partial response was already
+					// consumed, but a MOVED/ASK reply carries no payload — the command did
+					// NOT execute on this node — so there is nothing to replay, and the normal
+					// ClusterClient.process follows redirects for all commands before
+					// consulting NoRetry. So divert a redirect independent of the NoRetry gate
+					// below. reprocess re-routes MOVED to the target node (LazyReload) and
+					// follows ASK through cc.process's own loop (ASKING on the next hop),
+					// bounded by MaxRedirects; startAttempt is unused by the cluster reprocess
+					// (it re-runs the full loop from the base), so pass the redirect value (0).
+					// isMovedError/e here are reply-level only: a transport or protocol failure
+					// is !isRedisError and already broke the read loop via fdReplyIsFatal above.
 					//
-					// Divert a RETRYABLE reply only while retries are enabled AND the
-					// budget is not already spent. req.attempts counts FD attempts spent
-					// (1 at submit, +1 on each fdConnErr carry replay). Once it reaches
-					// MaxRetries+1 another execution would exceed the budget, so fall
-					// through to the inline settle, which surfaces the reply as the final
-					// error and reports the true attempt count. Without this guard the
-					// startAttempt clamp in processWithRetry would turn an exhausted budget
-					// into one more send.
-					if !moved && !ask &&
-						shouldRetry(e, false) &&
-						fd.client.opt.MaxRetries > 0 &&
-						req.attempts <= fd.client.opt.MaxRetries {
-						// The retryable reply executed on the FD socket, so the divert starts
-						// one attempt in; add req.attempts-1 for FD attempts already spent on
-						// carry replays so a carried-then-diverted command does not run the
-						// full loop from the base. The guard above keeps this within
-						// MaxRetries+1.
-						fd.retryOnNormalConn(req, retryStartAttempt(false, false)+req.attempts-1)
+					// Standalone FD (redirectAware == false) cannot follow a MOVED/ASK (it
+					// neither re-routes to the target node nor sends ASKING), so it falls
+					// through to the inline settle and surfaces the redirect, as before.
+					if fd.redirectAware && (moved || ask) {
+						fd.retryOnNormalConn(req, retryStartAttempt(moved, ask))
 						done++
 						continue
+					}
+					// A RETRYABLE execution error (not a redirect) may have produced a
+					// partially consumed response, so it stays gated on NoRetry.
+					if !fdNoRetrySafe(req.cmd) {
+						// Cluster full-duplex: divert a retryable server reply
+						// (LOADING/READONLY/TRYAGAIN/CLUSTERDOWN/MASTERDOWN/NOREPLICAS/
+						// max-clients) to the redirect-aware ClusterClient. It consults NO
+						// FD-side budget and — the key difference from the standalone branch
+						// below — does NOT gate on the node client's MaxRetries: cluster node
+						// clients default MaxRetries to -1 (osscluster.go), which is <= 0, so a
+						// MaxRetries>0 gate would wrongly settle the reply inline and fail the
+						// caller instead of recovering it the way half-duplex does. cc.process
+						// owns the whole cluster retry budget; startAttempt is unused by the
+						// cluster reprocess. shouldRetry(e) here matches only reply-level Redis
+						// errors (see the fdReplyIsFatal note above).
+						if fd.redirectAware && shouldRetry(e, false) {
+							fd.retryOnNormalConn(req, retryStartAttempt(false, false))
+							done++
+							continue
+						}
+						// Standalone FD: divert a RETRYABLE reply only while retries are
+						// enabled AND the budget is not already spent. req.attempts counts FD
+						// attempts spent (1 at submit, +1 on each fdConnErr carry replay). Once
+						// it reaches MaxRetries+1 another execution would exceed the budget, so
+						// fall through to the inline settle, which surfaces the reply as the
+						// final error and reports the true attempt count. Without this guard the
+						// startAttempt clamp in processWithRetry would turn an exhausted budget
+						// into one more send.
+						if !moved && !ask &&
+							shouldRetry(e, false) &&
+							fd.client.opt.MaxRetries > 0 &&
+							req.attempts <= fd.client.opt.MaxRetries {
+							// The retryable reply executed on the FD socket, so the divert starts
+							// one attempt in; add req.attempts-1 for FD attempts already spent on
+							// carry replays so a carried-then-diverted command does not run the
+							// full loop from the base. The guard above keeps this within
+							// MaxRetries+1.
+							fd.retryOnNormalConn(req, retryStartAttempt(false, false)+req.attempts-1)
+							done++
+							continue
+						}
 					}
 				}
 				req.cmd.SetErr(e) // nil, a redirect (MOVED/ASK), or a non-retryable Redis error
@@ -2403,7 +2488,7 @@ func (fd *fdEngine) shutdownFlush(bg context.Context, carry []fdReq) {
 	}
 	// Last flush: a transport failure is already handled inside flushReqs (it fails
 	// the remainder), and there is nothing after it, so the returned error is moot.
-	_ = fd.flushReqs(bg, fresh, fd.client.opt.MaxRetries)
+	_ = fd.flushReqs(bg, fresh, fd.retryBudget())
 }
 
 // fdCarryRemainingRetries returns the retry bound for a carried command flushed on
@@ -2430,7 +2515,7 @@ func fdCarryRemainingRetries(attempts, maxRetries int) int {
 // normally attempts-descending, so groups are few, but a non-sorted slice just
 // yields more groups). Returns a transport error that aborted the remainder.
 func (fd *fdEngine) flushCarryBudgeted(bg context.Context, carry []fdReq) error {
-	mr := fd.client.opt.MaxRetries
+	mr := fd.retryBudget()
 	for i := 0; i < len(carry); {
 		a := carry[i].attempts
 		j := i + 1

--- a/command_policy_resolver.go
+++ b/command_policy_resolver.go
@@ -200,10 +200,14 @@ func NewDefaultCommandPolicyResolver() *commandInfoResolver {
 	return NewCommandInfoResolver(func(ctx context.Context, cmd Cmder) *routing.CommandPolicy {
 		module := "core"
 		command := cmd.Name()
-		cmdParts := strings.Split(command, ".")
-		if len(cmdParts) == 2 {
-			module = cmdParts[0]
-			command = cmdParts[1]
+		// Split on the first '.' without allocating (strings.Split allocates a slice
+		// on every call; this resolver runs on the hot per-command path — twice per
+		// command for the autopipeline cluster gates — so the allocation showed up in
+		// CPU profiles). Only a single module.command form is recognized, matching the
+		// prior len==2 check.
+		if dot := strings.IndexByte(command, '.'); dot >= 0 && strings.IndexByte(command[dot+1:], '.') < 0 {
+			module = command[:dot]
+			command = command[dot+1:]
 		}
 
 		if policy, ok := defaultPolicies[module][command]; ok {

--- a/osscluster_autopipeline_fd_moved_test.go
+++ b/osscluster_autopipeline_fd_moved_test.go
@@ -1,0 +1,100 @@
+package redis_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// clusterFDAddrs is the local 6-node cluster (3 masters + 3 replicas) the FD
+// MOVED tests target; SwapNodes needs the replicas to swap a slot's master.
+var clusterFDAddrs = []string{":16600", ":16601", ":16602", ":16603", ":16604", ":16605"}
+
+// TestAPClusterFDMovedRedirectFollowed is the discriminating proof that native
+// cluster full-duplex FOLLOWS a MOVED redirect. SwapNodes forces the client to
+// believe a replica is the master for a slot; a command routed there is answered
+// with MOVED. The FD child's reader diverts the redirect to the redirect-aware
+// ClusterClient path, which re-routes to the real master and reloads topology, so
+// the value is still read back correctly. Before the redirect fix this returned
+// the MOVED error and the test failed.
+func TestAPClusterFDMovedRedirectFollowed(t *testing.T) {
+	ctx := context.Background()
+	c := redis.NewClusterClient(&redis.ClusterOptions{Addrs: clusterFDAddrs})
+	defer c.Close()
+	skipIfClusterUnhealthy(t, c)
+
+	ap, err := c.AutoPipelineWithOptions(&redis.AutoPipelineOptions{FullDuplex: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ap.Close()
+	if !ap.Config().FullDuplex {
+		t.Fatalf("Config().FullDuplex = false, want true (cluster FD not active)")
+	}
+
+	const key, val = "fdmoved:key", "fdmoved:val"
+	if err := ap.Set(ctx, key, val, 0).Err(); err != nil {
+		t.Fatalf("initial set: %v", err)
+	}
+	// Point the slot at the wrong node so the next access is answered with MOVED
+	// and must be followed.
+	if err := c.SwapNodes(ctx, key); err != nil {
+		t.Fatalf("SwapNodes: %v", err)
+	}
+
+	got, err := ap.Get(ctx, key).Result()
+	if err != nil {
+		t.Fatalf("get after MOVED: %v (FD redirect not followed)", err)
+	}
+	if got != val {
+		t.Fatalf("get after MOVED = %q, want %q (FD redirect not followed correctly)", got, val)
+	}
+}
+
+// TestAPClusterFDMovedSurfacedWithoutRedirects anchors the positive test: with
+// MaxRedirects disabled (-1 -> 0, one attempt), the FD divert still routes through
+// ClusterClient.process, which now honors the zero-redirect budget and surfaces
+// the forced MOVED as an error. This proves SwapNodes really induced a redirect on
+// the FD path (so the positive test exercised the redirect logic, not a trivial
+// pass) and that the FD reprocess goes through the cluster budget.
+func TestAPClusterFDMovedSurfacedWithoutRedirects(t *testing.T) {
+	ctx := context.Background()
+	c := redis.NewClusterClient(&redis.ClusterOptions{
+		Addrs:        clusterFDAddrs,
+		MaxRedirects: -1, // normalized to 0: a single attempt, no follow-through
+	})
+	defer c.Close()
+	skipIfClusterUnhealthy(t, c)
+
+	ap, err := c.AutoPipelineWithOptions(&redis.AutoPipelineOptions{FullDuplex: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ap.Close()
+	if !ap.Config().FullDuplex {
+		t.Fatalf("Config().FullDuplex = false, want true (cluster FD not active)")
+	}
+
+	const key = "fdmoved:noredir:key"
+	if err := ap.Set(ctx, key, "v", 0).Err(); err != nil {
+		t.Fatalf("initial set: %v", err)
+	}
+
+	// SwapNodes is racy against the periodic LazyReload, so re-swap and retry until
+	// we observe the MOVED (or give up and skip — the swap never stuck).
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := c.SwapNodes(ctx, key); err != nil {
+			t.Fatalf("SwapNodes: %v", err)
+		}
+		err := ap.Get(ctx, key).Err()
+		if err != nil && strings.Contains(err.Error(), "MOVED") {
+			return // proven: the redirect was needed and, with no redirects, surfaced
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Skip("could not observe a MOVED (swap kept being reverted by topology reload)")
+}


### PR DESCRIPTION
## Full-duplex autopipeline on cluster clients

Stacked on `feature/autopipeline-fullduplex-csc` (#4002). Makes the ordered
full-duplex (FD) autopipeline engage natively on a `*ClusterClient`.

### Problem

FD was a no-op on a `*ClusterClient`: the engine needs one held connection with a
writer/reader pair, which only a standalone `*Client` with a pipeline pool
provides, so `ClusterClient.AutoPipelineWithOptions({FullDuplex:true})` silently
fell back to the half-duplex per-shard flushers and `Config().FullDuplex` reported
`false`.

### Approach — per-node FD router

Every master's `node.Client` is a standalone `*Client` that gets a pipeline pool
by default (`PipelinePoolSize >= 0`). A new `clusterFDRouter`
(`autopipeline_cluster_fd.go`) keeps one FD child autopipeliner per master and
routes each command to the child that owns its slot, resolved against the live
cluster state on every submit. The parent `AutoPipeliner` keeps diversion
(blocking / fan-out / `ReqSpecial` / HIMPORT) on the `*ClusterClient`, so
cluster-wide commands still fan out; anything the router can't place on a single
node (keyless, unresolved slot, a non-FD node) falls back to
`ClusterClient.Process`.

Wiring in `autopipeline.go`: a construction gate (`clusterFDOn`) forces a single
flusherless shard like the standalone FD path, so no half-duplex flusher runs and
`enqueue`'s shard indexing stays safe. It requires `PipelinePoolSize >= 0` (so
every `node.Client` has a pipeline pool) and **bails when the client is set for
replica routing** (`ReadOnly` / `RouteByLatency` / `RouteRandomly`): the router
always routes to the slot **master**, so those options would be silently ignored —
fall back to the half-duplex flushers, which honor the `ShardPicker`.
`Config().FullDuplex` reports the effective per-node state (`false` when the gate
bails) and `NumShards` reports 1; the FD tuning defaults
(`FullDuplexWindow`/`FullDuplexIdleTimeout`/`FullDuplexMaxHold`) are resolved onto
the parent config so `Config()` reports the effective values rather than raw zeros,
matching the standalone path; `Len` sums the children; `Close` marks the
router closed, then closes the children before the parent drain and before
`clusterNodes` closes the node clients — and a child-drain failure is joined into
`AutoPipeliner.Close`'s result (taken from each child's `WaitClosed`, authoritative
even when an application-initiated close won the child's close CAS) rather than
masked by the empty shard sweep. A
`submit` that races `Close` rejects with `ErrClosed` and a child built in that race
window is discarded, so no held FD connection leaks. A `node.Client` that already
hosts an app-created standalone autopipeliner (no cluster reprocess) is diverted to
`Process` rather than dispatched through an engine that cannot follow redirects.

### MOVED/ASK and retryable replies

The FD engine already diverted retryable replies to a normal-path reprocess; it
surfaced redirects inline only because FD was standalone-only. The engine now
takes an injectable reprocess function (`AutoPipelineOptions.clusterReprocess`,
internal) plus a `redirectAware` flag; the router points each child's reprocess at
`ClusterClient.process` (the redirect loop — target-node routing, `ASKING` for an
ASK, `LazyReload` on MOVED, its own retry loop for a retryable reply, all bounded
by `MaxRedirects`) and flips `redirectAware` so the reader diverts MOVED/ASK **and
retryable replies** (`LOADING` / `READONLY` / `TRYAGAIN` / `CLUSTERDOWN` / …) there
instead of failing the caller. A MOVED/ASK is followed even for **`NoRetry`
commands** (`GetToBuffer`, `RawWriteTo`): the reply carries no payload, so there is
nothing to replay and `cc.process` follows redirects for every command; only
retryable *execution* errors stay gated on `NoRetry`. That retryable cluster divert
deliberately does **not** gate on the node client's `MaxRetries` (cluster node
clients default it to `-1`); `cc.process` owns the whole cluster budget. The
standalone default is unchanged (`client.processStartingAt`, `redirectAware=false`).

For a **connection-fatal** failure (no reply — the read loop broke), the engine
replays the unacked tail on a fresh connection of the same `node.Client` using a
recovery budget (`fdEngine.retryBudget`) of `MaxRedirects`, not the node client's
`MaxRetries` (`-1`). Without this the carry-replay would treat every in-flight
command as budget-spent and fail them all on the first socket blip; standalone FD
still uses `MaxRetries`.

### Tests

`autopipeline_cluster_fd_internal_test.go` (internal) and
`osscluster_autopipeline_fd_moved_test.go` (external). The functional tests
self-skip without a local cluster; the replica-routing gate test needs none:

- FD engaged on every master (`child.fd != nil`), effective `Config().FullDuplex`.
- 300-key mixed GET/SET across all slots, zero errors, correct read-back.
- Diversion still works (fan-out `DBSIZE`, blocking `BLPOP`).
- `Close` returns cleanly; a fresh autopipeliner after `Close` re-engages FD.
- Replica-routing gate: a `ReadOnly` / `RouteByLatency` / `RouteRandomly` cluster
  client reports `Config().FullDuplex == false` and engages no router (pure
  construction check, no cluster).
- Effective defaults: a default-constructed cluster-FD autopipeliner reports the
  resolved nonzero `FullDuplexWindow`/`IdleTimeout`/`MaxHold` from `Config()` (pure
  construction check, no cluster).
- Recovery budget: each per-node child engine carries `retryBudget == MaxRedirects`
  (a construction check on the child config, and the live per-master test asserts
  the engine field), so cluster carry-replay is not disabled by the node `-1`.
- MOVED **followed** to the correct value (`SwapNodes`), and **surfaced** with
  `MaxRedirects=0` — proving the divert routes through the cluster redirect budget.

`go build ./...`, `go vet`, and the autopipeline/cluster suites pass; the new path
is `-race` clean.

### Known limitations (tracked as follow-ups)

- **Hooks**: process hooks registered on the `ClusterClient` (`cc.AddHook`) do
  **not** wrap FD child submits — each child runs its own `node.Client`'s
  process-hook chain, so a hook added on the cluster client stops firing under
  cluster FD. Use `ClusterOptions.OnNewNode` to attach per-node hooks. Propagating
  cluster-client hooks to the children (with dynamic registration) is a larger
  design change.
- **Connection-fatal failover**: a fatal FD-socket failure replays the unacked tail
  on a **fresh connection of the same** `node.Client`, bounded by a recovery budget
  of `MaxRedirects` (the engine uses that, not the node client's `MaxRetries`, which
  cluster normalizes to `-1`). It does not route through `ClusterClient.process`, so
  a permanently dead master is not cross-node failed over the way half-duplex does —
  its resends surface as errors (or, once topology reloads, as MOVED replies that
  then divert). Reply-level retryable errors (including `MASTERDOWN` / `CLUSTERDOWN`)
  **do** route through `cc.process`.
- **Submit-path routing**: the router resolves the node on the submitter, so the
  first command on a fresh client may block on the initial topology load and a
  canceled per-command context can fail routing before admission (unlike the
  deferred face's engine-owned context). Half-duplex routes in the flusher, off the
  submit path.
- **Redirect/retry accounting**: the cluster reprocess drops the FD attempt's
  `startAttempt`/`writtenAt`, so the initial on-wire attempt is neither counted
  against `MaxRedirects` (a redirect/retry gets a fresh full budget — with
  `MaxRedirects: 0`, one extra request) nor reflected in the duration/attempt
  telemetry.
- **Unevicted children**: the router keeps per-node children until the parent
  `AutoPipeliner` is closed, so a long-lived cluster with sustained node-address
  churn (failovers, DNS/scaling changes) accumulates closed child engines rather
  than evicting them. The growth is bounded by address churn, not per-command.

### Notes

- The `command_policy_resolver.go` change is a separate commit: it drops a
  per-call `strings.Split` allocation on the command-policy hot path (used by
  `routeAndRun`/`process` and the autopipeline cluster gates). It benefits all
  cluster traffic, not just cluster-FD.
- `fdEngine`'s core dispatch is otherwise unchanged; the reprocess indirection is
  the only touch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches cluster routing, redirect/retry semantics, and connection recovery on a performance-critical autopipeline path; mis-routing or budget wiring could cause silent wrong-node reads or failed failovers.
> 
> **Overview**
> **Enables ordered full-duplex autopipeline on `*ClusterClient`**, where it previously no-op’d and `Config().FullDuplex` stayed false. A new **`clusterFDRouter`** lazily creates one full-duplex child autopipeliner per master `node.Client`, routes slot-owned commands to that child’s `fdEngine`, and keeps cluster-wide diversion (blocking, fan-out, HIMPORT) on the parent.
> 
> **Construction gates:** cluster FD engages only when `FullDuplex` is ordered, `PipelinePoolSize >= 0`, and replica routing (`ReadOnly` / `RouteByLatency` / `RouteRandomly`) is off—otherwise half-duplex flushers run and effective `FullDuplex` reports false. Parent config gets resolved FD defaults; `Close` drains children first and joins child errors; `Len` includes per-node backlog.
> 
> **`fdEngine` changes:** injectable `reprocess` (cluster uses `ClusterClient.process`) with `redirectAware` so **MOVED/ASK and retryable Redis errors** divert off the FD pipe; connection-fatal replay uses **`retryBudget()` = `MaxRedirects`** on cluster children instead of node `MaxRetries` (-1). Internal options are stripped from `Config()` copies.
> 
> **Minor:** `command_policy_resolver` avoids per-call `strings.Split` on the hot path.
> 
> Tests cover engagement, workload, replica gate, MOVED follow/surface, reuse after close, and recovery budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 413be3ca8ccb3a59c6bf6b1c5e23256e0a36c8e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->