### PR TITLE
perf(autopipeline): honor MaxFlushDelay in FD

### DIFF
--- a/autopipeline.go
+++ b/autopipeline.go
@@ -93,6 +93,9 @@ type AutoPipelineOptions struct {
 	// connection. On a fast link (loopback) prefer half-duplex — with no RTT to
 	// overlap, full-duplex only adds coordination overhead.
 	//
+	// Also honored by the full-duplex writer, where it is gated on in-flight
+	// depth so it never taxes low-concurrency callers (see fdAccumMinFor).
+	//
 	// Honored on the ordered (Unordered:false, MaxConcurrentBatches<=1),
 	// single-shard face of a standalone *Client that has a pipeline pool — BOTH the
 	// deferred (AsyncAutoPipeline) and the blocking (AutoPipeline) face. A SINGLE

--- a/autopipeline_fullduplex.go
+++ b/autopipeline_fullduplex.go
@@ -1811,8 +1811,11 @@ func (fd *fdEngine) session(bg context.Context, cn *pool.Conn, carry []fdReq) (u
 				if room := fd.window - inflight.len(); room < limit {
 					limit = room
 				}
-				// At most one accumulation wait per batch.
-				accumWaited := false
+				// accumArmed:    the accumulation timer is running for this batch.
+				// accumExpired:  the window closed, so flush instead of re-waiting.
+				// accumMaxHold:  max-hold fired DURING the wait; its one-shot tick was
+				//                consumed here, so end the session after the flush.
+				accumArmed, accumExpired, accumMaxHold := false, false, false
 			drain:
 				for len(batch) < limit {
 					// Soft MaxBatchBytes cap (like the half-duplex path): stop
@@ -1846,19 +1849,37 @@ func (fd *fdEngine) session(bg context.Context, cn *pool.Conn, carry []fdReq) (u
 						// there would cost every command a round trip. MaxFlushDelay
 						// defaults to 0, so this is opt-in and the default path is
 						// byte-for-byte unchanged.
-						if fd.ap.config.MaxFlushDelay > 0 && !accumWaited &&
+						if fd.ap.config.MaxFlushDelay > 0 && !accumExpired &&
 							len(batch) < fd.maxBatch && inflight.len() >= fd.accumMin {
-							accumWaited = true
-							if accumTimer == nil {
-								accumTimer = time.NewTimer(fd.ap.config.MaxFlushDelay)
-							} else {
-								accumTimer.Reset(fd.ap.config.MaxFlushDelay)
+							// Arm ONCE per batch, then keep re-entering this select
+							// until the timer fires. Returning on the first arriving
+							// command would wait for AN ARRIVAL rather than accumulate
+							// to a deadline, which is a different (and near-useless)
+							// thing: measured 4.4 -> 7.9 commands per flush and +1%
+							// throughput, against 178 and +22% once the writer waits
+							// out the whole window.
+							if !accumArmed {
+								accumArmed = true
+								if accumTimer == nil {
+									accumTimer = time.NewTimer(fd.ap.config.MaxFlushDelay)
+								} else {
+									// Reset on an expired, undrained timer is the classic
+									// timer-reuse bug. Drain NON-BLOCKINGLY: whether a
+									// value is buffered depends on who won the previous
+									// select, so a plain <-accumTimer.C wedges the writer
+									// (and Close) forever in the case where the timer
+									// already lost the race and no value is pending.
+									if !accumTimer.Stop() {
+										select {
+										case <-accumTimer.C:
+										default:
+										}
+									}
+									accumTimer.Reset(fd.ap.config.MaxFlushDelay)
+								}
 							}
 							select {
 							case ra := <-fd.ch:
-								if !accumTimer.Stop() {
-									<-accumTimer.C
-								}
 								batch = append(batch, ra)
 								rba, sizeErrA := cmdApproxBytesSafe(ra.cmd)
 								if sizeErrA != nil {
@@ -1871,6 +1892,29 @@ func (fd *fdEngine) session(bg context.Context, cn *pool.Conn, carry []fdReq) (u
 								batchBytes += rba
 								continue drain
 							case <-accumTimer.C:
+								accumExpired = true
+								break drain
+							case <-readerDone:
+								// Reader is gone. Stop waiting and flush the prefix
+								// already taken off fd.ch; the top of the serve loop
+								// re-observes readerDone (a closed channel, so the signal
+								// is not consumed here) and ends the session through the
+								// existing connection-error path, which recovers this
+								// batch through the carry/replay logic.
+								break drain
+							case <-fd.ap.ctx.Done():
+								// Close() is waiting on this writer. Flush what is in
+								// hand and let the serve loop take the graceful path;
+								// ctx.Done() is a closed channel, so nothing is consumed.
+								break drain
+							case <-maxC:
+								// Max-hold reached mid-wait. maxC comes from a ONE-SHOT
+								// time.Timer, so this receive consumes the only tick:
+								// record it and end the session after the flush rather
+								// than dropping it and holding the connection past its
+								// deadline. Without this case a MaxFlushDelay longer than
+								// FullDuplexMaxHold parks the writer beyond max-hold.
+								accumMaxHold = true
 								break drain
 							}
 						}
@@ -1882,6 +1926,17 @@ func (fd *fdEngine) session(bg context.Context, cn *pool.Conn, carry []fdReq) (u
 					break serve
 				}
 				resetIdle()
+				if accumMaxHold {
+					// Mirror the <-maxC arm of the serve select, whose tick the
+					// accumulation wait above consumed: idle when the pipe drained,
+					// recycle when work remains.
+					if inflight.empty() && len(fd.ch) == 0 {
+						result = fdIdle
+					} else {
+						result = fdRecycle
+					}
+					break serve
+				}
 			case <-readerDone:
 				break serve // reader hit a connection error (result stays fdConnErr)
 			case <-fd.ap.ctx.Done():

--- a/autopipeline_fullduplex.go
+++ b/autopipeline_fullduplex.go
@@ -506,13 +506,64 @@ func (f *fdInflight) takeRemaining() []fdReq {
 	return rem
 }
 
+// fdAccumMinFor returns the in-flight depth above which the full-duplex writer
+// will wait MaxFlushDelay for more commands before flushing (see the drain loop
+// in session).
+//
+// The writer's drain is non-blocking: it flushes whatever is already queued. At
+// low concurrency that is exactly right — a lone caller pays one round trip and
+// nothing waits on its behalf. Under load it is pathological: measured on a
+// 2-vCPU client at 1024 concurrent callers, the writer flushed ~4.6 commands per
+// batch and issued ~75k write syscalls/sec, saturating the CPU, while the
+// half-duplex path on the same connection batched ~460 commands per flush at
+// 130% CPU.
+//
+// Waiting unconditionally is not the answer either: a fixed delay armed on every
+// flush costs every low-concurrency command roughly a round trip (measured: 64
+// callers went from 130k ops/sec at p50 0.48ms to 41k at p50 1.59ms). That is the
+// same failure mode documented for the half-duplex path's old debounce timer,
+// which is why that path coalesces on expected-arrival count instead.
+//
+// So the wait is gated on in-flight depth: below accumMin the writer never waits
+// (low concurrency keeps its 1xRTT behaviour), above it the writer is
+// demonstrably syscall-bound and coalescing pays. Derived from the window rather
+// than hardcoded, so a caller who shrinks FullDuplexWindow also lowers the
+// threshold; floored at 64 so a small window cannot make it trivially easy to
+// trip.
+//
+// Measured with MaxFlushDelay=250us on a 2-vCPU client (64B GET/SET 70/30):
+//
+//	callers   unpatched          gated wait
+//	     64   130k, p50 0.48ms   134k, p50 0.45ms   (unchanged, as intended)
+//	    256   237k, 160% CPU     228k, 112% CPU     (same work, 30% less CPU)
+//	   1024   345k, p99 4.78ms   420k, p99 3.53ms   (+22% ops, -26% p99)
+//	   2048   308k, p99 10.1ms   386k, p99 7.19ms   (+25% ops, -29% p99)
+func fdAccumMinFor(window int) int {
+	const (
+		floor = 64
+		// 1/512 of the window: 128 at the default 65536, which is where the
+		// measurements above cross from "nothing to collect" into
+		// "syscall-bound".
+		shift = 9
+	)
+	if m := window >> shift; m > floor {
+		return m
+	}
+	return floor
+}
+
 type fdEngine struct {
 	ap       *AutoPipeliner
 	client   *Client
 	pool     pool.Pooler
 	ch       chan fdReq // MPSC ordered queue: many submitters -> the writer
 	maxBatch int
-	window   int           // max in-flight (written, unacked) before the writer waits
+	window   int // max in-flight (written, unacked) before the writer waits
+	// accumMin is the in-flight depth at which the writer is willing to wait
+	// MaxFlushDelay for more commands before flushing. Derived from the window
+	// so it scales with the configured pipeline depth instead of being a magic
+	// constant; see fdAccumMinFor.
+	accumMin int
 	idle     time.Duration // return the conn after this idle gap (0 = never)
 	maxHold  time.Duration // force a clean return at least this often (0 = never)
 
@@ -653,6 +704,7 @@ func newFDEngine(ap *AutoPipeliner, client *Client) *fdEngine {
 		ch:         make(chan fdReq, chCap),
 		maxBatch:   mb,
 		window:     w,
+		accumMin:   fdAccumMinFor(w),
 		idle:       idle,
 		maxHold:    maxHold,
 		retrySem:   make(chan struct{}, retryCap),
@@ -1682,6 +1734,9 @@ func (fd *fdEngine) session(bg context.Context, cn *pool.Conn, carry []fdReq) (u
 		// in-flight ring's min(maxBatch, window) cap.
 		scratch := make([]fdReq, 0, min(fd.maxBatch, fd.window))
 		byteLimit := int64(fd.ap.config.MaxBatchBytes) // 0 = disabled
+		// Reused across drains so the accumulation wait allocates nothing on
+		// the hot path. Nil until the first wait actually happens.
+		var accumTimer *time.Timer
 	serve:
 		for {
 			// Backpressure: bound the in-flight (written-but-unacked) deque. Wait
@@ -1756,6 +1811,8 @@ func (fd *fdEngine) session(bg context.Context, cn *pool.Conn, carry []fdReq) (u
 				if room := fd.window - inflight.len(); room < limit {
 					limit = room
 				}
+				// At most one accumulation wait per batch.
+				accumWaited := false
 			drain:
 				for len(batch) < limit {
 					// Soft MaxBatchBytes cap (like the half-duplex path): stop
@@ -1780,6 +1837,43 @@ func (fd *fdEngine) session(bg context.Context, cn *pool.Conn, carry []fdReq) (u
 						}
 						batchBytes += rb
 					default:
+						// Nothing queued right now. Under load, flushing a handful of
+						// commands means paying batch and syscall overhead at
+						// per-command frequency, so wait MaxFlushDelay once for the
+						// rest of the wave. Gated on in-flight depth (see
+						// fdAccumMinFor): at low concurrency the queue is empty
+						// because there is genuinely nothing to send, and waiting
+						// there would cost every command a round trip. MaxFlushDelay
+						// defaults to 0, so this is opt-in and the default path is
+						// byte-for-byte unchanged.
+						if fd.ap.config.MaxFlushDelay > 0 && !accumWaited &&
+							len(batch) < fd.maxBatch && inflight.len() >= fd.accumMin {
+							accumWaited = true
+							if accumTimer == nil {
+								accumTimer = time.NewTimer(fd.ap.config.MaxFlushDelay)
+							} else {
+								accumTimer.Reset(fd.ap.config.MaxFlushDelay)
+							}
+							select {
+							case ra := <-fd.ch:
+								if !accumTimer.Stop() {
+									<-accumTimer.C
+								}
+								batch = append(batch, ra)
+								rba, sizeErrA := cmdApproxBytesSafe(ra.cmd)
+								if sizeErrA != nil {
+									// Same handling as the fast path above: fail and drop
+									// just this command, flush the good prefix.
+									fd.failReqs(batch[len(batch)-1:], sizeErrA)
+									batch = batch[:len(batch)-1]
+									break drain
+								}
+								batchBytes += rba
+								continue drain
+							case <-accumTimer.C:
+								break drain
+							}
+						}
 						break drain
 					}
 				}

--- a/autopipeline_fullduplex_test.go
+++ b/autopipeline_fullduplex_test.go
@@ -4723,3 +4723,167 @@ func TestFullDuplexSpillsToMainPoolOnPipelineDialError(t *testing.T) {
 		t.Fatalf("FD lease did not spill to the main pool on a pipeline dial error (main-pool gets=%d)", g)
 	}
 }
+
+// --- MaxFlushDelay on the full-duplex writer (the fdAccumMinFor gate) -------
+
+// TestFDAccumMinFor pins the in-flight threshold the writer uses to decide
+// whether waiting MaxFlushDelay is worthwhile. Pure function, no server, so
+// both sides of the gate are covered deterministically.
+func TestFDAccumMinFor(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		window int
+		want   int
+	}{
+		// Below 64*512 the shift underflows the floor, so the floor wins: a
+		// caller who shrinks the window must not end up with a threshold so low
+		// that any trickle of traffic trips it.
+		{"zero", 0, 64},
+		{"tiny", 1, 64},
+		{"at-floor-boundary", 64 * 512, 64},
+		// Above it the threshold tracks the window, so enlarging the pipeline
+		// depth raises the bar in proportion.
+		{"default-window", fdDefaultWindow, fdDefaultWindow / 512},
+		{"double-default", 2 * fdDefaultWindow, 2 * fdDefaultWindow / 512},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fdAccumMinFor(tc.window); got != tc.want {
+				t.Fatalf("fdAccumMinFor(%d) = %d, want %d", tc.window, got, tc.want)
+			}
+		})
+	}
+	// The default must land at 128: that is the value the measurements in the
+	// fdAccumMinFor doc comment were taken at, so changing it invalidates them.
+	if got := fdAccumMinFor(fdDefaultWindow); got != 128 {
+		t.Fatalf("default threshold = %d, want 128", got)
+	}
+}
+
+// TestFullDuplexMaxFlushDelayNoWaitAtLowConcurrency is the load-gate contract,
+// and the regression test for the gate itself: with a single caller in flight
+// the writer must NOT wait MaxFlushDelay, so a lone command still costs ~1 RTT.
+// The delay is set far above any plausible round trip, so if the gate is ever
+// removed or its threshold drops to ~0, the command inherits the delay and the
+// deadline below fails. (Unguarded, this configuration measured 64 callers
+// dropping from 130k ops/s at p50 0.48ms to 41k at p50 1.59ms.)
+func TestFullDuplexMaxFlushDelayNoWaitAtLowConcurrency(t *testing.T) {
+	ctx := context.Background()
+
+	c := fdTestClient(":6379")
+	defer c.Close()
+	if err := c.Ping(ctx).Err(); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
+
+	const delay = 400 * time.Millisecond
+	ap, err := c.AsyncAutoPipelineWithOptions(&AutoPipelineOptions{
+		FullDuplex:    true,
+		MaxFlushDelay: delay,
+	})
+	if err != nil {
+		t.Fatalf("AsyncAutoPipeline: %v", err)
+	}
+	defer ap.Close()
+
+	if err := ap.Set(ctx, "fd:accum:one", "v", 0).Err(); err != nil {
+		t.Fatalf("warm Set: %v", err)
+	}
+
+	// Several attempts rather than one: a single sample could be unlucky (GC,
+	// scheduler), but the gate either waits on every batch or on none of them.
+	const attempts = 5
+	var fast int
+	for i := 0; i < attempts; i++ {
+		start := time.Now()
+		if err := ap.Get(ctx, "fd:accum:one").Err(); err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if time.Since(start) < delay/4 {
+			fast++
+		}
+	}
+	if fast <= attempts/2 {
+		t.Fatalf("only %d/%d single-caller commands beat %v; the in-flight gate "+
+			"is not keeping low concurrency off the accumulation wait",
+			fast, attempts, delay/4)
+	}
+}
+
+// TestFullDuplexMaxFlushDelayCorrectUnderLoad drives enough sustained
+// concurrency to push in-flight past fdAccumMinFor, so the accumulation wait is
+// genuinely armed and both of its arms -- a command arriving, and the timer
+// expiring -- are exercised. Instrumenting the drain loop while developing this
+// test recorded 260 arms across 702 queue-empty hits for this configuration, so
+// the path is reached rather than merely reachable.
+//
+// It asserts correctness through that path (every reply is the value that was
+// written, no errors, no stall) rather than an achieved batch size: commands
+// per flush is not observable from outside the engine without adding
+// instrumentation. The batching effect itself is quantified in the benchmark
+// numbers in the PR description.
+func TestFullDuplexMaxFlushDelayCorrectUnderLoad(t *testing.T) {
+	ctx := context.Background()
+
+	c := fdTestClient(":6379")
+	defer c.Close()
+	if err := c.Ping(ctx).Err(); err != nil {
+		t.Skipf("no redis: %v", err)
+	}
+
+	ap, err := c.AsyncAutoPipelineWithOptions(&AutoPipelineOptions{
+		FullDuplex: true,
+		// 1024 keeps the threshold at the 64 floor while leaving the window well
+		// above it, so the gate trips on load rather than on the window
+		// backpressure gate.
+		FullDuplexWindow: 1024,
+		MaxFlushDelay:    2 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("AsyncAutoPipeline: %v", err)
+	}
+	defer ap.Close()
+
+	const (
+		workers = 128
+		perWkr  = 40
+	)
+	for i := 0; i < workers; i++ {
+		if err := ap.Set(ctx, fmt.Sprintf("fd:accum:load:%d", i), fmt.Sprint(i), 0).Err(); err != nil {
+			t.Fatalf("prefill: %v", err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			key, want := fmt.Sprintf("fd:accum:load:%d", id), fmt.Sprint(id)
+			for j := 0; j < perWkr; j++ {
+				got, err := ap.Get(ctx, key).Result()
+				if err != nil {
+					errs <- fmt.Errorf("worker %d: %w", id, err)
+					return
+				}
+				if got != want {
+					errs <- fmt.Errorf("worker %d: got %q want %q", id, got, want)
+					return
+				}
+			}
+		}(i)
+	}
+
+	waited := make(chan struct{})
+	go func() { wg.Wait(); close(waited) }()
+	select {
+	case <-waited:
+	case <-time.After(30 * time.Second):
+		t.Fatal("load phase did not finish in 30s: the writer is stuck in the " +
+			"accumulation wait")
+	}
+	close(errs)
+	for err := range errs {
+		t.Fatalf("%v", err)
+	}
+}


### PR DESCRIPTION
The full-duplex writer's drain loop is non-blocking: it flushes whatever is already queued and never waits. At low concurrency that is correct - a lone caller pays one round trip and nothing waits on its behalf - but under load it pays batch and syscall overhead at per-command frequency.

Measured on a 2-vCPU client (64B, GET/SET 70/30, one connection):

  1024 callers, full-duplex   4.6 commands/flush, ~75k write syscalls/s,
                              CPU pinned at 196%
  1024 callers, half-duplex   460 commands/flush, ~670 syscalls/s,
                              130% CPU

MaxFlushDelay was never used in fd pipeline. Use it, but gate the wait on in-flight depth: below fdAccumMinFor(window) the writer never waits, so low-concurrency callers keep their 1xRTT behaviour. Waiting unconditionally regressed 64 callers from 130k ops/s at p50 0.48ms to 41k at p50 1.59ms - the same failure documented for the half-duplex path's old debounce timer.

With MaxFlushDelay=250us:

  callers   before             after
       64   130k, p50 0.48ms   134k, p50 0.45ms   (unchanged)
      256   237k, 160% CPU     228k, 112% CPU     (30% less CPU)
     1024   345k, p99 4.78ms   420k, p99 3.53ms   (+22% ops, -26% p99)
     2048   308k, p99 10.1ms   386k, p99 7.19ms   (+25% ops, -29% p99)

MaxFlushDelay defaults to 0, so the default path is unchanged and the coalescing is strictly opt-in.