### PR TITLE
chore(release): v9.23.0-beta.1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,17 +2,42 @@
 
 # 9.23.0-beta.1 (2026-09-11)
 
-This is a **beta** release, and a drop-in upgrade. It is headlined by an experimental **full-duplex mode** for the automatic pipeliner, refresh and miss-coalescing improvements to client-side caching, and fairer latency-based cluster read routing, alongside a batch of stability and robustness fixes.
+This is a **beta** release. You can upgrade without changes to your code. The release adds three primary features:
 
-⚠️ One behavior change to be aware of: every `Client` (including failover and cluster node clients) now creates a small **dedicated pipeline connection pool** by default, so `Pipeline` / `TxPipeline` / autopipeline traffic no longer competes with regular commands for main-pool connections ([#4002](https://github.com/redis/go-redis/pull/4002)). The pool is pure burst capacity — it never pre-dials, holds zero connections while unused, and spills to the main pool immediately when exhausted — so idle cost is zero; `PipelinePoolSize: -1` restores the previous single-pool behavior.
+- An experimental **full-duplex mode** for the automatic pipeliner.
+- Refresh and miss-coalescing functions for client-side caching.
+- Better distribution of cluster reads under latency-based routing.
+
+The release also contains many stability fixes and robustness fixes.
+
+⚠️ This release changes one default behavior. Each `Client` (this includes failover clients and cluster node clients) now creates a small, dedicated **pipeline connection pool** ([#4002](https://github.com/redis/go-redis/pull/4002)). `Pipeline`, `TxPipeline`, and autopipeline operations use this pool. These operations do not compete with regular commands for main-pool connections. The pool supplies burst capacity only:
+
+- The pool does not dial a connection before the connection is necessary.
+- An unused pool holds zero connections. The idle cost is zero.
+- If the pool is full, an operation immediately uses the main pool.
+
+Set `PipelinePoolSize: -1` to get the previous single-pool behavior.
 
 ## 🚀 Highlights
 
 ### Full-Duplex Auto-Pipelining (Experimental)
 
-`AutoPipelineOptions.FullDuplex` switches the automatic pipeliner from one-batch-per-round-trip flushing to a streaming engine: one held pipeline-pool connection with a dedicated writer/reader goroutine pair keeps the ordered command stream flowing in both directions at once. On latency-bound links this delivers ~1 RTT per command at a single connection — measured on a 50 ms WAN profile: ~389k ops/s at 52 ms p50 versus ~207k ops/s at 116 ms for the half-duplex ordered path.
+Set `AutoPipelineOptions.FullDuplex` to enable the full-duplex mode of the automatic pipeliner. The default mode sends one batch for each round trip. The full-duplex mode is different: the engine holds one pipeline-pool connection, and a writer goroutine and a reader goroutine move the ordered command stream in the two directions at the same time. On a link with high latency, each command completes in approximately one round-trip time (RTT) on a single connection. A test on a 50 ms WAN profile measured ~389k operations/s at 52 ms p50. The half-duplex ordered path measured ~207k operations/s at 116 ms.
 
-It works on both faces (`AutoPipeline()` and `AsyncAutoPipeline()`) of a standalone `Client`, and natively on `ClusterClient`: a per-master child engine routes each command to the node that owns its slot, with `MOVED`/`ASK` redirects and retryable replies (`LOADING`, `READONLY`, ...) followed through the cluster's normal redirect machinery. Tuning knobs: `FullDuplexWindow` (in-flight bound / backpressure), `FullDuplexIdleTimeout` and `FullDuplexMaxHold` (when the held connection is returned to the pool so re-auth and maintenance-notification handoffs run), and the opt-in `FullDuplexFastSubmit` for high-producer-count, low-RTT workloads. Blocking commands, `Options.Limiter` (admitted per written batch), per-command hooks, OTel metrics, retry budgets (including `NoRetry` commands, which are never re-sent once on the wire), and seamless maintenance handoffs are all honored on the full-duplex path.
+The mode operates on the two faces of a standalone `Client`: `AutoPipeline()` and `AsyncAutoPipeline()`. The mode also operates natively on a `ClusterClient` if the routing goes to masters only. A child engine for each master sends each command to the node that owns the command's slot. The engine obeys `MOVED` and `ASK` redirects and retryable replies (`LOADING`, `READONLY`, ...) through the usual cluster redirect procedure. If replica routing is set (`ReadOnly`, `RouteByLatency`, or `RouteRandomly`), the autopipeliner uses the half-duplex shard flushers, which obey the shard picker. `Config().FullDuplex` reports the mode that is in effect.
+
+These options tune the mode:
+
+- `FullDuplexWindow` — the maximum number of commands in flight (backpressure).
+- `FullDuplexIdleTimeout` and `FullDuplexMaxHold` — control when the engine returns the held connection to the pool. The pool hooks then do the re-authentication and the maintenance-notification handoffs.
+- `FullDuplexFastSubmit` — an optional fast submit path for many producers on low-RTT links.
+
+The full-duplex path supports blocking commands, `Options.Limiter` (one admission for each written batch), per-command hooks, OTel metrics, retry budgets (the client never sends a `NoRetry` command again after the command is on the wire), and seamless maintenance handoffs. The stream model causes these limits:
+
+- **A hook can monitor a command. A hook cannot stop a command.** A `ProcessHook` that returns without a call to `next` does not cancel the command on the full-duplex path. The command is already in the queue of the held connection, and the client sends it. Run policy hooks and kill-switch hooks on a plain client or on the half-duplex autopipeliner.
+- **The order guarantee does not include diverted commands.** The commands of one caller keep their order on the shared stream. The engine diverts some commands from the stream: blocking commands, connection-hostile commands, and managed `HIMPORT` commands. A diverted command has no order relation to the stream. On the async face, wait for the result of a diverted command before you submit a command that depends on it.
+- **The fast path does not use the client-side cache.** If CSC is enabled, a cacheable command on the full-duplex pipe does not read the cache and does not write to the cache. A subsequent change will correct this.
+- **The engine records a duration metric for each reply.** Some commands fail before they get to the reader: a lease failure, a limiter denial, retry exhaustion, or a close. These commands cause the error callback, but they do not cause an operation-duration sample.
 
 ```go
 rdb := redis.NewClient(&redis.Options{
@@ -44,69 +69,73 @@ for _, cmd := range cmds {
 //	val, err := ap.Get(ctx, "key").Result()
 ```
 
-A runnable tour of all the autopipeliner faces lives in [`example/autopipeline`](example/autopipeline).
+The [`example/autopipeline`](example/autopipeline) directory contains a runnable tour of all the autopipeliner faces.
 
-Alongside it, `AutoPipelineOptions.MaxBatchBytes` now defaults to 128 KiB (previously unbounded) as a write/reply deadlock guardrail, and the pipeline pool's buffers default to 128 KiB.
+Two related defaults changed. `AutoPipelineOptions.MaxBatchBytes` now has a default of 128 KiB (before, the size had no limit). This default prevents a write/reply deadlock. It is not a throughput control. The buffers of the pipeline pool also have a default of 128 KiB.
 
-**Experimental:** auto-pipelining APIs may change in a minor release.
+**Experimental:** the auto-pipelining APIs can change in a minor release.
 
 ([#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
 
 ### Client-Side Caching: Refresh-on-Invalidate and Miss Coalescing
 
-Two additions to the experimental shared-tracking client-side cache, both inert unless CSC is enabled ([#3989](https://github.com/redis/go-redis/pull/3989)) by [@ndyakov](https://github.com/ndyakov):
+The release adds two functions to the experimental shared-tracking client-side cache. The functions have no effect unless CSC is enabled ([#3989](https://github.com/redis/go-redis/pull/3989)) by [@ndyakov](https://github.com/ndyakov):
 
-- **Refresh-on-invalidate** (`Options.ClientSideCacheRefreshOnInvalidate`): recently-read keys are re-fetched in the background as soon as their invalidation push arrives, instead of waiting for the next reader to pay the miss. Invalidated hot keys are batched over a short window and re-read on a pipelined connection; window and demand behavior are tunable via `GOREDIS_CSC_REFRESH_WINDOW_MS` and `GOREDIS_CSC_REFRESH_DEMAND`.
-- **Reader-miss coalescing** (`GOREDIS_CSC_COALESCE_MISSES`, worker count via `GOREDIS_CSC_COALESCE_WORKERS`): concurrent cache-miss reads are pipelined onto a single tracked connection — each miss stays the caller's own per-key command (cluster-safe, no MGET rewrite) and every reply is published to the cache under the connection's tracking generation, so entries stay invalidatable.
+- **Refresh-on-invalidate** (`Options.ClientSideCacheRefreshOnInvalidate`): the client reads recently-read keys again in the background immediately after their invalidation push arrives. The next reader does not pay the cache miss. The client collects invalidated hot keys in a short window and reads them again on a pipelined connection. `ClientSideCacheRefreshRecencyWindow` sets which entries count as recently read. `ClientSideCacheInvalidationBatchWindow` collects invalidation-driven cache deletes into background batches; without it, the connection reader applies each delete inline.
+- **Miss coalescing** (`Options.ClientSideCacheCoalesceMisses`): the client pipelines concurrent cache-miss reads onto one tracked connection. Each miss keeps the caller's own per-key command. The client does not rewrite the commands to `MGET`, so the function is safe on a cluster. The client writes each reply to the cache with the tracking generation of the connection. The server can thus invalidate each entry.
 
-### Fairer Latency-Based Cluster Read Routing
+These options have the same requirement as the other CSC options: the built-in cache (`ClientSideCacheConfig`, or `ClientSideCache` set to a `*LocalCache`). The client ignores the options if a custom `Cache` implementation is set.
 
-`RouteByLatency` picks the strict minimum of a noisy measurement (the mean of ten pings, refreshed every 10s), so effectively-equidistant replicas all converge on one node — observed in production as a 590x GET-rate spread across a five-replica set within one availability zone. The new `ClusterOptions.RouteByLatencyTolerance` (also on `FailoverOptions`) widens the selection to "any node within this much of the fastest" and round-robins among them, preserving zone locality while spreading reads; zero (the default) keeps the strict-minimum behavior ([#3973](https://github.com/redis/go-redis/pull/3973)) by [@jozenstar](https://github.com/jozenstar).
+### Better Distribution for Latency-Based Cluster Read Routing
 
-The same work fixed a latent routing bug: the closest *healthy* node was only tracked when it was also the outright fastest, so a fast-failing node (connection refused fails fast, so this is common) hid every healthy node behind it and reads were served from the failing node. The healthy minimum is now tracked independently ([#3994](https://github.com/redis/go-redis/pull/3994)) by [@jozenstar](https://github.com/jozenstar).
+`RouteByLatency` selects the node with the strictly minimum latency. The latency measurement has noise: the value is the mean of ten pings, and the client refreshes it at most each 10 s. Thus all clients can select the same node from a set of nodes that have almost equal latency. A production system showed this problem: the GET rates across a five-replica set in one availability zone had a 590x spread.
+
+The new `ClusterOptions.RouteByLatencyTolerance` widens the selection to each node with a latency in the tolerance above the fastest node. The client distributes reads across these nodes with the round-robin procedure of the `ShardPicker`. A node in a different availability zone stays outside a sensible tolerance, so zone locality is kept. The default is zero, which keeps the strict-minimum behavior. The option is also on `FailoverOptions`, where it applies to clients from `NewFailoverClusterClient`. The plain `NewFailoverClient` does not support latency routing. ([#3973](https://github.com/redis/go-redis/pull/3973)) by [@jozenstar](https://github.com/jozenstar)
+
+The same work corrected a routing defect. The client recorded the nearest healthy node only when that node was also the fastest node overall. A node that fails fast (a refused connection fails fast, so this is frequent) thus hid each healthy node, and the client sent reads to the node that failed. The client now records the healthy minimum separately. ([#3994](https://github.com/redis/go-redis/pull/3994)) by [@jozenstar](https://github.com/jozenstar)
 
 ## ✨ New Features
 
-- **Full-duplex auto-pipelining**: `AutoPipelineOptions.FullDuplex` with `FullDuplexWindow` / `FullDuplexIdleTimeout` / `FullDuplexMaxHold` / `FullDuplexFastSubmit`, on standalone and cluster clients ([#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
-- **Dedicated pipeline pool by default**: `PipelinePoolSize` defaults to `DefaultPipelinePoolSize` (10) on every client, with immediate spill to the main pool when exhausted and `-1` as the opt-out ([#4002](https://github.com/redis/go-redis/pull/4002), [#3959](https://github.com/redis/go-redis/pull/3959)) by [@ndyakov](https://github.com/ndyakov)
-- **CSC refresh-on-invalidate and reader-miss coalescing**: `Options.ClientSideCacheRefreshOnInvalidate` plus the `GOREDIS_CSC_*` coalescing knobs ([#3989](https://github.com/redis/go-redis/pull/3989)) by [@ndyakov](https://github.com/ndyakov)
-- **`RouteByLatencyTolerance`**: spread cluster/failover reads across equally-close nodes ([#3973](https://github.com/redis/go-redis/pull/3973)) by [@jozenstar](https://github.com/jozenstar)
-- **`AutoPipeliner.WaitClosed`**: block until the winning `Close`'s drain of accepted commands completes — for wrappers that must not tear down shared pools while a flush is in flight ([#3998](https://github.com/redis/go-redis/pull/3998)) by [@ndyakov](https://github.com/ndyakov)
-- **`CMSInfo.CellSize`**: expose the Redis 8.12 `CMS.INFO` cell-size field ([#4010](https://github.com/redis/go-redis/pull/4010)) by [@elena-kolevska](https://github.com/elena-kolevska)
+- **Full-duplex auto-pipelining**: `AutoPipelineOptions.FullDuplex`, with `FullDuplexWindow` / `FullDuplexIdleTimeout` / `FullDuplexMaxHold` / `FullDuplexFastSubmit`. Available on standalone clients and cluster clients ([#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
+- **Dedicated pipeline pool by default**: `PipelinePoolSize` has a default of `DefaultPipelinePoolSize` (10) on each client. If the pool is full, an operation immediately uses the main pool. Set `-1` to disable the pool ([#4002](https://github.com/redis/go-redis/pull/4002), [#3959](https://github.com/redis/go-redis/pull/3959)) by [@ndyakov](https://github.com/ndyakov)
+- **CSC refresh-on-invalidate and miss coalescing**: `Options.ClientSideCacheRefreshOnInvalidate` (with `ClientSideCacheRefreshRecencyWindow` / `ClientSideCacheInvalidationBatchWindow`) and `Options.ClientSideCacheCoalesceMisses` ([#3989](https://github.com/redis/go-redis/pull/3989)) by [@ndyakov](https://github.com/ndyakov)
+- **`RouteByLatencyTolerance`**: distributes reads across nodes that have almost equal latency, on cluster clients and on `NewFailoverClusterClient` ([#3973](https://github.com/redis/go-redis/pull/3973)) by [@jozenstar](https://github.com/jozenstar)
+- **`AutoPipeliner.WaitClosed`**: blocks until the drain of the accepted commands completes, and returns the drain result. Use it in a wrapper that must not close shared pools while a flush is in progress ([#3998](https://github.com/redis/go-redis/pull/3998)) by [@ndyakov](https://github.com/ndyakov)
+- **`CMSInfo.CellSize`**: contains the cell-size field of `CMS.INFO` in Redis 8.12 ([#4010](https://github.com/redis/go-redis/pull/4010)) by [@elena-kolevska](https://github.com/elena-kolevska)
 
 ## 🐛 Bug Fixes
 
-- **Cluster read routing**: track the closest healthy node independently of the overall minimum, so a fast-failing node no longer hides healthy ones ([#3994](https://github.com/redis/go-redis/pull/3994)) by [@jozenstar](https://github.com/jozenstar)
-- **Probabilistic `*.INFO` forward compatibility**: `BF.INFO` / `CF.INFO` / `CMS.INFO` / `TOPK.INFO` / `TDIGEST.INFO` parsers skip unknown fields instead of erroring (Redis 8.12 adds `cell size` to `CMS.INFO`) ([#4010](https://github.com/redis/go-redis/pull/4010)) by [@elena-kolevska](https://github.com/elena-kolevska)
-- **`NewClient` panic leak**: a panic during construction (e.g. maintnotifications `ModeEnabled` failing) no longer leaks the already-created connection pools; a typed-nil pool can no longer mask the original panic ([#4003](https://github.com/redis/go-redis/pull/4003)) by [@ndyakov](https://github.com/ndyakov); the same guards applied to `NewFailoverClient` ([#4002](https://github.com/redis/go-redis/pull/4002))
-- **File-descriptor leak on rejected connections**: `Conn.Close` runs the socket teardown and unsubscribe/CSC callbacks even when the connection is already `CLOSED` (init/auth failures accumulated open descriptors), closing the transport exactly once per socket generation (fixes [#3982](https://github.com/redis/go-redis/issues/3982)) ([#3985](https://github.com/redis/go-redis/pull/3985)) by [@ndyakov](https://github.com/ndyakov)
-- **Global logger races**: guard the global `Logger` and `LogLevel` with atomics, with call-site attribution corrected ([#3988](https://github.com/redis/go-redis/pull/3988)) by [@saddamr3e](https://github.com/saddamr3e)
-- **`Conn.onClose` data race**: connection close hooks installed during init are now atomic against a concurrent `Close` (`onClose` and `onCscClose`) ([#3966](https://github.com/redis/go-redis/pull/3966)) by [@saddamr3e](https://github.com/saddamr3e)
-- **Reply-parser hardening**: guard zero-length entry arrays in reply parsers ([#3995](https://github.com/redis/go-redis/pull/3995)) by [@saddamr3e](https://github.com/saddamr3e); read the full RESP3 map reply in `FTHybridCmd` instead of desyncing the connection ([#3956](https://github.com/redis/go-redis/pull/3956)) by [@saddamr3e](https://github.com/saddamr3e)
-- **`CLIENT INFO` forward compatibility**: skip unrecognized client-flag characters instead of failing the whole reply ([#3977](https://github.com/redis/go-redis/pull/3977)) by [@ndyakov](https://github.com/ndyakov)
-- **`GEOSEARCH` duplicate args**: don't emit duplicate arguments ([#3955](https://github.com/redis/go-redis/pull/3955)) by [@mehmettokgoz](https://github.com/mehmettokgoz)
-- **`MSetEX` cluster routing**: set the first-key position via the constructor so typed calls route to the right slot ([#3984](https://github.com/redis/go-redis/pull/3984)) by [@shivamrustagi](https://github.com/shivamrustagi)
-- **Maintenance notifications**: skip endpoint DNS detection entirely when the mode is disabled ([#3969](https://github.com/redis/go-redis/pull/3969)) by [@Phalanyx](https://github.com/Phalanyx)
-- **Autopipeliner `Close`**: concurrent `Close` stays non-blocking (no re-entrant deadlock) while `WaitClosed` exposes the drain result ([#3998](https://github.com/redis/go-redis/pull/3998)) by [@ndyakov](https://github.com/ndyakov)
-- **Buffered-push log noise**: the healthy buffered-push-data notice in `isHealthyConn` is gated behind debug level, so CSC invalidations no longer flood the log ([#3948](https://github.com/redis/go-redis/pull/3948)) by [@ndyakov](https://github.com/ndyakov)
-- **Sentinel teardown ordering**: close hooks run LIFO so an autopipeliner drain completes before Sentinel discovery is torn down, and a closed failover client can no longer rebuild its Sentinel resources from a late dial ([#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
-- **Pipeline desync containment**: a failed pre-write push-notification drain or a panicking command encoder now retires the connection instead of returning a desynced one to the pool (shared `Pipeline`/`TxPipeline` path) ([#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
+- **Cluster read routing**: the client records the nearest healthy node separately from the overall minimum. A node that fails fast does not hide the healthy nodes ([#3994](https://github.com/redis/go-redis/pull/3994)) by [@jozenstar](https://github.com/jozenstar)
+- **Probabilistic `*.INFO` forward compatibility**: the parsers for `BF.INFO` / `CF.INFO` / `CMS.INFO` / `TOPK.INFO` / `TDIGEST.INFO` skip unknown fields and do not return an error. Redis 8.12 adds `cell size` to `CMS.INFO` ([#4010](https://github.com/redis/go-redis/pull/4010)) by [@elena-kolevska](https://github.com/elena-kolevska)
+- **`NewClient` panic leak**: a panic during construction (for example, a maintnotifications failure in `ModeEnabled`) does not leak the connection pools that already exist. A typed-nil pool cannot hide the initial panic ([#4003](https://github.com/redis/go-redis/pull/4003)) by [@ndyakov](https://github.com/ndyakov). The same guards are applied to `NewFailoverClient` ([#4002](https://github.com/redis/go-redis/pull/4002))
+- **File-descriptor leak on rejected connections**: `Conn.Close` does the socket teardown and the unsubscribe/CSC callbacks when the connection is already `CLOSED`. Before, init and auth failures collected open descriptors. The transport now closes exactly one time for each socket generation (fixes [#3982](https://github.com/redis/go-redis/issues/3982)) ([#3985](https://github.com/redis/go-redis/pull/3985)) by [@ndyakov](https://github.com/ndyakov)
+- **Global logger races**: atomics protect the global `Logger` and `LogLevel`. The call-site attribution is correct again ([#3988](https://github.com/redis/go-redis/pull/3988)) by [@saddamr3e](https://github.com/saddamr3e)
+- **`Conn.onClose` data race**: the close hooks that init installs (`onClose` and `onCscClose`) are now atomic against a concurrent `Close` ([#3966](https://github.com/redis/go-redis/pull/3966)) by [@saddamr3e](https://github.com/saddamr3e)
+- **Reply-parser hardening**: the reply parsers accept zero-length entry arrays ([#3995](https://github.com/redis/go-redis/pull/3995)) by [@saddamr3e](https://github.com/saddamr3e). `FTHybridCmd` reads the full RESP3 map reply and does not desynchronize the connection ([#3956](https://github.com/redis/go-redis/pull/3956)) by [@saddamr3e](https://github.com/saddamr3e)
+- **`CLIENT INFO` forward compatibility**: the parser skips unknown client-flag characters. The full reply does not fail ([#3977](https://github.com/redis/go-redis/pull/3977)) by [@ndyakov](https://github.com/ndyakov)
+- **`GEOSEARCH` duplicate args**: the command does not send duplicate arguments ([#3955](https://github.com/redis/go-redis/pull/3955)) by [@mehmettokgoz](https://github.com/mehmettokgoz)
+- **`MSetEX` cluster routing**: the constructor sets the first-key position. Typed calls thus go to the correct slot ([#3984](https://github.com/redis/go-redis/pull/3984)) by [@shivamrustagi](https://github.com/shivamrustagi)
+- **Maintenance notifications**: the client does not do the endpoint DNS detection when the mode is disabled ([#3969](https://github.com/redis/go-redis/pull/3969)) by [@Phalanyx](https://github.com/Phalanyx)
+- **Autopipeliner `Close`**: a concurrent `Close` does not block (no re-entrant deadlock). `WaitClosed` supplies the drain result ([#3998](https://github.com/redis/go-redis/pull/3998)) by [@ndyakov](https://github.com/ndyakov)
+- **Buffered-push log noise**: the buffered-push-data notice in `isHealthyConn` shows only at the debug level. CSC invalidations do not fill the log ([#3948](https://github.com/redis/go-redis/pull/3948)) by [@ndyakov](https://github.com/ndyakov)
+- **Sentinel teardown order**: close hooks run in LIFO order. An autopipeliner drain thus completes before the Sentinel discovery stops. A closed failover client cannot create its Sentinel resources again from a late dial ([#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
+- **Pipeline desync containment**: if a pre-write push-notification drain fails, or if a command encoder panics, the client removes the connection. The client does not return a desynchronized connection to the pool. This applies to the shared `Pipeline`/`TxPipeline` path ([#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
 
 ## ⚡ Performance
 
-- **Zero-copy scanning**: zero-copy semantics in `Scan` and removal of redundant data conversions in the RESP reader ([#3972](https://github.com/redis/go-redis/pull/3972)) by [@vlady-kotsev](https://github.com/vlady-kotsev)
-- **Autopipeline straggler hold**: bound the hold on queued stragglers when the pipeline pool has a free connection — uncached p95 111→65 ms on a 50 ms link, real-WAN uncached p99 314→177 ms ([#3962](https://github.com/redis/go-redis/pull/3962)) by [@ndyakov](https://github.com/ndyakov)
-- **Full-duplex allocations halved**: ring-buffer in-flight queue and pooled blocking-face batches — 770→353 B/op at 2048 concurrent callers ([#3970](https://github.com/redis/go-redis/pull/3970), part of [#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
+- **Zero-copy scan**: `Scan` gets zero-copy semantics, and the RESP reader does not do unnecessary data conversions ([#3972](https://github.com/redis/go-redis/pull/3972)) by [@vlady-kotsev](https://github.com/vlady-kotsev)
+- **Autopipeline straggler hold**: the engine limits the hold on queued commands when the pipeline pool has a free connection. Uncached p95 decreased from 111 ms to 65 ms on a 50 ms link. Real-WAN uncached p99 decreased from 314 ms to 177 ms ([#3962](https://github.com/redis/go-redis/pull/3962)) by [@ndyakov](https://github.com/ndyakov)
+- **Full-duplex allocations**: a ring buffer holds the in-flight queue, and the blocking face uses a pool of batches. Allocations decreased from 770 B/op to 353 B/op at 2048 concurrent callers ([#3970](https://github.com/redis/go-redis/pull/3970), part of [#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
 
 ## 🧪 Testing & Infrastructure
 
-- **Fast skip gates**: TCP-probe test addresses before the `Ping` gate, cutting ~1.6 min of dial-retry waits from environments without the full stack ([#4001](https://github.com/redis/go-redis/pull/4001)) by [@ndyakov](https://github.com/ndyakov)
-- **Redis Enterprise coverage**: autopipeline suites reach the RE database and use the suite DB ([#3976](https://github.com/redis/go-redis/pull/3976), [#3975](https://github.com/redis/go-redis/pull/3975)), timing assertions scale to measured RTT ([#3978](https://github.com/redis/go-redis/pull/3978)), and the `CLIENT INFO` tracking-flag assert is skipped behind the RE proxy ([#3981](https://github.com/redis/go-redis/pull/3981)) by [@ndyakov](https://github.com/ndyakov)
-- **Security policy**: vulnerability reports now point at the Redis VDP ([#3949](https://github.com/redis/go-redis/pull/3949)) by [@ndyakov](https://github.com/ndyakov)
+- **Fast skip gates**: the tests do a TCP probe of each address before the `Ping` gate. This removes ~1.6 min of dial-retry waits in environments without the full stack ([#4001](https://github.com/redis/go-redis/pull/4001)) by [@ndyakov](https://github.com/ndyakov)
+- **Redis Enterprise coverage**: the autopipeline suites connect to the RE database and use the suite DB ([#3976](https://github.com/redis/go-redis/pull/3976), [#3975](https://github.com/redis/go-redis/pull/3975)). The timing assertions scale to the measured RTT ([#3978](https://github.com/redis/go-redis/pull/3978)). The `CLIENT INFO` tracking-flag assertion does not run behind the RE proxy ([#3981](https://github.com/redis/go-redis/pull/3981)) by [@ndyakov](https://github.com/ndyakov)
+- **Security policy**: send vulnerability reports to the Redis VDP ([#3949](https://github.com/redis/go-redis/pull/3949)) by [@ndyakov](https://github.com/ndyakov)
 
 ## 👥 Contributors
 
-We'd like to thank all the contributors who worked on this release!
+We thank all the contributors who worked on this release!
 
 [@elena-kolevska](https://github.com/elena-kolevska), [@jozenstar](https://github.com/jozenstar), [@mehmettokgoz](https://github.com/mehmettokgoz), [@ndyakov](https://github.com/ndyakov), [@Phalanyx](https://github.com/Phalanyx), [@saddamr3e](https://github.com/saddamr3e), [@shivamrustagi](https://github.com/shivamrustagi), [@vlady-kotsev](https://github.com/vlady-kotsev)
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,119 @@
 # Release Notes
 
+# 9.23.0-beta.1 (2026-09-11)
+
+This is a **beta** release, and a drop-in upgrade. It is headlined by an experimental **full-duplex mode** for the automatic pipeliner, refresh and miss-coalescing improvements to client-side caching, and fairer latency-based cluster read routing, alongside a batch of stability and robustness fixes.
+
+⚠️ One behavior change to be aware of: every `Client` (including failover and cluster node clients) now creates a small **dedicated pipeline connection pool** by default, so `Pipeline` / `TxPipeline` / autopipeline traffic no longer competes with regular commands for main-pool connections ([#4002](https://github.com/redis/go-redis/pull/4002)). The pool is pure burst capacity — it never pre-dials, holds zero connections while unused, and spills to the main pool immediately when exhausted — so idle cost is zero; `PipelinePoolSize: -1` restores the previous single-pool behavior.
+
+## 🚀 Highlights
+
+### Full-Duplex Auto-Pipelining (Experimental)
+
+`AutoPipelineOptions.FullDuplex` switches the automatic pipeliner from one-batch-per-round-trip flushing to a streaming engine: one held pipeline-pool connection with a dedicated writer/reader goroutine pair keeps the ordered command stream flowing in both directions at once. On latency-bound links this delivers ~1 RTT per command at a single connection — measured on a 50 ms WAN profile: ~389k ops/s at 52 ms p50 versus ~207k ops/s at 116 ms for the half-duplex ordered path.
+
+It works on both faces (`AutoPipeline()` and `AsyncAutoPipeline()`) of a standalone `Client`, and natively on `ClusterClient`: a per-master child engine routes each command to the node that owns its slot, with `MOVED`/`ASK` redirects and retryable replies (`LOADING`, `READONLY`, ...) followed through the cluster's normal redirect machinery. Tuning knobs: `FullDuplexWindow` (in-flight bound / backpressure), `FullDuplexIdleTimeout` and `FullDuplexMaxHold` (when the held connection is returned to the pool so re-auth and maintenance-notification handoffs run), and the opt-in `FullDuplexFastSubmit` for high-producer-count, low-RTT workloads. Blocking commands, `Options.Limiter` (admitted per written batch), per-command hooks, OTel metrics, retry budgets (including `NoRetry` commands, which are never re-sent once on the wire), and seamless maintenance handoffs are all honored on the full-duplex path.
+
+```go
+rdb := redis.NewClient(&redis.Options{
+	Addr: "localhost:6379",
+	AutoPipelineOptions: &redis.AutoPipelineOptions{
+		FullDuplex: true, // stream commands on one held connection, ~1 RTT each
+	},
+})
+defer rdb.Close()
+
+// Deferred face: calls return immediately; result accessors block until executed.
+ap, err := rdb.AsyncAutoPipeline()
+if err != nil {
+	panic(err)
+}
+cmds := make([]*redis.StatusCmd, 0, 1000)
+for i := 0; i < 1000; i++ {
+	cmds = append(cmds, ap.Set(ctx, fmt.Sprintf("key:%d", i), i, 0))
+}
+for _, cmd := range cmds {
+	if err := cmd.Err(); err != nil {
+		// handle error
+	}
+}
+
+// Or the blocking face — a drop-in Cmdable where each call blocks like a
+// plain client while concurrent callers share the full-duplex pipe:
+//	ap, err := rdb.AutoPipeline()
+//	val, err := ap.Get(ctx, "key").Result()
+```
+
+A runnable tour of all the autopipeliner faces lives in [`example/autopipeline`](example/autopipeline).
+
+Alongside it, `AutoPipelineOptions.MaxBatchBytes` now defaults to 128 KiB (previously unbounded) as a write/reply deadlock guardrail, and the pipeline pool's buffers default to 128 KiB.
+
+**Experimental:** auto-pipelining APIs may change in a minor release.
+
+([#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
+
+### Client-Side Caching: Refresh-on-Invalidate and Miss Coalescing
+
+Two additions to the experimental shared-tracking client-side cache, both inert unless CSC is enabled ([#3989](https://github.com/redis/go-redis/pull/3989)) by [@ndyakov](https://github.com/ndyakov):
+
+- **Refresh-on-invalidate** (`Options.ClientSideCacheRefreshOnInvalidate`): recently-read keys are re-fetched in the background as soon as their invalidation push arrives, instead of waiting for the next reader to pay the miss. Invalidated hot keys are batched over a short window and re-read on a pipelined connection; window and demand behavior are tunable via `GOREDIS_CSC_REFRESH_WINDOW_MS` and `GOREDIS_CSC_REFRESH_DEMAND`.
+- **Reader-miss coalescing** (`GOREDIS_CSC_COALESCE_MISSES`, worker count via `GOREDIS_CSC_COALESCE_WORKERS`): concurrent cache-miss reads are pipelined onto a single tracked connection — each miss stays the caller's own per-key command (cluster-safe, no MGET rewrite) and every reply is published to the cache under the connection's tracking generation, so entries stay invalidatable.
+
+### Fairer Latency-Based Cluster Read Routing
+
+`RouteByLatency` picks the strict minimum of a noisy measurement (the mean of ten pings, refreshed every 10s), so effectively-equidistant replicas all converge on one node — observed in production as a 590x GET-rate spread across a five-replica set within one availability zone. The new `ClusterOptions.RouteByLatencyTolerance` (also on `FailoverOptions`) widens the selection to "any node within this much of the fastest" and round-robins among them, preserving zone locality while spreading reads; zero (the default) keeps the strict-minimum behavior ([#3973](https://github.com/redis/go-redis/pull/3973)) by [@jozenstar](https://github.com/jozenstar).
+
+The same work fixed a latent routing bug: the closest *healthy* node was only tracked when it was also the outright fastest, so a fast-failing node (connection refused fails fast, so this is common) hid every healthy node behind it and reads were served from the failing node. The healthy minimum is now tracked independently ([#3994](https://github.com/redis/go-redis/pull/3994)) by [@jozenstar](https://github.com/jozenstar).
+
+## ✨ New Features
+
+- **Full-duplex auto-pipelining**: `AutoPipelineOptions.FullDuplex` with `FullDuplexWindow` / `FullDuplexIdleTimeout` / `FullDuplexMaxHold` / `FullDuplexFastSubmit`, on standalone and cluster clients ([#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
+- **Dedicated pipeline pool by default**: `PipelinePoolSize` defaults to `DefaultPipelinePoolSize` (10) on every client, with immediate spill to the main pool when exhausted and `-1` as the opt-out ([#4002](https://github.com/redis/go-redis/pull/4002), [#3959](https://github.com/redis/go-redis/pull/3959)) by [@ndyakov](https://github.com/ndyakov)
+- **CSC refresh-on-invalidate and reader-miss coalescing**: `Options.ClientSideCacheRefreshOnInvalidate` plus the `GOREDIS_CSC_*` coalescing knobs ([#3989](https://github.com/redis/go-redis/pull/3989)) by [@ndyakov](https://github.com/ndyakov)
+- **`RouteByLatencyTolerance`**: spread cluster/failover reads across equally-close nodes ([#3973](https://github.com/redis/go-redis/pull/3973)) by [@jozenstar](https://github.com/jozenstar)
+- **`AutoPipeliner.WaitClosed`**: block until the winning `Close`'s drain of accepted commands completes — for wrappers that must not tear down shared pools while a flush is in flight ([#3998](https://github.com/redis/go-redis/pull/3998)) by [@ndyakov](https://github.com/ndyakov)
+- **`CMSInfo.CellSize`**: expose the Redis 8.12 `CMS.INFO` cell-size field ([#4010](https://github.com/redis/go-redis/pull/4010)) by [@elena-kolevska](https://github.com/elena-kolevska)
+
+## 🐛 Bug Fixes
+
+- **Cluster read routing**: track the closest healthy node independently of the overall minimum, so a fast-failing node no longer hides healthy ones ([#3994](https://github.com/redis/go-redis/pull/3994)) by [@jozenstar](https://github.com/jozenstar)
+- **Probabilistic `*.INFO` forward compatibility**: `BF.INFO` / `CF.INFO` / `CMS.INFO` / `TOPK.INFO` / `TDIGEST.INFO` parsers skip unknown fields instead of erroring (Redis 8.12 adds `cell size` to `CMS.INFO`) ([#4010](https://github.com/redis/go-redis/pull/4010)) by [@elena-kolevska](https://github.com/elena-kolevska)
+- **`NewClient` panic leak**: a panic during construction (e.g. maintnotifications `ModeEnabled` failing) no longer leaks the already-created connection pools; a typed-nil pool can no longer mask the original panic ([#4003](https://github.com/redis/go-redis/pull/4003)) by [@ndyakov](https://github.com/ndyakov); the same guards applied to `NewFailoverClient` ([#4002](https://github.com/redis/go-redis/pull/4002))
+- **File-descriptor leak on rejected connections**: `Conn.Close` runs the socket teardown and unsubscribe/CSC callbacks even when the connection is already `CLOSED` (init/auth failures accumulated open descriptors), closing the transport exactly once per socket generation (fixes [#3982](https://github.com/redis/go-redis/issues/3982)) ([#3985](https://github.com/redis/go-redis/pull/3985)) by [@ndyakov](https://github.com/ndyakov)
+- **Global logger races**: guard the global `Logger` and `LogLevel` with atomics, with call-site attribution corrected ([#3988](https://github.com/redis/go-redis/pull/3988)) by [@saddamr3e](https://github.com/saddamr3e)
+- **`Conn.onClose` data race**: connection close hooks installed during init are now atomic against a concurrent `Close` (`onClose` and `onCscClose`) ([#3966](https://github.com/redis/go-redis/pull/3966)) by [@saddamr3e](https://github.com/saddamr3e)
+- **Reply-parser hardening**: guard zero-length entry arrays in reply parsers ([#3995](https://github.com/redis/go-redis/pull/3995)) by [@saddamr3e](https://github.com/saddamr3e); read the full RESP3 map reply in `FTHybridCmd` instead of desyncing the connection ([#3956](https://github.com/redis/go-redis/pull/3956)) by [@saddamr3e](https://github.com/saddamr3e)
+- **`CLIENT INFO` forward compatibility**: skip unrecognized client-flag characters instead of failing the whole reply ([#3977](https://github.com/redis/go-redis/pull/3977)) by [@ndyakov](https://github.com/ndyakov)
+- **`GEOSEARCH` duplicate args**: don't emit duplicate arguments ([#3955](https://github.com/redis/go-redis/pull/3955)) by [@mehmettokgoz](https://github.com/mehmettokgoz)
+- **`MSetEX` cluster routing**: set the first-key position via the constructor so typed calls route to the right slot ([#3984](https://github.com/redis/go-redis/pull/3984)) by [@shivamrustagi](https://github.com/shivamrustagi)
+- **Maintenance notifications**: skip endpoint DNS detection entirely when the mode is disabled ([#3969](https://github.com/redis/go-redis/pull/3969)) by [@Phalanyx](https://github.com/Phalanyx)
+- **Autopipeliner `Close`**: concurrent `Close` stays non-blocking (no re-entrant deadlock) while `WaitClosed` exposes the drain result ([#3998](https://github.com/redis/go-redis/pull/3998)) by [@ndyakov](https://github.com/ndyakov)
+- **Buffered-push log noise**: the healthy buffered-push-data notice in `isHealthyConn` is gated behind debug level, so CSC invalidations no longer flood the log ([#3948](https://github.com/redis/go-redis/pull/3948)) by [@ndyakov](https://github.com/ndyakov)
+- **Sentinel teardown ordering**: close hooks run LIFO so an autopipeliner drain completes before Sentinel discovery is torn down, and a closed failover client can no longer rebuild its Sentinel resources from a late dial ([#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
+- **Pipeline desync containment**: a failed pre-write push-notification drain or a panicking command encoder now retires the connection instead of returning a desynced one to the pool (shared `Pipeline`/`TxPipeline` path) ([#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
+
+## ⚡ Performance
+
+- **Zero-copy scanning**: zero-copy semantics in `Scan` and removal of redundant data conversions in the RESP reader ([#3972](https://github.com/redis/go-redis/pull/3972)) by [@vlady-kotsev](https://github.com/vlady-kotsev)
+- **Autopipeline straggler hold**: bound the hold on queued stragglers when the pipeline pool has a free connection — uncached p95 111→65 ms on a 50 ms link, real-WAN uncached p99 314→177 ms ([#3962](https://github.com/redis/go-redis/pull/3962)) by [@ndyakov](https://github.com/ndyakov)
+- **Full-duplex allocations halved**: ring-buffer in-flight queue and pooled blocking-face batches — 770→353 B/op at 2048 concurrent callers ([#3970](https://github.com/redis/go-redis/pull/3970), part of [#4002](https://github.com/redis/go-redis/pull/4002)) by [@ndyakov](https://github.com/ndyakov)
+
+## 🧪 Testing & Infrastructure
+
+- **Fast skip gates**: TCP-probe test addresses before the `Ping` gate, cutting ~1.6 min of dial-retry waits from environments without the full stack ([#4001](https://github.com/redis/go-redis/pull/4001)) by [@ndyakov](https://github.com/ndyakov)
+- **Redis Enterprise coverage**: autopipeline suites reach the RE database and use the suite DB ([#3976](https://github.com/redis/go-redis/pull/3976), [#3975](https://github.com/redis/go-redis/pull/3975)), timing assertions scale to measured RTT ([#3978](https://github.com/redis/go-redis/pull/3978)), and the `CLIENT INFO` tracking-flag assert is skipped behind the RE proxy ([#3981](https://github.com/redis/go-redis/pull/3981)) by [@ndyakov](https://github.com/ndyakov)
+- **Security policy**: vulnerability reports now point at the Redis VDP ([#3949](https://github.com/redis/go-redis/pull/3949)) by [@ndyakov](https://github.com/ndyakov)
+
+## 👥 Contributors
+
+We'd like to thank all the contributors who worked on this release!
+
+[@elena-kolevska](https://github.com/elena-kolevska), [@jozenstar](https://github.com/jozenstar), [@mehmettokgoz](https://github.com/mehmettokgoz), [@ndyakov](https://github.com/ndyakov), [@Phalanyx](https://github.com/Phalanyx), [@saddamr3e](https://github.com/saddamr3e), [@shivamrustagi](https://github.com/shivamrustagi), [@vlady-kotsev](https://github.com/vlady-kotsev)
+
+---
+
+**Full Changelog**: https://github.com/redis/go-redis/compare/v9.22.0...v9.23.0-beta.1
+
 # 9.22.0 (2026-08-03)
 
 This is a minor release introducing two flagship (experimental) features — **client-side caching** and **automatic pipelining** — alongside support for Redis 8.10, new commands, and a large batch of stability and parser-robustness fixes. It consolidates everything shipped in 9.22.0-beta.1, so the notes below cover the full 9.21.0 → 9.22.0 upgrade.

--- a/example/autopipeline/go.mod
+++ b/example/autopipeline/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/client-side-caching/go.mod
+++ b/example/client-side-caching/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.21.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/cluster-mget/go.mod
+++ b/example/cluster-mget/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/del-keys-without-ttl/go.mod
+++ b/example/del-keys-without-ttl/go.mod
@@ -5,7 +5,7 @@ go 1.24
 replace github.com/redis/go-redis/v9 => ../..
 
 require (
-	github.com/redis/go-redis/v9 v9.22.0
+	github.com/redis/go-redis/v9 v9.23.0-beta.1
 	go.uber.org/zap v1.24.0
 )
 

--- a/example/digest-optimistic-locking/go.mod
+++ b/example/digest-optimistic-locking/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/disable-maintnotifications/go.mod
+++ b/example/disable-maintnotifications/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/ft-aliaslist/go.mod
+++ b/example/ft-aliaslist/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/himport/go.mod
+++ b/example/himport/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/hll/go.mod
+++ b/example/hll/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/hset-struct/go.mod
+++ b/example/hset-struct/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/redis/go-redis/v9 v9.22.0
+	github.com/redis/go-redis/v9 v9.23.0-beta.1
 )
 
 require (

--- a/example/lua-scripting/go.mod
+++ b/example/lua-scripting/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/maintnotifiations-pubsub/go.mod
+++ b/example/maintnotifiations-pubsub/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/otel-metrics/go.mod
+++ b/example/otel-metrics/go.mod
@@ -7,8 +7,8 @@ replace github.com/redis/go-redis/v9 => ../..
 replace github.com/redis/go-redis/extra/redisotel-native/v9 => ../../extra/redisotel-native
 
 require (
-	github.com/redis/go-redis/extra/redisotel-native/v9 v9.22.0
-	github.com/redis/go-redis/v9 v9.22.0
+	github.com/redis/go-redis/extra/redisotel-native/v9 v9.23.0-beta.1
+	github.com/redis/go-redis/v9 v9.23.0-beta.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0

--- a/example/otel/go.mod
+++ b/example/otel/go.mod
@@ -9,8 +9,8 @@ replace github.com/redis/go-redis/extra/redisotel/v9 => ../../extra/redisotel
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../../extra/rediscmd
 
 require (
-	github.com/redis/go-redis/extra/redisotel/v9 v9.22.0
-	github.com/redis/go-redis/v9 v9.22.0
+	github.com/redis/go-redis/extra/redisotel/v9 v9.23.0-beta.1
+	github.com/redis/go-redis/v9 v9.23.0-beta.1
 	github.com/uptrace/uptrace-go v1.41.1
 	go.opentelemetry.io/otel v1.43.0
 )
@@ -22,7 +22,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.22.0 // indirect
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.23.0-beta.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0 // indirect
 	go.opentelemetry.io/contrib/processors/minsev v0.16.0 // indirect

--- a/example/redis-bloom/go.mod
+++ b/example/redis-bloom/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/scan-struct/go.mod
+++ b/example/scan-struct/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/redis/go-redis/v9 v9.22.0
+	github.com/redis/go-redis/v9 v9.23.0-beta.1
 )
 
 require (

--- a/example/search-aggregate-collect/go.mod
+++ b/example/search-aggregate-collect/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/search-aggregate-steps/go.mod
+++ b/example/search-aggregate-steps/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/tls-cert-auth/go.mod
+++ b/example/tls-cert-auth/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/tls-connection/go.mod
+++ b/example/tls-connection/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/ts-querylabels/go.mod
+++ b/example/ts-querylabels/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/example/zerocopy-buffer/go.mod
+++ b/example/zerocopy-buffer/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 replace github.com/redis/go-redis/v9 => ../..
 
-require github.com/redis/go-redis/v9 v9.22.0
+require github.com/redis/go-redis/v9 v9.23.0-beta.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/extra/rediscensus/go.mod
+++ b/extra/rediscensus/go.mod
@@ -7,8 +7,8 @@ replace github.com/redis/go-redis/v9 => ../..
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../rediscmd
 
 require (
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.22.0
-	github.com/redis/go-redis/v9 v9.22.0
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.23.0-beta.1
+	github.com/redis/go-redis/v9 v9.23.0-beta.1
 	go.opencensus.io v0.24.0
 )
 

--- a/extra/rediscmd/go.mod
+++ b/extra/rediscmd/go.mod
@@ -7,7 +7,7 @@ replace github.com/redis/go-redis/v9 => ../..
 require (
 	github.com/bsm/ginkgo/v2 v2.12.0
 	github.com/bsm/gomega v1.27.10
-	github.com/redis/go-redis/v9 v9.22.0
+	github.com/redis/go-redis/v9 v9.23.0-beta.1
 )
 
 require (

--- a/extra/redisotel-native/go.mod
+++ b/extra/redisotel-native/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 replace github.com/redis/go-redis/v9 => ../..
 
 require (
-	github.com/redis/go-redis/v9 v9.22.0
+	github.com/redis/go-redis/v9 v9.23.0-beta.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0

--- a/extra/redisotel/go.mod
+++ b/extra/redisotel/go.mod
@@ -7,8 +7,8 @@ replace github.com/redis/go-redis/v9 => ../..
 replace github.com/redis/go-redis/extra/rediscmd/v9 => ../rediscmd
 
 require (
-	github.com/redis/go-redis/extra/rediscmd/v9 v9.22.0
-	github.com/redis/go-redis/v9 v9.22.0
+	github.com/redis/go-redis/extra/rediscmd/v9 v9.23.0-beta.1
+	github.com/redis/go-redis/v9 v9.23.0-beta.1
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/extra/redisprometheus/go.mod
+++ b/extra/redisprometheus/go.mod
@@ -6,7 +6,7 @@ replace github.com/redis/go-redis/v9 => ../..
 
 require (
 	github.com/prometheus/client_golang v1.14.0
-	github.com/redis/go-redis/v9 v9.22.0
+	github.com/redis/go-redis/v9 v9.23.0-beta.1
 )
 
 require (

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package redis
 
 // Version is the current release version.
 func Version() string {
-	return "9.22.0"
+	return "9.23.0-beta.1"
 }


### PR DESCRIPTION
- Updated release notes
- Bumped version to v9.23.0-beta.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version string and module pin updates plus release documentation only; no runtime code changes in this PR.
> 
> **Overview**
> **Release packaging for `v9.23.0-beta.1`:** bumps `Version()` in `version.go` and updates `require` lines across `example/*` and `extra/*` modules (including OTel extras) from `9.22.0` / `9.21.0` to `9.23.0-beta.1`.
> 
> Adds a new **9.23.0-beta.1** section at the top of `RELEASE-NOTES.md` that documents what ships in this beta: experimental full-duplex auto-pipelining, client-side cache refresh-on-invalidate and miss coalescing, `RouteByLatencyTolerance` and related cluster routing fixes, the new default dedicated pipeline connection pool (`PipelinePoolSize`, opt out with `-1`), `AutoPipeliner.WaitClosed`, `CMSInfo.CellSize`, plus bug fixes, performance notes, and testing/infrastructure changes. No library implementation changes appear in this diff—only version alignment and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 833640000146e69452cfc117a28e1b581764d8bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->